### PR TITLE
ci: add integration tests to CI with Docker and coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,47 +79,6 @@ jobs:
       - name: Validate snapshots
         run: cargo insta test --workspace --check --unreferenced=reject
 
-  coverage:
-    name: Coverage
-    runs-on: ubuntu-24.04-arm
-    if: github.event_name == 'pull_request'
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
-
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@06203676c62f0d3c765be3f2fcfbebbcb02d09f5 # v2.69.6
-        with:
-          tool: cargo-llvm-cov
-
-      - name: Generate coverage
-        run: cargo llvm-cov --workspace > coverage-report.txt
-
-      - name: Build coverage comment
-        id: coverage
-        run: |
-          {
-            echo 'comment<<EOF'
-            echo '## Coverage Report'
-            echo ''
-            echo '```'
-            grep -E '^(Filename|-|TOTAL)' coverage-report.txt
-            echo '```'
-            echo 'EOF'
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Post coverage comment
-        uses: marocchino/sticky-pull-request-comment@70d2764d1a7d5d9560b100cbea0077fc8f633987 # v3.0.2
-        with:
-          header: coverage
-          message: ${{ steps.coverage.outputs.comment }}
-
   integration-test:
     name: Integration Test
     runs-on: ubuntu-24.04-arm
@@ -143,34 +102,39 @@ jobs:
       - name: Log in to ghcr.io
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
+      - name: Run unit tests with coverage
+        run: cargo llvm-cov --no-report --workspace
+
       - name: Run integration tests with coverage
         run: >
-          cargo llvm-cov
+          cargo llvm-cov --no-report
           -p cella-features
           -p cella-daemon
           -p cella-credential-proxy
           --features integration-tests
-          > integration-coverage-report.txt
 
-      - name: Build integration coverage comment
+      - name: Generate combined coverage report
+        run: cargo llvm-cov report > coverage-report.txt
+
+      - name: Build coverage comment
         if: github.event_name == 'pull_request'
         id: coverage
         run: |
           {
             echo 'comment<<EOF'
-            echo '## Integration Test Coverage'
+            echo '## Coverage Report'
             echo ''
             echo '```'
-            grep -E '^(Filename|-|TOTAL)' integration-coverage-report.txt
+            grep -E '^(Filename|-|TOTAL)' coverage-report.txt
             echo '```'
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 
-      - name: Post integration coverage comment
+      - name: Post coverage comment
         if: github.event_name == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@70d2764d1a7d5d9560b100cbea0077fc8f633987 # v3.0.2
         with:
-          header: integration-coverage
+          header: coverage
           message: ${{ steps.coverage.outputs.comment }}
 
   cross-compile:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,6 +120,59 @@ jobs:
           header: coverage
           message: ${{ steps.coverage.outputs.comment }}
 
+  integration-test:
+    name: Integration Test
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@06203676c62f0d3c765be3f2fcfbebbcb02d09f5 # v2.69.6
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Log in to ghcr.io
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Run integration tests with coverage
+        run: >
+          cargo llvm-cov
+          -p cella-features
+          -p cella-daemon
+          -p cella-credential-proxy
+          --features integration-tests
+          > integration-coverage-report.txt
+
+      - name: Build integration coverage comment
+        if: github.event_name == 'pull_request'
+        id: coverage
+        run: |
+          {
+            echo 'comment<<EOF'
+            echo '## Integration Test Coverage'
+            echo ''
+            echo '```'
+            grep -E '^(Filename|-|TOTAL)' integration-coverage-report.txt
+            echo '```'
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post integration coverage comment
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@70d2764d1a7d5d9560b100cbea0077fc8f633987 # v3.0.2
+        with:
+          header: integration-coverage
+          message: ${{ steps.coverage.outputs.comment }}
+
   cross-compile:
     name: Build (${{ matrix.target }})
     runs-on: ${{ matrix.runner }}

--- a/crates/cella-config/src/devcontainer/discover.rs
+++ b/crates/cella-config/src/devcontainer/discover.rs
@@ -243,19 +243,14 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let custom_path = tmp.path().join("custom").join("my-devcontainer.json");
         create_file(&custom_path);
-        let resolved =
-            crate::resolve::config(tmp.path(), Some(&custom_path)).unwrap();
+        let resolved = crate::resolve::config(tmp.path(), Some(&custom_path)).unwrap();
         assert_eq!(resolved.config_path, custom_path);
     }
 
     #[test]
     fn spec_no_parent_traversal() {
         let tmp = TempDir::new().unwrap();
-        create_file(
-            &tmp.path()
-                .join(".devcontainer")
-                .join("devcontainer.json"),
-        );
+        create_file(&tmp.path().join(".devcontainer").join("devcontainer.json"));
         let subdir = tmp.path().join("subproject");
         std::fs::create_dir_all(&subdir).unwrap();
         let result = config(&subdir);

--- a/crates/cella-config/src/devcontainer/merge.rs
+++ b/crates/cella-config/src/devcontainer/merge.rs
@@ -387,7 +387,11 @@ mod tests {
         let mut sorted = cap_strs.clone();
         sorted.sort_unstable();
         sorted.dedup();
-        assert_eq!(cap_strs.len(), sorted.len(), "capAdd should have no duplicates");
+        assert_eq!(
+            cap_strs.len(),
+            sorted.len(),
+            "capAdd should have no duplicates"
+        );
     }
 
     #[test]
@@ -405,7 +409,11 @@ mod tests {
         let mut sorted = opt_strs.clone();
         sorted.sort_unstable();
         sorted.dedup();
-        assert_eq!(opt_strs.len(), sorted.len(), "securityOpt should have no duplicates");
+        assert_eq!(
+            opt_strs.len(),
+            sorted.len(),
+            "securityOpt should have no duplicates"
+        );
     }
 
     #[test]
@@ -424,7 +432,11 @@ mod tests {
         let mut sorted = port_nums.clone();
         sorted.sort_unstable();
         sorted.dedup();
-        assert_eq!(port_nums.len(), sorted.len(), "forwardPorts should have no duplicates");
+        assert_eq!(
+            port_nums.len(),
+            sorted.len(),
+            "forwardPorts should have no duplicates"
+        );
     }
 
     #[test]
@@ -523,7 +535,8 @@ mod tests {
     #[test]
     fn spec_ports_attributes_per_port_last_wins() {
         let mut base = json!({"portsAttributes": {"3000": {"label": "app"}}});
-        let overlay = json!({"portsAttributes": {"3000": {"label": "frontend"}, "8080": {"label": "api"}}});
+        let overlay =
+            json!({"portsAttributes": {"3000": {"label": "frontend"}, "8080": {"label": "api"}}});
         layers(&mut base, &overlay);
         assert_eq!(base["portsAttributes"]["3000"]["label"], "frontend");
         assert_eq!(base["portsAttributes"]["8080"]["label"], "api");
@@ -534,7 +547,10 @@ mod tests {
         let mut base = json!({"hostRequirements": {"cpus": 2, "memory": "4gb"}});
         let overlay = json!({"hostRequirements": {"cpus": 4, "memory": "2gb"}});
         layers(&mut base, &overlay);
-        assert_eq!(base["hostRequirements"]["cpus"], 4, "cpus should use max value");
+        assert_eq!(
+            base["hostRequirements"]["cpus"], 4,
+            "cpus should use max value"
+        );
         assert_eq!(
             base["hostRequirements"]["memory"], "4gb",
             "memory should use max value (4gb > 2gb)"
@@ -544,9 +560,13 @@ mod tests {
     #[test]
     fn spec_customizations_deep_merge() {
         let mut base = json!({"customizations": {"vscode": {"extensions": ["ext1"]}}});
-        let overlay = json!({"customizations": {"vscode": {"settings": {}}, "cella": {"key": "val"}}});
+        let overlay =
+            json!({"customizations": {"vscode": {"settings": {}}, "cella": {"key": "val"}}});
         layers(&mut base, &overlay);
-        assert_eq!(base["customizations"]["vscode"]["extensions"], json!(["ext1"]));
+        assert_eq!(
+            base["customizations"]["vscode"]["extensions"],
+            json!(["ext1"])
+        );
         assert_eq!(base["customizations"]["vscode"]["settings"], json!({}));
         assert_eq!(base["customizations"]["cella"]["key"], "val");
     }

--- a/crates/cella-config/src/devcontainer/resolve.rs
+++ b/crates/cella-config/src/devcontainer/resolve.rs
@@ -317,9 +317,7 @@ mod tests {
                 let quotient = current / 32;
                 remainder = current % 32;
                 if !new_digits.is_empty() || quotient > 0 {
-                    new_digits.push(
-                        u8::try_from(quotient).expect("quotient fits in u8"),
-                    );
+                    new_digits.push(u8::try_from(quotient).expect("quotient fits in u8"));
                 }
             }
             let r = u8::try_from(remainder).expect("remainder fits in u8");
@@ -334,9 +332,7 @@ mod tests {
         }
     }
 
-    fn spec_devcontainer_id(
-        labels: &std::collections::BTreeMap<String, String>,
-    ) -> String {
+    fn spec_devcontainer_id(labels: &std::collections::BTreeMap<String, String>) -> String {
         let json = serde_json::to_string(labels).expect("serialize");
         let hash = Sha256::digest(json.as_bytes());
         let num = bytes_to_bigint(&hash);
@@ -373,10 +369,7 @@ mod tests {
             "devcontainer.local_folder".to_string(),
             "/home/user/project".to_string(),
         );
-        assert_eq!(
-            spec_devcontainer_id(&labels),
-            spec_devcontainer_id(&labels)
-        );
+        assert_eq!(spec_devcontainer_id(&labels), spec_devcontainer_id(&labels));
     }
 
     #[test]

--- a/crates/cella-credential-proxy/Cargo.toml
+++ b/crates/cella-credential-proxy/Cargo.toml
@@ -13,5 +13,8 @@ tracing.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 
+[features]
+integration-tests = []
+
 [lints]
 workspace = true

--- a/crates/cella-credential-proxy/src/daemon.rs
+++ b/crates/cella-credential-proxy/src/daemon.rs
@@ -247,7 +247,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "requires Docker"]
+    #[cfg(feature = "integration-tests")]
     fn running_container_count_with_no_containers() {
         let count = running_cella_container_count();
         assert_eq!(count, 0);

--- a/crates/cella-credential-proxy/src/server.rs
+++ b/crates/cella-credential-proxy/src/server.rs
@@ -198,7 +198,6 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    #[ignore = "requires TCP port binding"]
     async fn tcp_server_reuses_port() {
         let dir = tempfile::tempdir().unwrap();
         let port_path = dir.path().join("test.port");

--- a/crates/cella-daemon/Cargo.toml
+++ b/crates/cella-daemon/Cargo.toml
@@ -16,5 +16,8 @@ tracing-subscriber.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 
+[features]
+integration-tests = []
+
 [lints]
 workspace = true

--- a/crates/cella-daemon/src/proxy.rs
+++ b/crates/cella-daemon/src/proxy.rs
@@ -151,7 +151,6 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    #[ignore = "requires TCP port binding"]
     async fn proxy_starts_and_stops() {
         let target = ProxyTarget::DirectIp {
             ip: "127.0.0.1".to_string(),

--- a/crates/cella-daemon/src/shared.rs
+++ b/crates/cella-daemon/src/shared.rs
@@ -273,7 +273,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "requires Docker"]
+    #[cfg(feature = "integration-tests")]
     fn container_count_with_no_containers() {
         assert_eq!(running_cella_container_count(), 0);
     }

--- a/crates/cella-features/Cargo.toml
+++ b/crates/cella-features/Cargo.toml
@@ -26,5 +26,8 @@ tracing.workspace = true
 insta.workspace = true
 tempfile.workspace = true
 
+[features]
+integration-tests = []
+
 [lints]
 workspace = true

--- a/crates/cella-features/src/lib.rs
+++ b/crates/cella-features/src/lib.rs
@@ -621,6 +621,19 @@ mod tests {
 
     use super::*;
 
+    #[cfg(feature = "integration-tests")]
+    fn test_platform() -> Platform {
+        let architecture = match std::env::consts::ARCH {
+            "x86_64" => "amd64",
+            "aarch64" => "arm64",
+            other => other,
+        };
+        Platform {
+            os: "linux".to_string(),
+            architecture: architecture.to_string(),
+        }
+    }
+
     // -----------------------------------------------------------------------
     // generate_metadata_label
     // -----------------------------------------------------------------------
@@ -1085,7 +1098,7 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[tokio::test]
-    #[ignore = "requires Docker and network access"]
+    #[cfg(feature = "integration-tests")]
     async fn e2e_resolve_node_feature() {
         let config = json!({
             "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
@@ -1100,10 +1113,7 @@ mod tests {
         let config_path = tmp.path().join("devcontainer.json");
         std::fs::write(&config_path, config.to_string()).unwrap();
 
-        let platform = Platform {
-            os: "linux".to_string(),
-            architecture: "amd64".to_string(),
-        };
+        let platform = test_platform();
         let cache = FeatureCache::new();
 
         let result = resolve_features(

--- a/crates/cella-features/src/lib.rs
+++ b/crates/cella-features/src/lib.rs
@@ -10,6 +10,9 @@ pub mod ordering;
 pub mod reference;
 pub mod types;
 
+#[cfg(test)]
+mod test_utils;
+
 pub use cache::FeatureCache;
 pub use dockerfile::{
     generate_builtin_env, generate_dockerfile, generate_entrypoint_script, generate_feature_env,
@@ -622,17 +625,7 @@ mod tests {
     use super::*;
 
     #[cfg(feature = "integration-tests")]
-    fn test_platform() -> Platform {
-        let architecture = match std::env::consts::ARCH {
-            "x86_64" => "amd64",
-            "aarch64" => "arm64",
-            other => other,
-        };
-        Platform {
-            os: "linux".to_string(),
-            architecture: architecture.to_string(),
-        }
-    }
+    use crate::test_utils::test_platform;
 
     // -----------------------------------------------------------------------
     // generate_metadata_label

--- a/crates/cella-features/src/oci.rs
+++ b/crates/cella-features/src/oci.rs
@@ -364,6 +364,19 @@ fn extract_layer(blob: &[u8], media_type: &str, dest: &std::path::Path) -> std::
 mod tests {
     use super::*;
 
+    #[cfg(feature = "integration-tests")]
+    fn test_platform() -> Platform {
+        let architecture = match std::env::consts::ARCH {
+            "x86_64" => "amd64",
+            "aarch64" => "arm64",
+            other => other,
+        };
+        Platform {
+            os: "linux".to_string(),
+            architecture: architecture.to_string(),
+        }
+    }
+
     // -----------------------------------------------------------------------
     // Unit tests
     // -----------------------------------------------------------------------
@@ -543,7 +556,7 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[tokio::test]
-    #[ignore = "requires network access to ghcr.io"]
+    #[cfg(feature = "integration-tests")]
     async fn fetch_node_feature_from_ghcr() {
         let fetcher = OciFetcher::new();
         let cache_dir = tempfile::tempdir().unwrap();
@@ -555,10 +568,7 @@ mod tests {
             tag: "1".to_owned(),
         };
 
-        let platform = Platform {
-            os: "linux".to_owned(),
-            architecture: "amd64".to_owned(),
-        };
+        let platform = test_platform();
 
         let path = fetcher.fetch(&reference, &platform, &cache).await.unwrap();
 
@@ -580,7 +590,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires network access to ghcr.io"]
+    #[cfg(feature = "integration-tests")]
     async fn fetch_github_cli_feature_from_ghcr() {
         let fetcher = OciFetcher::new();
         let cache_dir = tempfile::tempdir().unwrap();
@@ -592,10 +602,7 @@ mod tests {
             tag: "1".to_owned(),
         };
 
-        let platform = Platform {
-            os: "linux".to_owned(),
-            architecture: "amd64".to_owned(),
-        };
+        let platform = test_platform();
 
         let path = fetcher.fetch(&reference, &platform, &cache).await.unwrap();
 

--- a/crates/cella-features/src/oci.rs
+++ b/crates/cella-features/src/oci.rs
@@ -365,17 +365,7 @@ mod tests {
     use super::*;
 
     #[cfg(feature = "integration-tests")]
-    fn test_platform() -> Platform {
-        let architecture = match std::env::consts::ARCH {
-            "x86_64" => "amd64",
-            "aarch64" => "arm64",
-            other => other,
-        };
-        Platform {
-            os: "linux".to_string(),
-            architecture: architecture.to_string(),
-        }
-    }
+    use crate::test_utils::test_platform;
 
     // -----------------------------------------------------------------------
     // Unit tests

--- a/crates/cella-features/src/ordering.rs
+++ b/crates/cella-features/src/ordering.rs
@@ -610,7 +610,13 @@ mod tests {
     fn option_key_to_env_var(key: &str) -> String {
         let mut result: String = key
             .chars()
-            .map(|c| if c.is_alphanumeric() || c == '_' { c } else { '_' })
+            .map(|c| {
+                if c.is_alphanumeric() || c == '_' {
+                    c
+                } else {
+                    '_'
+                }
+            })
             .collect();
         let first_valid = result
             .chars()

--- a/crates/cella-features/src/test_utils.rs
+++ b/crates/cella-features/src/test_utils.rs
@@ -1,0 +1,19 @@
+//! Shared test utilities for the cella-features crate.
+
+#[cfg(feature = "integration-tests")]
+use crate::types::Platform;
+
+/// Build a [`Platform`] matching the current host — used by integration tests
+/// that pull real OCI images from ghcr.io.
+#[cfg(feature = "integration-tests")]
+pub fn test_platform() -> Platform {
+    let architecture = match std::env::consts::ARCH {
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        other => other,
+    };
+    Platform {
+        os: "linux".to_string(),
+        architecture: architecture.to_string(),
+    }
+}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -31,26 +31,40 @@ cargo test --workspace
 
 ## Integration Tests
 
-Integration tests that require Docker or other external dependencies use the `#[ignore]` attribute:
+Tests that require Docker or network access (e.g. OCI registry fetches) are
+gated behind a Cargo feature flag:
 
 ```rust
-#[test]
-#[ignore] // requires Docker
-fn container_lifecycle() {
+#[cfg(feature = "integration-tests")]
+#[tokio::test]
+async fn fetch_from_ghcr() {
     // ...
 }
 ```
 
-Run integration tests:
+Run integration tests locally (requires Docker):
 
 ```sh
-cargo test --workspace -- --ignored
+cargo test -p cella-features -p cella-daemon -p cella-credential-proxy --features integration-tests
 ```
 
-Run all tests (unit + integration):
+These tests run automatically in CI via the **Integration Test** job, which
+authenticates to `ghcr.io` and collects coverage.
+
+### Architecture-aware tests
+
+OCI tests use `test_platform()` instead of hardcoding `"amd64"`. This maps
+`std::env::consts::ARCH` to OCI platform names (`x86_64` → `amd64`,
+`aarch64` → `arm64`), so tests work on both Intel and ARM runners.
+
+### Locally-only tests
+
+One test (`credential_helper_invocation` in `cella-features`) requires
+`docker-credential-desktop` on `PATH` and uses `#[ignore]`. It does not run
+in CI. Run it manually:
 
 ```sh
-cargo test --workspace -- --include-ignored
+cargo test -p cella-features -- --ignored credential_helper
 ```
 
 ## Mocking Patterns
@@ -75,8 +89,9 @@ impl ContainerRuntime for MockRuntime {
 ## Adding New Tests
 
 1. **Unit test**: Add a `#[cfg(test)]` module in the same file as the code being tested
-2. **Integration test**: Create a file in the crate's `tests/` directory. Use `#[ignore]` if it requires Docker
+2. **Integration test**: Use `#[cfg(feature = "integration-tests")]` for tests needing Docker or network. Add the feature to the crate's `Cargo.toml` if not already present
 3. **Async tests**: Use `#[tokio::test]` for async test functions
+4. **Architecture**: Use `test_platform()` instead of hardcoding `"amd64"` in OCI tests
 
 ## Test Organization by Crate
 


### PR DESCRIPTION
## Summary
- Gate Docker/network-dependent integration tests behind `integration-tests` cargo feature flag instead of `#[ignore]`, so they run reliably in CI
- Authenticate to `ghcr.io` with `GITHUB_TOKEN` for OCI registry tests
- Use architecture-aware `test_platform()` helpers so tests work on both x86_64 and ARM runners
- Merge unit and integration coverage into a single CI job with one combined PR comment

## Test plan
- [ ] CI `integration-test` job passes on this PR
- [ ] Coverage comment appears on the PR
- [ ] `cargo test --workspace` still passes locally (unit tests unaffected)
- [ ] `cargo test -p cella-features -p cella-daemon -p cella-credential-proxy --features integration-tests` passes with Docker available

🤖 Generated with [Claude Code](https://claude.com/claude-code)