### PR TITLE
feat: add Codex/Gemini CLI support, indicatif progress display, and daemon logging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ cargo build                      # build
 cargo test --workspace           # all tests
 cargo test -p <crate>            # single crate
 cargo test -p <crate> -- <name>  # single test
-cargo clippy --workspace --all-targets  # lint
+cargo clippy --workspace --all-targets -- -D warnings -D clippy::all  # lint (CI denies warnings)
 cargo fmt --all                  # format
 cargo insta review               # accept/reject snapshot changes
 ```
@@ -29,7 +29,7 @@ cargo insta review               # accept/reject snapshot changes
 
 ## Crates
 
-cella-cli, cella-config, cella-codegen, cella-docker, cella-git, cella-port, cella-agent
+cella-agent, cella-cli, cella-codegen, cella-config, cella-credential-proxy, cella-daemon, cella-doctor, cella-docker, cella-env, cella-features, cella-git, cella-port
 
 ## Testing
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,6 +273,7 @@ dependencies = [
  "chrono",
  "clap",
  "hex",
+ "indicatif",
  "miette",
  "serde_json",
  "sha2",
@@ -531,6 +532,18 @@ dependencies = [
  "libc",
  "once_cell",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width 0.2.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1202,12 +1215,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+dependencies = [
+ "console 0.16.3",
+ "portable-atomic",
+ "unicode-width 0.2.2",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
 name = "insta"
 version = "1.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4"
 dependencies = [
- "console",
+ "console 0.15.11",
  "once_cell",
  "pest",
  "pest_derive",
@@ -1697,6 +1723,12 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -2753,6 +2785,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,7 @@ dependencies = [
  "clap",
  "hex",
  "indicatif",
+ "insta",
  "miette",
  "serde_json",
  "sha2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,6 +336,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,9 @@ futures-util = "0.3.32"
 # Terminal
 crossterm = { version = "0.29.0", default-features = false }
 
+# Progress display
+indicatif = "0.18.4"
+
 # Timestamps
 chrono = { version = "0.4.44", default-features = false, features = ["clock"] }
 

--- a/crates/cella-cli/Cargo.toml
+++ b/crates/cella-cli/Cargo.toml
@@ -28,6 +28,7 @@ sha2.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+indicatif.workspace = true
 
 [lints]
 workspace = true

--- a/crates/cella-cli/Cargo.toml
+++ b/crates/cella-cli/Cargo.toml
@@ -30,5 +30,8 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 indicatif.workspace = true
 
+[dev-dependencies]
+insta = { version = "1.46.3", features = ["json", "redactions"] }
+
 [lints]
 workspace = true

--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -41,7 +41,14 @@ enum OutputFormat {
 }
 
 impl BuildArgs {
-    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+    pub const fn is_text_output(&self) -> bool {
+        matches!(self.output, OutputFormat::Text)
+    }
+
+    pub async fn execute(
+        self,
+        progress: crate::progress::Progress,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let cwd = if let Some(ref wf) = self.workspace_folder {
             wf.canonicalize().unwrap_or_else(|_| wf.clone())
         } else {
@@ -67,7 +74,6 @@ impl BuildArgs {
         client.ping().await?;
 
         // 3. Build image via shared ensure_image logic
-        let is_text = matches!(self.output, OutputFormat::Text);
         let (img_name, _resolved_features, _image_details) = ensure_image(
             &client,
             config,
@@ -75,7 +81,7 @@ impl BuildArgs {
             config_name,
             &resolved.config_path,
             self.no_cache,
-            is_text,
+            &progress,
         )
         .await?;
 

--- a/crates/cella-cli/src/commands/daemon.rs
+++ b/crates/cella-cli/src/commands/daemon.rs
@@ -53,6 +53,9 @@ impl DaemonArgs {
 async fn run_start(args: StartArgs) -> Result<(), Box<dyn std::error::Error>> {
     let data_dir = cella_data_dir().ok_or("cannot determine data dir: HOME not set")?;
 
+    // Initialize file-based logging for the daemon process.
+    cella_daemon::logging::init_daemon_logging(&data_dir.join("daemon.log"));
+
     let socket_path = args
         .socket
         .unwrap_or_else(|| data_dir.join("credential-proxy.sock"));

--- a/crates/cella-cli/src/commands/down.rs
+++ b/crates/cella-cli/src/commands/down.rs
@@ -45,6 +45,10 @@ pub struct DownArgs {
 }
 
 impl DownArgs {
+    pub const fn is_text_output(&self) -> bool {
+        matches!(self.output, OutputFormat::Text)
+    }
+
     pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
         let client = match &self.docker_host {
             Some(host) => DockerClient::connect_with_host(host)?,

--- a/crates/cella-cli/src/commands/image.rs
+++ b/crates/cella-cli/src/commands/image.rs
@@ -68,19 +68,24 @@ pub async fn build_features_layer(
         "Building features layer image (context: {})",
         ctx.resolved.build_context.display()
     );
-    let step = ctx.progress.step("Building features layer...");
+    let start = std::time::Instant::now();
     let progress_ref = ctx.progress.clone();
     let result = ctx
         .client
         .build_image(&build_opts, |line| {
             if !line.trim().is_empty() {
-                progress_ref.println(line);
+                progress_ref.println(&format!("  {line}"));
             }
         })
         .await;
+    let elapsed = crate::progress::format_elapsed_pub(start.elapsed());
     match &result {
-        Ok(_) => step.finish(),
-        Err(e) => step.fail(&e.to_string()),
+        Ok(_) => ctx.progress.println(&format!(
+            "  \x1b[32m✓\x1b[0m Building features layer...{elapsed}"
+        )),
+        Err(e) => ctx.progress.println(&format!(
+            "  \x1b[31m✗\x1b[0m Building features layer...: {e}"
+        )),
     }
     result?;
     Ok(features_image)
@@ -161,18 +166,21 @@ async fn resolve_base_image(
     } else if let Some(build) = config.get("build").and_then(|v| v.as_object()) {
         let img_name = image_name(workspace_root, config_name);
         let build_opts = parse_build_options(build, &img_name, workspace_root, no_cache);
-        let step = progress.step("Building Dockerfile...");
+        let start = std::time::Instant::now();
         let progress_ref = progress.clone();
         let result = client
             .build_image(&build_opts, |line| {
                 if !line.trim().is_empty() {
-                    progress_ref.println(line);
+                    progress_ref.println(&format!("  {line}"));
                 }
             })
             .await;
+        let elapsed = crate::progress::format_elapsed_pub(start.elapsed());
         match &result {
-            Ok(_) => step.finish(),
-            Err(e) => step.fail(&e.to_string()),
+            Ok(_) => progress.println(&format!(
+                "  \x1b[32m✓\x1b[0m Building Dockerfile...{elapsed}"
+            )),
+            Err(e) => progress.println(&format!("  \x1b[31m✗\x1b[0m Building Dockerfile...: {e}")),
         }
         result?;
         Ok(img_name)

--- a/crates/cella-cli/src/commands/image.rs
+++ b/crates/cella-cli/src/commands/image.rs
@@ -9,6 +9,8 @@ use cella_docker::{
 };
 use cella_features::ResolvedFeatures;
 
+use crate::progress::Progress;
+
 /// Compute a SHA-256 digest of the features config for image tagging.
 pub fn compute_features_digest(config: &serde_json::Value) -> String {
     let features = config.get("features").unwrap_or(&serde_json::Value::Null);
@@ -26,7 +28,7 @@ pub struct FeaturesLayerContext<'a> {
     pub base_image: &'a str,
     pub image_user: &'a str,
     pub no_cache: bool,
-    pub is_text: bool,
+    pub progress: &'a Progress,
 }
 
 /// Build the features layer image on top of a base image.
@@ -66,15 +68,12 @@ pub async fn build_features_layer(
         "Building features layer image (context: {})",
         ctx.resolved.build_context.display()
     );
-    if ctx.is_text {
-        eprintln!("Building features layer...");
-    }
-    let start = std::time::Instant::now();
-    ctx.client.build_image(&build_opts).await?;
-    if ctx.is_text {
-        let elapsed = start.elapsed();
-        eprintln!(" ({:.1}s)", elapsed.as_secs_f64());
-    }
+    ctx.progress
+        .run_step(
+            "Building features layer...",
+            ctx.client.build_image(&build_opts),
+        )
+        .await?;
     Ok(features_image)
 }
 
@@ -90,7 +89,7 @@ pub async fn ensure_image(
     config_name: Option<&str>,
     config_path: &Path,
     no_cache: bool,
-    is_text: bool,
+    progress: &Progress,
 ) -> Result<(String, Option<ResolvedFeatures>, ImageDetails), Box<dyn std::error::Error>> {
     let has_features = config
         .get("features")
@@ -104,7 +103,7 @@ pub async fn ensure_image(
         workspace_root,
         config_name,
         no_cache,
-        is_text,
+        progress,
     )
     .await?;
 
@@ -126,7 +125,7 @@ pub async fn ensure_image(
         &base_image_tag,
         &base_image_details,
         no_cache,
-        is_text,
+        progress,
     )
     .await?;
 
@@ -140,38 +139,22 @@ async fn resolve_base_image(
     workspace_root: &Path,
     config_name: Option<&str>,
     no_cache: bool,
-    is_text: bool,
+    progress: &Progress,
 ) -> Result<String, Box<dyn std::error::Error>> {
     if let Some(image) = config.get("image").and_then(|v| v.as_str()) {
         // Pull base image if needed (force re-pull when no_cache)
         if no_cache || !client.image_exists(image).await? {
-            if is_text {
-                eprint!("Pulling base image...");
-            }
-            let start = std::time::Instant::now();
-            client.pull_image(image).await?;
-            if is_text {
-                let elapsed = start.elapsed();
-                if elapsed.as_millis() >= 100 {
-                    eprintln!(" ({:.1}s)", elapsed.as_secs_f64());
-                } else {
-                    eprintln!();
-                }
-            }
+            progress
+                .run_step("Pulling base image...", client.pull_image(image))
+                .await?;
         }
         Ok(image.to_string())
     } else if let Some(build) = config.get("build").and_then(|v| v.as_object()) {
         let img_name = image_name(workspace_root, config_name);
         let build_opts = parse_build_options(build, &img_name, workspace_root, no_cache);
-        if is_text {
-            eprintln!("Building Dockerfile...");
-        }
-        let start = std::time::Instant::now();
-        client.build_image(&build_opts).await?;
-        if is_text {
-            let elapsed = start.elapsed();
-            eprintln!(" ({:.1}s)", elapsed.as_secs_f64());
-        }
+        progress
+            .run_step("Building Dockerfile...", client.build_image(&build_opts))
+            .await?;
         Ok(img_name)
     } else {
         Err("devcontainer.json must specify either 'image' or 'build'".into())
@@ -189,7 +172,7 @@ async fn resolve_and_build_features(
     base_image_tag: &str,
     base_image_details: &ImageDetails,
     no_cache: bool,
-    is_text: bool,
+    progress: &Progress,
 ) -> Result<(String, ResolvedFeatures), Box<dyn std::error::Error>> {
     info!("Resolving devcontainer features...");
     let platform = cella_features::oci::detect_platform(client.inner())
@@ -218,7 +201,7 @@ async fn resolve_and_build_features(
         base_image: base_image_tag,
         image_user: &base_image_details.user,
         no_cache,
-        is_text,
+        progress,
     };
     let features_image = build_features_layer(&ctx).await?;
 

--- a/crates/cella-cli/src/commands/image.rs
+++ b/crates/cella-cli/src/commands/image.rs
@@ -68,12 +68,19 @@ pub async fn build_features_layer(
         "Building features layer image (context: {})",
         ctx.resolved.build_context.display()
     );
-    ctx.progress
-        .run_step(
-            "Building features layer...",
-            ctx.client.build_image(&build_opts),
-        )
-        .await?;
+    let step = ctx.progress.step("Building features layer...");
+    let progress_ref = ctx.progress.clone();
+    let result = ctx
+        .client
+        .build_image(&build_opts, |line| {
+            progress_ref.println(line);
+        })
+        .await;
+    match &result {
+        Ok(_) => step.finish(),
+        Err(e) => step.fail(&e.to_string()),
+    }
+    result?;
     Ok(features_image)
 }
 
@@ -152,9 +159,18 @@ async fn resolve_base_image(
     } else if let Some(build) = config.get("build").and_then(|v| v.as_object()) {
         let img_name = image_name(workspace_root, config_name);
         let build_opts = parse_build_options(build, &img_name, workspace_root, no_cache);
-        progress
-            .run_step("Building Dockerfile...", client.build_image(&build_opts))
-            .await?;
+        let step = progress.step("Building Dockerfile...");
+        let progress_ref = progress.clone();
+        let result = client
+            .build_image(&build_opts, |line| {
+                progress_ref.println(line);
+            })
+            .await;
+        match &result {
+            Ok(_) => step.finish(),
+            Err(e) => step.fail(&e.to_string()),
+        }
+        result?;
         Ok(img_name)
     } else {
         Err("devcontainer.json must specify either 'image' or 'build'".into())

--- a/crates/cella-cli/src/commands/image.rs
+++ b/crates/cella-cli/src/commands/image.rs
@@ -70,11 +70,14 @@ pub async fn build_features_layer(
     );
     let start = std::time::Instant::now();
     let progress_ref = ctx.progress.clone();
+    // Print header before streaming build output.
+    ctx.progress
+        .println("  \x1b[36m▸\x1b[0m Building features layer...");
     let result = ctx
         .client
         .build_image(&build_opts, |line| {
             if !line.trim().is_empty() {
-                progress_ref.println(&format!("  {line}"));
+                progress_ref.println(&format!("      {line}"));
             }
         })
         .await;
@@ -168,10 +171,11 @@ async fn resolve_base_image(
         let build_opts = parse_build_options(build, &img_name, workspace_root, no_cache);
         let start = std::time::Instant::now();
         let progress_ref = progress.clone();
+        progress.println("  \x1b[36m▸\x1b[0m Building Dockerfile...");
         let result = client
             .build_image(&build_opts, |line| {
                 if !line.trim().is_empty() {
-                    progress_ref.println(&format!("  {line}"));
+                    progress_ref.println(&format!("      {line}"));
                 }
             })
             .await;

--- a/crates/cella-cli/src/commands/image.rs
+++ b/crates/cella-cli/src/commands/image.rs
@@ -73,7 +73,9 @@ pub async fn build_features_layer(
     let result = ctx
         .client
         .build_image(&build_opts, |line| {
-            progress_ref.println(line);
+            if !line.trim().is_empty() {
+                progress_ref.println(line);
+            }
         })
         .await;
     match &result {
@@ -163,7 +165,9 @@ async fn resolve_base_image(
         let progress_ref = progress.clone();
         let result = client
             .build_image(&build_opts, |line| {
-                progress_ref.println(line);
+                if !line.trim().is_empty() {
+                    progress_ref.println(line);
+                }
             })
             .await;
         match &result {

--- a/crates/cella-cli/src/commands/image.rs
+++ b/crates/cella-cli/src/commands/image.rs
@@ -70,6 +70,8 @@ pub async fn build_features_layer(
     );
     let start = std::time::Instant::now();
     let progress_ref = ctx.progress.clone();
+    ctx.progress
+        .println("  \x1b[36m▸\x1b[0m Building features layer...");
     let result = ctx
         .client
         .build_image(&build_opts, |line| {
@@ -80,12 +82,12 @@ pub async fn build_features_layer(
         .await;
     let elapsed = crate::progress::format_elapsed_pub(start.elapsed());
     match &result {
-        Ok(_) => ctx.progress.println(&format!(
-            "  \x1b[32m✓\x1b[0m Building features layer...{elapsed}"
-        )),
-        Err(e) => ctx.progress.println(&format!(
-            "  \x1b[31m✗\x1b[0m Building features layer...: {e}"
-        )),
+        Ok(_) => ctx
+            .progress
+            .println(&format!("  \x1b[32m✓\x1b[0m Built features layer{elapsed}")),
+        Err(e) => ctx
+            .progress
+            .println(&format!("  \x1b[31m✗\x1b[0m Building features layer: {e}")),
     }
     result?;
     Ok(features_image)
@@ -168,6 +170,7 @@ async fn resolve_base_image(
         let build_opts = parse_build_options(build, &img_name, workspace_root, no_cache);
         let start = std::time::Instant::now();
         let progress_ref = progress.clone();
+        progress.println("  \x1b[36m▸\x1b[0m Building Dockerfile...");
         let result = client
             .build_image(&build_opts, |line| {
                 if !line.trim().is_empty() {
@@ -177,10 +180,8 @@ async fn resolve_base_image(
             .await;
         let elapsed = crate::progress::format_elapsed_pub(start.elapsed());
         match &result {
-            Ok(_) => progress.println(&format!(
-                "  \x1b[32m✓\x1b[0m Building Dockerfile...{elapsed}"
-            )),
-            Err(e) => progress.println(&format!("  \x1b[31m✗\x1b[0m Building Dockerfile...: {e}")),
+            Ok(_) => progress.println(&format!("  \x1b[32m✓\x1b[0m Built Dockerfile{elapsed}")),
+            Err(e) => progress.println(&format!("  \x1b[31m✗\x1b[0m Building Dockerfile: {e}")),
         }
         result?;
         Ok(img_name)

--- a/crates/cella-cli/src/commands/image.rs
+++ b/crates/cella-cli/src/commands/image.rs
@@ -70,9 +70,6 @@ pub async fn build_features_layer(
     );
     let start = std::time::Instant::now();
     let progress_ref = ctx.progress.clone();
-    // Print header before streaming build output.
-    ctx.progress
-        .println("  \x1b[36m▸\x1b[0m Building features layer...");
     let result = ctx
         .client
         .build_image(&build_opts, |line| {
@@ -171,7 +168,6 @@ async fn resolve_base_image(
         let build_opts = parse_build_options(build, &img_name, workspace_root, no_cache);
         let start = std::time::Instant::now();
         let progress_ref = progress.clone();
-        progress.println("  \x1b[36m▸\x1b[0m Building Dockerfile...");
         let result = client
             .build_image(&build_opts, |line| {
                 if !line.trim().is_empty() {

--- a/crates/cella-cli/src/commands/logs.rs
+++ b/crates/cella-cli/src/commands/logs.rs
@@ -1,17 +1,159 @@
+use std::path::PathBuf;
+
 use clap::Args;
+
+use cella_docker::DockerClient;
 
 /// View logs from the dev container.
 #[derive(Args)]
 pub struct LogsArgs {
-    /// Follow log output.
+    /// Follow log output (streams new logs in real-time).
     #[arg(short, long)]
     follow: bool,
+
+    /// Show captured lifecycle command output from the last `cella up`.
+    #[arg(long)]
+    lifecycle: bool,
+
+    /// Show daemon log output.
+    #[arg(long)]
+    daemon: bool,
+
+    /// Number of lines to show from the end of the logs.
+    #[arg(long, default_value = "100")]
+    tail: u32,
+
+    /// Explicit workspace folder path (defaults to current directory).
+    #[arg(long)]
+    workspace_folder: Option<PathBuf>,
+
+    /// Explicit Docker host URL (overrides `DOCKER_HOST`).
+    #[arg(long)]
+    docker_host: Option<String>,
 }
 
 impl LogsArgs {
-    pub fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
-        let _ = self;
-        eprintln!("cella logs: not yet implemented");
-        Err("not yet implemented".into())
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+        if self.daemon {
+            return self.show_daemon_logs();
+        }
+        if self.lifecycle {
+            return self.show_lifecycle_logs();
+        }
+        self.show_container_logs().await
+    }
+
+    async fn show_container_logs(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let client = match &self.docker_host {
+            Some(host) => DockerClient::connect_with_host(host)?,
+            None => DockerClient::connect()?,
+        };
+
+        let cwd = if let Some(ref wf) = self.workspace_folder {
+            wf.canonicalize().unwrap_or_else(|_| wf.clone())
+        } else {
+            std::env::current_dir()?
+        };
+
+        let container = client
+            .find_container(&cwd)
+            .await?
+            .ok_or("No cella container found for this workspace")?;
+
+        if self.follow {
+            // Use docker CLI for follow mode (bollard streaming is complex)
+            let status = std::process::Command::new("docker")
+                .args([
+                    "logs",
+                    "-f",
+                    "--tail",
+                    &self.tail.to_string(),
+                    &container.id,
+                ])
+                .status()?;
+            if !status.success() {
+                return Err(format!(
+                    "docker logs exited with code {}",
+                    status.code().unwrap_or(-1)
+                )
+                .into());
+            }
+        } else {
+            let logs = client.container_logs(&container.id, self.tail).await?;
+            print!("{logs}");
+        }
+        Ok(())
+    }
+
+    fn show_daemon_logs(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let Some(data_dir) = cella_env::git_credential::cella_data_dir() else {
+            return Err("Cannot determine cella data directory".into());
+        };
+        let log_path = data_dir.join("daemon.log");
+        if !log_path.exists() {
+            eprintln!("No daemon log found at {}", log_path.display());
+            return Ok(());
+        }
+        let content = std::fs::read_to_string(&log_path)?;
+        // Show last N lines
+        let lines: Vec<&str> = content.lines().collect();
+        let start = lines.len().saturating_sub(self.tail as usize);
+        for line in &lines[start..] {
+            println!("{line}");
+        }
+        Ok(())
+    }
+
+    fn show_lifecycle_logs(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let _ = self; // tail unused for lifecycle logs
+        let Some(data_dir) = cella_env::git_credential::cella_data_dir() else {
+            return Err("Cannot determine cella data directory".into());
+        };
+        let logs_dir = data_dir.join("logs");
+        if !logs_dir.exists() {
+            eprintln!("No lifecycle logs found. Run `cella up` first.");
+            return Ok(());
+        }
+
+        // Find the most recent container log directory
+        let mut entries: Vec<_> = std::fs::read_dir(&logs_dir)?
+            .filter_map(Result::ok)
+            .filter(|e| e.file_type().is_ok_and(|ft| ft.is_dir()))
+            .collect();
+        entries
+            .sort_by_key(|e| std::cmp::Reverse(e.metadata().ok().and_then(|m| m.modified().ok())));
+
+        let Some(latest) = entries.first() else {
+            eprintln!("No lifecycle logs found.");
+            return Ok(());
+        };
+
+        eprintln!(
+            "Lifecycle logs for {}:",
+            latest.file_name().to_string_lossy()
+        );
+        eprintln!();
+
+        // Read and print each phase log file
+        let mut phase_files: Vec<_> = std::fs::read_dir(latest.path())?
+            .filter_map(Result::ok)
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "log"))
+            .collect();
+        phase_files.sort_by_key(std::fs::DirEntry::file_name);
+
+        for file in phase_files {
+            let phase_name = file
+                .path()
+                .file_stem()
+                .map(|s| s.to_string_lossy().to_string())
+                .unwrap_or_default();
+            let content = std::fs::read_to_string(file.path())?;
+            if !content.is_empty() {
+                eprintln!("[{phase_name}]");
+                eprint!("{content}");
+                eprintln!();
+            }
+        }
+        Ok(())
     }
 }

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -24,6 +24,8 @@ mod up;
 use clap::Subcommand;
 use tracing::warn;
 
+use crate::progress::Progress;
+
 /// Top-level CLI commands.
 #[derive(Subcommand)]
 pub enum Command {
@@ -72,13 +74,23 @@ pub enum Command {
 }
 
 impl Command {
-    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+    /// Whether this command uses text (non-JSON) output, i.e. spinners should be active.
+    pub const fn is_text_output(&self) -> bool {
         match self {
-            Self::Up(args) => args.execute().await,
+            Self::Up(args) => args.is_text_output(),
+            Self::Build(args) => args.is_text_output(),
+            Self::Down(args) => args.is_text_output(),
+            _ => true,
+        }
+    }
+
+    pub async fn execute(self, progress: Progress) -> Result<(), Box<dyn std::error::Error>> {
+        match self {
+            Self::Up(args) => args.execute(progress).await,
             Self::Down(args) => args.execute().await,
             Self::Shell(args) => args.execute().await,
             Self::Exec(args) => args.execute().await,
-            Self::Build(args) => args.execute().await,
+            Self::Build(args) => args.execute(progress).await,
             Self::List(args) => args.execute().await,
             Self::Logs(args) => args.execute(),
             Self::Doctor(args) => args.execute().await,

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -92,7 +92,7 @@ impl Command {
             Self::Exec(args) => args.execute().await,
             Self::Build(args) => args.execute(progress).await,
             Self::List(args) => args.execute().await,
-            Self::Logs(args) => args.execute(),
+            Self::Logs(args) => args.execute().await,
             Self::Doctor(args) => args.execute().await,
             Self::Branch(args) => args.execute(),
             Self::Spawn(args) => args.execute(),

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -84,6 +84,12 @@ impl Command {
         }
     }
 
+    /// Whether this is the `daemon start` subcommand, which initializes
+    /// its own file-based tracing instead of the normal indicatif writer.
+    pub const fn is_daemon_start(&self) -> bool {
+        matches!(self, Self::Daemon(_))
+    }
+
     pub async fn execute(self, progress: Progress) -> Result<(), Box<dyn std::error::Error>> {
         match self {
             Self::Up(args) => args.execute(progress).await,

--- a/crates/cella-cli/src/commands/up.rs
+++ b/crates/cella-cli/src/commands/up.rs
@@ -616,14 +616,17 @@ impl UpContext {
         }
 
         // Agent volume mount and env vars
-        if let Err(e) =
-            cella_docker::volume::ensure_agent_volume_populated(self.client.inner()).await
-        {
-            warn!("Failed to populate agent volume: {e}");
-            self.progress
-                .warn("Port forwarding and BROWSER interception will not work.");
-            self.progress
-                .hint(&format!("Agent volume population failed: {e}"));
+        let agent_step = self.progress.step("Populating agent volume...");
+        match cella_docker::volume::ensure_agent_volume_populated(self.client.inner()).await {
+            Ok(()) => agent_step.finish(),
+            Err(e) => {
+                agent_step.fail("failed");
+                warn!("Failed to populate agent volume: {e}");
+                self.progress
+                    .warn("Port forwarding and BROWSER interception will not work.");
+                self.progress
+                    .hint(&format!("Agent volume population failed: {e}"));
+            }
         }
 
         let agent_env = cella_docker::config_map::env::agent_env_vars();

--- a/crates/cella-cli/src/commands/up.rs
+++ b/crates/cella-cli/src/commands/up.rs
@@ -185,8 +185,8 @@ impl UpContext {
             .unwrap_or_else(|| "root".to_string())
     }
 
-    /// Run the env forwarding + Claude auth + Claude Code install + userEnvProbe
-    /// sequence that is shared between the running and stopped-restart paths.
+    /// Run the env forwarding + tool auth/install + userEnvProbe sequence
+    /// that is shared between the running and stopped-restart paths.
     async fn prepare_container_env(
         &self,
         container_id: &str,
@@ -207,16 +207,36 @@ impl UpContext {
         .await;
 
         // Claude Code: re-sync auth + ensure installed
-        let cc_settings = cella_config::Settings::load(&self.resolved.workspace_root);
-        if cc_settings.tools.claude_code.forward_config {
+        let settings = cella_config::Settings::load(&self.resolved.workspace_root);
+        if settings.tools.claude_code.forward_config {
             resync_claude_auth(&self.client, container_id, remote_user).await;
         }
-        if cc_settings.tools.claude_code.enabled {
+        if settings.tools.claude_code.enabled {
             install_claude_code(
                 &self.client,
                 container_id,
                 remote_user,
-                &cc_settings.tools.claude_code,
+                &settings.tools.claude_code,
+            )
+            .await;
+        }
+
+        // Codex/Gemini: no auth resync needed (bind mount), just ensure installed
+        if settings.tools.codex.enabled {
+            install_codex(
+                &self.client,
+                container_id,
+                remote_user,
+                &settings.tools.codex,
+            )
+            .await;
+        }
+        if settings.tools.gemini.enabled {
+            install_gemini(
+                &self.client,
+                container_id,
+                remote_user,
+                &settings.tools.gemini,
             )
             .await;
         }
@@ -485,6 +505,32 @@ impl UpContext {
             });
         }
 
+        // Auto-mount ~/.codex if Codex config forwarding is enabled
+        if settings.tools.codex.forward_config
+            && let Some(host_path) = cella_env::codex::host_codex_dir()
+        {
+            let target = cella_env::codex::container_codex_dir(remote_user);
+            create_opts.mounts.push(MountConfig {
+                mount_type: "bind".to_string(),
+                source: host_path.to_string_lossy().to_string(),
+                target,
+                consistency: None,
+            });
+        }
+
+        // Auto-mount ~/.gemini if Gemini config forwarding is enabled
+        if settings.tools.gemini.forward_config
+            && let Some(host_path) = cella_env::gemini::host_gemini_dir()
+        {
+            let target = cella_env::gemini::container_gemini_dir(remote_user);
+            create_opts.mounts.push(MountConfig {
+                mount_type: "bind".to_string(),
+                source: host_path.to_string_lossy().to_string(),
+                target,
+                consistency: None,
+            });
+        }
+
         // Forwarding env vars
         if !env_fwd.env.is_empty() {
             let fwd_env: Vec<String> = env_fwd
@@ -663,7 +709,38 @@ impl UpContext {
             .await;
         }
 
-        // Claude Code: forward config + install (first create)
+        // Forward config and install AI coding tools
+        self.install_tools(container_id, remote_user, settings)
+            .await;
+
+        // Probe and cache user environment (userEnvProbe)
+        let probed_env = timed_step(
+            self.is_text,
+            "Running userEnvProbe...",
+            super::env_cache::probe_and_cache_user_env(
+                &self.client,
+                container_id,
+                remote_user,
+                self.probe_type(),
+            ),
+        )
+        .await;
+
+        let lifecycle_env = probed_env.as_ref().map_or_else(
+            || remote_env.to_vec(),
+            |probed| cella_env::user_env_probe::merge_env(probed, remote_env),
+        );
+
+        (probed_env, lifecycle_env)
+    }
+
+    /// Forward config and install AI coding tools (Claude Code, Codex, Gemini).
+    async fn install_tools(
+        &self,
+        container_id: &str,
+        remote_user: &str,
+        settings: &cella_config::Settings,
+    ) {
         if settings.tools.claude_code.forward_config {
             timed_step(
                 self.is_text,
@@ -691,26 +768,32 @@ impl UpContext {
             )
             .await;
         }
-
-        // Probe and cache user environment (userEnvProbe)
-        let probed_env = timed_step(
-            self.is_text,
-            "Running userEnvProbe...",
-            super::env_cache::probe_and_cache_user_env(
-                &self.client,
-                container_id,
-                remote_user,
-                self.probe_type(),
-            ),
-        )
-        .await;
-
-        let lifecycle_env = probed_env.as_ref().map_or_else(
-            || remote_env.to_vec(),
-            |probed| cella_env::user_env_probe::merge_env(probed, remote_env),
-        );
-
-        (probed_env, lifecycle_env)
+        if settings.tools.codex.enabled {
+            timed_step(
+                self.is_text,
+                "Installing Codex...",
+                install_codex(
+                    &self.client,
+                    container_id,
+                    remote_user,
+                    &settings.tools.codex,
+                ),
+            )
+            .await;
+        }
+        if settings.tools.gemini.enabled {
+            timed_step(
+                self.is_text,
+                "Installing Gemini CLI...",
+                install_gemini(
+                    &self.client,
+                    container_id,
+                    remote_user,
+                    &settings.tools.gemini,
+                ),
+            )
+            .await;
+        }
     }
 
     /// The full build/create/start/lifecycle path for a new container.
@@ -1497,10 +1580,9 @@ async fn is_claude_code_installed(
     false
 }
 
-/// Detect Alpine and install Claude Code native dependencies if needed.
-/// Returns `true` if the container is Alpine-based.
-async fn ensure_alpine_claude_deps(client: &DockerClient, container_id: &str) -> bool {
-    let is_alpine = client
+/// Check if the container is Alpine-based.
+async fn is_alpine_container(client: &DockerClient, container_id: &str) -> bool {
+    client
         .exec_command(
             container_id,
             &ExecOptions {
@@ -1515,7 +1597,13 @@ async fn ensure_alpine_claude_deps(client: &DockerClient, container_id: &str) ->
             },
         )
         .await
-        .is_ok_and(|r| r.exit_code == 0);
+        .is_ok_and(|r| r.exit_code == 0)
+}
+
+/// Detect Alpine and install Claude Code native dependencies if needed.
+/// Returns `true` if the container is Alpine-based.
+async fn ensure_alpine_claude_deps(client: &DockerClient, container_id: &str) -> bool {
+    let is_alpine = is_alpine_container(client, container_id).await;
 
     if is_alpine {
         info!("Alpine detected, installing Claude Code dependencies...");
@@ -1612,4 +1700,230 @@ fn log_install_result(result: Result<cella_docker::ExecResult, CellaDockerError>
             warn!("Claude Code installation failed: {e}");
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Codex / Gemini CLI installation (npm-based)
+// ---------------------------------------------------------------------------
+
+/// Ensure Node.js and npm are available in the container.
+///
+/// If npm is not found, attempts to install Node.js via the system package
+/// manager (apt-get or apk). Returns `true` if npm is available after the check.
+async fn ensure_node_available(client: &DockerClient, container_id: &str) -> bool {
+    let npm_check = client
+        .exec_command(
+            container_id,
+            &ExecOptions {
+                cmd: vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    "command -v npm".to_string(),
+                ],
+                user: Some("root".to_string()),
+                env: None,
+                working_dir: None,
+            },
+        )
+        .await;
+
+    if npm_check.is_ok_and(|r| r.exit_code == 0) {
+        return true;
+    }
+
+    info!("npm not found, installing Node.js...");
+    let install_cmd = if is_alpine_container(client, container_id).await {
+        "apk add --no-cache nodejs npm"
+    } else {
+        "apt-get update -qq && apt-get install -y -qq nodejs npm"
+    };
+
+    let result = client
+        .exec_command(
+            container_id,
+            &ExecOptions {
+                cmd: vec!["sh".to_string(), "-c".to_string(), install_cmd.to_string()],
+                user: Some("root".to_string()),
+                env: None,
+                working_dir: None,
+            },
+        )
+        .await;
+
+    match &result {
+        Ok(r) if r.exit_code == 0 => {
+            info!("Node.js installed successfully");
+            true
+        }
+        Ok(r) => {
+            warn!(
+                "Node.js installation failed (exit {}): {}",
+                r.exit_code,
+                r.stderr.trim()
+            );
+            false
+        }
+        Err(e) => {
+            warn!("Node.js installation failed: {e}");
+            false
+        }
+    }
+}
+
+/// Check if an npm-installed CLI tool is already present at the desired version.
+async fn is_npm_tool_installed(
+    client: &DockerClient,
+    container_id: &str,
+    remote_user: &str,
+    binary_name: &str,
+    version: &str,
+) -> bool {
+    let version_check = client
+        .exec_command(
+            container_id,
+            &ExecOptions {
+                cmd: vec![binary_name.to_string(), "--version".to_string()],
+                user: Some(remote_user.to_string()),
+                env: None,
+                working_dir: None,
+            },
+        )
+        .await;
+
+    if let Ok(result) = &version_check
+        && result.exit_code == 0
+    {
+        let installed = result.stdout.trim();
+        if version == "latest" {
+            tracing::debug!("{binary_name} already installed: {installed}");
+            return true;
+        }
+        if installed.contains(version) {
+            tracing::debug!("{binary_name} already at version {version}: {installed}");
+            return true;
+        }
+    }
+    false
+}
+
+/// Install an npm package globally inside the container.
+async fn npm_install_global(
+    client: &DockerClient,
+    container_id: &str,
+    package: &str,
+    version: &str,
+) -> Result<cella_docker::ExecResult, CellaDockerError> {
+    let pkg = if version == "latest" {
+        package.to_string()
+    } else {
+        format!("{package}@{version}")
+    };
+
+    client
+        .exec_command(
+            container_id,
+            &ExecOptions {
+                cmd: vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    format!("npm install -g {pkg}"),
+                ],
+                user: Some("root".to_string()),
+                env: None,
+                working_dir: None,
+            },
+        )
+        .await
+}
+
+/// Log the result of an npm tool installation attempt.
+fn log_npm_install_result(
+    tool_name: &str,
+    result: Result<cella_docker::ExecResult, CellaDockerError>,
+) {
+    match result {
+        Ok(r) if r.exit_code == 0 => {
+            info!("{tool_name} installed successfully");
+        }
+        Ok(r) => {
+            warn!(
+                "{tool_name} installation exited with code {}: {}",
+                r.exit_code,
+                r.stderr.trim()
+            );
+        }
+        Err(e) => {
+            warn!("{tool_name} installation failed: {e}");
+        }
+    }
+}
+
+/// Install `OpenAI` Codex CLI inside the container via npm.
+///
+/// Checks if already installed, ensures Node.js/npm are available,
+/// then runs `npm install -g @openai/codex`.
+async fn install_codex(
+    client: &DockerClient,
+    container_id: &str,
+    remote_user: &str,
+    settings: &cella_config::Codex,
+) {
+    if is_npm_tool_installed(
+        client,
+        container_id,
+        remote_user,
+        "codex",
+        &settings.version,
+    )
+    .await
+    {
+        return;
+    }
+
+    if !ensure_node_available(client, container_id).await {
+        warn!("Cannot install Codex: Node.js/npm not available");
+        return;
+    }
+
+    info!("Installing Codex ({})...", settings.version);
+    let result = npm_install_global(client, container_id, "@openai/codex", &settings.version).await;
+    log_npm_install_result("Codex", result);
+}
+
+/// Install Google Gemini CLI inside the container via npm.
+///
+/// Checks if already installed, ensures Node.js/npm are available,
+/// then runs `npm install -g @google/gemini-cli`.
+async fn install_gemini(
+    client: &DockerClient,
+    container_id: &str,
+    remote_user: &str,
+    settings: &cella_config::Gemini,
+) {
+    if is_npm_tool_installed(
+        client,
+        container_id,
+        remote_user,
+        "gemini",
+        &settings.version,
+    )
+    .await
+    {
+        return;
+    }
+
+    if !ensure_node_available(client, container_id).await {
+        warn!("Cannot install Gemini CLI: Node.js/npm not available");
+        return;
+    }
+
+    info!("Installing Gemini CLI ({})...", settings.version);
+    let result = npm_install_global(
+        client,
+        container_id,
+        "@google/gemini-cli",
+        &settings.version,
+    )
+    .await;
+    log_npm_install_result("Gemini CLI", result);
 }

--- a/crates/cella-cli/src/commands/up.rs
+++ b/crates/cella-cli/src/commands/up.rs
@@ -185,7 +185,7 @@ impl UpContext {
             .unwrap_or_else(|| "root".to_string())
     }
 
-    /// Run the env forwarding + tool auth/install + userEnvProbe sequence
+    /// Run the env forwarding + userEnvProbe + tool auth/install sequence
     /// that is shared between the running and stopped-restart paths.
     async fn prepare_container_env(
         &self,
@@ -206,41 +206,8 @@ impl UpContext {
         )
         .await;
 
-        // Claude Code: re-sync auth + ensure installed
-        let settings = cella_config::Settings::load(&self.resolved.workspace_root);
-        if settings.tools.claude_code.forward_config {
-            resync_claude_auth(&self.client, container_id, remote_user).await;
-        }
-        if settings.tools.claude_code.enabled {
-            install_claude_code(
-                &self.client,
-                container_id,
-                remote_user,
-                &settings.tools.claude_code,
-            )
-            .await;
-        }
-
-        // Codex/Gemini: no auth resync needed (bind mount), just ensure installed
-        if settings.tools.codex.enabled {
-            install_codex(
-                &self.client,
-                container_id,
-                remote_user,
-                &settings.tools.codex,
-            )
-            .await;
-        }
-        if settings.tools.gemini.enabled {
-            install_gemini(
-                &self.client,
-                container_id,
-                remote_user,
-                &settings.tools.gemini,
-            )
-            .await;
-        }
-
+        // Probe user environment first so tool installs can use feature-provided PATH
+        // (e.g., nvm adds /usr/local/share/nvm/current/bin via login shell profiles)
         let probed_env = timed_step(
             self.is_text,
             "Running userEnvProbe...",
@@ -252,6 +219,44 @@ impl UpContext {
             ),
         )
         .await;
+
+        // Claude Code: re-sync auth + ensure installed
+        let settings = cella_config::Settings::load(&self.resolved.workspace_root);
+        if settings.tools.claude_code.forward_config {
+            resync_claude_auth(&self.client, container_id, remote_user).await;
+        }
+        if settings.tools.claude_code.enabled {
+            install_claude_code(
+                &self.client,
+                container_id,
+                remote_user,
+                &settings.tools.claude_code,
+                probed_env.as_ref(),
+            )
+            .await;
+        }
+
+        // Codex/Gemini: no auth resync needed (bind mount), just ensure installed
+        if settings.tools.codex.enabled {
+            install_codex(
+                &self.client,
+                container_id,
+                remote_user,
+                &settings.tools.codex,
+                probed_env.as_ref(),
+            )
+            .await;
+        }
+        if settings.tools.gemini.enabled {
+            install_gemini(
+                &self.client,
+                container_id,
+                remote_user,
+                &settings.tools.gemini,
+                probed_env.as_ref(),
+            )
+            .await;
+        }
 
         let lifecycle_env = probed_env.as_ref().map_or_else(
             || self.remote_env.clone(),
@@ -709,11 +714,8 @@ impl UpContext {
             .await;
         }
 
-        // Forward config and install AI coding tools
-        self.install_tools(container_id, remote_user, settings)
-            .await;
-
-        // Probe and cache user environment (userEnvProbe)
+        // Probe user environment first so tool installs can use feature-provided PATH
+        // (e.g., nvm adds /usr/local/share/nvm/current/bin via login shell profiles)
         let probed_env = timed_step(
             self.is_text,
             "Running userEnvProbe...",
@@ -725,6 +727,10 @@ impl UpContext {
             ),
         )
         .await;
+
+        // Forward config and install AI coding tools
+        self.install_tools(container_id, remote_user, settings, probed_env.as_ref())
+            .await;
 
         let lifecycle_env = probed_env.as_ref().map_or_else(
             || remote_env.to_vec(),
@@ -740,6 +746,7 @@ impl UpContext {
         container_id: &str,
         remote_user: &str,
         settings: &cella_config::Settings,
+        probed_env: Option<&std::collections::HashMap<String, String>>,
     ) {
         if settings.tools.claude_code.forward_config {
             timed_step(
@@ -764,6 +771,7 @@ impl UpContext {
                     container_id,
                     remote_user,
                     &settings.tools.claude_code,
+                    probed_env,
                 ),
             )
             .await;
@@ -777,6 +785,7 @@ impl UpContext {
                     container_id,
                     remote_user,
                     &settings.tools.codex,
+                    probed_env,
                 ),
             )
             .await;
@@ -790,6 +799,7 @@ impl UpContext {
                     container_id,
                     remote_user,
                     &settings.tools.gemini,
+                    probed_env,
                 ),
             )
             .await;
@@ -1539,11 +1549,6 @@ async fn resync_claude_auth(client: &DockerClient, container_id: &str, remote_us
     }
 }
 
-/// Install Claude Code inside the container using the native installer.
-///
-/// Checks if already installed at the correct version first.
-/// On Alpine/musl, pre-installs required dependencies.
-/// Never fails `cella up` — logs errors and continues.
 /// Check if Claude Code is already installed at the desired version.
 /// Returns `true` if already installed and no (re)install is needed.
 async fn is_claude_code_installed(
@@ -1551,14 +1556,15 @@ async fn is_claude_code_installed(
     container_id: &str,
     remote_user: &str,
     version: &str,
+    probed_env: Option<&std::collections::HashMap<String, String>>,
 ) -> bool {
     let version_check = client
         .exec_command(
             container_id,
             &ExecOptions {
-                cmd: vec!["claude".to_string(), "--version".to_string()],
+                cmd: tool_shell_cmd(probed_env, "claude --version"),
                 user: Some(remote_user.to_string()),
-                env: None,
+                env: tool_exec_env(probed_env),
                 working_dir: None,
             },
         )
@@ -1631,8 +1637,17 @@ async fn install_claude_code(
     container_id: &str,
     remote_user: &str,
     settings: &cella_config::ClaudeCode,
+    probed_env: Option<&std::collections::HashMap<String, String>>,
 ) {
-    if is_claude_code_installed(client, container_id, remote_user, &settings.version).await {
+    if is_claude_code_installed(
+        client,
+        container_id,
+        remote_user,
+        &settings.version,
+        probed_env,
+    )
+    .await
+    {
         return;
     }
 
@@ -1643,6 +1658,7 @@ async fn install_claude_code(
         remote_user,
         &settings.version,
         is_alpine,
+        probed_env,
     )
     .await;
 }
@@ -1654,6 +1670,7 @@ async fn run_claude_install(
     remote_user: &str,
     version: &str,
     is_alpine: bool,
+    probed_env: Option<&std::collections::HashMap<String, String>>,
 ) {
     if version != "latest" && version != "stable" {
         info!("Installing Claude Code v{version} (native installer will attempt version pinning)");
@@ -1662,11 +1679,11 @@ async fn run_claude_install(
     let install_cmd = format!("curl -fsSL https://claude.ai/install.sh | bash -s {version}");
     info!("Installing Claude Code ({version})...");
 
-    let env = if is_alpine {
-        Some(vec!["USE_BUILTIN_RIPGREP=0".to_string()])
-    } else {
-        None
-    };
+    let mut env = tool_exec_env(probed_env).unwrap_or_default();
+    if is_alpine {
+        env.push("USE_BUILTIN_RIPGREP=0".to_string());
+    }
+    let env = if env.is_empty() { None } else { Some(env) };
 
     let result = client
         .exec_command(
@@ -1706,22 +1723,58 @@ fn log_install_result(result: Result<cella_docker::ExecResult, CellaDockerError>
 // Codex / Gemini CLI installation (npm-based)
 // ---------------------------------------------------------------------------
 
+/// Extract PATH from the probed user environment for tool exec calls.
+///
+/// Returns `Some(vec!["PATH=..."])` when the probed env contains PATH,
+/// `None` otherwise (caller should fall back to a login shell).
+fn tool_exec_env(
+    probed_env: Option<&std::collections::HashMap<String, String>>,
+) -> Option<Vec<String>> {
+    probed_env
+        .and_then(|env| env.get("PATH"))
+        .map(|path| vec![format!("PATH={path}")])
+}
+
+/// Build the shell command prefix for a tool exec call.
+///
+/// When the probed env is available (and thus PATH will be passed via `env`),
+/// uses a plain `sh -c`. Otherwise falls back to a login shell (`sh -l -c`)
+/// so that `/etc/profile.d/` scripts (e.g. nvm) are sourced.
+fn tool_shell_cmd(
+    probed_env: Option<&std::collections::HashMap<String, String>>,
+    inner_cmd: &str,
+) -> Vec<String> {
+    if probed_env.and_then(|e| e.get("PATH")).is_some() {
+        vec!["sh".to_string(), "-c".to_string(), inner_cmd.to_string()]
+    } else {
+        vec![
+            "sh".to_string(),
+            "-l".to_string(),
+            "-c".to_string(),
+            inner_cmd.to_string(),
+        ]
+    }
+}
+
 /// Ensure Node.js and npm are available in the container.
 ///
-/// If npm is not found, attempts to install Node.js via the system package
-/// manager (apt-get or apk). Returns `true` if npm is available after the check.
-async fn ensure_node_available(client: &DockerClient, container_id: &str) -> bool {
+/// Uses the probed user environment PATH (from `userEnvProbe`) to detect
+/// npm installed by devcontainer features (e.g. nvm). Falls back to a login
+/// shell when no probed env is available. If npm is still not found, attempts
+/// to install Node.js via the system package manager (apt-get or apk).
+/// Returns `true` if npm is available after the check.
+async fn ensure_node_available(
+    client: &DockerClient,
+    container_id: &str,
+    probed_env: Option<&std::collections::HashMap<String, String>>,
+) -> bool {
     let npm_check = client
         .exec_command(
             container_id,
             &ExecOptions {
-                cmd: vec![
-                    "sh".to_string(),
-                    "-c".to_string(),
-                    "command -v npm".to_string(),
-                ],
+                cmd: tool_shell_cmd(probed_env, "command -v npm"),
                 user: Some("root".to_string()),
-                env: None,
+                env: tool_exec_env(probed_env),
                 working_dir: None,
             },
         )
@@ -1777,14 +1830,15 @@ async fn is_npm_tool_installed(
     remote_user: &str,
     binary_name: &str,
     version: &str,
+    probed_env: Option<&std::collections::HashMap<String, String>>,
 ) -> bool {
     let version_check = client
         .exec_command(
             container_id,
             &ExecOptions {
-                cmd: vec![binary_name.to_string(), "--version".to_string()],
+                cmd: tool_shell_cmd(probed_env, &format!("{binary_name} --version")),
                 user: Some(remote_user.to_string()),
-                env: None,
+                env: tool_exec_env(probed_env),
                 working_dir: None,
             },
         )
@@ -1812,6 +1866,7 @@ async fn npm_install_global(
     container_id: &str,
     package: &str,
     version: &str,
+    probed_env: Option<&std::collections::HashMap<String, String>>,
 ) -> Result<cella_docker::ExecResult, CellaDockerError> {
     let pkg = if version == "latest" {
         package.to_string()
@@ -1823,13 +1878,9 @@ async fn npm_install_global(
         .exec_command(
             container_id,
             &ExecOptions {
-                cmd: vec![
-                    "sh".to_string(),
-                    "-c".to_string(),
-                    format!("npm install -g {pkg}"),
-                ],
+                cmd: tool_shell_cmd(probed_env, &format!("npm install -g {pkg}")),
                 user: Some("root".to_string()),
-                env: None,
+                env: tool_exec_env(probed_env),
                 working_dir: None,
             },
         )
@@ -1867,6 +1918,7 @@ async fn install_codex(
     container_id: &str,
     remote_user: &str,
     settings: &cella_config::Codex,
+    probed_env: Option<&std::collections::HashMap<String, String>>,
 ) {
     if is_npm_tool_installed(
         client,
@@ -1874,19 +1926,27 @@ async fn install_codex(
         remote_user,
         "codex",
         &settings.version,
+        probed_env,
     )
     .await
     {
         return;
     }
 
-    if !ensure_node_available(client, container_id).await {
+    if !ensure_node_available(client, container_id, probed_env).await {
         warn!("Cannot install Codex: Node.js/npm not available");
         return;
     }
 
     info!("Installing Codex ({})...", settings.version);
-    let result = npm_install_global(client, container_id, "@openai/codex", &settings.version).await;
+    let result = npm_install_global(
+        client,
+        container_id,
+        "@openai/codex",
+        &settings.version,
+        probed_env,
+    )
+    .await;
     log_npm_install_result("Codex", result);
 }
 
@@ -1899,6 +1959,7 @@ async fn install_gemini(
     container_id: &str,
     remote_user: &str,
     settings: &cella_config::Gemini,
+    probed_env: Option<&std::collections::HashMap<String, String>>,
 ) {
     if is_npm_tool_installed(
         client,
@@ -1906,13 +1967,14 @@ async fn install_gemini(
         remote_user,
         "gemini",
         &settings.version,
+        probed_env,
     )
     .await
     {
         return;
     }
 
-    if !ensure_node_available(client, container_id).await {
+    if !ensure_node_available(client, container_id, probed_env).await {
         warn!("Cannot install Gemini CLI: Node.js/npm not available");
         return;
     }
@@ -1923,6 +1985,7 @@ async fn install_gemini(
         container_id,
         "@google/gemini-cli",
         &settings.version,
+        probed_env,
     )
     .await;
     log_npm_install_result("Gemini CLI", result);

--- a/crates/cella-cli/src/commands/up.rs
+++ b/crates/cella-cli/src/commands/up.rs
@@ -220,43 +220,61 @@ impl UpContext {
         )
         .await;
 
-        // Claude Code: re-sync auth + ensure installed
+        // Sequential prerequisites
         let settings = cella_config::Settings::load(&self.resolved.workspace_root);
         if settings.tools.claude_code.forward_config {
             resync_claude_auth(&self.client, container_id, remote_user).await;
         }
-        if settings.tools.claude_code.enabled {
-            install_claude_code(
-                &self.client,
-                container_id,
-                remote_user,
-                &settings.tools.claude_code,
-                probed_env.as_ref(),
-            )
-            .await;
-        }
 
-        // Codex/Gemini: no auth resync needed (bind mount), just ensure installed
-        if settings.tools.codex.enabled {
-            install_codex(
-                &self.client,
-                container_id,
-                remote_user,
-                &settings.tools.codex,
-                probed_env.as_ref(),
-            )
-            .await;
-        }
-        if settings.tools.gemini.enabled {
-            install_gemini(
-                &self.client,
-                container_id,
-                remote_user,
-                &settings.tools.gemini,
-                probed_env.as_ref(),
-            )
-            .await;
-        }
+        let needs_npm = settings.tools.codex.enabled || settings.tools.gemini.enabled;
+        let node_available = if needs_npm {
+            ensure_node_available(&self.client, container_id, probed_env.as_ref()).await
+        } else {
+            false
+        };
+
+        // Parallel branches: Claude Code (curl) || npm tools (Codex → Gemini)
+        let claude_branch = async {
+            if settings.tools.claude_code.enabled {
+                install_claude_code(
+                    &self.client,
+                    container_id,
+                    remote_user,
+                    &settings.tools.claude_code,
+                    probed_env.as_ref(),
+                )
+                .await;
+            }
+        };
+
+        let npm_branch = async {
+            if needs_npm && !node_available {
+                warn!("Skipping npm tool installs: Node.js/npm not available");
+                return;
+            }
+            if settings.tools.codex.enabled {
+                install_codex(
+                    &self.client,
+                    container_id,
+                    remote_user,
+                    &settings.tools.codex,
+                    probed_env.as_ref(),
+                )
+                .await;
+            }
+            if settings.tools.gemini.enabled {
+                install_gemini(
+                    &self.client,
+                    container_id,
+                    remote_user,
+                    &settings.tools.gemini,
+                    probed_env.as_ref(),
+                )
+                .await;
+            }
+        };
+
+        tokio::join!(claude_branch, npm_branch);
 
         let lifecycle_env = probed_env.as_ref().map_or_else(
             || self.remote_env.clone(),
@@ -741,6 +759,9 @@ impl UpContext {
     }
 
     /// Forward config and install AI coding tools (Claude Code, Codex, Gemini).
+    ///
+    /// Claude Code (curl-based) runs in parallel with npm-based tools (Codex, Gemini).
+    /// Codex and Gemini run sequentially to avoid npm global lock contention.
     async fn install_tools(
         &self,
         container_id: &str,
@@ -748,6 +769,7 @@ impl UpContext {
         settings: &cella_config::Settings,
         probed_env: Option<&std::collections::HashMap<String, String>>,
     ) {
+        // Sequential prerequisite: forward Claude Code config before install
         if settings.tools.claude_code.forward_config {
             timed_step(
                 self.is_text,
@@ -762,48 +784,69 @@ impl UpContext {
             )
             .await;
         }
-        if settings.tools.claude_code.enabled {
-            timed_step(
-                self.is_text,
-                "Installing Claude Code...",
-                install_claude_code(
-                    &self.client,
-                    container_id,
-                    remote_user,
-                    &settings.tools.claude_code,
-                    probed_env,
-                ),
-            )
-            .await;
-        }
-        if settings.tools.codex.enabled {
-            timed_step(
-                self.is_text,
-                "Installing Codex...",
-                install_codex(
-                    &self.client,
-                    container_id,
-                    remote_user,
-                    &settings.tools.codex,
-                    probed_env,
-                ),
-            )
-            .await;
-        }
-        if settings.tools.gemini.enabled {
-            timed_step(
-                self.is_text,
-                "Installing Gemini CLI...",
-                install_gemini(
-                    &self.client,
-                    container_id,
-                    remote_user,
-                    &settings.tools.gemini,
-                    probed_env,
-                ),
-            )
-            .await;
-        }
+
+        // Sequential prerequisite: ensure Node.js/npm once for all npm tools
+        let needs_npm = settings.tools.codex.enabled || settings.tools.gemini.enabled;
+        let node_available = if needs_npm {
+            ensure_node_available(&self.client, container_id, probed_env).await
+        } else {
+            false
+        };
+
+        // Parallel branches: Claude Code (curl) || npm tools (Codex → Gemini)
+        let claude_branch = async {
+            if settings.tools.claude_code.enabled {
+                timed_step(
+                    self.is_text,
+                    "Installing Claude Code...",
+                    install_claude_code(
+                        &self.client,
+                        container_id,
+                        remote_user,
+                        &settings.tools.claude_code,
+                        probed_env,
+                    ),
+                )
+                .await;
+            }
+        };
+
+        let npm_branch = async {
+            if needs_npm && !node_available {
+                warn!("Skipping npm tool installs: Node.js/npm not available");
+                return;
+            }
+            if settings.tools.codex.enabled {
+                timed_step(
+                    self.is_text,
+                    "Installing Codex...",
+                    install_codex(
+                        &self.client,
+                        container_id,
+                        remote_user,
+                        &settings.tools.codex,
+                        probed_env,
+                    ),
+                )
+                .await;
+            }
+            if settings.tools.gemini.enabled {
+                timed_step(
+                    self.is_text,
+                    "Installing Gemini CLI...",
+                    install_gemini(
+                        &self.client,
+                        container_id,
+                        remote_user,
+                        &settings.tools.gemini,
+                        probed_env,
+                    ),
+                )
+                .await;
+            }
+        };
+
+        tokio::join!(claude_branch, npm_branch);
     }
 
     /// The full build/create/start/lifecycle path for a new container.
@@ -1864,6 +1907,7 @@ async fn is_npm_tool_installed(
 async fn npm_install_global(
     client: &DockerClient,
     container_id: &str,
+    remote_user: &str,
     package: &str,
     version: &str,
     probed_env: Option<&std::collections::HashMap<String, String>>,
@@ -1879,7 +1923,7 @@ async fn npm_install_global(
             container_id,
             &ExecOptions {
                 cmd: tool_shell_cmd(probed_env, &format!("npm install -g {pkg}")),
-                user: Some("root".to_string()),
+                user: Some(remote_user.to_string()),
                 env: tool_exec_env(probed_env),
                 working_dir: None,
             },
@@ -1911,8 +1955,8 @@ fn log_npm_install_result(
 
 /// Install `OpenAI` Codex CLI inside the container via npm.
 ///
-/// Checks if already installed, ensures Node.js/npm are available,
-/// then runs `npm install -g @openai/codex`.
+/// Checks if already installed, then runs `npm install -g @openai/codex`.
+/// Caller must ensure Node.js/npm are available before calling this.
 async fn install_codex(
     client: &DockerClient,
     container_id: &str,
@@ -1933,15 +1977,11 @@ async fn install_codex(
         return;
     }
 
-    if !ensure_node_available(client, container_id, probed_env).await {
-        warn!("Cannot install Codex: Node.js/npm not available");
-        return;
-    }
-
     info!("Installing Codex ({})...", settings.version);
     let result = npm_install_global(
         client,
         container_id,
+        remote_user,
         "@openai/codex",
         &settings.version,
         probed_env,
@@ -1952,8 +1992,8 @@ async fn install_codex(
 
 /// Install Google Gemini CLI inside the container via npm.
 ///
-/// Checks if already installed, ensures Node.js/npm are available,
-/// then runs `npm install -g @google/gemini-cli`.
+/// Checks if already installed, then runs `npm install -g @google/gemini-cli`.
+/// Caller must ensure Node.js/npm are available before calling this.
 async fn install_gemini(
     client: &DockerClient,
     container_id: &str,
@@ -1974,15 +2014,11 @@ async fn install_gemini(
         return;
     }
 
-    if !ensure_node_available(client, container_id, probed_env).await {
-        warn!("Cannot install Gemini CLI: Node.js/npm not available");
-        return;
-    }
-
     info!("Installing Gemini CLI ({})...", settings.version);
     let result = npm_install_global(
         client,
         container_id,
+        remote_user,
         "@google/gemini-cli",
         &settings.version,
         probed_env,

--- a/crates/cella-cli/src/commands/up.rs
+++ b/crates/cella-cli/src/commands/up.rs
@@ -1467,6 +1467,9 @@ async fn upload_to_container(
 }
 
 /// Run a sequence of origin-tracked lifecycle entries with progress tracking.
+///
+/// Prints a permanent header line before each lifecycle command, then streams
+/// the command's output indented below it, then prints the completion status.
 async fn run_lifecycle_entries(
     ctx: &LifecycleContext<'_>,
     phase: &str,
@@ -1474,11 +1477,15 @@ async fn run_lifecycle_entries(
     progress: &crate::progress::Progress,
 ) -> Result<(), CellaDockerError> {
     for entry in entries {
-        let step = progress.step(&format!("Running the {phase} from {}...", entry.origin));
+        let label = format!("Running the {phase} from {}...", entry.origin);
+        let start = std::time::Instant::now();
+        // Print header so user knows what's running during streaming.
+        progress.println(&format!("  \x1b[36m▸\x1b[0m {label}"));
         let result = run_lifecycle_phase(ctx, phase, &entry.command, &entry.origin).await;
+        let elapsed = crate::progress::format_elapsed_pub(start.elapsed());
         match &result {
-            Ok(()) => step.finish(),
-            Err(e) => step.fail(&e.to_string()),
+            Ok(()) => progress.println(&format!("  \x1b[32m✓\x1b[0m {label}{elapsed}")),
+            Err(e) => progress.println(&format!("  \x1b[31m✗\x1b[0m {label}: {e}")),
         }
         result?;
     }
@@ -1516,11 +1523,14 @@ async fn run_all_lifecycle_phases(
             && let Some(cmd) = config.get(phase)
             && !cmd.is_null()
         {
-            let step = progress.step(&format!("Running the {phase} from devcontainer.json..."));
+            let label = format!("Running the {phase} from devcontainer.json...");
+            let start = std::time::Instant::now();
+            progress.println(&format!("  \x1b[36m▸\x1b[0m {label}"));
             let result = run_lifecycle_phase(lc_ctx, phase, cmd, "devcontainer.json").await;
+            let elapsed = crate::progress::format_elapsed_pub(start.elapsed());
             match &result {
-                Ok(()) => step.finish(),
-                Err(e) => step.fail(&e.to_string()),
+                Ok(()) => progress.println(&format!("  \x1b[32m✓\x1b[0m {label}{elapsed}")),
+                Err(e) => progress.println(&format!("  \x1b[31m✗\x1b[0m {label}: {e}")),
             }
             result?;
         }

--- a/crates/cella-cli/src/commands/up.rs
+++ b/crates/cella-cli/src/commands/up.rs
@@ -326,6 +326,7 @@ impl UpContext {
             self.config(),
             "postAttachCommand",
         );
+        let progress_ref = self.progress.clone();
         let lc_ctx = LifecycleContext {
             client: &self.client,
             container_id: &container.id,
@@ -333,8 +334,13 @@ impl UpContext {
             env: &lifecycle_env,
             working_dir: self.workspace_folder(),
             is_text: self.progress.is_enabled(),
+            on_output: if self.progress.is_enabled() {
+                Some(Box::new(move |line| progress_ref.println(line)))
+            } else {
+                None
+            },
         };
-        run_lifecycle_entries(&lc_ctx, "postAttachCommand", &entries).await?;
+        run_lifecycle_entries(&lc_ctx, "postAttachCommand", &entries, &self.progress).await?;
 
         output_result(
             &self.output,
@@ -362,10 +368,10 @@ impl UpContext {
         if let Some(old_hash) = &container.config_hash
             && *old_hash != self.resolved.config_hash
         {
-            eprintln!(
-                "\x1b[33mWARNING:\x1b[0m Config has changed since this container was created."
-            );
-            eprintln!("  Run `cella up --rebuild` to recreate with the updated config.");
+            self.progress
+                .warn("Config has changed since this container was created.");
+            self.progress
+                .hint("Run `cella up --rebuild` to recreate with the updated config.");
         }
 
         // Warn if Docker runtime has changed
@@ -373,10 +379,11 @@ impl UpContext {
         if let Some(old_runtime) = container.labels.get("dev.cella.docker_runtime") {
             let current_label = current_runtime.as_label();
             if old_runtime != current_label {
-                eprintln!(
-                    "\x1b[33mWARNING:\x1b[0m Docker runtime changed ({old_runtime} \u{2192} {current_label})."
-                );
-                eprintln!("  Run `cella up --rebuild` to recreate with the updated runtime.");
+                self.progress.warn(&format!(
+                    "Docker runtime changed ({old_runtime} \u{2192} {current_label})."
+                ));
+                self.progress
+                    .hint("Run `cella up --rebuild` to recreate with the updated runtime.");
             }
         }
 
@@ -404,6 +411,7 @@ impl UpContext {
                         self.config(),
                         phase,
                     );
+                    let progress_ref = self.progress.clone();
                     let lc_ctx = LifecycleContext {
                         client: &self.client,
                         container_id: &container.id,
@@ -411,8 +419,13 @@ impl UpContext {
                         env: &lifecycle_env,
                         working_dir: self.workspace_folder(),
                         is_text: self.progress.is_enabled(),
+                        on_output: if self.progress.is_enabled() {
+                            Some(Box::new(move |line| progress_ref.println(line)))
+                        } else {
+                            None
+                        },
                     };
-                    run_lifecycle_entries(&lc_ctx, phase, &entries).await?;
+                    run_lifecycle_entries(&lc_ctx, phase, &entries, &self.progress).await?;
                 }
 
                 output_result(
@@ -426,8 +439,9 @@ impl UpContext {
             }
             Err(e) => {
                 warn!("Failed to start existing container: {e}");
-                eprintln!("\x1b[33mWARNING:\x1b[0m Could not start existing container: {e}");
-                eprintln!("Recreating container...");
+                self.progress
+                    .warn(&format!("Could not start existing container: {e}"));
+                self.progress.hint("Recreating container...");
                 let _ = self.client.remove_container(&container.id, false).await;
                 // Fall through to creation path
                 Ok(false)
@@ -606,10 +620,10 @@ impl UpContext {
             cella_docker::volume::ensure_agent_volume_populated(self.client.inner()).await
         {
             warn!("Failed to populate agent volume: {e}");
-            eprintln!(
-                "\x1b[33mWARNING:\x1b[0m Port forwarding and BROWSER interception will not work."
-            );
-            eprintln!("  Agent volume population failed: {e}");
+            self.progress
+                .warn("Port forwarding and BROWSER interception will not work.");
+            self.progress
+                .hint(&format!("Agent volume population failed: {e}"));
         }
 
         let agent_env = cella_docker::config_map::env::agent_env_vars();
@@ -632,11 +646,14 @@ impl UpContext {
         &self,
         container_id: &str,
     ) -> Result<(), Box<dyn std::error::Error>> {
+        let start_label = if self.progress.is_verbose() {
+            let short_id = &container_id[..12.min(container_id.len())];
+            format!("Starting container: {short_id}...")
+        } else {
+            "Starting container...".to_string()
+        };
         self.progress
-            .run_step(
-                "Starting container...",
-                self.client.start_container(container_id),
-            )
+            .run_step(&start_label, self.client.start_container(container_id))
             .await?;
         verify_container_running(&self.client, container_id).await?;
 
@@ -955,13 +972,24 @@ impl UpContext {
         .await;
 
         // Create and start container
-        let container_id = self
-            .progress
-            .run_step(
-                "Creating container...",
-                self.client.create_container(&create_opts),
-            )
-            .await?;
+        let container_id = if self.progress.is_verbose() {
+            let step = self
+                .progress
+                .step(&format!("Creating container: {}...", self.container_nm));
+            let result = self.client.create_container(&create_opts).await;
+            match &result {
+                Ok(_) => step.finish(),
+                Err(e) => step.fail(&e.to_string()),
+            }
+            result?
+        } else {
+            self.progress
+                .run_step(
+                    "Creating container...",
+                    self.client.create_container(&create_opts),
+                )
+                .await?
+        };
 
         self.start_and_register(&container_id).await?;
 
@@ -977,6 +1005,7 @@ impl UpContext {
             .await;
 
         // Lifecycle commands (first create)
+        let progress_ref = self.progress.clone();
         let lc_ctx = LifecycleContext {
             client: &self.client,
             container_id: &container_id,
@@ -984,8 +1013,14 @@ impl UpContext {
             env: &lifecycle_env,
             working_dir: self.workspace_folder(),
             is_text: self.progress.is_enabled(),
+            on_output: if self.progress.is_enabled() {
+                Some(Box::new(move |line| progress_ref.println(line)))
+            } else {
+                None
+            },
         };
-        run_all_lifecycle_phases(&lc_ctx, config, resolved_features.as_ref()).await?;
+        run_all_lifecycle_phases(&lc_ctx, config, resolved_features.as_ref(), &self.progress)
+            .await?;
 
         output_result(
             &self.output,
@@ -1431,14 +1466,21 @@ async fn upload_to_container(
     true
 }
 
-/// Run a sequence of origin-tracked lifecycle entries.
+/// Run a sequence of origin-tracked lifecycle entries with progress tracking.
 async fn run_lifecycle_entries(
     ctx: &LifecycleContext<'_>,
     phase: &str,
     entries: &[cella_features::LifecycleEntry],
+    progress: &crate::progress::Progress,
 ) -> Result<(), CellaDockerError> {
     for entry in entries {
-        run_lifecycle_phase(ctx, phase, &entry.command, &entry.origin).await?;
+        let step = progress.step(&format!("Running the {phase} from {}...", entry.origin));
+        let result = run_lifecycle_phase(ctx, phase, &entry.command, &entry.origin).await;
+        match &result {
+            Ok(()) => step.finish(),
+            Err(e) => step.fail(&e.to_string()),
+        }
+        result?;
     }
     Ok(())
 }
@@ -1448,6 +1490,7 @@ async fn run_all_lifecycle_phases(
     lc_ctx: &LifecycleContext<'_>,
     config: &serde_json::Value,
     resolved_features: Option<&cella_features::ResolvedFeatures>,
+    progress: &crate::progress::Progress,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let phases = [
         "onCreateCommand",
@@ -1467,13 +1510,19 @@ async fn run_all_lifecycle_phases(
             _ => &empty,
         });
 
-        run_lifecycle_entries(lc_ctx, phase, entries).await?;
+        run_lifecycle_entries(lc_ctx, phase, entries, progress).await?;
 
         if entries.is_empty()
             && let Some(cmd) = config.get(phase)
             && !cmd.is_null()
         {
-            run_lifecycle_phase(lc_ctx, phase, cmd, "devcontainer.json").await?;
+            let step = progress.step(&format!("Running the {phase} from devcontainer.json..."));
+            let result = run_lifecycle_phase(lc_ctx, phase, cmd, "devcontainer.json").await;
+            match &result {
+                Ok(()) => step.finish(),
+                Err(e) => step.fail(&e.to_string()),
+            }
+            result?;
         }
     }
 

--- a/crates/cella-cli/src/commands/up.rs
+++ b/crates/cella-cli/src/commands/up.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use clap::{Args, ValueEnum};
 use serde_json::json;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use cella_config::resolve::{self, ResolvedConfig};
 use cella_docker::{
@@ -52,6 +52,12 @@ pub enum OutputFormat {
     Json,
 }
 
+impl UpArgs {
+    pub const fn is_text_output(&self) -> bool {
+        matches!(self.output, OutputFormat::Text)
+    }
+}
+
 /// Holds resolved state for an `up` invocation, shared across all code paths.
 struct UpContext {
     resolved: ResolvedConfig,
@@ -60,14 +66,17 @@ struct UpContext {
     remote_env: Vec<String>,
     workspace_folder_from_config: Option<String>,
     default_workspace_folder: String,
-    is_text: bool,
+    progress: crate::progress::Progress,
     output: OutputFormat,
     remove_container: bool,
     build_no_cache: bool,
 }
 
 impl UpContext {
-    async fn new(args: &UpArgs) -> Result<Self, Box<dyn std::error::Error>> {
+    async fn new(
+        args: &UpArgs,
+        progress: crate::progress::Progress,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
         let cwd = if let Some(ref wf) = args.workspace_folder {
             wf.canonicalize().unwrap_or_else(|_| wf.clone())
         } else {
@@ -75,13 +84,13 @@ impl UpContext {
         };
 
         let remove_container = args.rebuild || args.remove_existing_container;
-        let is_text = matches!(&args.output, OutputFormat::Text);
 
         // 1. Resolve config
-        if is_text {
-            eprintln!("Resolving devcontainer configuration...");
-        }
-        let resolved = resolve::config(&cwd, args.file.as_deref())?;
+        let resolved = progress
+            .run_step("Resolving devcontainer configuration...", async {
+                resolve::config(&cwd, args.file.as_deref())
+            })
+            .await?;
 
         for w in &resolved.warnings {
             warn!("{}", w.message);
@@ -116,7 +125,7 @@ impl UpContext {
             remote_env,
             workspace_folder_from_config,
             default_workspace_folder,
-            is_text,
+            progress,
             output: args.output.clone(),
             remove_container,
             build_no_cache: args.build_no_cache,
@@ -199,26 +208,27 @@ impl UpContext {
 
         // Re-inject env forwarding (git config + SSH files may have changed)
         let env_fwd = cella_env::prepare_env_forwarding(config, remote_user);
-        timed_step(
-            self.is_text,
-            "Configuring environment...",
-            inject_post_start(&self.client, container_id, &env_fwd.post_start, remote_user),
-        )
-        .await;
+        self.progress
+            .run_step(
+                "Configuring environment...",
+                inject_post_start(&self.client, container_id, &env_fwd.post_start, remote_user),
+            )
+            .await;
 
         // Probe user environment first so tool installs can use feature-provided PATH
         // (e.g., nvm adds /usr/local/share/nvm/current/bin via login shell profiles)
-        let probed_env = timed_step(
-            self.is_text,
-            "Running userEnvProbe...",
-            super::env_cache::probe_and_cache_user_env(
-                &self.client,
-                container_id,
-                remote_user,
-                self.probe_type(),
-            ),
-        )
-        .await;
+        let probed_env = self
+            .progress
+            .run_step(
+                "Running userEnvProbe...",
+                super::env_cache::probe_and_cache_user_env(
+                    &self.client,
+                    container_id,
+                    remote_user,
+                    self.probe_type(),
+                ),
+            )
+            .await;
 
         // Sequential prerequisites
         let settings = cella_config::Settings::load(&self.resolved.workspace_root);
@@ -233,48 +243,62 @@ impl UpContext {
             false
         };
 
-        // Parallel branches: Claude Code (curl) || npm tools (Codex → Gemini)
-        let claude_branch = async {
-            if settings.tools.claude_code.enabled {
-                install_claude_code(
-                    &self.client,
-                    container_id,
-                    remote_user,
-                    &settings.tools.claude_code,
-                    probed_env.as_ref(),
-                )
-                .await;
-            }
-        };
+        let any_tool = settings.tools.claude_code.enabled
+            || settings.tools.codex.enabled
+            || settings.tools.gemini.enabled;
 
-        let npm_branch = async {
-            if needs_npm && !node_available {
-                warn!("Skipping npm tool installs: Node.js/npm not available");
-                return;
-            }
-            if settings.tools.codex.enabled {
-                install_codex(
-                    &self.client,
-                    container_id,
-                    remote_user,
-                    &settings.tools.codex,
-                    probed_env.as_ref(),
-                )
-                .await;
-            }
-            if settings.tools.gemini.enabled {
-                install_gemini(
-                    &self.client,
-                    container_id,
-                    remote_user,
-                    &settings.tools.gemini,
-                    probed_env.as_ref(),
-                )
-                .await;
-            }
-        };
+        if any_tool {
+            let phase = self.progress.phase("Installing tools...");
 
-        tokio::join!(claude_branch, npm_branch);
+            let claude_branch = async {
+                if settings.tools.claude_code.enabled {
+                    let step = phase.step("Claude Code");
+                    install_claude_code(
+                        &self.client,
+                        container_id,
+                        remote_user,
+                        &settings.tools.claude_code,
+                        probed_env.as_ref(),
+                    )
+                    .await;
+                    step.finish();
+                }
+            };
+
+            let npm_branch = async {
+                if needs_npm && !node_available {
+                    warn!("Skipping npm tool installs: Node.js/npm not available");
+                    return;
+                }
+                if settings.tools.codex.enabled {
+                    let step = phase.step("Codex");
+                    install_codex(
+                        &self.client,
+                        container_id,
+                        remote_user,
+                        &settings.tools.codex,
+                        probed_env.as_ref(),
+                    )
+                    .await;
+                    step.finish();
+                }
+                if settings.tools.gemini.enabled {
+                    let step = phase.step("Gemini CLI");
+                    install_gemini(
+                        &self.client,
+                        container_id,
+                        remote_user,
+                        &settings.tools.gemini,
+                        probed_env.as_ref(),
+                    )
+                    .await;
+                    step.finish();
+                }
+            };
+
+            tokio::join!(claude_branch, npm_branch);
+            phase.finish();
+        }
 
         let lifecycle_env = probed_env.as_ref().map_or_else(
             || self.remote_env.clone(),
@@ -308,7 +332,7 @@ impl UpContext {
             user: Some(remote_user),
             env: &lifecycle_env,
             working_dir: self.workspace_folder(),
-            is_text: self.is_text,
+            is_text: self.progress.is_enabled(),
         };
         run_lifecycle_entries(&lc_ctx, "postAttachCommand", &entries).await?;
 
@@ -357,12 +381,13 @@ impl UpContext {
         }
 
         // Attempt to start directly -- let Docker validate mounts
-        let start_result = timed_step(
-            self.is_text,
-            "Starting container...",
-            self.client.start_container(&container.id),
-        )
-        .await;
+        let step = self.progress.step("Starting container...");
+        let start_result = self.client.start_container(&container.id).await;
+        if start_result.is_ok() {
+            step.finish();
+        } else {
+            step.fail("failed to start");
+        }
 
         match start_result {
             Ok(()) => {
@@ -385,7 +410,7 @@ impl UpContext {
                         user: Some(remote_user),
                         env: &lifecycle_env,
                         working_dir: self.workspace_folder(),
-                        is_text: self.is_text,
+                        is_text: self.progress.is_enabled(),
                     };
                     run_lifecycle_entries(&lc_ctx, phase, &entries).await?;
                 }
@@ -607,12 +632,12 @@ impl UpContext {
         &self,
         container_id: &str,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        timed_step(
-            self.is_text,
-            "Starting container...",
-            self.client.start_container(container_id),
-        )
-        .await?;
+        self.progress
+            .run_step(
+                "Starting container...",
+                self.client.start_container(container_id),
+            )
+            .await?;
         verify_container_running(&self.client, container_id).await?;
 
         if let Err(e) =
@@ -714,12 +739,12 @@ impl UpContext {
         }
 
         // Inject post-start environment forwarding
-        timed_step(
-            self.is_text,
-            "Configuring environment...",
-            inject_post_start(&self.client, container_id, &env_fwd.post_start, remote_user),
-        )
-        .await;
+        self.progress
+            .run_step(
+                "Configuring environment...",
+                inject_post_start(&self.client, container_id, &env_fwd.post_start, remote_user),
+            )
+            .await;
 
         // Seed gh CLI credentials (first create only)
         if settings.credentials.gh {
@@ -734,17 +759,18 @@ impl UpContext {
 
         // Probe user environment first so tool installs can use feature-provided PATH
         // (e.g., nvm adds /usr/local/share/nvm/current/bin via login shell profiles)
-        let probed_env = timed_step(
-            self.is_text,
-            "Running userEnvProbe...",
-            super::env_cache::probe_and_cache_user_env(
-                &self.client,
-                container_id,
-                remote_user,
-                self.probe_type(),
-            ),
-        )
-        .await;
+        let probed_env = self
+            .progress
+            .run_step(
+                "Running userEnvProbe...",
+                super::env_cache::probe_and_cache_user_env(
+                    &self.client,
+                    container_id,
+                    remote_user,
+                    self.probe_type(),
+                ),
+            )
+            .await;
 
         // Forward config and install AI coding tools
         self.install_tools(container_id, remote_user, settings, probed_env.as_ref())
@@ -771,18 +797,18 @@ impl UpContext {
     ) {
         // Sequential prerequisite: forward Claude Code config before install
         if settings.tools.claude_code.forward_config {
-            timed_step(
-                self.is_text,
-                "Forwarding Claude Code config...",
-                seed_claude_config(
-                    &self.client,
-                    container_id,
-                    &self.resolved.workspace_root,
-                    remote_user,
-                    &settings.tools.claude_code,
-                ),
-            )
-            .await;
+            self.progress
+                .run_step(
+                    "Forwarding Claude Code config...",
+                    seed_claude_config(
+                        &self.client,
+                        container_id,
+                        &self.resolved.workspace_root,
+                        remote_user,
+                        &settings.tools.claude_code,
+                    ),
+                )
+                .await;
         }
 
         // Sequential prerequisite: ensure Node.js/npm once for all npm tools
@@ -793,21 +819,29 @@ impl UpContext {
             false
         };
 
-        // Parallel branches: Claude Code (curl) || npm tools (Codex → Gemini)
+        let any_tool = settings.tools.claude_code.enabled
+            || settings.tools.codex.enabled
+            || settings.tools.gemini.enabled;
+
+        if !any_tool {
+            return;
+        }
+
+        // Grouped phase: parallel Claude Code (curl) || npm tools (Codex → Gemini)
+        let phase = self.progress.phase("Installing tools...");
+
         let claude_branch = async {
             if settings.tools.claude_code.enabled {
-                timed_step(
-                    self.is_text,
-                    "Installing Claude Code...",
-                    install_claude_code(
-                        &self.client,
-                        container_id,
-                        remote_user,
-                        &settings.tools.claude_code,
-                        probed_env,
-                    ),
+                let step = phase.step("Claude Code");
+                install_claude_code(
+                    &self.client,
+                    container_id,
+                    remote_user,
+                    &settings.tools.claude_code,
+                    probed_env,
                 )
                 .await;
+                step.finish();
             }
         };
 
@@ -817,36 +851,33 @@ impl UpContext {
                 return;
             }
             if settings.tools.codex.enabled {
-                timed_step(
-                    self.is_text,
-                    "Installing Codex...",
-                    install_codex(
-                        &self.client,
-                        container_id,
-                        remote_user,
-                        &settings.tools.codex,
-                        probed_env,
-                    ),
+                let step = phase.step("Codex");
+                install_codex(
+                    &self.client,
+                    container_id,
+                    remote_user,
+                    &settings.tools.codex,
+                    probed_env,
                 )
                 .await;
+                step.finish();
             }
             if settings.tools.gemini.enabled {
-                timed_step(
-                    self.is_text,
-                    "Installing Gemini CLI...",
-                    install_gemini(
-                        &self.client,
-                        container_id,
-                        remote_user,
-                        &settings.tools.gemini,
-                        probed_env,
-                    ),
+                let step = phase.step("Gemini CLI");
+                install_gemini(
+                    &self.client,
+                    container_id,
+                    remote_user,
+                    &settings.tools.gemini,
+                    probed_env,
                 )
                 .await;
+                step.finish();
             }
         };
 
         tokio::join!(claude_branch, npm_branch);
+        phase.finish();
     }
 
     /// The full build/create/start/lifecycle path for a new container.
@@ -869,7 +900,7 @@ impl UpContext {
             self.config_name(),
             &self.resolved.config_path,
             build_no_cache,
-            self.is_text,
+            &self.progress,
         )
         .await?;
 
@@ -924,12 +955,13 @@ impl UpContext {
         .await;
 
         // Create and start container
-        let container_id = timed_step(
-            self.is_text,
-            "Creating container...",
-            self.client.create_container(&create_opts),
-        )
-        .await?;
+        let container_id = self
+            .progress
+            .run_step(
+                "Creating container...",
+                self.client.create_container(&create_opts),
+            )
+            .await?;
 
         self.start_and_register(&container_id).await?;
 
@@ -951,7 +983,7 @@ impl UpContext {
             user: Some(remote_user.as_str()),
             env: &lifecycle_env,
             working_dir: self.workspace_folder(),
-            is_text: self.is_text,
+            is_text: self.progress.is_enabled(),
         };
         run_all_lifecycle_phases(&lc_ctx, config, resolved_features.as_ref()).await?;
 
@@ -968,8 +1000,11 @@ impl UpContext {
 }
 
 impl UpArgs {
-    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
-        let ctx = UpContext::new(&self).await?;
+    pub async fn execute(
+        self,
+        progress: crate::progress::Progress,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let ctx = UpContext::new(&self, progress).await?;
         let existing = ctx
             .client
             .find_container(&ctx.resolved.workspace_root)
@@ -1318,27 +1353,6 @@ async fn apply_git_config(
     }
 }
 
-/// Print a progress label, run an async operation, and optionally show elapsed time.
-async fn timed_step<F, T>(is_text: bool, label: &str, f: F) -> T
-where
-    F: std::future::Future<Output = T>,
-{
-    if is_text {
-        eprint!("{label}");
-    }
-    let start = std::time::Instant::now();
-    let result = f.await;
-    if is_text {
-        let elapsed = start.elapsed();
-        if elapsed.as_millis() >= 100 {
-            eprintln!(" ({:.1}s)", elapsed.as_secs_f64());
-        } else {
-            eprintln!();
-        }
-    }
-    result
-}
-
 // ── Shared container-operation helpers ──────────────────────────────────────
 
 /// Create a directory inside the container with the given mode (as root).
@@ -1507,7 +1521,7 @@ async fn seed_gh_credentials(
     )
     .await
     {
-        info!("Seeded gh CLI credentials into container");
+        debug!("Seeded gh CLI credentials into container");
     }
 }
 
@@ -1574,7 +1588,7 @@ async fn seed_claude_config(
     )
     .await;
 
-    info!("Seeded Claude Code config into container");
+    debug!("Seeded Claude Code config into container");
 }
 
 /// Re-sync Claude Code auth credentials on container restart.
@@ -1655,7 +1669,7 @@ async fn ensure_alpine_claude_deps(client: &DockerClient, container_id: &str) ->
     let is_alpine = is_alpine_container(client, container_id).await;
 
     if is_alpine {
-        info!("Alpine detected, installing Claude Code dependencies...");
+        debug!("Alpine detected, installing Claude Code dependencies...");
         let _ = client
             .exec_command(
                 container_id,
@@ -1716,11 +1730,11 @@ async fn run_claude_install(
     probed_env: Option<&std::collections::HashMap<String, String>>,
 ) {
     if version != "latest" && version != "stable" {
-        info!("Installing Claude Code v{version} (native installer will attempt version pinning)");
+        debug!("Installing Claude Code v{version} (native installer will attempt version pinning)");
     }
 
     let install_cmd = format!("curl -fsSL https://claude.ai/install.sh | bash -s {version}");
-    info!("Installing Claude Code ({version})...");
+    debug!("Installing Claude Code ({version})...");
 
     let mut env = tool_exec_env(probed_env).unwrap_or_default();
     if is_alpine {
@@ -1747,7 +1761,7 @@ async fn run_claude_install(
 fn log_install_result(result: Result<cella_docker::ExecResult, CellaDockerError>) {
     match result {
         Ok(r) if r.exit_code == 0 => {
-            info!("Claude Code installed successfully");
+            debug!("Claude Code installed successfully");
         }
         Ok(r) => {
             warn!(
@@ -1827,7 +1841,7 @@ async fn ensure_node_available(
         return true;
     }
 
-    info!("npm not found, installing Node.js...");
+    debug!("npm not found, installing Node.js...");
     let install_cmd = if is_alpine_container(client, container_id).await {
         "apk add --no-cache nodejs npm"
     } else {
@@ -1848,7 +1862,7 @@ async fn ensure_node_available(
 
     match &result {
         Ok(r) if r.exit_code == 0 => {
-            info!("Node.js installed successfully");
+            debug!("Node.js installed successfully");
             true
         }
         Ok(r) => {
@@ -1938,7 +1952,7 @@ fn log_npm_install_result(
 ) {
     match result {
         Ok(r) if r.exit_code == 0 => {
-            info!("{tool_name} installed successfully");
+            debug!("{tool_name} installed successfully");
         }
         Ok(r) => {
             warn!(
@@ -1977,7 +1991,7 @@ async fn install_codex(
         return;
     }
 
-    info!("Installing Codex ({})...", settings.version);
+    debug!("Installing Codex ({})...", settings.version);
     let result = npm_install_global(
         client,
         container_id,
@@ -2014,7 +2028,7 @@ async fn install_gemini(
         return;
     }
 
-    info!("Installing Gemini CLI ({})...", settings.version);
+    debug!("Installing Gemini CLI ({})...", settings.version);
     let result = npm_install_global(
         client,
         container_id,

--- a/crates/cella-cli/src/commands/up.rs
+++ b/crates/cella-cli/src/commands/up.rs
@@ -7,8 +7,8 @@ use tracing::{debug, info, warn};
 use cella_config::resolve::{self, ResolvedConfig};
 use cella_docker::{
     CellaDockerError, ContainerInfo, ContainerState, DockerClient, ExecOptions, FileToUpload,
-    LifecycleContext, MountConfig, container_labels, container_name, run_lifecycle_phase,
-    update_remote_user_uid,
+    ImageDetails, LifecycleContext, MountConfig, container_labels, container_name,
+    run_lifecycle_phase, update_remote_user_uid,
 };
 
 use super::image::ensure_image;
@@ -70,6 +70,14 @@ struct UpContext {
     output: OutputFormat,
     remove_container: bool,
     build_no_cache: bool,
+}
+
+/// Resolved image configuration for container creation.
+struct ImageConfig {
+    image_env: Vec<String>,
+    remote_user: String,
+    env_fwd: cella_env::EnvForwarding,
+    create_opts: cella_docker::config_map::CreateContainerOptions,
 }
 
 impl UpContext {
@@ -900,6 +908,61 @@ impl UpContext {
         phase.finish();
     }
 
+    /// Resolve image metadata, environment forwarding, and container creation options.
+    async fn resolve_image_config(
+        &self,
+        config: &serde_json::Value,
+        img_name: &str,
+        base_image_details: ImageDetails,
+        resolved_features: Option<&cella_features::ResolvedFeatures>,
+    ) -> ImageConfig {
+        let image_env = base_image_details.env;
+        let image_meta_user = base_image_details
+            .metadata
+            .as_deref()
+            .map(|m| cella_features::parse_image_metadata(m).1);
+        let remote_user =
+            resolve_remote_user(config, image_meta_user.as_ref(), &base_image_details.user);
+
+        super::ensure_cella_daemon().await;
+        let env_fwd = cella_env::prepare_env_forwarding(config, &remote_user);
+
+        let labels = self.build_labels(
+            resolved_features,
+            base_image_details.metadata.as_deref(),
+            &env_fwd,
+            &remote_user,
+        );
+
+        let feature_config = resolved_features.map(|r| &r.container_config);
+        let image_meta_config = if feature_config.is_none() {
+            base_image_details
+                .metadata
+                .as_deref()
+                .map(|m| cella_features::parse_image_metadata(m).0)
+        } else {
+            None
+        };
+        let effective_feature_config = feature_config.or(image_meta_config.as_ref());
+
+        let create_opts = cella_docker::config_map::map_config(
+            config,
+            &self.container_nm,
+            img_name,
+            labels,
+            &self.resolved.workspace_root,
+            effective_feature_config,
+            &image_env,
+        );
+
+        ImageConfig {
+            image_env,
+            remote_user,
+            env_fwd,
+            create_opts,
+        }
+    }
+
     /// The full build/create/start/lifecycle path for a new container.
     async fn create_and_start(
         &self,
@@ -924,45 +987,19 @@ impl UpContext {
         )
         .await?;
 
-        let image_env = base_image_details.env;
-        let image_meta_user = base_image_details
-            .metadata
-            .as_deref()
-            .map(|m| cella_features::parse_image_metadata(m).1);
-        let remote_user =
-            resolve_remote_user(config, image_meta_user.as_ref(), &base_image_details.user);
-
-        super::ensure_cella_daemon().await;
-        let env_fwd = cella_env::prepare_env_forwarding(config, &remote_user);
-
-        // Build labels and create options
-        let labels = self.build_labels(
-            resolved_features.as_ref(),
-            base_image_details.metadata.as_deref(),
-            &env_fwd,
-            &remote_user,
-        );
-
-        let feature_config = resolved_features.as_ref().map(|r| &r.container_config);
-        let image_meta_config = if feature_config.is_none() {
-            base_image_details
-                .metadata
-                .as_deref()
-                .map(|m| cella_features::parse_image_metadata(m).0)
-        } else {
-            None
-        };
-        let effective_feature_config = feature_config.or(image_meta_config.as_ref());
-
-        let mut create_opts = cella_docker::config_map::map_config(
-            config,
-            &self.container_nm,
-            &img_name,
-            labels,
-            &self.resolved.workspace_root,
-            effective_feature_config,
-            &image_env,
-        );
+        let ImageConfig {
+            image_env,
+            remote_user,
+            env_fwd,
+            mut create_opts,
+        } = self
+            .resolve_image_config(
+                config,
+                &img_name,
+                base_image_details,
+                resolved_features.as_ref(),
+            )
+            .await;
 
         let settings = cella_config::Settings::load(&self.resolved.workspace_root);
         self.apply_env_and_mounts(

--- a/crates/cella-cli/src/main.rs
+++ b/crates/cella-cli/src/main.rs
@@ -46,11 +46,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let progress = Progress::new(spinners_enabled, verbosity);
 
-    // Route tracing through indicatif so log lines never corrupt spinners.
-    tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
-        .with_writer(IndicatifMakeWriter::new(progress.multi().clone()))
-        .init();
+    // The daemon subprocess initializes its own file-based tracing.
+    // Skip the normal indicatif-based tracing for daemon start.
+    if !cli.command.is_daemon_start() {
+        tracing_subscriber::fmt()
+            .with_env_filter(EnvFilter::from_default_env())
+            .with_writer(IndicatifMakeWriter::new(progress.multi().clone()))
+            .init();
+    }
 
     cli.command.execute(progress).await
 }

--- a/crates/cella-cli/src/main.rs
+++ b/crates/cella-cli/src/main.rs
@@ -1,7 +1,10 @@
 mod commands;
+pub mod progress;
 
 use clap::Parser;
 use tracing_subscriber::EnvFilter;
+
+use progress::{IndicatifMakeWriter, Progress};
 
 /// cella — Dev containers reinvented for the AI age
 #[derive(Parser)]
@@ -21,10 +24,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }))
     .ok();
 
+    // Parse CLI first to determine output mode before creating progress.
+    let cli = Cli::parse();
+    let progress = Progress::new(cli.command.is_text_output());
+
+    // Route tracing through indicatif so log lines never corrupt spinners.
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
+        .with_writer(IndicatifMakeWriter::new(progress.multi().clone()))
         .init();
 
-    let cli = Cli::parse();
-    cli.command.execute().await
+    cli.command.execute(progress).await
 }

--- a/crates/cella-cli/src/main.rs
+++ b/crates/cella-cli/src/main.rs
@@ -1,15 +1,21 @@
 mod commands;
 pub mod progress;
 
+use std::io::IsTerminal;
+
 use clap::Parser;
 use tracing_subscriber::EnvFilter;
 
-use progress::{IndicatifMakeWriter, Progress};
+use progress::{IndicatifMakeWriter, Progress, Verbosity};
 
 /// cella — Dev containers reinvented for the AI age
 #[derive(Parser)]
 #[command(version, about)]
 struct Cli {
+    /// Show expanded step details (container names, feature resolution, etc.).
+    #[arg(short, long, global = true)]
+    verbose: bool,
+
     #[command(subcommand)]
     command: commands::Command,
 }
@@ -26,7 +32,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Parse CLI first to determine output mode before creating progress.
     let cli = Cli::parse();
-    let progress = Progress::new(cli.command.is_text_output());
+
+    let verbosity = if cli.verbose {
+        Verbosity::Verbose
+    } else {
+        Verbosity::Normal
+    };
+
+    // Spinners are active when: text output mode AND no RUST_LOG AND stderr is a TTY.
+    let rust_log_set = std::env::var_os("RUST_LOG").is_some();
+    let is_tty = std::io::stderr().is_terminal();
+    let spinners_enabled = cli.command.is_text_output() && !rust_log_set && is_tty;
+
+    let progress = Progress::new(spinners_enabled, verbosity);
 
     // Route tracing through indicatif so log lines never corrupt spinners.
     tracing_subscriber::fmt()

--- a/crates/cella-cli/src/progress.rs
+++ b/crates/cella-cli/src/progress.rs
@@ -1,0 +1,272 @@
+//! Terminal progress display using indicatif spinners.
+//!
+//! Provides [`Progress`] as the central coordinator for all user-facing
+//! status output.  When enabled (text mode), operations show animated
+//! spinners that resolve to checkmarks on completion.  When disabled
+//! (JSON mode), every method is a silent no-op.
+//!
+//! Tracing integration: [`IndicatifMakeWriter`] routes `tracing` output
+//! through [`indicatif::MultiProgress::println`] so structured log lines
+//! never corrupt active spinners.
+
+use std::io;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use tracing_subscriber::fmt::MakeWriter;
+
+// ── style constants ──────────────────────────────────────────────────
+
+const SPINNER_TICK_CHARS: &str = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏ ";
+const TICK_INTERVAL: Duration = Duration::from_millis(80);
+
+fn spinner_style() -> ProgressStyle {
+    ProgressStyle::with_template("{spinner:.cyan} {msg}")
+        .expect("hard-coded template")
+        .tick_chars(SPINNER_TICK_CHARS)
+}
+
+fn child_spinner_style() -> ProgressStyle {
+    ProgressStyle::with_template("  {spinner:.cyan} {msg}")
+        .expect("hard-coded template")
+        .tick_chars(SPINNER_TICK_CHARS)
+}
+
+// ── Progress ─────────────────────────────────────────────────────────
+
+/// Shared progress context threaded through all commands.
+#[derive(Clone)]
+pub struct Progress {
+    inner: Arc<ProgressInner>,
+}
+
+struct ProgressInner {
+    multi: MultiProgress,
+    enabled: bool,
+}
+
+impl Progress {
+    /// Create a new progress context.
+    ///
+    /// When `enabled` is false (JSON mode), all methods are silent no-ops
+    /// and the [`MultiProgress`] is hidden.
+    pub fn new(enabled: bool) -> Self {
+        let multi = if enabled {
+            MultiProgress::new()
+        } else {
+            MultiProgress::with_draw_target(indicatif::ProgressDrawTarget::hidden())
+        };
+        Self {
+            inner: Arc::new(ProgressInner { multi, enabled }),
+        }
+    }
+
+    /// Whether spinners are active (text mode).
+    pub fn is_enabled(&self) -> bool {
+        self.inner.enabled
+    }
+
+    /// Access the underlying [`MultiProgress`] for tracing writer setup.
+    pub fn multi(&self) -> &MultiProgress {
+        &self.inner.multi
+    }
+
+    /// Start a spinner for a single operation.
+    pub fn step(&self, label: &str) -> Step {
+        let bar = self.inner.multi.add(ProgressBar::new_spinner());
+        bar.set_style(spinner_style());
+        bar.set_message(label.to_string());
+        if self.inner.enabled {
+            bar.enable_steady_tick(TICK_INTERVAL);
+        }
+        Step {
+            bar,
+            label: label.to_string(),
+            start: Instant::now(),
+        }
+    }
+
+    /// Start a grouped phase with indented child spinners.
+    pub fn phase(&self, label: &str) -> Phase {
+        let bar = self.inner.multi.add(ProgressBar::new_spinner());
+        bar.set_style(spinner_style());
+        bar.set_message(label.to_string());
+        if self.inner.enabled {
+            bar.enable_steady_tick(TICK_INTERVAL);
+        }
+        Phase {
+            parent: bar,
+            multi: self.inner.multi.clone(),
+            label: label.to_string(),
+            start: Instant::now(),
+            enabled: self.inner.enabled,
+        }
+    }
+
+    /// Convenience: run an async operation with a spinner.
+    pub async fn run_step<F, T>(&self, label: &str, f: F) -> T
+    where
+        F: std::future::Future<Output = T>,
+    {
+        let step = self.step(label);
+        let result = f.await;
+        step.finish();
+        result
+    }
+}
+
+// ── Step ─────────────────────────────────────────────────────────────
+
+/// Handle for a single timed operation (one spinner line).
+pub struct Step {
+    bar: ProgressBar,
+    label: String,
+    start: Instant,
+}
+
+impl Step {
+    /// Finish with checkmark and elapsed time.
+    pub fn finish(self) {
+        let elapsed = self.start.elapsed();
+        let time_suffix = format_elapsed(elapsed);
+        self.bar
+            .finish_with_message(format!("\x1b[32m✓\x1b[0m {}{time_suffix}", self.label));
+    }
+
+    /// Finish with a custom completion message.
+    pub fn finish_with(self, msg: &str) {
+        let elapsed = self.start.elapsed();
+        let time_suffix = format_elapsed(elapsed);
+        self.bar
+            .finish_with_message(format!("\x1b[32m✓\x1b[0m {msg}{time_suffix}"));
+    }
+
+    /// Mark as failed.
+    pub fn fail(self, msg: &str) {
+        self.bar
+            .finish_with_message(format!("\x1b[31m✗\x1b[0m {}: {msg}", self.label));
+    }
+}
+
+impl Drop for Step {
+    fn drop(&mut self) {
+        // If not yet finished (e.g. early error return), clear the spinner.
+        if !self.bar.is_finished() {
+            self.bar.finish_and_clear();
+        }
+    }
+}
+
+// ── Phase ────────────────────────────────────────────────────────────
+
+/// Grouped parent spinner that can have indented child steps.
+pub struct Phase {
+    parent: ProgressBar,
+    multi: MultiProgress,
+    label: String,
+    start: Instant,
+    enabled: bool,
+}
+
+impl Phase {
+    /// Add a child step under this phase (indented spinner).
+    pub fn step(&self, label: &str) -> Step {
+        let bar = self
+            .multi
+            .insert_after(&self.parent, ProgressBar::new_spinner());
+        bar.set_style(child_spinner_style());
+        bar.set_message(label.to_string());
+        if self.enabled {
+            bar.enable_steady_tick(TICK_INTERVAL);
+        }
+        Step {
+            bar,
+            label: label.to_string(),
+            start: Instant::now(),
+        }
+    }
+
+    /// Finish the phase with total elapsed time.
+    pub fn finish(self) {
+        let elapsed = self.start.elapsed();
+        let time_suffix = format_elapsed(elapsed);
+        self.parent
+            .finish_with_message(format!("\x1b[32m✓\x1b[0m {}{time_suffix}", self.label));
+    }
+}
+
+impl Drop for Phase {
+    fn drop(&mut self) {
+        if !self.parent.is_finished() {
+            self.parent.finish_and_clear();
+        }
+    }
+}
+
+// ── Tracing writer ───────────────────────────────────────────────────
+
+/// Routes tracing output through [`MultiProgress::println`] so log lines
+/// appear above active spinners instead of corrupting them.
+#[derive(Clone)]
+pub struct IndicatifMakeWriter {
+    multi: MultiProgress,
+}
+
+impl IndicatifMakeWriter {
+    pub const fn new(multi: MultiProgress) -> Self {
+        Self { multi }
+    }
+}
+
+impl<'a> MakeWriter<'a> for IndicatifMakeWriter {
+    type Writer = IndicatifLineWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        IndicatifLineWriter {
+            multi: self.multi.clone(),
+            buf: Vec::with_capacity(256),
+        }
+    }
+}
+
+/// Buffers a single tracing event, then flushes via `MultiProgress::println` on drop.
+pub struct IndicatifLineWriter {
+    multi: MultiProgress,
+    buf: Vec<u8>,
+}
+
+impl io::Write for IndicatifLineWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buf.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        if !self.buf.is_empty() {
+            let msg = String::from_utf8_lossy(&self.buf);
+            let trimmed = msg.trim_end();
+            if !trimmed.is_empty() {
+                let _ = self.multi.println(trimmed);
+            }
+            self.buf.clear();
+        }
+        Ok(())
+    }
+}
+
+impl Drop for IndicatifLineWriter {
+    fn drop(&mut self) {
+        let _ = io::Write::flush(self);
+    }
+}
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+fn format_elapsed(elapsed: Duration) -> String {
+    if elapsed.as_millis() >= 100 {
+        format!(" ({:.1}s)", elapsed.as_secs_f64())
+    } else {
+        String::new()
+    }
+}

--- a/crates/cella-cli/src/progress.rs
+++ b/crates/cella-cli/src/progress.rs
@@ -130,10 +130,8 @@ impl Progress {
         }
         Step {
             bar,
-            multi: self.inner.multi.clone(),
             label: label.to_string(),
             start: Instant::now(),
-            enabled: self.inner.enabled,
         }
     }
 
@@ -217,10 +215,8 @@ impl Progress {
 /// Handle for a single timed operation (one spinner line).
 pub struct Step {
     bar: ProgressBar,
-    multi: MultiProgress,
     label: String,
     start: Instant,
-    enabled: bool,
 }
 
 impl Step {
@@ -228,38 +224,22 @@ impl Step {
     pub fn finish(self) {
         let elapsed = self.start.elapsed();
         let time_suffix = format_elapsed(elapsed);
-        let msg = format!("  \x1b[32m✓\x1b[0m {}{time_suffix}", self.label);
-        // Print as permanent line, then clear the ephemeral spinner.
-        if self.enabled {
-            let _ = self.multi.println(&msg);
-            self.bar.finish_and_clear();
-        } else {
-            self.bar.finish_with_message(msg);
-        }
+        self.bar
+            .finish_with_message(format!("\x1b[32m✓\x1b[0m {}{time_suffix}", self.label));
     }
 
     /// Finish with a custom completion message.
     pub fn finish_with(self, msg: &str) {
         let elapsed = self.start.elapsed();
         let time_suffix = format_elapsed(elapsed);
-        let line = format!("  \x1b[32m✓\x1b[0m {msg}{time_suffix}");
-        if self.enabled {
-            let _ = self.multi.println(&line);
-            self.bar.finish_and_clear();
-        } else {
-            self.bar.finish_with_message(line);
-        }
+        self.bar
+            .finish_with_message(format!("\x1b[32m✓\x1b[0m {msg}{time_suffix}"));
     }
 
     /// Mark as failed.
     pub fn fail(self, msg: &str) {
-        let line = format!("  \x1b[31m✗\x1b[0m {}: {msg}", self.label);
-        if self.enabled {
-            let _ = self.multi.println(&line);
-            self.bar.finish_and_clear();
-        } else {
-            self.bar.finish_with_message(line);
-        }
+        self.bar
+            .finish_with_message(format!("\x1b[31m✗\x1b[0m {}: {msg}", self.label));
     }
 }
 
@@ -296,10 +276,8 @@ impl Phase {
         }
         Step {
             bar,
-            multi: self.multi.clone(),
             label: label.to_string(),
             start: Instant::now(),
-            enabled: self.enabled,
         }
     }
 
@@ -307,13 +285,8 @@ impl Phase {
     pub fn finish(self) {
         let elapsed = self.start.elapsed();
         let time_suffix = format_elapsed(elapsed);
-        let msg = format!("  \x1b[32m✓\x1b[0m {}{time_suffix}", self.label);
-        if self.enabled {
-            let _ = self.multi.println(&msg);
-            self.parent.finish_and_clear();
-        } else {
-            self.parent.finish_with_message(msg);
-        }
+        self.parent
+            .finish_with_message(format!("\x1b[32m✓\x1b[0m {}{time_suffix}", self.label));
     }
 }
 

--- a/crates/cella-cli/src/progress.rs
+++ b/crates/cella-cli/src/progress.rs
@@ -121,6 +121,9 @@ impl Progress {
     }
 
     /// Start a spinner for a single operation.
+    ///
+    /// Top-level steps are permanent: their completion line survives
+    /// streaming output from Docker builds and lifecycle commands.
     pub fn step(&self, label: &str) -> Step {
         let bar = self.inner.multi.add(ProgressBar::new_spinner());
         bar.set_style(spinner_style());
@@ -130,6 +133,7 @@ impl Progress {
         }
         Step {
             bar,
+            multi: Some(self.inner.multi.clone()),
             label: label.to_string(),
             start: Instant::now(),
         }
@@ -158,6 +162,7 @@ impl Progress {
             label: label.to_string(),
             start: Instant::now(),
             enabled: self.inner.enabled,
+            completed_children: Arc::new(std::sync::Mutex::new(Vec::new())),
         }
     }
 
@@ -213,8 +218,17 @@ impl Progress {
 // ── Step ─────────────────────────────────────────────────────────────
 
 /// Handle for a single timed operation (one spinner line).
+///
+/// Top-level steps (created via [`Progress::step`]) finish as permanent
+/// terminal output that survives streaming output (docker build, lifecycle).
+/// Phase children (created via [`Phase::step`]) finish in-place to preserve
+/// parent-above-children ordering.
 pub struct Step {
     bar: ProgressBar,
+    /// When set, finish prints a permanent line via `MultiProgress::println`
+    /// and then clears the ephemeral spinner. This prevents the line from
+    /// being scrolled away when streaming output follows.
+    multi: Option<MultiProgress>,
     label: String,
     start: Instant,
 }
@@ -224,22 +238,33 @@ impl Step {
     pub fn finish(self) {
         let elapsed = self.start.elapsed();
         let time_suffix = format_elapsed(elapsed);
-        self.bar
-            .finish_with_message(format!("\x1b[32m✓\x1b[0m {}{time_suffix}", self.label));
+        let msg = format!("\x1b[32m✓\x1b[0m {}{time_suffix}", self.label);
+        self.finish_impl(&msg);
     }
 
     /// Finish with a custom completion message.
     pub fn finish_with(self, msg: &str) {
         let elapsed = self.start.elapsed();
         let time_suffix = format_elapsed(elapsed);
-        self.bar
-            .finish_with_message(format!("\x1b[32m✓\x1b[0m {msg}{time_suffix}"));
+        let line = format!("\x1b[32m✓\x1b[0m {msg}{time_suffix}");
+        self.finish_impl(&line);
     }
 
     /// Mark as failed.
     pub fn fail(self, msg: &str) {
-        self.bar
-            .finish_with_message(format!("\x1b[31m✗\x1b[0m {}: {msg}", self.label));
+        let line = format!("\x1b[31m✗\x1b[0m {}: {msg}", self.label);
+        self.finish_impl(&line);
+    }
+
+    fn finish_impl(&self, msg: &str) {
+        if let Some(ref multi) = self.multi {
+            // Top-level: print permanent line, then clear spinner from managed region.
+            let _ = multi.println(format!("  {msg}"));
+            self.bar.finish_and_clear();
+        } else {
+            // Phase child: finish in-place to preserve ordering.
+            self.bar.finish_with_message(msg.to_string());
+        }
     }
 }
 
@@ -255,17 +280,24 @@ impl Drop for Step {
 // ── Phase ────────────────────────────────────────────────────────────
 
 /// Grouped parent spinner that can have indented child steps.
+///
+/// On finish, prints the parent line followed by all completed child
+/// lines as permanent output, then clears all bars from the managed
+/// region. This ensures correct ordering (parent above children) AND
+/// permanence (lines survive subsequent streaming output).
 pub struct Phase {
     parent: ProgressBar,
     multi: MultiProgress,
     label: String,
     start: Instant,
     enabled: bool,
+    /// Completed child descriptions, collected as children finish.
+    completed_children: Arc<std::sync::Mutex<Vec<String>>>,
 }
 
 impl Phase {
     /// Add a child step under this phase (indented spinner).
-    pub fn step(&self, label: &str) -> Step {
+    pub fn step(&self, label: &str) -> PhaseChild {
         let bar = self
             .multi
             .insert_after(&self.parent, ProgressBar::new_spinner());
@@ -274,19 +306,37 @@ impl Phase {
         if self.enabled {
             bar.enable_steady_tick(TICK_INTERVAL);
         }
-        Step {
+        PhaseChild {
             bar,
             label: label.to_string(),
             start: Instant::now(),
+            completed: Arc::clone(&self.completed_children),
         }
     }
 
     /// Finish the phase with total elapsed time.
+    ///
+    /// Prints parent + children as permanent output in correct order,
+    /// then clears all bars from the managed region.
     pub fn finish(self) {
         let elapsed = self.start.elapsed();
         let time_suffix = format_elapsed(elapsed);
-        self.parent
-            .finish_with_message(format!("\x1b[32m✓\x1b[0m {}{time_suffix}", self.label));
+
+        // Print parent line first (permanent).
+        let _ = self
+            .multi
+            .println(format!("  \x1b[32m✓\x1b[0m {}{time_suffix}", self.label));
+
+        // Print completed children in the order they finished (permanent).
+        let Ok(children) = self.completed_children.lock() else {
+            self.parent.finish_and_clear();
+            return;
+        };
+        for child_line in children.iter() {
+            let _ = self.multi.println(child_line);
+        }
+
+        self.parent.finish_and_clear();
     }
 }
 
@@ -294,6 +344,38 @@ impl Drop for Phase {
     fn drop(&mut self) {
         if !self.parent.is_finished() {
             self.parent.finish_and_clear();
+        }
+    }
+}
+
+/// Handle for a child step within a [`Phase`].
+///
+/// On finish, records its completion message for the parent Phase
+/// to print in order, then clears its spinner.
+pub struct PhaseChild {
+    bar: ProgressBar,
+    label: String,
+    start: Instant,
+    completed: Arc<std::sync::Mutex<Vec<String>>>,
+}
+
+impl PhaseChild {
+    /// Finish with checkmark and elapsed time.
+    pub fn finish(self) {
+        let elapsed = self.start.elapsed();
+        let time_suffix = format_elapsed(elapsed);
+        let msg = format!("      \x1b[32m✓\x1b[0m {}{time_suffix}", self.label);
+        if let Ok(mut children) = self.completed.lock() {
+            children.push(msg);
+        }
+        self.bar.finish_and_clear();
+    }
+}
+
+impl Drop for PhaseChild {
+    fn drop(&mut self) {
+        if !self.bar.is_finished() {
+            self.bar.finish_and_clear();
         }
     }
 }

--- a/crates/cella-cli/src/progress.rs
+++ b/crates/cella-cli/src/progress.rs
@@ -447,6 +447,12 @@ fn format_elapsed(elapsed: Duration) -> String {
     }
 }
 
+/// Public version of [`format_elapsed`] for use by command modules
+/// that manually format completion lines (e.g., Docker build output).
+pub fn format_elapsed_pub(elapsed: Duration) -> String {
+    format_elapsed(elapsed)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/cella-cli/src/progress.rs
+++ b/crates/cella-cli/src/progress.rs
@@ -3,11 +3,22 @@
 //! Provides [`Progress`] as the central coordinator for all user-facing
 //! status output.  When enabled (text mode), operations show animated
 //! spinners that resolve to checkmarks on completion.  When disabled
-//! (JSON mode), every method is a silent no-op.
+//! (JSON mode, `RUST_LOG` set, non-TTY), every spinner method is a silent
+//! no-op.
 //!
-//! Tracing integration: [`IndicatifMakeWriter`] routes `tracing` output
-//! through [`indicatif::MultiProgress::println`] so structured log lines
-//! never corrupt active spinners.
+//! ## Two output axes
+//!
+//! - **User verbosity** (`--verbose`/`-v`): controls which progress steps
+//!   and details are shown. Managed by [`Verbosity`].
+//! - **Developer tracing** (`RUST_LOG`): controls `tracing` subscriber
+//!   filtering. When `RUST_LOG` is set, spinners are automatically
+//!   disabled to avoid corruption.
+//!
+//! ## Tracing integration
+//!
+//! [`IndicatifMakeWriter`] routes `tracing` output through
+//! [`indicatif::MultiProgress::println`] so structured log lines never
+//! corrupt active spinners.
 
 use std::io;
 use std::sync::Arc;
@@ -33,6 +44,28 @@ fn child_spinner_style() -> ProgressStyle {
         .tick_chars(SPINNER_TICK_CHARS)
 }
 
+// ── Verbosity ────────────────────────────────────────────────────────
+
+/// User-facing verbosity level.
+///
+/// This is independent of `RUST_LOG` tracing. It controls which progress
+/// steps are shown, not which tracing events are emitted.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Verbosity {
+    /// Default: show phase spinners, lifecycle headers, streaming output.
+    Normal,
+    /// Expanded: additionally show container names, feature resolution,
+    /// UID remapping, SSH/git/credential forwarding, network connections,
+    /// individual tool install sub-steps.
+    Verbose,
+}
+
+impl Verbosity {
+    pub fn is_verbose(self) -> bool {
+        self == Self::Verbose
+    }
+}
+
 // ── Progress ─────────────────────────────────────────────────────────
 
 /// Shared progress context threaded through all commands.
@@ -44,27 +77,42 @@ pub struct Progress {
 struct ProgressInner {
     multi: MultiProgress,
     enabled: bool,
+    verbosity: Verbosity,
 }
 
 impl Progress {
     /// Create a new progress context.
     ///
-    /// When `enabled` is false (JSON mode), all methods are silent no-ops
-    /// and the [`MultiProgress`] is hidden.
-    pub fn new(enabled: bool) -> Self {
+    /// When `enabled` is false (JSON mode, `RUST_LOG` set, non-TTY),
+    /// spinner methods are silent no-ops and [`MultiProgress`] is hidden.
+    pub fn new(enabled: bool, verbosity: Verbosity) -> Self {
         let multi = if enabled {
             MultiProgress::new()
         } else {
             MultiProgress::with_draw_target(indicatif::ProgressDrawTarget::hidden())
         };
         Self {
-            inner: Arc::new(ProgressInner { multi, enabled }),
+            inner: Arc::new(ProgressInner {
+                multi,
+                enabled,
+                verbosity,
+            }),
         }
     }
 
-    /// Whether spinners are active (text mode).
+    /// Whether spinners are active (text mode, TTY, no `RUST_LOG`).
     pub fn is_enabled(&self) -> bool {
         self.inner.enabled
+    }
+
+    /// Current user verbosity level.
+    pub fn verbosity(&self) -> Verbosity {
+        self.inner.verbosity
+    }
+
+    /// Whether verbose mode is active.
+    pub fn is_verbose(&self) -> bool {
+        self.inner.verbosity.is_verbose()
     }
 
     /// Access the underlying [`MultiProgress`] for tracing writer setup.
@@ -82,8 +130,19 @@ impl Progress {
         }
         Step {
             bar,
+            multi: self.inner.multi.clone(),
             label: label.to_string(),
             start: Instant::now(),
+            enabled: self.inner.enabled,
+        }
+    }
+
+    /// Start a spinner only in verbose mode. Returns `None` in normal mode.
+    pub fn verbose_step(&self, label: &str) -> Option<Step> {
+        if self.inner.verbosity.is_verbose() {
+            Some(self.step(label))
+        } else {
+            None
         }
     }
 
@@ -114,6 +173,43 @@ impl Progress {
         step.finish();
         result
     }
+
+    /// Print a warning message in the spinner flow.
+    ///
+    /// Shows a yellow `⚠` prefix. Always visible regardless of verbosity.
+    pub fn warn(&self, msg: &str) {
+        let _ = self
+            .inner
+            .multi
+            .println(format!("  \x1b[33m⚠\x1b[0m {msg}"));
+    }
+
+    /// Print an error message in the spinner flow.
+    ///
+    /// Shows a red `✗` prefix. Always visible regardless of verbosity.
+    pub fn error(&self, msg: &str) {
+        let _ = self
+            .inner
+            .multi
+            .println(format!("  \x1b[31m✗\x1b[0m {msg}"));
+    }
+
+    /// Print a hint/fix suggestion in the spinner flow.
+    ///
+    /// Shows a dim `→` prefix, indented. Always visible regardless of verbosity.
+    pub fn hint(&self, msg: &str) {
+        let _ = self
+            .inner
+            .multi
+            .println(format!("    \x1b[2m→ {msg}\x1b[0m"));
+    }
+
+    /// Print a line through the progress system (appears above spinners).
+    ///
+    /// Used for streaming lifecycle command output under an active spinner.
+    pub fn println(&self, msg: &str) {
+        let _ = self.inner.multi.println(msg);
+    }
 }
 
 // ── Step ─────────────────────────────────────────────────────────────
@@ -121,8 +217,10 @@ impl Progress {
 /// Handle for a single timed operation (one spinner line).
 pub struct Step {
     bar: ProgressBar,
+    multi: MultiProgress,
     label: String,
     start: Instant,
+    enabled: bool,
 }
 
 impl Step {
@@ -130,22 +228,38 @@ impl Step {
     pub fn finish(self) {
         let elapsed = self.start.elapsed();
         let time_suffix = format_elapsed(elapsed);
-        self.bar
-            .finish_with_message(format!("\x1b[32m✓\x1b[0m {}{time_suffix}", self.label));
+        let msg = format!("  \x1b[32m✓\x1b[0m {}{time_suffix}", self.label);
+        // Print as permanent line, then clear the ephemeral spinner.
+        if self.enabled {
+            let _ = self.multi.println(&msg);
+            self.bar.finish_and_clear();
+        } else {
+            self.bar.finish_with_message(msg);
+        }
     }
 
     /// Finish with a custom completion message.
     pub fn finish_with(self, msg: &str) {
         let elapsed = self.start.elapsed();
         let time_suffix = format_elapsed(elapsed);
-        self.bar
-            .finish_with_message(format!("\x1b[32m✓\x1b[0m {msg}{time_suffix}"));
+        let line = format!("  \x1b[32m✓\x1b[0m {msg}{time_suffix}");
+        if self.enabled {
+            let _ = self.multi.println(&line);
+            self.bar.finish_and_clear();
+        } else {
+            self.bar.finish_with_message(line);
+        }
     }
 
     /// Mark as failed.
     pub fn fail(self, msg: &str) {
-        self.bar
-            .finish_with_message(format!("\x1b[31m✗\x1b[0m {}: {msg}", self.label));
+        let line = format!("  \x1b[31m✗\x1b[0m {}: {msg}", self.label);
+        if self.enabled {
+            let _ = self.multi.println(&line);
+            self.bar.finish_and_clear();
+        } else {
+            self.bar.finish_with_message(line);
+        }
     }
 }
 
@@ -182,8 +296,10 @@ impl Phase {
         }
         Step {
             bar,
+            multi: self.multi.clone(),
             label: label.to_string(),
             start: Instant::now(),
+            enabled: self.enabled,
         }
     }
 
@@ -191,8 +307,13 @@ impl Phase {
     pub fn finish(self) {
         let elapsed = self.start.elapsed();
         let time_suffix = format_elapsed(elapsed);
-        self.parent
-            .finish_with_message(format!("\x1b[32m✓\x1b[0m {}{time_suffix}", self.label));
+        let msg = format!("  \x1b[32m✓\x1b[0m {}{time_suffix}", self.label);
+        if self.enabled {
+            let _ = self.multi.println(&msg);
+            self.parent.finish_and_clear();
+        } else {
+            self.parent.finish_with_message(msg);
+        }
     }
 }
 
@@ -268,5 +389,174 @@ fn format_elapsed(elapsed: Duration) -> String {
         format!(" ({:.1}s)", elapsed.as_secs_f64())
     } else {
         String::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Verbosity ────────────────────────────────────────────────────
+
+    #[test]
+    fn verbosity_normal_is_not_verbose() {
+        assert!(!Verbosity::Normal.is_verbose());
+    }
+
+    #[test]
+    fn verbosity_verbose_is_verbose() {
+        assert!(Verbosity::Verbose.is_verbose());
+    }
+
+    // ── format_elapsed ───────────────────────────────────────────────
+
+    #[test]
+    fn format_elapsed_below_threshold_is_empty() {
+        let result = format_elapsed(Duration::from_millis(50));
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn format_elapsed_at_threshold_shows_time() {
+        let result = format_elapsed(Duration::from_millis(100));
+        assert_eq!(result, " (0.1s)");
+    }
+
+    #[test]
+    fn format_elapsed_above_threshold_shows_time() {
+        let result = format_elapsed(Duration::from_millis(1500));
+        assert_eq!(result, " (1.5s)");
+    }
+
+    #[test]
+    fn format_elapsed_large_duration() {
+        let result = format_elapsed(Duration::from_secs(66));
+        assert_eq!(result, " (66.0s)");
+    }
+
+    // ── Progress construction ────────────────────────────────────────
+
+    #[test]
+    fn progress_disabled_reports_not_enabled() {
+        let p = Progress::new(false, Verbosity::Normal);
+        assert!(!p.is_enabled());
+    }
+
+    #[test]
+    fn progress_enabled_reports_enabled() {
+        let p = Progress::new(true, Verbosity::Normal);
+        assert!(p.is_enabled());
+    }
+
+    #[test]
+    fn progress_verbosity_is_threaded_through() {
+        let p = Progress::new(false, Verbosity::Verbose);
+        assert!(p.is_verbose());
+        assert_eq!(p.verbosity(), Verbosity::Verbose);
+    }
+
+    // ── verbose_step ─────────────────────────────────────────────────
+
+    #[test]
+    fn verbose_step_returns_none_in_normal_mode() {
+        let p = Progress::new(false, Verbosity::Normal);
+        assert!(p.verbose_step("test").is_none());
+    }
+
+    #[test]
+    fn verbose_step_returns_some_in_verbose_mode() {
+        let p = Progress::new(false, Verbosity::Verbose);
+        assert!(p.verbose_step("test").is_some());
+    }
+
+    // ── warn/error/hint output ───────────────────────────────────────
+
+    #[test]
+    fn warn_contains_yellow_triangle() {
+        // Progress::warn() writes through MultiProgress::println().
+        // With a hidden draw target, the output is discarded, but we
+        // can verify the method doesn't panic.
+        let p = Progress::new(false, Verbosity::Normal);
+        p.warn("test warning");
+    }
+
+    #[test]
+    fn error_contains_red_x() {
+        let p = Progress::new(false, Verbosity::Normal);
+        p.error("test error");
+    }
+
+    #[test]
+    fn hint_contains_dim_arrow() {
+        let p = Progress::new(false, Verbosity::Normal);
+        p.hint("try this fix");
+    }
+
+    // ── IndicatifLineWriter ──────────────────────────────────────────
+
+    #[test]
+    fn indicatif_line_writer_buffers_and_flushes() {
+        use std::io::Write;
+        let multi = MultiProgress::with_draw_target(indicatif::ProgressDrawTarget::hidden());
+        let mut writer = IndicatifLineWriter {
+            multi,
+            buf: Vec::new(),
+        };
+        writer.write_all(b"hello world\n").unwrap();
+        writer.flush().unwrap();
+        // Buffer should be cleared after flush
+        assert!(writer.buf.is_empty());
+    }
+
+    #[test]
+    fn indicatif_line_writer_empty_flush_is_noop() {
+        use std::io::Write;
+        let multi = MultiProgress::with_draw_target(indicatif::ProgressDrawTarget::hidden());
+        let mut writer = IndicatifLineWriter {
+            multi,
+            buf: Vec::new(),
+        };
+        writer.flush().unwrap();
+        assert!(writer.buf.is_empty());
+    }
+
+    // ── Snapshot tests for output formatting ─────────────────────────
+
+    #[test]
+    fn snapshot_format_elapsed_values() {
+        let cases = [
+            (Duration::from_millis(0), "0ms"),
+            (Duration::from_millis(50), "50ms"),
+            (Duration::from_millis(99), "99ms"),
+            (Duration::from_millis(100), "100ms"),
+            (Duration::from_millis(500), "500ms"),
+            (Duration::from_secs(1), "1s"),
+            (Duration::from_secs(10), "10s"),
+            (Duration::from_secs(66), "66s"),
+        ];
+
+        let results: Vec<String> = cases
+            .iter()
+            .map(|(dur, label)| {
+                let formatted = format_elapsed(*dur);
+                let display = if formatted.is_empty() {
+                    "(empty)".to_string()
+                } else {
+                    formatted
+                };
+                format!("{label}: {display}")
+            })
+            .collect();
+
+        insta::assert_snapshot!(results.join("\n"), @r"
+        0ms: (empty)
+        50ms: (empty)
+        99ms: (empty)
+        100ms:  (0.1s)
+        500ms:  (0.5s)
+        1s:  (1.0s)
+        10s:  (10.0s)
+        66s:  (66.0s)
+        ");
     }
 }

--- a/crates/cella-config/src/lib.rs
+++ b/crates/cella-config/src/lib.rs
@@ -3,7 +3,7 @@ pub mod settings;
 
 // Re-export all devcontainer modules at crate root for backward compatibility.
 pub use devcontainer::*;
-pub use settings::{ClaudeCode, Settings};
+pub use settings::{ClaudeCode, Codex, Gemini, Settings};
 
 /// Types and validators generated from the devcontainer JSON Schema.
 #[allow(

--- a/crates/cella-config/src/settings/codex.rs
+++ b/crates/cella-config/src/settings/codex.rs
@@ -1,0 +1,80 @@
+use serde::Deserialize;
+
+const fn default_true() -> bool {
+    true
+}
+
+fn default_latest() -> String {
+    "latest".to_string()
+}
+
+/// `OpenAI` Codex CLI tool settings.
+///
+/// Controls automatic installation and config forwarding of the Codex CLI
+/// into dev containers.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Codex {
+    /// Install Codex in the container (default: true).
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+
+    /// Bind-mount `~/.codex` from host into the container (default: true).
+    #[serde(default = "default_true")]
+    pub forward_config: bool,
+
+    /// Version to install: `"latest"` or pinned e.g. `"0.1.2"`.
+    #[serde(default = "default_latest")]
+    pub version: String,
+}
+
+impl Default for Codex {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            forward_config: true,
+            version: "latest".to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_enables_all() {
+        let settings = Codex::default();
+        assert!(settings.enabled);
+        assert!(settings.forward_config);
+        assert_eq!(settings.version, "latest");
+    }
+
+    #[test]
+    fn deserialize_empty_uses_defaults() {
+        let settings: Codex = toml::from_str("").unwrap();
+        assert!(settings.enabled);
+        assert!(settings.forward_config);
+        assert_eq!(settings.version, "latest");
+    }
+
+    #[test]
+    fn deserialize_disabled() {
+        let settings: Codex = toml::from_str("enabled = false\nforward_config = false").unwrap();
+        assert!(!settings.enabled);
+        assert!(!settings.forward_config);
+    }
+
+    #[test]
+    fn deserialize_pinned_version() {
+        let settings: Codex = toml::from_str("version = \"0.1.2\"").unwrap();
+        assert_eq!(settings.version, "0.1.2");
+    }
+
+    #[test]
+    fn deserialize_only_enabled() {
+        let settings: Codex = toml::from_str("enabled = true").unwrap();
+        assert!(settings.enabled);
+        assert!(settings.forward_config);
+        assert_eq!(settings.version, "latest");
+    }
+}

--- a/crates/cella-config/src/settings/gemini.rs
+++ b/crates/cella-config/src/settings/gemini.rs
@@ -1,0 +1,80 @@
+use serde::Deserialize;
+
+const fn default_true() -> bool {
+    true
+}
+
+fn default_latest() -> String {
+    "latest".to_string()
+}
+
+/// Google Gemini CLI tool settings.
+///
+/// Controls automatic installation and config forwarding of the Gemini CLI
+/// into dev containers.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Gemini {
+    /// Install Gemini CLI in the container (default: true).
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+
+    /// Bind-mount `~/.gemini` from host into the container (default: true).
+    #[serde(default = "default_true")]
+    pub forward_config: bool,
+
+    /// Version to install: `"latest"` or pinned e.g. `"0.1.2"`.
+    #[serde(default = "default_latest")]
+    pub version: String,
+}
+
+impl Default for Gemini {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            forward_config: true,
+            version: "latest".to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_enables_all() {
+        let settings = Gemini::default();
+        assert!(settings.enabled);
+        assert!(settings.forward_config);
+        assert_eq!(settings.version, "latest");
+    }
+
+    #[test]
+    fn deserialize_empty_uses_defaults() {
+        let settings: Gemini = toml::from_str("").unwrap();
+        assert!(settings.enabled);
+        assert!(settings.forward_config);
+        assert_eq!(settings.version, "latest");
+    }
+
+    #[test]
+    fn deserialize_disabled() {
+        let settings: Gemini = toml::from_str("enabled = false\nforward_config = false").unwrap();
+        assert!(!settings.enabled);
+        assert!(!settings.forward_config);
+    }
+
+    #[test]
+    fn deserialize_pinned_version() {
+        let settings: Gemini = toml::from_str("version = \"0.1.2\"").unwrap();
+        assert_eq!(settings.version, "0.1.2");
+    }
+
+    #[test]
+    fn deserialize_only_enabled() {
+        let settings: Gemini = toml::from_str("enabled = true").unwrap();
+        assert!(settings.enabled);
+        assert!(settings.forward_config);
+        assert_eq!(settings.version, "latest");
+    }
+}

--- a/crates/cella-config/src/settings/mod.rs
+++ b/crates/cella-config/src/settings/mod.rs
@@ -1,5 +1,7 @@
 mod claude_code;
+mod codex;
 mod credentials;
+mod gemini;
 
 use std::path::Path;
 
@@ -7,7 +9,9 @@ use serde::Deserialize;
 use tracing::debug;
 
 pub use claude_code::ClaudeCode;
+pub use codex::Codex;
 pub use credentials::Credentials;
+pub use gemini::Gemini;
 
 /// Tool installation and forwarding settings.
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -15,6 +19,14 @@ pub struct Tools {
     /// Claude Code settings.
     #[serde(default, rename = "claude-code")]
     pub claude_code: ClaudeCode,
+
+    /// `OpenAI` Codex CLI settings.
+    #[serde(default)]
+    pub codex: Codex,
+
+    /// Google Gemini CLI settings.
+    #[serde(default)]
+    pub gemini: Gemini,
 }
 
 /// Cella's own settings, loaded from TOML config files.
@@ -74,20 +86,34 @@ impl Settings {
         }
     }
 
-    /// Merge global and project settings. Project overrides global per-key.
+    /// Merge global and project settings. Project overrides global per-section.
+    ///
+    /// Destructuring both sides forces a compile error when new fields are added
+    /// to `Settings` or `Tools` without updating this method.
     fn merge(global: Option<Self>, project: Option<Self>) -> Self {
         match (global, project) {
             (None, None) => Self::default(),
             (Some(g), None) => g,
             (None, Some(p)) => p,
-            (Some(_global), Some(p)) => Self {
-                credentials: Credentials {
-                    gh: p.credentials.gh,
-                },
-                tools: Tools {
-                    claude_code: p.tools.claude_code,
-                },
-            },
+            (Some(_g), Some(p)) => {
+                let Self {
+                    credentials: pc,
+                    tools: pt,
+                } = p;
+                let Tools {
+                    claude_code: pt_claude,
+                    codex: pt_codex,
+                    gemini: pt_gemini,
+                } = pt;
+                Self {
+                    credentials: pc,
+                    tools: Tools {
+                        claude_code: pt_claude,
+                        codex: pt_codex,
+                        gemini: pt_gemini,
+                    },
+                }
+            }
         }
     }
 }
@@ -104,6 +130,12 @@ mod tests {
         assert!(settings.tools.claude_code.enabled);
         assert!(settings.tools.claude_code.forward_config);
         assert_eq!(settings.tools.claude_code.version, "latest");
+        assert!(settings.tools.codex.enabled);
+        assert!(settings.tools.codex.forward_config);
+        assert_eq!(settings.tools.codex.version, "latest");
+        assert!(settings.tools.gemini.enabled);
+        assert!(settings.tools.gemini.forward_config);
+        assert_eq!(settings.tools.gemini.version, "latest");
     }
 
     #[test]
@@ -144,11 +176,23 @@ gh = false
 [tools.claude-code]
 enabled = false
 version = "stable"
+
+[tools.codex]
+enabled = false
+version = "0.1.2"
+
+[tools.gemini]
+enabled = false
+version = "0.5.0"
 "#;
         let settings: Settings = toml::from_str(toml_str).unwrap();
         assert!(!settings.credentials.gh);
         assert!(!settings.tools.claude_code.enabled);
         assert_eq!(settings.tools.claude_code.version, "stable");
+        assert!(!settings.tools.codex.enabled);
+        assert_eq!(settings.tools.codex.version, "0.1.2");
+        assert!(!settings.tools.gemini.enabled);
+        assert_eq!(settings.tools.gemini.version, "0.5.0");
     }
 
     #[test]
@@ -165,8 +209,44 @@ exclude = ["plans/**"]
         assert!(!settings.tools.claude_code.forward_config);
         assert_eq!(settings.tools.claude_code.version, "1.0.58");
         assert_eq!(settings.tools.claude_code.exclude, vec!["plans/**"]);
-        // credentials should still be default
+        // credentials and other tools should still be default
         assert!(settings.credentials.gh);
+        assert!(settings.tools.codex.enabled);
+        assert!(settings.tools.gemini.enabled);
+    }
+
+    #[test]
+    fn parse_codex_only() {
+        let toml_str = r#"
+[tools.codex]
+enabled = false
+forward_config = false
+version = "0.1.2"
+"#;
+        let settings: Settings = toml::from_str(toml_str).unwrap();
+        assert!(!settings.tools.codex.enabled);
+        assert!(!settings.tools.codex.forward_config);
+        assert_eq!(settings.tools.codex.version, "0.1.2");
+        // other tools default
+        assert!(settings.tools.claude_code.enabled);
+        assert!(settings.tools.gemini.enabled);
+    }
+
+    #[test]
+    fn parse_gemini_only() {
+        let toml_str = r#"
+[tools.gemini]
+enabled = false
+forward_config = false
+version = "0.5.0"
+"#;
+        let settings: Settings = toml::from_str(toml_str).unwrap();
+        assert!(!settings.tools.gemini.enabled);
+        assert!(!settings.tools.gemini.forward_config);
+        assert_eq!(settings.tools.gemini.version, "0.5.0");
+        // other tools default
+        assert!(settings.tools.claude_code.enabled);
+        assert!(settings.tools.codex.enabled);
     }
 
     #[test]

--- a/crates/cella-daemon/Cargo.toml
+++ b/crates/cella-daemon/Cargo.toml
@@ -11,6 +11,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/cella-daemon/src/lib.rs
+++ b/crates/cella-daemon/src/lib.rs
@@ -11,6 +11,7 @@ pub mod credential;
 pub mod daemon;
 mod error;
 pub mod health;
+pub mod logging;
 pub mod management;
 pub mod orbstack;
 pub mod port_manager;

--- a/crates/cella-daemon/src/logging.rs
+++ b/crates/cella-daemon/src/logging.rs
@@ -1,0 +1,45 @@
+//! Daemon file-based logging.
+//!
+//! Initializes a `tracing` subscriber that writes to `~/.cella/daemon.log`.
+//! Uses `CELLA_DAEMON_LOG` (or `RUST_LOG`) for filtering, defaulting to `info`.
+
+use std::fs::{File, OpenOptions};
+use std::path::Path;
+
+use tracing_subscriber::EnvFilter;
+
+/// Maximum log file size before truncation (5 MB).
+const MAX_LOG_SIZE: u64 = 5 * 1024 * 1024;
+
+/// Initialize file-based tracing for the daemon process.
+///
+/// Writes to the given log path. If the file exceeds [`MAX_LOG_SIZE`],
+/// it is truncated before opening.
+///
+/// Filter priority: `CELLA_DAEMON_LOG` > `RUST_LOG` > default `info`.
+pub fn init_daemon_logging(log_path: &Path) {
+    // Truncate if over size limit.
+    if std::fs::metadata(log_path).is_ok_and(|m| m.len() > MAX_LOG_SIZE) {
+        let _ = File::create(log_path);
+    }
+
+    let file = OpenOptions::new().create(true).append(true).open(log_path);
+
+    let Ok(file) = file else {
+        // Can't open log file — fall back to no-op.
+        return;
+    };
+
+    let filter = std::env::var("CELLA_DAEMON_LOG")
+        .or_else(|_| std::env::var("RUST_LOG"))
+        .unwrap_or_else(|_| "info".to_string());
+
+    let subscriber = tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::new(filter))
+        .with_writer(file)
+        .with_ansi(false)
+        .with_target(true)
+        .compact();
+
+    let _ = subscriber.try_init();
+}

--- a/crates/cella-docker/src/docker_api_impl.rs
+++ b/crates/cella-docker/src/docker_api_impl.rs
@@ -114,7 +114,7 @@ impl DockerApi for DockerClient {
         &'a self,
         opts: &'a BuildOptions,
     ) -> BoxFuture<'a, Result<String, CellaDockerError>> {
-        Box::pin(DockerClient::build_image(self, opts))
+        Box::pin(DockerClient::build_image(self, opts, |_| {}))
     }
 
     fn image_exists<'a>(&'a self, image: &'a str) -> BoxFuture<'a, Result<bool, CellaDockerError>> {

--- a/crates/cella-docker/src/image.rs
+++ b/crates/cella-docker/src/image.rs
@@ -195,47 +195,37 @@ impl DockerClient {
                 source,
             })?;
 
-        // Read stdout and stderr concurrently, collecting lines.
-        let stdout_task = child.stdout.take().map(|stdout| {
+        // Stream stdout and stderr lines in real-time via a channel.
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+
+        if let Some(stdout) = child.stdout.take() {
+            let tx = tx.clone();
             tokio::spawn(async move {
                 use tokio::io::{AsyncBufReadExt, BufReader};
                 let mut lines = BufReader::new(stdout).lines();
-                let mut collected = Vec::new();
                 while let Ok(Some(line)) = lines.next_line().await {
-                    collected.push(line);
+                    let _ = tx.send(line);
                 }
-                collected
-            })
-        });
+            });
+        }
 
-        let stderr_task = child.stderr.take().map(|stderr| {
+        if let Some(stderr) = child.stderr.take() {
+            let tx = tx.clone();
             tokio::spawn(async move {
                 use tokio::io::{AsyncBufReadExt, BufReader};
                 let mut lines = BufReader::new(stderr).lines();
-                let mut collected = Vec::new();
                 while let Ok(Some(line)) = lines.next_line().await {
-                    collected.push(line);
+                    let _ = tx.send(line);
                 }
-                collected
-            })
-        });
-
-        // Wait for output collection and process exit
-        let stdout_lines = match stdout_task {
-            Some(task) => task.await.unwrap_or_default(),
-            None => Vec::new(),
-        };
-        let stderr_lines = match stderr_task {
-            Some(task) => task.await.unwrap_or_default(),
-            None => Vec::new(),
-        };
-
-        // Forward collected lines through the callback
-        for line in &stdout_lines {
-            on_output(line);
+            });
         }
-        for line in &stderr_lines {
-            on_output(line);
+
+        // Drop our sender so rx closes when spawned tasks finish.
+        drop(tx);
+
+        // Forward lines to the callback as they arrive.
+        while let Some(line) = rx.recv().await {
+            on_output(&line);
         }
 
         let status = child

--- a/crates/cella-docker/src/image.rs
+++ b/crates/cella-docker/src/image.rs
@@ -160,10 +160,17 @@ impl DockerClient {
     /// Prefers `docker buildx build` when available. Falls back to
     /// `docker build` with `DOCKER_BUILDKIT=1` otherwise.
     ///
+    /// Build output (stdout/stderr) is captured and forwarded to the
+    /// provided callback line by line. Pass `|_| {}` to discard output.
+    ///
     /// # Errors
     ///
     /// Returns error if the docker CLI is not found or the build fails.
-    pub async fn build_image(&self, opts: &BuildOptions) -> Result<String, CellaDockerError> {
+    pub async fn build_image(
+        &self,
+        opts: &BuildOptions,
+        mut on_output: impl FnMut(&str),
+    ) -> Result<String, CellaDockerError> {
         info!("Building image: {}", opts.image_name);
 
         let bin = docker_binary()?;
@@ -174,15 +181,65 @@ impl DockerClient {
 
         let mut cmd = tokio::process::Command::new(bin);
         cmd.args(&args)
-            .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit());
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
 
         if !use_buildx {
             cmd.env("DOCKER_BUILDKIT", "1");
         }
 
-        let status = cmd
-            .status()
+        let mut child = cmd
+            .spawn()
+            .map_err(|source| CellaDockerError::HostCommandFailed {
+                command: format!("{bin} {}", args.join(" ")),
+                source,
+            })?;
+
+        // Read stdout and stderr concurrently, collecting lines.
+        let stdout_task = child.stdout.take().map(|stdout| {
+            tokio::spawn(async move {
+                use tokio::io::{AsyncBufReadExt, BufReader};
+                let mut lines = BufReader::new(stdout).lines();
+                let mut collected = Vec::new();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    collected.push(line);
+                }
+                collected
+            })
+        });
+
+        let stderr_task = child.stderr.take().map(|stderr| {
+            tokio::spawn(async move {
+                use tokio::io::{AsyncBufReadExt, BufReader};
+                let mut lines = BufReader::new(stderr).lines();
+                let mut collected = Vec::new();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    collected.push(line);
+                }
+                collected
+            })
+        });
+
+        // Wait for output collection and process exit
+        let stdout_lines = match stdout_task {
+            Some(task) => task.await.unwrap_or_default(),
+            None => Vec::new(),
+        };
+        let stderr_lines = match stderr_task {
+            Some(task) => task.await.unwrap_or_default(),
+            None => Vec::new(),
+        };
+
+        // Forward collected lines through the callback
+        for line in &stdout_lines {
+            on_output(line);
+        }
+        for line in &stderr_lines {
+            on_output(line);
+        }
+
+        let status = child
+            .wait()
             .await
             .map_err(|source| CellaDockerError::HostCommandFailed {
                 command: format!("{bin} {}", args.join(" ")),

--- a/crates/cella-docker/src/lifecycle.rs
+++ b/crates/cella-docker/src/lifecycle.rs
@@ -98,7 +98,7 @@ impl<'a> CallbackWriter<'a> {
         while let Some(pos) = self.buf.iter().position(|&b| b == b'\n') {
             let line = String::from_utf8_lossy(&self.buf[..pos]);
             if !line.trim().is_empty() {
-                (self.callback)(&format!("    {line}"));
+                (self.callback)(&format!("      {line}"));
             }
             self.buf.drain(..=pos);
         }
@@ -108,7 +108,7 @@ impl<'a> CallbackWriter<'a> {
         if !self.buf.is_empty() {
             let line = String::from_utf8_lossy(&self.buf);
             if !line.trim().is_empty() {
-                (self.callback)(&format!("    {line}"));
+                (self.callback)(&format!("      {line}"));
             }
             self.buf.clear();
         }
@@ -356,22 +356,22 @@ mod tests {
     fn callback_writer_indents_lines() {
         let lines = collect_callback_lines(b"first line\nsecond line\n");
         assert_eq!(lines.len(), 2);
-        assert_eq!(lines[0], "    first line");
-        assert_eq!(lines[1], "    second line");
+        assert_eq!(lines[0], "      first line");
+        assert_eq!(lines[1], "      second line");
     }
 
     #[test]
     fn callback_writer_flushes_partial_line_on_drop() {
         let lines = collect_callback_lines(b"no newline");
         assert_eq!(lines.len(), 1);
-        assert_eq!(lines[0], "    no newline");
+        assert_eq!(lines[0], "      no newline");
     }
 
     #[test]
     fn callback_writer_skips_blank_lines() {
         let lines = collect_callback_lines(b"content\n\n  \nanother\n");
         assert_eq!(lines.len(), 2);
-        assert_eq!(lines[0], "    content");
-        assert_eq!(lines[1], "    another");
+        assert_eq!(lines[0], "      content");
+        assert_eq!(lines[1], "      another");
     }
 }

--- a/crates/cella-docker/src/lifecycle.rs
+++ b/crates/cella-docker/src/lifecycle.rs
@@ -1,7 +1,7 @@
 //! Lifecycle command parsing and execution.
 
 use serde_json::Value;
-use tracing::debug;
+use tracing::{debug, info};
 
 use crate::CellaDockerError;
 use crate::client::DockerClient;
@@ -196,9 +196,7 @@ pub async fn run_lifecycle_phase(
     value: &Value,
     origin: &str,
 ) -> Result<(), CellaDockerError> {
-    if ctx.is_text {
-        eprintln!("Running the {phase} from {origin}...");
-    }
+    info!("Running the {phase} from {origin}...");
     debug!("Running {phase} from {origin}");
 
     match parse_lifecycle_command(value) {

--- a/crates/cella-docker/src/lifecycle.rs
+++ b/crates/cella-docker/src/lifecycle.rs
@@ -1,5 +1,7 @@
 //! Lifecycle command parsing and execution.
 
+use std::io;
+
 use serde_json::Value;
 use tracing::{debug, info};
 
@@ -53,6 +55,9 @@ pub fn parse_lifecycle_command(value: &Value) -> ParsedLifecycle {
     }
 }
 
+/// Callback type for routing lifecycle output through a progress system.
+pub type OutputCallback<'a> = Box<dyn Fn(&str) + Send + Sync + 'a>;
+
 /// Shared container context for lifecycle phase execution.
 pub struct LifecycleContext<'a> {
     /// Docker client.
@@ -67,6 +72,66 @@ pub struct LifecycleContext<'a> {
     pub working_dir: Option<&'a str>,
     /// Whether to print progress and stream output to stderr.
     pub is_text: bool,
+    /// Optional callback for routing output lines through a progress system.
+    ///
+    /// When set, sequential lifecycle output is written through this callback
+    /// (e.g., indented under an active spinner) instead of directly to stderr.
+    pub on_output: Option<OutputCallback<'a>>,
+}
+
+/// A `Write` adapter that buffers lines and forwards each complete line
+/// through a callback with indentation.
+struct CallbackWriter<'a> {
+    callback: &'a (dyn Fn(&str) + Send + Sync),
+    buf: Vec<u8>,
+}
+
+impl<'a> CallbackWriter<'a> {
+    fn new(callback: &'a (dyn Fn(&str) + Send + Sync)) -> Self {
+        Self {
+            callback,
+            buf: Vec::with_capacity(256),
+        }
+    }
+
+    fn flush_lines(&mut self) {
+        while let Some(pos) = self.buf.iter().position(|&b| b == b'\n') {
+            let line = String::from_utf8_lossy(&self.buf[..pos]);
+            if !line.trim().is_empty() {
+                (self.callback)(&format!("    {line}"));
+            }
+            self.buf.drain(..=pos);
+        }
+    }
+
+    fn flush_remaining(&mut self) {
+        if !self.buf.is_empty() {
+            let line = String::from_utf8_lossy(&self.buf);
+            if !line.trim().is_empty() {
+                (self.callback)(&format!("    {line}"));
+            }
+            self.buf.clear();
+        }
+    }
+}
+
+impl io::Write for CallbackWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buf.extend_from_slice(buf);
+        self.flush_lines();
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.flush_remaining();
+        Ok(())
+    }
+}
+
+impl Drop for CallbackWriter<'_> {
+    fn drop(&mut self) {
+        self.flush_remaining();
+    }
 }
 
 /// Run sequential lifecycle commands, streaming output when `is_text`.
@@ -87,14 +152,27 @@ async fn run_sequential(
             working_dir: ctx.working_dir.map(String::from),
         };
         let result = if ctx.is_text {
-            ctx.client
-                .exec_stream(
-                    ctx.container_id,
-                    &opts,
-                    std::io::stderr(),
-                    std::io::stderr(),
-                )
-                .await?
+            if let Some(ref on_output) = ctx.on_output {
+                // Route through progress system with indentation
+                ctx.client
+                    .exec_stream(
+                        ctx.container_id,
+                        &opts,
+                        CallbackWriter::new(on_output.as_ref()),
+                        CallbackWriter::new(on_output.as_ref()),
+                    )
+                    .await?
+            } else {
+                // Fallback: stream directly to stderr
+                ctx.client
+                    .exec_stream(
+                        ctx.container_id,
+                        &opts,
+                        std::io::stderr(),
+                        std::io::stderr(),
+                    )
+                    .await?
+            }
         } else {
             ctx.client.exec_command(ctx.container_id, &opts).await?
         };
@@ -257,5 +335,43 @@ mod tests {
             }
             ParsedLifecycle::Parallel(_) => panic!("expected Sequential"),
         }
+    }
+
+    fn collect_callback_lines(input: &[u8]) -> Vec<String> {
+        use std::sync::Mutex;
+
+        let collected = Mutex::new(Vec::new());
+        let callback = |line: &str| {
+            collected.lock().unwrap().push(line.to_string());
+        };
+
+        let mut writer = CallbackWriter::new(&callback);
+        io::Write::write_all(&mut writer, input).unwrap();
+        drop(writer);
+
+        collected.into_inner().unwrap()
+    }
+
+    #[test]
+    fn callback_writer_indents_lines() {
+        let lines = collect_callback_lines(b"first line\nsecond line\n");
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0], "    first line");
+        assert_eq!(lines[1], "    second line");
+    }
+
+    #[test]
+    fn callback_writer_flushes_partial_line_on_drop() {
+        let lines = collect_callback_lines(b"no newline");
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0], "    no newline");
+    }
+
+    #[test]
+    fn callback_writer_skips_blank_lines() {
+        let lines = collect_callback_lines(b"content\n\n  \nanother\n");
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0], "    content");
+        assert_eq!(lines[1], "    another");
     }
 }

--- a/crates/cella-env/src/codex.rs
+++ b/crates/cella-env/src/codex.rs
@@ -1,0 +1,34 @@
+//! `OpenAI` Codex CLI host detection and container path helpers.
+//!
+//! Detects host `~/.codex/` directory for bind-mount forwarding.
+
+use std::path::PathBuf;
+
+use crate::claude_code::container_home;
+
+/// Host-side `~/.codex` directory path (if it exists).
+pub fn host_codex_dir() -> Option<PathBuf> {
+    let home = std::env::var("HOME").ok().map(PathBuf::from)?;
+    let dir = home.join(".codex");
+    if dir.is_dir() { Some(dir) } else { None }
+}
+
+/// Container-side `~/.codex` directory path for a given user.
+pub fn container_codex_dir(remote_user: &str) -> String {
+    format!("{}/.codex", container_home(remote_user))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn container_codex_dir_root() {
+        assert_eq!(container_codex_dir("root"), "/root/.codex");
+    }
+
+    #[test]
+    fn container_codex_dir_regular() {
+        assert_eq!(container_codex_dir("vscode"), "/home/vscode/.codex");
+    }
+}

--- a/crates/cella-env/src/gemini.rs
+++ b/crates/cella-env/src/gemini.rs
@@ -1,0 +1,34 @@
+//! Google Gemini CLI host detection and container path helpers.
+//!
+//! Detects host `~/.gemini/` directory for bind-mount forwarding.
+
+use std::path::PathBuf;
+
+use crate::claude_code::container_home;
+
+/// Host-side `~/.gemini` directory path (if it exists).
+pub fn host_gemini_dir() -> Option<PathBuf> {
+    let home = std::env::var("HOME").ok().map(PathBuf::from)?;
+    let dir = home.join(".gemini");
+    if dir.is_dir() { Some(dir) } else { None }
+}
+
+/// Container-side `~/.gemini` directory path for a given user.
+pub fn container_gemini_dir(remote_user: &str) -> String {
+    format!("{}/.gemini", container_home(remote_user))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn container_gemini_dir_root() {
+        assert_eq!(container_gemini_dir("root"), "/root/.gemini");
+    }
+
+    #[test]
+    fn container_gemini_dir_regular() {
+        assert_eq!(container_gemini_dir("vscode"), "/home/vscode/.gemini");
+    }
+}

--- a/crates/cella-env/src/lib.rs
+++ b/crates/cella-env/src/lib.rs
@@ -5,7 +5,9 @@
 //! for the container.
 
 pub mod claude_code;
+pub mod codex;
 mod error;
+pub mod gemini;
 pub mod gh_credential;
 pub mod git_config;
 pub mod git_credential;


### PR DESCRIPTION
## Summary

- **Codex & Gemini CLI support**: config forwarding (bind mounts of `~/.codex` and `~/.gemini`), auto-install via npm with version pinning, parallel tool installation (~72s → ~50s), npm EACCES fix by running as `remote_user`, and `userEnvProbe`-aware PATH detection for feature-installed npm (e.g. nvm)
- **Progress display overhaul**: replace broken `eprint`/`eprintln` logging with `indicatif` spinners (`Progress`/`Step`/`Phase` types), two-axis verbosity (`--verbose` for user output, `RUST_LOG` for developer tracing), TTY auto-detection, Docker build streaming via `mpsc` channel, lifecycle phase spinners with indented output, and `cella logs` command
- **Daemon logging**: file-based tracing output to `~/.cella/daemon.log` with auto-truncation at 5 MB, viewable via `cella logs --daemon`

## Test plan

- [x] `cella up` in a devcontainer with Claude, Codex, and Gemini enabled — verify parallel install, spinners, and config bind mounts
- [x] `cella up` with `--verbose` — verify expanded output
- [x] `cella up` with `RUST_LOG=debug` — verify spinners auto-disable and tracing output is clean
- [x] `cella up` piped to file — verify plain text fallback (no ANSI)
- [x] `cella build` — verify Docker build output streams in real-time under spinners
- [x] `cella logs --daemon` — verify daemon log file contents
- [x] `cargo test --workspace` — all unit tests pass (20 new tests including insta snapshots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)