### PR TITLE
fix: Claude Code plugin manifests and exec PATH resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,12 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -248,6 +254,7 @@ name = "cella-agent"
 version = "0.0.7"
 dependencies = [
  "cella-port",
+ "notify",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
@@ -605,7 +612,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "document-features",
  "parking_lot",
  "rustix",
@@ -754,6 +761,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futures-channel"
@@ -1217,6 +1233,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+dependencies = [
+ "bitflags 2.11.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "insta"
 version = "1.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1345,6 +1381,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1368,7 +1424,7 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
  "plain",
  "redox_syscall 0.7.3",
@@ -1481,6 +1537,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1491,10 +1548,37 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1835,7 +1919,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1844,7 +1928,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1995,7 +2079,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2120,7 +2204,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2586,7 +2670,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -2926,7 +3010,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3355,7 +3439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,9 @@ reqwest = { version = "0.13.2", default-features = false, features = [
 regex = "1.12.3"
 glob = "0.3.3"
 
+# File watching
+notify = "8.0.0"
+
 # Process inspection
 nix = { version = "0.31.2", default-features = false, features = ["signal"] }
 

--- a/crates/cella-agent/Cargo.toml
+++ b/crates/cella-agent/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 cella-port.workspace = true
+notify.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/crates/cella-agent/src/main.rs
+++ b/crates/cella-agent/src/main.rs
@@ -164,9 +164,8 @@ async fn run_daemon(poll_interval_ms: u64) {
 
     // Spawn plugin manifest sync watcher (reverse-rewrites paths back to host)
     let container_home = std::env::var("HOME").unwrap_or_default();
-    let host_home = std::env::var("CELLA_HOST_HOME").unwrap_or_default();
-    if !host_home.is_empty() && host_home != container_home {
-        tokio::spawn(plugin_sync::run(container_home, host_home));
+    if !container_home.is_empty() {
+        tokio::spawn(plugin_sync::run(container_home));
     }
 
     // Spawn health reporter

--- a/crates/cella-agent/src/main.rs
+++ b/crates/cella-agent/src/main.rs
@@ -9,6 +9,7 @@
 mod browser;
 mod control;
 mod credential;
+mod plugin_sync;
 mod port_proxy;
 mod port_watcher;
 mod reconnecting_client;
@@ -160,6 +161,13 @@ async fn run_daemon(poll_interval_ms: u64) {
     let watcher_handle = tokio::spawn(async move {
         port_watcher::run(poll_interval, ctrl, pd, pm).await;
     });
+
+    // Spawn plugin manifest sync watcher (reverse-rewrites paths back to host)
+    let container_home = std::env::var("HOME").unwrap_or_default();
+    let host_home = std::env::var("CELLA_HOST_HOME").unwrap_or_default();
+    if !host_home.is_empty() && host_home != container_home {
+        tokio::spawn(plugin_sync::run(container_home, host_home));
+    }
 
     // Spawn health reporter
     let ctrl = control.clone();

--- a/crates/cella-agent/src/plugin_sync.rs
+++ b/crates/cella-agent/src/plugin_sync.rs
@@ -21,18 +21,46 @@ const SYNC_FILES: &[&str] = &["installed_plugins.json", "known_marketplaces.json
 /// Host-side plugins directory (bind-mounted at this path inside the container).
 const HOST_PLUGINS_DIR: &str = "/tmp/.cella/host-plugins";
 
+/// Detect the original home path from a host JSON file by finding `/.claude/`
+/// path references. Returns the home portion (e.g., `/home/node`).
+fn detect_home_from_json(content: &str) -> Option<String> {
+    // Look for patterns like "/home/USER/.claude/" or "/Users/USER/.claude/"
+    // or "/root/.claude/" in JSON string values
+    for line in content.lines() {
+        // Find /.claude/ and extract the home prefix
+        if let Some(idx) = line.find("/.claude/") {
+            // Walk backwards to find the start of the path (after a quote)
+            let prefix = &line[..idx];
+            if let Some(quote_idx) = prefix.rfind('"') {
+                let home = &prefix[quote_idx + 1..];
+                if home.starts_with('/') {
+                    return Some(home.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
 /// Run the plugin manifest sync watcher.
 ///
 /// Watches the container's plugin manifest files and reverse-rewrites paths
-/// back to the host on every change. Runs until the channel closes (container
-/// shutdown).
-pub async fn run(container_home: String, host_home: String) {
+/// back to the host on every change. Detects the original host home path from
+/// the host's JSON files at startup.
+pub async fn run(container_home: String) {
     let plugins_dir = format!("{container_home}/.claude/plugins");
 
     if !Path::new(&plugins_dir).exists() || !Path::new(HOST_PLUGINS_DIR).exists() {
         tracing::debug!("Plugin sync: paths not ready, skipping");
         return;
     }
+
+    // Detect the original home path from host JSON files
+    let host_home = detect_host_home().await;
+    let Some(host_home) = host_home else {
+        tracing::debug!("Plugin sync: could not detect host home path, skipping");
+        return;
+    };
 
     let (tx, mut rx) = mpsc::channel::<()>(16);
 
@@ -41,12 +69,12 @@ pub async fn run(container_home: String, host_home: String) {
         if let Ok(event) = res
             && matches!(event.kind, EventKind::Modify(_) | EventKind::Create(_))
         {
-            let dominated = event.paths.iter().any(|p| {
+            let is_sync_file = event.paths.iter().any(|p| {
                 p.file_name()
                     .and_then(|n| n.to_str())
                     .is_some_and(|name| SYNC_FILES.contains(&name))
             });
-            if dominated {
+            if is_sync_file {
                 let _ = tx.blocking_send(());
             }
         }
@@ -63,13 +91,12 @@ pub async fn run(container_home: String, host_home: String) {
         return;
     }
 
-    tracing::debug!("Plugin sync: watching {watch_dir}");
+    tracing::debug!("Plugin sync: watching {watch_dir}, host home: {host_home}");
 
     let from_prefix = format!("{container_home}/.claude");
     let to_prefix = format!("{host_home}/.claude");
 
     loop {
-        // Wait for an event
         if rx.recv().await.is_none() {
             break;
         }
@@ -95,5 +122,50 @@ pub async fn run(container_home: String, host_home: String) {
                 tracing::debug!("Plugin sync: synced {file} back to host");
             }
         }
+    }
+}
+
+/// Detect the original host home path from any host JSON in the hidden mount.
+async fn detect_host_home() -> Option<String> {
+    for &file in SYNC_FILES {
+        let path = PathBuf::from(HOST_PLUGINS_DIR).join(file);
+        if let Ok(content) = tokio::fs::read_to_string(&path).await
+            && let Some(home) = detect_home_from_json(&content)
+        {
+            return Some(home);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_home_linux() {
+        let json = r#"{"installPath": "/home/node/.claude/plugins/cache/foo"}"#;
+        assert_eq!(detect_home_from_json(json), Some("/home/node".to_string()));
+    }
+
+    #[test]
+    fn detect_home_macos() {
+        let json = r#"{"path": "/Users/alice/.claude/plugins"}"#;
+        assert_eq!(
+            detect_home_from_json(json),
+            Some("/Users/alice".to_string())
+        );
+    }
+
+    #[test]
+    fn detect_home_root() {
+        let json = r#"{"installLocation": "/root/.claude/plugins/marketplaces/foo"}"#;
+        assert_eq!(detect_home_from_json(json), Some("/root".to_string()));
+    }
+
+    #[test]
+    fn detect_home_no_match() {
+        let json = r#"{"name": "no paths here"}"#;
+        assert_eq!(detect_home_from_json(json), None);
     }
 }

--- a/crates/cella-agent/src/plugin_sync.rs
+++ b/crates/cella-agent/src/plugin_sync.rs
@@ -1,0 +1,99 @@
+//! Bidirectional sync for Claude Code plugin manifest files.
+//!
+//! Watches `installed_plugins.json` and `known_marketplaces.json` in the
+//! container's `~/.claude/plugins/` directory (backed by tmpfs). When Claude
+//! Code modifies these files (plugin install, marketplace refresh), the watcher
+//! reverse-rewrites home paths and writes the result to the host bind mount
+//! at `/tmp/.cella/host-plugins/`.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use notify::{EventKind, RecursiveMode, Watcher};
+use tokio::sync::mpsc;
+
+/// Debounce interval — wait this long after the last event before syncing.
+const DEBOUNCE: Duration = Duration::from_secs(5);
+
+/// Files that need bidirectional path rewriting.
+const SYNC_FILES: &[&str] = &["installed_plugins.json", "known_marketplaces.json"];
+
+/// Host-side plugins directory (bind-mounted at this path inside the container).
+const HOST_PLUGINS_DIR: &str = "/tmp/.cella/host-plugins";
+
+/// Run the plugin manifest sync watcher.
+///
+/// Watches the container's plugin manifest files and reverse-rewrites paths
+/// back to the host on every change. Runs until the channel closes (container
+/// shutdown).
+pub async fn run(container_home: String, host_home: String) {
+    let plugins_dir = format!("{container_home}/.claude/plugins");
+
+    if !Path::new(&plugins_dir).exists() || !Path::new(HOST_PLUGINS_DIR).exists() {
+        tracing::debug!("Plugin sync: paths not ready, skipping");
+        return;
+    }
+
+    let (tx, mut rx) = mpsc::channel::<()>(16);
+
+    let watch_dir = plugins_dir.clone();
+    let mut watcher = match notify::recommended_watcher(move |res: Result<notify::Event, _>| {
+        if let Ok(event) = res
+            && matches!(event.kind, EventKind::Modify(_) | EventKind::Create(_))
+        {
+            let dominated = event.paths.iter().any(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|name| SYNC_FILES.contains(&name))
+            });
+            if dominated {
+                let _ = tx.blocking_send(());
+            }
+        }
+    }) {
+        Ok(w) => w,
+        Err(e) => {
+            tracing::warn!("Plugin sync: failed to create watcher: {e}");
+            return;
+        }
+    };
+
+    if let Err(e) = watcher.watch(Path::new(&watch_dir), RecursiveMode::NonRecursive) {
+        tracing::warn!("Plugin sync: failed to watch {watch_dir}: {e}");
+        return;
+    }
+
+    tracing::debug!("Plugin sync: watching {watch_dir}");
+
+    let from_prefix = format!("{container_home}/.claude");
+    let to_prefix = format!("{host_home}/.claude");
+
+    loop {
+        // Wait for an event
+        if rx.recv().await.is_none() {
+            break;
+        }
+
+        // Debounce: drain buffered events and wait
+        tokio::time::sleep(DEBOUNCE).await;
+        while rx.try_recv().is_ok() {}
+
+        // Reverse-rewrite and sync each file
+        for &file in SYNC_FILES {
+            let src = PathBuf::from(&plugins_dir).join(file);
+            let dst = PathBuf::from(HOST_PLUGINS_DIR).join(file);
+
+            let Ok(content) = tokio::fs::read_to_string(&src).await else {
+                continue;
+            };
+
+            let rewritten = content.replace(&from_prefix, &to_prefix);
+
+            if let Err(e) = tokio::fs::write(&dst, rewritten).await {
+                tracing::warn!("Plugin sync: failed to write {file} to host: {e}");
+            } else {
+                tracing::debug!("Plugin sync: synced {file} back to host");
+            }
+        }
+    }
+}

--- a/crates/cella-cli/src/commands/env_cache.rs
+++ b/crates/cella-cli/src/commands/env_cache.rs
@@ -5,8 +5,14 @@ use tracing::debug;
 use cella_docker::{DockerClient, ExecOptions};
 use cella_env::platform::DockerRuntime;
 
-/// Path inside the container where probed environment is cached.
-const PROBED_ENV_CACHE_PATH: &str = "/tmp/.cella-probed-env.json";
+/// Compute the per-user cache path for the probed environment.
+///
+/// Stores under `$HOME/.cella/probed-env.json` so it survives container
+/// restarts (unlike `/tmp` which can be cleared).
+fn cache_path(user: &str) -> String {
+    let home = cella_env::claude_code::container_home(user);
+    format!("{home}/.cella/probed-env.json")
+}
 
 /// Read the cached probed environment from a running container.
 ///
@@ -17,11 +23,12 @@ pub async fn read_probed_env_cache(
     container_id: &str,
     user: &str,
 ) -> Option<HashMap<String, String>> {
+    let path = cache_path(user);
     let result = client
         .exec_command(
             container_id,
             &ExecOptions {
-                cmd: vec!["cat".to_string(), PROBED_ENV_CACHE_PATH.to_string()],
+                cmd: vec!["cat".to_string(), path],
                 user: Some(user.to_string()),
                 env: None,
                 working_dir: None,
@@ -48,9 +55,10 @@ pub async fn probe_and_cache_user_env(
     container_id: &str,
     user: &str,
     probe_type: &str,
+    shell: &str,
 ) -> Option<HashMap<String, String>> {
-    let env = run_env_probe(client, container_id, user, probe_type).await?;
-    write_env_cache(client, container_id, &env).await;
+    let env = run_env_probe(client, container_id, user, probe_type, shell).await?;
+    write_env_cache(client, container_id, user, &env).await;
     Some(env)
 }
 
@@ -60,10 +68,11 @@ async fn run_env_probe(
     container_id: &str,
     user: &str,
     probe_type: &str,
+    shell: &str,
 ) -> Option<HashMap<String, String>> {
-    let probe_cmd = cella_env::user_env_probe::probe_command(probe_type, "/bin/sh")?;
+    let probe_cmd = cella_env::user_env_probe::probe_command(probe_type, shell)?;
 
-    debug!("Running userEnvProbe ({probe_type}): {probe_cmd:?}");
+    debug!("Running userEnvProbe ({probe_type}) with {shell}: {probe_cmd:?}");
 
     let result = client
         .exec_command(
@@ -92,12 +101,37 @@ async fn run_env_probe(
 }
 
 /// Write the probed environment to a cache file inside the container.
-async fn write_env_cache(client: &DockerClient, container_id: &str, env: &HashMap<String, String>) {
+///
+/// Creates the `~/.cella/` directory if it doesn't exist.
+async fn write_env_cache(
+    client: &DockerClient,
+    container_id: &str,
+    user: &str,
+    env: &HashMap<String, String>,
+) {
     let Some(json) = serde_json::to_string(env).ok() else {
         return;
     };
+
+    let path = cache_path(user);
+
+    // Ensure the parent directory exists
+    let home = cella_env::claude_code::container_home(user);
+    let dir_path = format!("{home}/.cella");
+    let _ = client
+        .exec_command(
+            container_id,
+            &ExecOptions {
+                cmd: vec!["mkdir".to_string(), "-p".to_string(), dir_path],
+                user: Some(user.to_string()),
+                env: None,
+                working_dir: None,
+            },
+        )
+        .await;
+
     let cache_file = cella_docker::FileToUpload {
-        path: PROBED_ENV_CACHE_PATH.to_string(),
+        path,
         content: json.into_bytes(),
         mode: 0o644,
     };

--- a/crates/cella-cli/src/commands/exec.rs
+++ b/crates/cella-cli/src/commands/exec.rs
@@ -114,12 +114,17 @@ impl ExecArgs {
             }
         }
 
+        // Wrap command in a login shell so that shell profiles are sourced
+        // and the full PATH (including ~/.local/bin etc.) is available.
+        let shell = super::shell_detect::detect_shell(&client, &container.id, &user).await;
+        let cmd = super::shell_detect::wrap_in_login_shell(&shell, &self.command);
+
         if self.detach {
             let exec_id = client
                 .exec_detached(
                     &container.id,
                     &ExecOptions {
-                        cmd: self.command,
+                        cmd,
                         user: Some(user),
                         env: Some(env),
                         working_dir,
@@ -133,7 +138,7 @@ impl ExecArgs {
                 .exec_interactive(
                     &container.id,
                     &InteractiveExecOptions {
-                        cmd: self.command,
+                        cmd,
                         user: Some(user),
                         env: Some(env),
                         working_dir,

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -19,6 +19,7 @@ mod ports;
 mod prune;
 mod read_configuration;
 mod shell;
+pub mod shell_detect;
 
 mod switch;
 mod template;

--- a/crates/cella-cli/src/commands/shell.rs
+++ b/crates/cella-cli/src/commands/shell.rs
@@ -1,9 +1,9 @@
 use std::path::PathBuf;
 
 use clap::Args;
-use tracing::{debug, warn};
+use tracing::debug;
 
-use cella_docker::{ContainerTarget, DockerClient, ExecOptions, InteractiveExecOptions};
+use cella_docker::{ContainerTarget, InteractiveExecOptions};
 
 /// Open a shell inside the running dev container.
 #[derive(Args)]
@@ -70,7 +70,7 @@ impl ShellArgs {
         let shell = if let Some(s) = self.shell {
             s
         } else {
-            detect_shell(&client, &container.id, &user).await
+            super::shell_detect::detect_shell(&client, &container.id, &user).await
         };
 
         debug!("Using shell: {shell}");
@@ -109,119 +109,4 @@ impl ShellArgs {
 
         std::process::exit(i32::try_from(exit_code).unwrap_or(125));
     }
-}
-
-/// Detect the best available shell in the container.
-///
-/// Tries, in order:
-/// 1. `$SHELL` environment variable
-/// 2. `/etc/passwd` entry for the user
-/// 3. Probing `/bin/zsh`, `/bin/bash`, `/bin/sh`
-async fn detect_shell(client: &DockerClient, container_id: &str, user: &str) -> String {
-    if let Some(shell) = detect_shell_from_env(client, container_id, user).await {
-        return shell;
-    }
-    if let Some(shell) = detect_shell_from_passwd(client, container_id, user).await {
-        return shell;
-    }
-    if let Some(shell) = detect_shell_by_probing(client, container_id, user).await {
-        return shell;
-    }
-
-    warn!("Could not detect shell, falling back to /bin/sh");
-    "/bin/sh".to_string()
-}
-
-/// Try to detect the shell from the `$SHELL` environment variable.
-async fn detect_shell_from_env(
-    client: &DockerClient,
-    container_id: &str,
-    user: &str,
-) -> Option<String> {
-    let result = client
-        .exec_command(
-            container_id,
-            &ExecOptions {
-                cmd: vec![
-                    "sh".to_string(),
-                    "-c".to_string(),
-                    "echo $SHELL".to_string(),
-                ],
-                user: Some(user.to_string()),
-                env: None,
-                working_dir: None,
-            },
-        )
-        .await
-        .ok()?;
-
-    let shell = result.stdout.trim().to_string();
-    if !shell.is_empty() && shell != "$SHELL" {
-        debug!("Detected shell from $SHELL: {shell}");
-        return Some(shell);
-    }
-    None
-}
-
-/// Try to detect the shell from `/etc/passwd`.
-async fn detect_shell_from_passwd(
-    client: &DockerClient,
-    container_id: &str,
-    user: &str,
-) -> Option<String> {
-    let result = client
-        .exec_command(
-            container_id,
-            &ExecOptions {
-                cmd: vec![
-                    "sh".to_string(),
-                    "-c".to_string(),
-                    format!("getent passwd {user} 2>/dev/null || grep '^{user}:' /etc/passwd"),
-                ],
-                user: Some(user.to_string()),
-                env: None,
-                working_dir: None,
-            },
-        )
-        .await
-        .ok()?;
-
-    let output = result.stdout.trim().to_string();
-    let shell = output.split(':').nth(6)?.trim();
-    if !shell.is_empty() {
-        debug!("Detected shell from passwd: {shell}");
-        return Some(shell.to_string());
-    }
-    None
-}
-
-/// Probe common shell paths to find one that exists.
-async fn detect_shell_by_probing(
-    client: &DockerClient,
-    container_id: &str,
-    user: &str,
-) -> Option<String> {
-    for candidate in &["/bin/zsh", "/bin/bash", "/bin/sh"] {
-        if let Ok(result) = client
-            .exec_command(
-                container_id,
-                &ExecOptions {
-                    cmd: vec![
-                        "test".to_string(),
-                        "-x".to_string(),
-                        (*candidate).to_string(),
-                    ],
-                    user: Some(user.to_string()),
-                    env: None,
-                    working_dir: None,
-                },
-            )
-            .await
-            && result.exit_code == 0
-        {
-            debug!("Detected shell by probing: {candidate}");
-            return Some((*candidate).to_string());
-        }
-    }
-    None
 }

--- a/crates/cella-cli/src/commands/shell_detect.rs
+++ b/crates/cella-cli/src/commands/shell_detect.rs
@@ -1,0 +1,213 @@
+//! Shared shell detection, quoting, and command wrapping.
+//!
+//! Used by `exec`, `shell`, and `env_cache` to consistently detect the
+//! container user's shell and wrap commands in a login shell.
+
+use tracing::{debug, warn};
+
+use cella_docker::{DockerClient, ExecOptions};
+
+/// Detect the best available shell for a user inside a container.
+///
+/// Tries, in order:
+/// 1. `$SHELL` environment variable
+/// 2. `/etc/passwd` entry for the user
+/// 3. Probing `/bin/zsh`, `/bin/bash`, `/bin/sh`
+pub async fn detect_shell(client: &DockerClient, container_id: &str, user: &str) -> String {
+    if let Some(shell) = detect_shell_from_env(client, container_id, user).await {
+        return shell;
+    }
+    if let Some(shell) = detect_shell_from_passwd(client, container_id, user).await {
+        return shell;
+    }
+    if let Some(shell) = detect_shell_by_probing(client, container_id, user).await {
+        return shell;
+    }
+
+    warn!("Could not detect shell, falling back to /bin/sh");
+    "/bin/sh".to_string()
+}
+
+/// POSIX-safe shell quoting: wrap each argument in single quotes.
+///
+/// Single quotes inside arguments are escaped as `'\''` (end quote, escaped
+/// literal quote, restart quote).
+pub fn shell_quote(args: &[String]) -> String {
+    args.iter()
+        .map(|arg| {
+            if arg.is_empty() {
+                "''".to_string()
+            } else {
+                format!("'{}'", arg.replace('\'', "'\\''"))
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Wrap a command in a login shell with `exec` for proper signal propagation.
+///
+/// Returns `[shell, "-lc", "exec <quoted_command>"]`.
+/// The `exec` replaces the shell process with the command so that signals
+/// (e.g. SIGTERM from Docker) reach the actual process directly.
+pub fn wrap_in_login_shell(shell: &str, command: &[String]) -> Vec<String> {
+    let quoted = shell_quote(command);
+    vec![
+        shell.to_string(),
+        "-lc".to_string(),
+        format!("exec {quoted}"),
+    ]
+}
+
+/// Try to detect the shell from the `$SHELL` environment variable.
+async fn detect_shell_from_env(
+    client: &DockerClient,
+    container_id: &str,
+    user: &str,
+) -> Option<String> {
+    let result = client
+        .exec_command(
+            container_id,
+            &ExecOptions {
+                cmd: vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    "echo $SHELL".to_string(),
+                ],
+                user: Some(user.to_string()),
+                env: None,
+                working_dir: None,
+            },
+        )
+        .await
+        .ok()?;
+
+    let shell = result.stdout.trim().to_string();
+    if !shell.is_empty() && shell != "$SHELL" {
+        debug!("Detected shell from $SHELL: {shell}");
+        return Some(shell);
+    }
+    None
+}
+
+/// Try to detect the shell from `/etc/passwd`.
+async fn detect_shell_from_passwd(
+    client: &DockerClient,
+    container_id: &str,
+    user: &str,
+) -> Option<String> {
+    let result = client
+        .exec_command(
+            container_id,
+            &ExecOptions {
+                cmd: vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    format!("getent passwd {user} 2>/dev/null || grep '^{user}:' /etc/passwd"),
+                ],
+                user: Some(user.to_string()),
+                env: None,
+                working_dir: None,
+            },
+        )
+        .await
+        .ok()?;
+
+    let output = result.stdout.trim().to_string();
+    let shell = output.split(':').nth(6)?.trim();
+    if !shell.is_empty() {
+        debug!("Detected shell from passwd: {shell}");
+        return Some(shell.to_string());
+    }
+    None
+}
+
+/// Probe common shell paths to find one that exists.
+async fn detect_shell_by_probing(
+    client: &DockerClient,
+    container_id: &str,
+    user: &str,
+) -> Option<String> {
+    for candidate in &["/bin/zsh", "/bin/bash", "/bin/sh"] {
+        if let Ok(result) = client
+            .exec_command(
+                container_id,
+                &ExecOptions {
+                    cmd: vec![
+                        "test".to_string(),
+                        "-x".to_string(),
+                        (*candidate).to_string(),
+                    ],
+                    user: Some(user.to_string()),
+                    env: None,
+                    working_dir: None,
+                },
+            )
+            .await
+            && result.exit_code == 0
+        {
+            debug!("Detected shell by probing: {candidate}");
+            return Some((*candidate).to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shell_quote_simple_args() {
+        let args: Vec<String> = vec!["claude".into(), "--version".into()];
+        assert_eq!(shell_quote(&args), "'claude' '--version'");
+    }
+
+    #[test]
+    fn shell_quote_args_with_spaces() {
+        let args: Vec<String> = vec!["echo".into(), "hello world".into()];
+        assert_eq!(shell_quote(&args), "'echo' 'hello world'");
+    }
+
+    #[test]
+    fn shell_quote_args_with_single_quotes() {
+        let args: Vec<String> = vec!["echo".into(), "it's".into()];
+        assert_eq!(shell_quote(&args), "'echo' 'it'\\''s'");
+    }
+
+    #[test]
+    fn shell_quote_empty_string() {
+        let args: Vec<String> = vec!["cmd".into(), String::new()];
+        assert_eq!(shell_quote(&args), "'cmd' ''");
+    }
+
+    #[test]
+    fn shell_quote_special_chars() {
+        let args: Vec<String> = vec!["echo".into(), "$HOME && rm -rf /".into()];
+        assert_eq!(shell_quote(&args), "'echo' '$HOME && rm -rf /'");
+    }
+
+    #[test]
+    fn wrap_in_login_shell_basic() {
+        let cmd: Vec<String> = vec!["claude".into(), "--dangerously-skip-permissions".into()];
+        let wrapped = wrap_in_login_shell("/bin/zsh", &cmd);
+        assert_eq!(
+            wrapped,
+            vec![
+                "/bin/zsh",
+                "-lc",
+                "exec 'claude' '--dangerously-skip-permissions'"
+            ]
+        );
+    }
+
+    #[test]
+    fn wrap_in_login_shell_with_spaces() {
+        let cmd: Vec<String> = vec!["echo".into(), "hello world".into()];
+        let wrapped = wrap_in_login_shell("/bin/bash", &cmd);
+        assert_eq!(
+            wrapped,
+            vec!["/bin/bash", "-lc", "exec 'echo' 'hello world'"]
+        );
+    }
+}

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -331,6 +331,10 @@ impl UpContext {
             )
             .await;
 
+        // Detect user's shell for probing (use their actual shell, not /bin/sh)
+        let shell =
+            super::shell_detect::detect_shell(&self.client, container_id, remote_user).await;
+
         // Probe user environment first so tool installs can use feature-provided PATH
         // (e.g., nvm adds /usr/local/share/nvm/current/bin via login shell profiles)
         let probed_env = self
@@ -342,87 +346,50 @@ impl UpContext {
                     container_id,
                     remote_user,
                     self.probe_type(),
+                    &shell,
                 ),
             )
             .await;
 
-        // Sequential prerequisites
+        // Sequential prerequisites + tool installation
         let settings = cella_config::Settings::load(&self.resolved.workspace_root);
         if settings.tools.claude_code.forward_config {
             create_claude_home_symlink(&self.client, container_id, remote_user).await;
             setup_plugin_manifests(&self.client, container_id, remote_user).await;
         }
 
-        let needs_npm = settings.tools.codex.enabled || settings.tools.gemini.enabled;
-        let node_available = if needs_npm {
-            ensure_node_available(&self.client, container_id, probed_env.as_ref()).await
-        } else {
-            false
-        };
-
         let any_tool = settings.tools.claude_code.enabled
             || settings.tools.codex.enabled
             || settings.tools.gemini.enabled;
+        self.install_tools(container_id, remote_user, &settings, probed_env.as_ref())
+            .await;
 
-        if any_tool {
-            let phase = self.progress.phase("Installing tools...");
-
-            let claude_branch = async {
-                if settings.tools.claude_code.enabled {
-                    let step = phase.step("Claude Code");
-                    install_claude_code(
+        // Re-probe after tool installation to capture PATH changes
+        // (e.g., Claude Code installer adds ~/.local/bin to shell profiles)
+        let final_probed = if any_tool {
+            self.progress
+                .run_step(
+                    "Updating environment cache...",
+                    super::env_cache::probe_and_cache_user_env(
                         &self.client,
                         container_id,
                         remote_user,
-                        &settings.tools.claude_code,
-                        probed_env.as_ref(),
-                    )
-                    .await;
-                    step.finish();
-                }
-            };
+                        self.probe_type(),
+                        &shell,
+                    ),
+                )
+                .await
+                .or(probed_env)
+        } else {
+            probed_env
+        };
 
-            let npm_branch = async {
-                if needs_npm && !node_available {
-                    warn!("Skipping npm tool installs: Node.js/npm not available");
-                    return;
-                }
-                if settings.tools.codex.enabled {
-                    let step = phase.step("Codex");
-                    install_codex(
-                        &self.client,
-                        container_id,
-                        remote_user,
-                        &settings.tools.codex,
-                        probed_env.as_ref(),
-                    )
-                    .await;
-                    step.finish();
-                }
-                if settings.tools.gemini.enabled {
-                    let step = phase.step("Gemini CLI");
-                    install_gemini(
-                        &self.client,
-                        container_id,
-                        remote_user,
-                        &settings.tools.gemini,
-                        probed_env.as_ref(),
-                    )
-                    .await;
-                    step.finish();
-                }
-            };
-
-            tokio::join!(claude_branch, npm_branch);
-            phase.finish();
-        }
-
-        let lifecycle_env = probed_env.as_ref().map_or_else(
+        let lifecycle_env = final_probed.as_ref().map_or_else(
             || self.remote_env.clone(),
             |probed| cella_env::user_env_probe::merge_env(probed, &self.remote_env),
         );
 
-        (probed_env, lifecycle_env)
+        (final_probed, lifecycle_env)
     }
 
     /// Handle an already-running container (no rebuild requested, no `--build-no-cache`).
@@ -892,6 +859,10 @@ impl UpContext {
             .await;
         }
 
+        // Detect user's shell for probing (use their actual shell, not /bin/sh)
+        let shell =
+            super::shell_detect::detect_shell(&self.client, container_id, remote_user).await;
+
         // Probe user environment first so tool installs can use feature-provided PATH
         // (e.g., nvm adds /usr/local/share/nvm/current/bin via login shell profiles)
         let probed_env = self
@@ -903,13 +874,14 @@ impl UpContext {
                     container_id,
                     remote_user,
                     self.probe_type(),
+                    &shell,
                 ),
             )
             .await;
 
         // Fix /tmp permissions (must be world-writable with sticky bit).
-        // upload_files (used by write_env_cache above) can reset /tmp to 755
-        // via tar directory entries; some base images may also lack the sticky bit.
+        // upload_files can reset /tmp to 755 via tar directory entries;
+        // some base images may also lack the sticky bit.
         let _ = self
             .client
             .exec_command(
@@ -934,15 +906,38 @@ impl UpContext {
         }
 
         // Install AI coding tools
+        let any_tool = settings.tools.claude_code.enabled
+            || settings.tools.codex.enabled
+            || settings.tools.gemini.enabled;
         self.install_tools(container_id, remote_user, settings, probed_env.as_ref())
             .await;
 
-        let lifecycle_env = probed_env.as_ref().map_or_else(
+        // Re-probe after tool installation to capture PATH changes
+        // (e.g., Claude Code installer adds ~/.local/bin to shell profiles)
+        let final_probed = if any_tool {
+            self.progress
+                .run_step(
+                    "Updating environment cache...",
+                    super::env_cache::probe_and_cache_user_env(
+                        &self.client,
+                        container_id,
+                        remote_user,
+                        self.probe_type(),
+                        &shell,
+                    ),
+                )
+                .await
+                .or(probed_env)
+        } else {
+            probed_env
+        };
+
+        let lifecycle_env = final_probed.as_ref().map_or_else(
             || remote_env.to_vec(),
             |probed| cella_env::user_env_probe::merge_env(probed, remote_env),
         );
 
-        (probed_env, lifecycle_env)
+        (final_probed, lifecycle_env)
     }
 
     /// Forward config and install AI coding tools (Claude Code, Codex, Gemini).

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -350,6 +350,7 @@ impl UpContext {
         let settings = cella_config::Settings::load(&self.resolved.workspace_root);
         if settings.tools.claude_code.forward_config {
             create_claude_home_symlink(&self.client, container_id, remote_user).await;
+            setup_plugin_manifests(&self.client, container_id, remote_user).await;
         }
 
         let needs_npm = settings.tools.codex.enabled || settings.tools.gemini.enabled;
@@ -926,9 +927,10 @@ impl UpContext {
             )
             .await;
 
-        // Create home path symlink for Claude Code plugin resolution
+        // Create home path symlink and populate plugin manifests
         if settings.tools.claude_code.forward_config {
             create_claude_home_symlink(&self.client, container_id, remote_user).await;
+            setup_plugin_manifests(&self.client, container_id, remote_user).await;
         }
 
         // Install AI coding tools
@@ -1618,9 +1620,36 @@ fn add_tool_config_mounts(
             create_opts.mounts.push(MountConfig {
                 mount_type: "bind".to_string(),
                 source: host_path.to_string_lossy().to_string(),
-                target,
+                target: target.clone(),
                 consistency: None,
             });
+
+            // Hidden mount for host plugins (backward sync access)
+            if let Some(host_plugins) = cella_env::claude_code::host_plugins_dir() {
+                create_opts.mounts.push(MountConfig {
+                    mount_type: "bind".to_string(),
+                    source: host_plugins.to_string_lossy().to_string(),
+                    target: "/tmp/.cella/host-plugins".to_string(),
+                    consistency: None,
+                });
+                // tmpfs shadows the parent bind mount's plugins/ subdirectory
+                create_opts.mounts.push(MountConfig {
+                    mount_type: "tmpfs".to_string(),
+                    source: String::new(),
+                    target: format!("{target}/plugins"),
+                    consistency: None,
+                });
+            }
+        }
+
+        // Inject CELLA_HOST_HOME for cella-agent plugin sync
+        if let Some(host_home) = cella_env::claude_code::host_home() {
+            if create_opts.env.is_empty() {
+                // env will be populated by the caller; just push the var
+            }
+            create_opts
+                .env
+                .push(format!("CELLA_HOST_HOME={}", host_home.display()));
         }
     }
 
@@ -1826,6 +1855,63 @@ async fn create_claude_home_symlink(client: &DockerClient, container_id: &str, r
             },
         )
         .await;
+}
+
+/// Populate the tmpfs-backed `~/.claude/plugins/` directory.
+///
+/// Creates symlinks for plugin content (cache/, data/, marketplaces/) pointing
+/// to the hidden host mount at `/tmp/.cella/host-plugins/`, and copies
+/// `installed_plugins.json` and `known_marketplaces.json` with path rewriting.
+async fn setup_plugin_manifests(client: &DockerClient, container_id: &str, remote_user: &str) {
+    let Some(host_home) = cella_env::claude_code::host_home() else {
+        return;
+    };
+    let container_home = cella_env::claude_code::container_home(remote_user);
+
+    let host_home_str = host_home.to_string_lossy();
+    if *host_home_str == container_home {
+        return;
+    }
+
+    let plugins_dir = format!("{container_home}/.claude/plugins");
+    let host_plugins = "/tmp/.cella/host-plugins";
+    let old_prefix = format!("{host_home_str}/.claude");
+    let new_prefix = format!("{container_home}/.claude");
+
+    // Symlink all items except the 2 manifest JSONs (which get copied + rewritten)
+    let script = format!(
+        concat!(
+            "[ -d \"{host}\" ] || exit 0; ",
+            "for item in \"{host}\"/* \"{host}\"/.*; do ",
+            "  [ -e \"$item\" ] || continue; ",
+            "  name=$(basename \"$item\"); ",
+            "  case \"$name\" in ",
+            "    .|..) continue ;; ",
+            "    installed_plugins.json|known_marketplaces.json) ",
+            "      [ -f \"$item\" ] && sed 's|{old}|{new}|g' \"$item\" > \"{dir}/$name\" ;; ",
+            "    *) ln -sfn \"$item\" \"{dir}/$name\" ;; ",
+            "  esac; ",
+            "done",
+        ),
+        host = host_plugins,
+        dir = plugins_dir,
+        old = old_prefix,
+        new = new_prefix,
+    );
+
+    let _ = client
+        .exec_command(
+            container_id,
+            &ExecOptions {
+                cmd: vec!["sh".into(), "-c".into(), script],
+                user: Some("root".into()),
+                env: None,
+                working_dir: None,
+            },
+        )
+        .await;
+
+    chown_in_container(client, container_id, remote_user, &plugins_dir).await;
 }
 
 /// Check if Claude Code is already installed at the desired version.

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -1641,16 +1641,6 @@ fn add_tool_config_mounts(
                 });
             }
         }
-
-        // Inject CELLA_HOST_HOME for cella-agent plugin sync
-        if let Some(host_home) = cella_env::claude_code::host_home() {
-            if create_opts.env.is_empty() {
-                // env will be populated by the caller; just push the var
-            }
-            create_opts
-                .env
-                .push(format!("CELLA_HOST_HOME={}", host_home.display()));
-        }
     }
 
     // Codex: ~/.codex
@@ -1862,21 +1852,27 @@ async fn create_claude_home_symlink(client: &DockerClient, container_id: &str, r
 /// Creates symlinks for plugin content (cache/, data/, marketplaces/) pointing
 /// to the hidden host mount at `/tmp/.cella/host-plugins/`, and copies
 /// `installed_plugins.json` and `known_marketplaces.json` with path rewriting.
+///
+/// Uses regex-based sed to match ANY home path + `/.claude` (Linux, macOS, root)
+/// and replace with the container user's path. This handles files written by
+/// previous containers with different users (e.g. `/home/node/.claude` →
+/// `/home/vscode/.claude`).
 async fn setup_plugin_manifests(client: &DockerClient, container_id: &str, remote_user: &str) {
-    let Some(host_home) = cella_env::claude_code::host_home() else {
-        return;
-    };
     let container_home = cella_env::claude_code::container_home(remote_user);
-
-    let host_home_str = host_home.to_string_lossy();
-    if *host_home_str == container_home {
-        return;
-    }
-
     let plugins_dir = format!("{container_home}/.claude/plugins");
     let host_plugins = "/tmp/.cella/host-plugins";
-    let old_prefix = format!("{host_home_str}/.claude");
-    let new_prefix = format!("{container_home}/.claude");
+    let target_claude = format!("{container_home}/.claude");
+
+    // Regex sed: rewrite /home/USER/.claude, /Users/USER/.claude, /root/.claude
+    // to the container user's path. Handles any previous writer.
+    let sed_expr = format!(
+        concat!(
+            "s|/home/[^/\"]*/.claude|{t}|g; ",
+            "s|/Users/[^/\"]*/.claude|{t}|g; ",
+            "s|/root/.claude|{t}|g",
+        ),
+        t = target_claude,
+    );
 
     // Symlink all items except the 2 manifest JSONs (which get copied + rewritten)
     let script = format!(
@@ -1888,15 +1884,14 @@ async fn setup_plugin_manifests(client: &DockerClient, container_id: &str, remot
             "  case \"$name\" in ",
             "    .|..) continue ;; ",
             "    installed_plugins.json|known_marketplaces.json) ",
-            "      [ -f \"$item\" ] && sed 's|{old}|{new}|g' \"$item\" > \"{dir}/$name\" ;; ",
+            "      [ -f \"$item\" ] && sed -E '{sed}' \"$item\" > \"{dir}/$name\" ;; ",
             "    *) ln -sfn \"$item\" \"{dir}/$name\" ;; ",
             "  esac; ",
             "done",
         ),
         host = host_plugins,
         dir = plugins_dir,
-        old = old_prefix,
-        new = new_prefix,
+        sed = sed_expr,
     );
 
     let _ = client

--- a/crates/cella-env/src/claude_code.rs
+++ b/crates/cella-env/src/claude_code.rs
@@ -34,11 +34,28 @@ pub fn host_claude_json_path() -> Option<PathBuf> {
     if path.is_file() { Some(path) } else { None }
 }
 
+/// Host-side `~/.claude/plugins` directory path (if it exists).
+pub fn host_plugins_dir() -> Option<PathBuf> {
+    let dir = host_claude_dir()?.join("plugins");
+    if dir.is_dir() { Some(dir) } else { None }
+}
+
 /// Host home directory derived from the host `.claude` directory path.
 ///
 /// Returns `None` if `~/.claude/` doesn't exist on the host.
 pub fn host_home() -> Option<PathBuf> {
     host_claude_dir().and_then(|d| d.parent().map(PathBuf::from))
+}
+
+/// Replace home-path prefix in file content.
+///
+/// Performs a simple string replacement of `{from_home}/.claude` with
+/// `{to_home}/.claude` for rewriting plugin manifest paths.
+pub fn rewrite_claude_home(content: &str, from_home: &str, to_home: &str) -> String {
+    content.replace(
+        &format!("{from_home}/.claude"),
+        &format!("{to_home}/.claude"),
+    )
 }
 
 /// Get the host home directory.
@@ -85,5 +102,36 @@ mod tests {
             let home = host_home().expect("host_home should return Some when host_claude_dir does");
             assert_eq!(home, claude_dir.parent().unwrap());
         }
+    }
+
+    #[test]
+    fn rewrite_claude_home_replaces_paths() {
+        let content = r#"{"installPath": "/home/node/.claude/plugins/cache/foo"}"#;
+        let result = rewrite_claude_home(content, "/home/node", "/home/vscode");
+        assert_eq!(
+            result,
+            r#"{"installPath": "/home/vscode/.claude/plugins/cache/foo"}"#
+        );
+    }
+
+    #[test]
+    fn rewrite_claude_home_multiple_occurrences() {
+        let content = "/home/node/.claude/a /home/node/.claude/b";
+        let result = rewrite_claude_home(content, "/home/node", "/home/vscode");
+        assert_eq!(result, "/home/vscode/.claude/a /home/vscode/.claude/b");
+    }
+
+    #[test]
+    fn rewrite_claude_home_noop_when_same() {
+        let content = "/home/vscode/.claude/plugins";
+        let result = rewrite_claude_home(content, "/home/vscode", "/home/vscode");
+        assert_eq!(result, content);
+    }
+
+    #[test]
+    fn rewrite_claude_home_macos_to_linux() {
+        let content = r#"{"path": "/Users/alice/.claude/plugins"}"#;
+        let result = rewrite_claude_home(content, "/Users/alice", "/home/vscode");
+        assert_eq!(result, r#"{"path": "/home/vscode/.claude/plugins"}"#);
     }
 }


### PR DESCRIPTION
## Summary

- **Isolate plugin manifests with tmpfs + bidirectional sync** — Claude Code does string prefix checks on `installPath`/`installLocation` in plugin manifest JSONs. The bind-mount + symlink approach doesn't change the literal strings, causing "corrupted installLocation" errors. Fix by shadowing `~/.claude/plugins/` with per-container tmpfs, rewriting manifest paths with sed, and adding an inotify-based bidirectional sync daemon in cella-agent.
- **Fix manifest path rewriting** — `host_home()` reads `$HOME` which resolves to the container user's home when running inside a container, silently skipping rewrites. Switch to regex-based sed that matches any home path pattern and detect the original host home from JSON content.
- **Wrap exec commands in login shell** — `cella exec` passed commands directly to Docker without shell wrapping, so binaries only reachable via shell profile PATH (e.g. `~/.local/bin`) were not found. Now wraps as `<user-shell> -lc 'exec <command>'`, matching devcontainer CLI behavior. Also fixes env probe to use the user's actual shell and re-probe after tool installation.

## Test plan

- [ ] `cella up` with Claude Code extension — verify no "corrupted installLocation" errors
- [ ] Install a plugin inside container, verify it syncs back to host
- [ ] `cella exec <command>` where command is only on profile PATH — verify it resolves
- [ ] Multi-container: verify plugin changes in one container appear in others on next `cella up`

🤖 Generated with [Claude Code](https://claude.com/claude-code)