### PR TITLE
feat: add Apple Container backend (experimental)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,7 @@ dependencies = [
  "cella-backend",
  "cella-compose",
  "cella-config",
+ "cella-container",
  "cella-credential-proxy",
  "cella-daemon",
  "cella-docker",
@@ -348,6 +349,18 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "toml",
+ "tracing",
+]
+
+[[package]]
+name = "cella-container"
+version = "0.0.8"
+dependencies = [
+ "cella-backend",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/cella-codegen",
     "crates/cella-compose",
     "crates/cella-config",
+    "crates/cella-container",
     "crates/cella-credential-proxy",
     "crates/cella-daemon",
     "crates/cella-doctor",
@@ -115,6 +116,7 @@ cella-codegen = { path = "crates/cella-codegen" }
 cella-compose = { path = "crates/cella-compose" }
 cella-doctor = { path = "crates/cella-doctor" }
 cella-config = { path = "crates/cella-config" }
+cella-container = { path = "crates/cella-container" }
 cella-credential-proxy = { path = "crates/cella-credential-proxy" }
 cella-daemon = { path = "crates/cella-daemon" }
 cella-docker = { path = "crates/cella-docker" }

--- a/crates/cella-cli/Cargo.toml
+++ b/crates/cella-cli/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 cella-backend.workspace = true
 cella-compose.workspace = true
 cella-config.workspace = true
+cella-container.workspace = true
 cella-credential-proxy.workspace = true
 cella-daemon.workspace = true
 cella-doctor.workspace = true

--- a/crates/cella-cli/src/backend.rs
+++ b/crates/cella-cli/src/backend.rs
@@ -34,10 +34,7 @@ pub fn resolve_backend(
 ) -> Result<Box<dyn ContainerBackend>, Box<dyn std::error::Error>> {
     match choice {
         Some(BackendChoice::Docker) => connect_docker_backend(docker_host),
-        Some(BackendChoice::AppleContainer) => Err(
-            "Apple Container backend is not yet available. It will be added in a future release."
-                .into(),
-        ),
+        Some(BackendChoice::AppleContainer) => connect_apple_container_backend(),
         None => auto_detect(docker_host),
     }
 }
@@ -50,10 +47,13 @@ fn auto_detect(
         return Ok(client);
     }
 
-    // Apple Container will be added here as lowest priority fallback
+    // Apple Container is lowest priority fallback
+    if let Ok(client) = connect_apple_container_backend() {
+        return Ok(client);
+    }
 
     Err(
-        "No container backend available. Install Docker or another supported container runtime."
+        "No container backend available. Install Docker or Apple Container (macOS 26+, Apple Silicon)."
             .into(),
     )
 }
@@ -65,4 +65,17 @@ fn connect_docker_backend(
         DockerClient::connect_with_host(host)
     })?;
     Ok(Box::new(client))
+}
+
+fn connect_apple_container_backend() -> Result<Box<dyn ContainerBackend>, Box<dyn std::error::Error>>
+{
+    let cli = cella_container::discovery::discover()
+        .ok_or("Apple Container CLI not found. Install from https://github.com/apple/container")?;
+
+    eprintln!(
+        "warning: Apple Container backend is experimental. \
+         Report issues at https://github.com/eve0415/cella/issues"
+    );
+
+    Ok(Box::new(cella_container::AppleContainerBackend::new(cli)))
 }

--- a/crates/cella-container/Cargo.toml
+++ b/crates/cella-container/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "cella-container"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+cella-backend.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+
+[lints]
+workspace = true

--- a/crates/cella-container/src/backend.rs
+++ b/crates/cella-container/src/backend.rs
@@ -1,0 +1,998 @@
+//! `ContainerBackend` implementation for the Apple Container runtime.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+
+use cella_backend::{
+    BackendError, BackendKind, BoxFuture, BuildOptions, ContainerBackend, ContainerInfo,
+    ContainerState, CreateContainerOptions, ExecOptions, ExecResult, FileToUpload, ImageDetails,
+    InteractiveExecOptions, MountInfo, PortBinding,
+};
+use tracing::{debug, warn};
+
+use crate::sdk::ContainerCli;
+use crate::sdk::types::ContainerListEntry;
+
+/// Apple Container backend — drives the `container` CLI binary.
+pub struct AppleContainerBackend {
+    cli: ContainerCli,
+    staging_base: PathBuf,
+}
+
+impl AppleContainerBackend {
+    /// Create a new backend wrapping the given CLI handle.
+    pub fn new(cli: ContainerCli) -> Self {
+        warn!(
+            "Apple Container backend is EXPERIMENTAL — \
+             expect rough edges and missing features"
+        );
+        let staging_base = default_staging_base();
+        Self { cli, staging_base }
+    }
+}
+
+/// Default host-side staging directory for file uploads.
+fn default_staging_base() -> PathBuf {
+    std::env::var("HOME").map_or_else(
+        |_| PathBuf::from("/tmp/cella/containers"),
+        |h| {
+            PathBuf::from(h)
+                .join(".cache")
+                .join("cella")
+                .join("containers")
+        },
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Trait implementation
+// ---------------------------------------------------------------------------
+
+impl ContainerBackend for AppleContainerBackend {
+    fn kind(&self) -> BackendKind {
+        BackendKind::AppleContainer
+    }
+
+    // -- Container operations --
+
+    fn find_container<'a>(
+        &'a self,
+        workspace_root: &'a Path,
+    ) -> BoxFuture<'a, Result<Option<ContainerInfo>, BackendError>> {
+        Box::pin(async move {
+            let canonical = workspace_root
+                .canonicalize()
+                .unwrap_or_else(|_| workspace_root.to_path_buf());
+            let canonical_str = canonical.to_string_lossy();
+
+            let entries = self.cli.list(None).await?;
+
+            for entry in entries {
+                if let Some(info) = entry_to_container_info(&entry)
+                    && info
+                        .labels
+                        .get("dev.cella.workspace_path")
+                        .is_some_and(|wp| wp == canonical_str.as_ref())
+                {
+                    return Ok(Some(info));
+                }
+            }
+            Ok(None)
+        })
+    }
+
+    fn create_container<'a>(
+        &'a self,
+        opts: &'a CreateContainerOptions,
+    ) -> BoxFuture<'a, Result<String, BackendError>> {
+        Box::pin(async move {
+            let args = build_create_args(opts, &self.staging_base);
+            debug!(?args, "container create arguments");
+            self.cli.create(&args).await
+        })
+    }
+
+    fn start_container<'a>(&'a self, id: &'a str) -> BoxFuture<'a, Result<(), BackendError>> {
+        Box::pin(async move { self.cli.start(id).await })
+    }
+
+    fn stop_container<'a>(&'a self, id: &'a str) -> BoxFuture<'a, Result<(), BackendError>> {
+        Box::pin(async move { self.cli.stop(id).await })
+    }
+
+    fn remove_container<'a>(
+        &'a self,
+        id: &'a str,
+        remove_volumes: bool,
+    ) -> BoxFuture<'a, Result<(), BackendError>> {
+        Box::pin(async move {
+            self.cli.rm(id).await?;
+            if remove_volumes {
+                let staging_dir = self.staging_base.join(id);
+                if staging_dir.exists() {
+                    debug!(path = %staging_dir.display(), "removing staging directory");
+                    let _ = tokio::fs::remove_dir_all(&staging_dir).await;
+                }
+            }
+            Ok(())
+        })
+    }
+
+    fn inspect_container<'a>(
+        &'a self,
+        id: &'a str,
+    ) -> BoxFuture<'a, Result<ContainerInfo, BackendError>> {
+        Box::pin(async move {
+            let entry = self.cli.inspect(id).await?;
+            entry_to_container_info(&entry).ok_or_else(|| BackendError::ContainerNotFound {
+                identifier: id.to_string(),
+            })
+        })
+    }
+
+    fn list_cella_containers(
+        &self,
+        running_only: bool,
+    ) -> BoxFuture<'_, Result<Vec<ContainerInfo>, BackendError>> {
+        Box::pin(async move {
+            let entries = self.cli.list(None).await?;
+            let mut results = Vec::new();
+            for entry in &entries {
+                if let Some(info) = entry_to_container_info(entry) {
+                    // Only include containers managed by cella.
+                    if info.labels.contains_key("dev.cella.tool") {
+                        if running_only && info.state != ContainerState::Running {
+                            continue;
+                        }
+                        results.push(info);
+                    }
+                }
+            }
+            Ok(results)
+        })
+    }
+
+    fn container_logs<'a>(
+        &'a self,
+        id: &'a str,
+        tail: u32,
+    ) -> BoxFuture<'a, Result<String, BackendError>> {
+        Box::pin(async move { self.cli.logs(id, tail).await })
+    }
+
+    // -- Exec operations --
+
+    fn exec_command<'a>(
+        &'a self,
+        container_id: &'a str,
+        opts: &'a ExecOptions,
+    ) -> BoxFuture<'a, Result<ExecResult, BackendError>> {
+        Box::pin(async move {
+            let (exit_code, stdout, stderr) = self
+                .cli
+                .exec_capture(
+                    container_id,
+                    &opts.cmd,
+                    opts.user.as_deref(),
+                    opts.env.as_deref(),
+                    opts.working_dir.as_deref(),
+                )
+                .await?;
+            Ok(ExecResult {
+                exit_code,
+                stdout,
+                stderr,
+            })
+        })
+    }
+
+    fn exec_stream<'a>(
+        &'a self,
+        container_id: &'a str,
+        opts: &'a ExecOptions,
+        mut stdout_writer: Box<dyn Write + Send + 'a>,
+        mut stderr_writer: Box<dyn Write + Send + 'a>,
+    ) -> BoxFuture<'a, Result<ExecResult, BackendError>> {
+        Box::pin(async move {
+            // For now, capture all output then write it to the writers.
+            // A proper streaming implementation would use piped stdio with
+            // incremental reads, but the CLI may not support streaming JSON.
+            let (exit_code, stdout, stderr) = self
+                .cli
+                .exec_capture(
+                    container_id,
+                    &opts.cmd,
+                    opts.user.as_deref(),
+                    opts.env.as_deref(),
+                    opts.working_dir.as_deref(),
+                )
+                .await?;
+
+            let _ = stdout_writer.write_all(stdout.as_bytes());
+            let _ = stderr_writer.write_all(stderr.as_bytes());
+
+            Ok(ExecResult {
+                exit_code,
+                stdout,
+                stderr,
+            })
+        })
+    }
+
+    fn exec_interactive<'a>(
+        &'a self,
+        container_id: &'a str,
+        opts: &'a InteractiveExecOptions,
+    ) -> BoxFuture<'a, Result<i64, BackendError>> {
+        Box::pin(async move {
+            let mut args = vec!["exec".to_string()];
+
+            if opts.tty {
+                args.push("-it".to_string());
+            }
+            if let Some(ref u) = opts.user {
+                args.push("--user".to_string());
+                args.push(u.clone());
+            }
+            if let Some(ref vars) = opts.env {
+                for var in vars {
+                    args.push("-e".to_string());
+                    args.push(var.clone());
+                }
+            }
+            if let Some(ref wd) = opts.working_dir {
+                args.push("-w".to_string());
+                args.push(wd.clone());
+            }
+
+            args.push(container_id.to_string());
+            for c in &opts.cmd {
+                args.push(c.clone());
+            }
+
+            let status = std::process::Command::new(self.cli.binary_path())
+                .args(&args)
+                .stdin(Stdio::inherit())
+                .stdout(Stdio::inherit())
+                .stderr(Stdio::inherit())
+                .status()
+                .map_err(|e| BackendError::HostCommandFailed {
+                    command: format!("{} {}", self.cli.binary_path().display(), args.join(" ")),
+                    source: e,
+                })?;
+
+            Ok(i64::from(status.code().unwrap_or(-1)))
+        })
+    }
+
+    fn exec_detached<'a>(
+        &'a self,
+        container_id: &'a str,
+        opts: &'a ExecOptions,
+    ) -> BoxFuture<'a, Result<String, BackendError>> {
+        Box::pin(async move {
+            let mut args = vec!["exec".to_string(), "-d".to_string()];
+
+            if let Some(ref u) = opts.user {
+                args.push("--user".to_string());
+                args.push(u.clone());
+            }
+            if let Some(ref vars) = opts.env {
+                for var in vars {
+                    args.push("-e".to_string());
+                    args.push(var.clone());
+                }
+            }
+            if let Some(ref wd) = opts.working_dir {
+                args.push("-w".to_string());
+                args.push(wd.clone());
+            }
+
+            args.push(container_id.to_string());
+            for c in &opts.cmd {
+                args.push(c.clone());
+            }
+
+            let output = crate::sdk::run::run_cli_owned(self.cli.binary_path(), &args).await?;
+            if output.exit_code != 0 {
+                return Err(BackendError::Runtime(output.stderr.into()));
+            }
+            // Return the output as a "process ID" placeholder — the Apple
+            // Container CLI may not return a real exec ID.
+            Ok(output.stdout.trim().to_string())
+        })
+    }
+
+    // -- Image operations --
+
+    fn pull_image<'a>(&'a self, image: &'a str) -> BoxFuture<'a, Result<(), BackendError>> {
+        Box::pin(async move { self.cli.pull(image).await })
+    }
+
+    fn build_image<'a>(
+        &'a self,
+        opts: &'a BuildOptions,
+    ) -> BoxFuture<'a, Result<String, BackendError>> {
+        Box::pin(async move {
+            let build_args: Vec<(String, String)> = opts
+                .args
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
+            self.cli
+                .build(
+                    &opts.context_path,
+                    &opts.dockerfile,
+                    &opts.image_name,
+                    &build_args,
+                )
+                .await
+        })
+    }
+
+    fn image_exists<'a>(&'a self, image: &'a str) -> BoxFuture<'a, Result<bool, BackendError>> {
+        Box::pin(async move { self.cli.image_exists(image).await })
+    }
+
+    fn inspect_image_details<'a>(
+        &'a self,
+        image: &'a str,
+    ) -> BoxFuture<'a, Result<ImageDetails, BackendError>> {
+        Box::pin(async move {
+            // The Apple Container CLI's image inspect format is not fully
+            // documented. For now we return sensible defaults and parse what
+            // we can from the raw JSON output.
+            // TODO: parse OCI image config for user, env, labels once the
+            // CLI output format stabilizes.
+            let raw = self.cli.image_inspect(image).await?;
+
+            // Attempt to extract user and env from a JSON blob that might
+            // contain Docker-style config fields.
+            let (user, env, metadata) = parse_image_details_best_effort(&raw);
+
+            Ok(ImageDetails {
+                user,
+                env,
+                metadata,
+            })
+        })
+    }
+
+    // -- File injection --
+
+    fn upload_files<'a>(
+        &'a self,
+        container_id: &'a str,
+        files: &'a [FileToUpload],
+    ) -> BoxFuture<'a, Result<(), BackendError>> {
+        Box::pin(async move {
+            let staging_dir = self.staging_base.join(container_id);
+            tokio::fs::create_dir_all(&staging_dir).await?;
+
+            let staging_mount = "/tmp/.cella-staging";
+
+            for file in files {
+                // Write to host staging directory.
+                let host_path =
+                    staging_dir.join(file.path.trim_start_matches('/').replace('/', "_"));
+                tokio::fs::write(&host_path, &file.content).await?;
+
+                let staging_name = host_path
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string();
+                let staging_src = format!("{staging_mount}/{staging_name}");
+
+                // Ensure parent directory exists inside the container.
+                if let Some(parent) = Path::new(&file.path).parent() {
+                    let mkdir_cmd = vec![
+                        "mkdir".to_string(),
+                        "-p".to_string(),
+                        parent.to_string_lossy().to_string(),
+                    ];
+                    let _ = self
+                        .cli
+                        .exec_capture(container_id, &mkdir_cmd, Some("root"), None, None)
+                        .await;
+                }
+
+                // Copy from staging mount to final path.
+                let cp_cmd = vec!["cp".to_string(), staging_src, file.path.clone()];
+                let (exit_code, _, stderr) = self
+                    .cli
+                    .exec_capture(container_id, &cp_cmd, Some("root"), None, None)
+                    .await?;
+                if exit_code != 0 {
+                    return Err(BackendError::Runtime(
+                        format!("cp failed for {}: {stderr}", file.path).into(),
+                    ));
+                }
+
+                // Set permissions.
+                let chmod_cmd = vec![
+                    "chmod".to_string(),
+                    format!("{:o}", file.mode),
+                    file.path.clone(),
+                ];
+                let (exit_code, _, stderr) = self
+                    .cli
+                    .exec_capture(container_id, &chmod_cmd, Some("root"), None, None)
+                    .await?;
+                if exit_code != 0 {
+                    return Err(BackendError::Runtime(
+                        format!("chmod failed for {}: {stderr}", file.path).into(),
+                    ));
+                }
+            }
+
+            Ok(())
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Build CLI arguments for `container create` from `CreateContainerOptions`.
+fn build_create_args(opts: &CreateContainerOptions, staging_base: &Path) -> Vec<String> {
+    let mut args = Vec::new();
+
+    // Name
+    args.push("--name".to_string());
+    args.push(opts.name.clone());
+
+    // Labels
+    for (key, value) in &opts.labels {
+        args.push("--label".to_string());
+        args.push(format!("{key}={value}"));
+    }
+
+    // Environment variables
+    for var in &opts.env {
+        args.push("-e".to_string());
+        args.push(var.clone());
+    }
+    for var in &opts.remote_env {
+        args.push("-e".to_string());
+        args.push(var.clone());
+    }
+
+    // User
+    if let Some(ref user) = opts.user {
+        args.push("-u".to_string());
+        args.push(user.clone());
+    }
+
+    // Working directory
+    args.push("-w".to_string());
+    args.push(opts.workspace_folder.clone());
+
+    // Workspace mount
+    if let Some(ref wm) = opts.workspace_mount {
+        args.push("--volume".to_string());
+        args.push(format!("{}:{}", wm.source, wm.target));
+    }
+
+    // Additional mounts
+    for mount in &opts.mounts {
+        args.push("--volume".to_string());
+        args.push(format!("{}:{}", mount.source, mount.target));
+    }
+
+    // Staging directory mount for file uploads.
+    let staging_dir = staging_base.join(&opts.name);
+    args.push("--volume".to_string());
+    args.push(format!("{}:/tmp/.cella-staging", staging_dir.display()));
+
+    // Port bindings
+    for (container_port, forwards) in &opts.port_bindings {
+        for fwd in forwards {
+            let host_part = match (&fwd.host_ip, &fwd.host_port) {
+                (Some(ip), Some(port)) => format!("{ip}:{port}"),
+                (None, Some(port)) => port.clone(),
+                (Some(ip), None) => format!("{ip}:"),
+                (None, None) => String::new(),
+            };
+            args.push("-p".to_string());
+            if host_part.is_empty() {
+                args.push(container_port.clone());
+            } else {
+                args.push(format!("{host_part}:{container_port}"));
+            }
+        }
+    }
+
+    // Entrypoint
+    if let Some(ref ep) = opts.entrypoint
+        && !ep.is_empty()
+    {
+        args.push("--entrypoint".to_string());
+        args.push(ep.join(" "));
+    }
+
+    // SSH agent forwarding
+    if std::env::var("SSH_AUTH_SOCK").is_ok() {
+        args.push("--ssh".to_string());
+    }
+
+    // Warn about unsupported Docker-specific options.
+    emit_unsupported_warnings(opts);
+
+    // Image goes last.
+    args.push(opts.image.clone());
+
+    // Command after image.
+    if let Some(ref cmd) = opts.cmd {
+        for c in cmd {
+            args.push(c.clone());
+        }
+    }
+
+    args
+}
+
+/// Emit warnings for Docker-specific options that Apple Container does not support.
+fn emit_unsupported_warnings(opts: &CreateContainerOptions) {
+    if opts.privileged {
+        warn!("--privileged is not supported by Apple Container; ignoring");
+    }
+    if !opts.cap_add.is_empty() {
+        warn!(
+            caps = ?opts.cap_add,
+            "--cap-add is not supported by Apple Container; ignoring"
+        );
+    }
+    if !opts.security_opt.is_empty() {
+        warn!(
+            opts = ?opts.security_opt,
+            "--security-opt is not supported by Apple Container; ignoring"
+        );
+    }
+    if opts.gpu_request.is_some() {
+        warn!("GPU passthrough is not supported by Apple Container; ignoring");
+    }
+
+    if let Some(ref overrides) = opts.run_args_overrides {
+        if !overrides.devices.is_empty() {
+            warn!("--device is not supported by Apple Container; ignoring");
+        }
+        if overrides.gpus.is_some() {
+            warn!("--gpus is not supported by Apple Container; ignoring");
+        }
+        if !overrides.unrecognized.is_empty() {
+            warn!(
+                args = ?overrides.unrecognized,
+                "unrecognized runArgs passed to Apple Container; ignoring"
+            );
+        }
+    }
+}
+
+/// Convert a CLI list/inspect entry into a `ContainerInfo`.
+///
+/// Returns `None` if the entry lacks an ID (which is required).
+fn entry_to_container_info(entry: &ContainerListEntry) -> Option<ContainerInfo> {
+    let config = entry.configuration.as_ref()?;
+    let id = config.id.clone()?;
+
+    let state = entry
+        .status
+        .as_ref()
+        .and_then(|s| s.state.as_deref())
+        .map_or_else(
+            || ContainerState::Other("unknown".to_string()),
+            |s| {
+                // Apple Container uses "stopped" rather than Docker's "exited".
+                match s {
+                    "stopped" => ContainerState::Stopped,
+                    other => ContainerState::parse(other),
+                }
+            },
+        );
+
+    let exit_code = entry.status.as_ref().and_then(|s| s.exit_code);
+
+    let labels = config.labels.clone().unwrap_or_default();
+    let config_hash = labels.get("dev.cella.config_hash").cloned();
+
+    let ports = config
+        .published_ports
+        .as_ref()
+        .map(|ps| {
+            ps.iter()
+                .filter_map(|p| {
+                    Some(PortBinding {
+                        container_port: p.container_port?,
+                        host_port: p.host_port,
+                        protocol: p.protocol.clone().unwrap_or_else(|| "tcp".to_string()),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mounts = config
+        .mounts
+        .as_ref()
+        .map(|ms| {
+            ms.iter()
+                .map(|m| MountInfo {
+                    mount_type: m.mount_type.clone().unwrap_or_default(),
+                    source: m.source.clone().unwrap_or_default(),
+                    destination: m.destination.clone().unwrap_or_default(),
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let created_at = labels.get("dev.cella.created_at").cloned();
+
+    Some(ContainerInfo {
+        id,
+        name: config.name.clone().unwrap_or_default(),
+        state,
+        exit_code,
+        labels,
+        config_hash,
+        ports,
+        created_at,
+        container_user: None,
+        image: config.image.clone(),
+        mounts,
+        backend: BackendKind::AppleContainer,
+    })
+}
+
+/// Best-effort extraction of user, env, and metadata from raw image inspect JSON.
+fn parse_image_details_best_effort(raw: &str) -> (String, Vec<String>, Option<String>) {
+    let mut user = "root".to_string();
+    let mut env = Vec::new();
+    let mut metadata = None;
+
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(raw) {
+        // Try Docker-style config paths.
+        let config = value
+            .get("Config")
+            .or_else(|| value.get("config"))
+            .or_else(|| value.get("container_config"));
+
+        if let Some(cfg) = config {
+            if let Some(u) = cfg.get("User").or_else(|| cfg.get("user"))
+                && let Some(u_str) = u.as_str()
+                && !u_str.is_empty()
+            {
+                // Take only the user part (before any colon).
+                user = u_str.split(':').next().unwrap_or(u_str).to_string();
+            }
+            if let Some(e) = cfg.get("Env").or_else(|| cfg.get("env"))
+                && let Some(arr) = e.as_array()
+            {
+                env = arr
+                    .iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect();
+            }
+            if let Some(labels) = cfg.get("Labels").or_else(|| cfg.get("labels"))
+                && let Some(md) = labels.get("devcontainer.metadata").and_then(|v| v.as_str())
+            {
+                metadata = Some(md.to_string());
+            }
+        }
+    }
+
+    (user, env, metadata)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use cella_backend::{
+        CreateContainerOptions, GpuRequest, MountConfig, PortForward, RunArgsOverrides,
+    };
+
+    use super::*;
+
+    fn minimal_create_opts() -> CreateContainerOptions {
+        CreateContainerOptions {
+            name: "test-container".to_string(),
+            image: "ubuntu:latest".to_string(),
+            labels: HashMap::new(),
+            env: Vec::new(),
+            remote_env: Vec::new(),
+            user: None,
+            workspace_folder: "/workspace".to_string(),
+            workspace_mount: None,
+            mounts: Vec::new(),
+            port_bindings: HashMap::new(),
+            entrypoint: None,
+            cmd: None,
+            cap_add: Vec::new(),
+            security_opt: Vec::new(),
+            privileged: false,
+            run_args_overrides: None,
+            gpu_request: None,
+        }
+    }
+
+    #[test]
+    fn build_create_args_minimal() {
+        let opts = minimal_create_opts();
+        let staging = PathBuf::from("/tmp/staging");
+        let args = build_create_args(&opts, &staging);
+
+        assert!(args.contains(&"--name".to_string()));
+        assert!(args.contains(&"test-container".to_string()));
+        assert!(args.contains(&"-w".to_string()));
+        assert!(args.contains(&"/workspace".to_string()));
+        // Image should be the last non-cmd argument.
+        assert_eq!(args.last().unwrap(), "ubuntu:latest");
+    }
+
+    #[test]
+    fn build_create_args_with_labels() {
+        let mut opts = minimal_create_opts();
+        opts.labels
+            .insert("dev.cella.tool".to_string(), "cella".to_string());
+        let staging = PathBuf::from("/tmp/staging");
+        let args = build_create_args(&opts, &staging);
+
+        let label_idx = args.iter().position(|a| a == "--label").unwrap();
+        assert_eq!(args[label_idx + 1], "dev.cella.tool=cella");
+    }
+
+    #[test]
+    fn build_create_args_with_env() {
+        let mut opts = minimal_create_opts();
+        opts.env = vec!["FOO=bar".to_string()];
+        opts.remote_env = vec!["BAZ=qux".to_string()];
+        let staging = PathBuf::from("/tmp/staging");
+        let args = build_create_args(&opts, &staging);
+
+        let env_positions: Vec<usize> = args
+            .iter()
+            .enumerate()
+            .filter_map(|(i, a)| if a == "-e" { Some(i) } else { None })
+            .collect();
+        assert_eq!(env_positions.len(), 2);
+        assert_eq!(args[env_positions[0] + 1], "FOO=bar");
+        assert_eq!(args[env_positions[1] + 1], "BAZ=qux");
+    }
+
+    #[test]
+    fn build_create_args_with_user() {
+        let mut opts = minimal_create_opts();
+        opts.user = Some("vscode".to_string());
+        let staging = PathBuf::from("/tmp/staging");
+        let args = build_create_args(&opts, &staging);
+
+        let user_idx = args.iter().position(|a| a == "-u").unwrap();
+        assert_eq!(args[user_idx + 1], "vscode");
+    }
+
+    #[test]
+    fn build_create_args_with_workspace_mount() {
+        let mut opts = minimal_create_opts();
+        opts.workspace_mount = Some(MountConfig {
+            mount_type: "bind".to_string(),
+            source: "/host/project".to_string(),
+            target: "/workspace".to_string(),
+            consistency: None,
+        });
+        let staging = PathBuf::from("/tmp/staging");
+        let args = build_create_args(&opts, &staging);
+
+        let vol_idx = args.iter().position(|a| a == "--volume").unwrap();
+        assert_eq!(args[vol_idx + 1], "/host/project:/workspace");
+    }
+
+    #[test]
+    fn build_create_args_with_ports() {
+        let mut opts = minimal_create_opts();
+        opts.port_bindings.insert(
+            "8080/tcp".to_string(),
+            vec![PortForward {
+                host_ip: None,
+                host_port: Some("3000".to_string()),
+            }],
+        );
+        let staging = PathBuf::from("/tmp/staging");
+        let args = build_create_args(&opts, &staging);
+
+        let port_idx = args.iter().position(|a| a == "-p").unwrap();
+        assert_eq!(args[port_idx + 1], "3000:8080/tcp");
+    }
+
+    #[test]
+    fn build_create_args_with_entrypoint() {
+        let mut opts = minimal_create_opts();
+        opts.entrypoint = Some(vec!["/bin/sh".to_string(), "-c".to_string()]);
+        let staging = PathBuf::from("/tmp/staging");
+        let args = build_create_args(&opts, &staging);
+
+        let ep_idx = args.iter().position(|a| a == "--entrypoint").unwrap();
+        assert_eq!(args[ep_idx + 1], "/bin/sh -c");
+    }
+
+    #[test]
+    fn build_create_args_with_cmd() {
+        let mut opts = minimal_create_opts();
+        opts.cmd = Some(vec!["sleep".to_string(), "infinity".to_string()]);
+        let staging = PathBuf::from("/tmp/staging");
+        let args = build_create_args(&opts, &staging);
+
+        // Image should be followed by cmd.
+        let img_idx = args.iter().position(|a| a == "ubuntu:latest").unwrap();
+        assert_eq!(args[img_idx + 1], "sleep");
+        assert_eq!(args[img_idx + 2], "infinity");
+    }
+
+    #[test]
+    fn build_create_args_staging_mount() {
+        let opts = minimal_create_opts();
+        let staging = PathBuf::from("/tmp/staging");
+        let args = build_create_args(&opts, &staging);
+
+        // Should contain a volume mount for the staging directory.
+        let vol_args: Vec<&str> = args
+            .windows(2)
+            .filter_map(|w| {
+                if w[0] == "--volume" {
+                    Some(w[1].as_str())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let staging_mount = vol_args.iter().find(|v| v.contains(".cella-staging"));
+        assert!(staging_mount.is_some(), "expected staging volume mount");
+    }
+
+    #[test]
+    fn entry_to_container_info_basic() {
+        let entry = ContainerListEntry {
+            status: Some(crate::sdk::types::ContainerStatus {
+                state: Some("running".to_string()),
+                exit_code: Some(0),
+            }),
+            configuration: Some(crate::sdk::types::ContainerConfiguration {
+                id: Some("abc123".to_string()),
+                name: Some("test".to_string()),
+                image: Some("ubuntu:latest".to_string()),
+                labels: Some(HashMap::from([(
+                    "dev.cella.tool".to_string(),
+                    "cella".to_string(),
+                )])),
+                published_ports: None,
+                mounts: None,
+            }),
+        };
+
+        let info = entry_to_container_info(&entry).unwrap();
+        assert_eq!(info.id, "abc123");
+        assert_eq!(info.name, "test");
+        assert_eq!(info.state, ContainerState::Running);
+        assert_eq!(info.exit_code, Some(0));
+        assert_eq!(info.backend, BackendKind::AppleContainer);
+    }
+
+    #[test]
+    fn entry_to_container_info_stopped_state() {
+        let entry = ContainerListEntry {
+            status: Some(crate::sdk::types::ContainerStatus {
+                state: Some("stopped".to_string()),
+                exit_code: Some(137),
+            }),
+            configuration: Some(crate::sdk::types::ContainerConfiguration {
+                id: Some("def456".to_string()),
+                name: None,
+                image: None,
+                labels: None,
+                published_ports: None,
+                mounts: None,
+            }),
+        };
+
+        let info = entry_to_container_info(&entry).unwrap();
+        assert_eq!(info.state, ContainerState::Stopped);
+        assert_eq!(info.exit_code, Some(137));
+    }
+
+    #[test]
+    fn entry_to_container_info_no_id_returns_none() {
+        let entry = ContainerListEntry {
+            status: None,
+            configuration: Some(crate::sdk::types::ContainerConfiguration {
+                id: None,
+                name: Some("orphan".to_string()),
+                image: None,
+                labels: None,
+                published_ports: None,
+                mounts: None,
+            }),
+        };
+
+        assert!(entry_to_container_info(&entry).is_none());
+    }
+
+    #[test]
+    fn entry_to_container_info_no_config_returns_none() {
+        let entry = ContainerListEntry {
+            status: Some(crate::sdk::types::ContainerStatus {
+                state: Some("running".to_string()),
+                exit_code: None,
+            }),
+            configuration: None,
+        };
+
+        assert!(entry_to_container_info(&entry).is_none());
+    }
+
+    #[test]
+    fn parse_image_details_docker_style() {
+        let raw = r#"{
+            "Config": {
+                "User": "vscode:vscode",
+                "Env": ["PATH=/usr/bin", "HOME=/home/vscode"],
+                "Labels": {
+                    "devcontainer.metadata": "[{\"remoteUser\":\"vscode\"}]"
+                }
+            }
+        }"#;
+
+        let (user, env, metadata) = parse_image_details_best_effort(raw);
+        assert_eq!(user, "vscode");
+        assert_eq!(env.len(), 2);
+        assert!(metadata.is_some());
+    }
+
+    #[test]
+    fn parse_image_details_empty_json() {
+        let (user, env, metadata) = parse_image_details_best_effort("{}");
+        assert_eq!(user, "root");
+        assert!(env.is_empty());
+        assert!(metadata.is_none());
+    }
+
+    #[test]
+    fn parse_image_details_invalid_json() {
+        let (user, env, metadata) = parse_image_details_best_effort("not json");
+        assert_eq!(user, "root");
+        assert!(env.is_empty());
+        assert!(metadata.is_none());
+    }
+
+    #[test]
+    fn default_staging_base_contains_cella() {
+        let base = default_staging_base();
+        let base_str = base.to_string_lossy();
+        assert!(
+            base_str.contains("cella"),
+            "staging base should contain 'cella': {base_str}"
+        );
+    }
+
+    #[test]
+    fn unsupported_warnings_do_not_panic() {
+        let mut opts = minimal_create_opts();
+        opts.privileged = true;
+        opts.cap_add = vec!["SYS_PTRACE".to_string()];
+        opts.security_opt = vec!["seccomp=unconfined".to_string()];
+        opts.gpu_request = Some(GpuRequest::All);
+        opts.run_args_overrides = Some(RunArgsOverrides {
+            gpus: Some(GpuRequest::All),
+            unrecognized: vec!["--custom-flag".to_string()],
+            ..RunArgsOverrides::default()
+        });
+
+        // Should not panic — just emits warnings.
+        emit_unsupported_warnings(&opts);
+    }
+}

--- a/crates/cella-container/src/discovery.rs
+++ b/crates/cella-container/src/discovery.rs
@@ -1,0 +1,201 @@
+//! CLI binary discovery for the Apple Container runtime.
+//!
+//! Searches for the `container` binary using environment variables and `PATH`,
+//! then validates it by checking version output.
+
+use std::env;
+use std::path::{Path, PathBuf};
+
+use tracing::{debug, warn};
+
+use crate::sdk::ContainerCli;
+use crate::sdk::run::run_cli;
+use crate::sdk::types::VersionInfo;
+
+/// Name of the environment variable that overrides binary lookup.
+const ENV_BINARY_PATH: &str = "CELLA_CONTAINER_PATH";
+
+/// Default binary name to search for in `PATH`.
+const BINARY_NAME: &str = "container";
+
+/// Discover the Apple Container CLI binary.
+///
+/// Strategy:
+/// 1. Check `CELLA_CONTAINER_PATH` environment variable
+/// 2. Search for `container` in `PATH`
+/// 3. Run `container version --format json` to validate it is Apple's tool
+///
+/// Returns `None` if the binary is not found or is not the Apple Container CLI.
+pub fn discover() -> Option<ContainerCli> {
+    let binary_path = find_binary()?;
+    debug!(path = %binary_path.display(), "found container binary");
+
+    // Validate by running version command (blocking on an async operation).
+    // Discovery runs once at startup so spawning a short-lived runtime is fine.
+    let rt = tokio::runtime::Handle::try_current();
+    let version_result = if let Ok(handle) = rt {
+        // Already inside a tokio runtime — use `block_in_place` to avoid
+        // nesting a new runtime.
+        tokio::task::block_in_place(|| handle.block_on(validate_binary(&binary_path)))
+    } else {
+        // No runtime yet — create a temporary one.
+        let rt = tokio::runtime::Runtime::new().ok()?;
+        rt.block_on(validate_binary(&binary_path))
+    };
+
+    match version_result {
+        Ok(version) => {
+            debug!(version, "validated Apple Container CLI");
+            Some(ContainerCli::new(binary_path, version))
+        }
+        Err(e) => {
+            debug!(error = %e, "binary at path is not a valid Apple Container CLI");
+            None
+        }
+    }
+}
+
+/// Locate the binary on disk.
+fn find_binary() -> Option<PathBuf> {
+    // 1. Explicit override via env var.
+    if let Ok(path) = env::var(ENV_BINARY_PATH) {
+        let p = PathBuf::from(&path);
+        if p.is_file() {
+            return Some(p);
+        }
+        warn!(
+            path,
+            "{ENV_BINARY_PATH} is set but does not point to an existing file"
+        );
+    }
+
+    // 2. Search PATH.
+    which_binary(BINARY_NAME)
+}
+
+/// Search `PATH` for an executable with the given name.
+fn which_binary(name: &str) -> Option<PathBuf> {
+    let path_var = env::var("PATH").ok()?;
+    for dir in env::split_paths(&path_var) {
+        let candidate = dir.join(name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Run `container version --format json` and extract the version string.
+///
+/// Returns `Err` if the binary cannot be executed or the output does not
+/// look like Apple's Container CLI.
+async fn validate_binary(binary: &Path) -> Result<String, String> {
+    let output = run_cli(binary, &["version", "--format", "json"])
+        .await
+        .map_err(|e| format!("failed to run version command: {e}"))?;
+
+    if output.exit_code != 0 {
+        return Err(format!(
+            "version command exited with code {}",
+            output.exit_code
+        ));
+    }
+
+    // Parse as array of VersionInfo.
+    let entries: Vec<VersionInfo> = serde_json::from_str(&output.stdout)
+        .map_err(|e| format!("failed to parse version JSON: {e}"))?;
+
+    // Look for an entry that identifies as Apple's container tool.
+    for entry in &entries {
+        if is_apple_container_entry(entry) {
+            return Ok(entry
+                .version
+                .clone()
+                .unwrap_or_else(|| "unknown".to_string()));
+        }
+    }
+
+    // If we got valid JSON with at least one entry, accept it even if the
+    // app_name doesn't exactly match — the CLI format may evolve.
+    if let Some(first) = entries.first()
+        && first.version.is_some()
+    {
+        return Ok(first.version.clone().unwrap_or_default());
+    }
+
+    Err("no recognizable Apple Container version entry found".to_string())
+}
+
+/// Check whether a version entry looks like it belongs to Apple's container tool.
+fn is_apple_container_entry(entry: &VersionInfo) -> bool {
+    if let Some(name) = &entry.app_name {
+        let lower = name.to_ascii_lowercase();
+        return lower.contains("container");
+    }
+    // Without an app_name, accept any entry that has a version — the user
+    // explicitly put the binary in PATH or set CELLA_CONTAINER_PATH.
+    entry.version.is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_apple_container_entry_matches_name() {
+        let entry = VersionInfo {
+            version: Some("1.0.0".to_string()),
+            app_name: Some("container".to_string()),
+        };
+        assert!(is_apple_container_entry(&entry));
+    }
+
+    #[test]
+    fn is_apple_container_entry_case_insensitive() {
+        let entry = VersionInfo {
+            version: Some("1.0.0".to_string()),
+            app_name: Some("Apple Container".to_string()),
+        };
+        assert!(is_apple_container_entry(&entry));
+    }
+
+    #[test]
+    fn is_apple_container_entry_no_app_name_with_version() {
+        let entry = VersionInfo {
+            version: Some("1.0.0".to_string()),
+            app_name: None,
+        };
+        assert!(is_apple_container_entry(&entry));
+    }
+
+    #[test]
+    fn is_apple_container_entry_no_fields() {
+        let entry = VersionInfo {
+            version: None,
+            app_name: None,
+        };
+        assert!(!is_apple_container_entry(&entry));
+    }
+
+    #[test]
+    fn is_apple_container_entry_wrong_name_no_version() {
+        let entry = VersionInfo {
+            version: None,
+            app_name: Some("docker".to_string()),
+        };
+        assert!(!is_apple_container_entry(&entry));
+    }
+
+    #[test]
+    fn which_binary_finds_sh() {
+        // /bin/sh should exist on any POSIX system.
+        let result = which_binary("sh");
+        assert!(result.is_some(), "expected to find 'sh' in PATH");
+    }
+
+    #[test]
+    fn which_binary_returns_none_for_nonexistent() {
+        let result = which_binary("definitely_not_a_real_binary_xyz");
+        assert!(result.is_none());
+    }
+}

--- a/crates/cella-container/src/lib.rs
+++ b/crates/cella-container/src/lib.rs
@@ -1,0 +1,11 @@
+//! Apple Container backend for cella.
+//!
+//! This crate implements `cella_backend::ContainerBackend` by driving
+//! the Apple `container` CLI binary. It is an EXPERIMENTAL backend —
+//! the CLI output format is pre-1.0 and may change between releases.
+
+pub mod backend;
+pub mod discovery;
+pub mod sdk;
+
+pub use backend::AppleContainerBackend;

--- a/crates/cella-container/src/sdk/mod.rs
+++ b/crates/cella-container/src/sdk/mod.rs
@@ -1,0 +1,284 @@
+//! SDK for driving the Apple `container` CLI binary.
+//!
+//! [`ContainerCli`] wraps the binary and provides typed async methods
+//! for each CLI subcommand. All operations shell out to the binary and
+//! parse its stdout/stderr.
+
+pub mod run;
+pub mod types;
+
+use std::path::{Path, PathBuf};
+
+use cella_backend::BackendError;
+use tracing::debug;
+
+use self::run::{run_cli, run_cli_json, run_cli_owned};
+
+/// Handle to a discovered Apple Container CLI binary.
+pub struct ContainerCli {
+    binary_path: PathBuf,
+    version: String,
+}
+
+impl ContainerCli {
+    /// Create a new handle from a discovered binary path and version string.
+    pub const fn new(binary_path: PathBuf, version: String) -> Self {
+        Self {
+            binary_path,
+            version,
+        }
+    }
+
+    /// Path to the `container` binary.
+    pub fn binary_path(&self) -> &Path {
+        &self.binary_path
+    }
+
+    /// Discovered version string.
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+
+    // -- Container lifecycle operations --
+
+    /// Create a container (without starting it).
+    ///
+    /// `args` should contain all flags and the image name as the final element.
+    /// Returns the container ID (plain text from stdout).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the CLI exits non-zero or cannot be spawned.
+    pub async fn create(&self, args: &[String]) -> Result<String, BackendError> {
+        let mut cli_args = vec!["create".to_string()];
+        cli_args.extend_from_slice(args);
+        let output = run_cli_owned(&self.binary_path, &cli_args).await?;
+        if output.exit_code != 0 {
+            return Err(BackendError::Runtime(output.stderr.into()));
+        }
+        Ok(output.stdout.trim().to_string())
+    }
+
+    /// Start a stopped container.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the CLI exits non-zero or cannot be spawned.
+    pub async fn start(&self, id: &str) -> Result<(), BackendError> {
+        let output = run_cli(&self.binary_path, &["start", id]).await?;
+        if output.exit_code != 0 {
+            return Err(BackendError::Runtime(output.stderr.into()));
+        }
+        Ok(())
+    }
+
+    /// Stop a running container.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the CLI exits non-zero or cannot be spawned.
+    pub async fn stop(&self, id: &str) -> Result<(), BackendError> {
+        let output = run_cli(&self.binary_path, &["stop", id]).await?;
+        if output.exit_code != 0 {
+            return Err(BackendError::Runtime(output.stderr.into()));
+        }
+        Ok(())
+    }
+
+    /// Remove a container.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the CLI exits non-zero or cannot be spawned.
+    pub async fn rm(&self, id: &str) -> Result<(), BackendError> {
+        let output = run_cli(&self.binary_path, &["rm", id]).await?;
+        if output.exit_code != 0 {
+            return Err(BackendError::Runtime(output.stderr.into()));
+        }
+        Ok(())
+    }
+
+    /// Inspect a container and return its full metadata.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the container does not exist, the CLI exits
+    /// non-zero, or the JSON output cannot be parsed.
+    pub async fn inspect(&self, id: &str) -> Result<types::ContainerInspect, BackendError> {
+        run_cli_json(&self.binary_path, &["inspect", id, "--format", "json"]).await
+    }
+
+    /// List containers, optionally filtering by a label.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the CLI exits non-zero or JSON parsing fails.
+    pub async fn list(
+        &self,
+        label_filter: Option<&str>,
+    ) -> Result<Vec<types::ContainerListEntry>, BackendError> {
+        let mut args = vec!["ls", "--format", "json", "--all"];
+        if let Some(label) = label_filter {
+            args.push("--filter");
+            args.push(label);
+        }
+        run_cli_json(&self.binary_path, &args).await
+    }
+
+    /// Fetch the last `tail` lines of container logs.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the CLI cannot be spawned.
+    pub async fn logs(&self, id: &str, tail: u32) -> Result<String, BackendError> {
+        let tail_str = tail.to_string();
+        let output = run_cli(&self.binary_path, &["logs", id, "--tail", &tail_str]).await?;
+        // Logs may come on stderr for some runtimes; combine both.
+        let mut combined = output.stdout;
+        if !output.stderr.is_empty() {
+            if !combined.is_empty() {
+                combined.push('\n');
+            }
+            combined.push_str(&output.stderr);
+        }
+        Ok(combined)
+    }
+
+    // -- Exec operations --
+
+    /// Execute a command inside a container and capture its output.
+    ///
+    /// Returns `(exit_code, stdout, stderr)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the CLI cannot be spawned.
+    pub async fn exec_capture(
+        &self,
+        id: &str,
+        cmd: &[String],
+        user: Option<&str>,
+        env: Option<&[String]>,
+        workdir: Option<&str>,
+    ) -> Result<(i64, String, String), BackendError> {
+        let mut args = vec!["exec".to_string()];
+
+        if let Some(u) = user {
+            args.push("--user".to_string());
+            args.push(u.to_string());
+        }
+        if let Some(vars) = env {
+            for var in vars {
+                args.push("-e".to_string());
+                args.push(var.clone());
+            }
+        }
+        if let Some(wd) = workdir {
+            args.push("-w".to_string());
+            args.push(wd.to_string());
+        }
+
+        args.push(id.to_string());
+        for c in cmd {
+            args.push(c.clone());
+        }
+
+        let output = run_cli_owned(&self.binary_path, &args).await?;
+        let exit_code = i64::from(output.exit_code);
+        Ok((exit_code, output.stdout, output.stderr))
+    }
+
+    // -- Image operations --
+
+    /// Pull an image from a registry.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the CLI exits non-zero or cannot be spawned.
+    pub async fn pull(&self, image: &str) -> Result<(), BackendError> {
+        debug!(image, "pulling image");
+        let output = run_cli(&self.binary_path, &["image", "pull", image]).await?;
+        if output.exit_code != 0 {
+            return Err(BackendError::Runtime(output.stderr.into()));
+        }
+        Ok(())
+    }
+
+    /// Build an image from a Dockerfile.
+    ///
+    /// Returns the image tag.
+    ///
+    /// # Errors
+    ///
+    /// Returns `BackendError::ImageBuildFailed` if the build exits non-zero.
+    pub async fn build(
+        &self,
+        context: &Path,
+        dockerfile: &str,
+        tag: &str,
+        args: &[(String, String)],
+    ) -> Result<String, BackendError> {
+        let mut cli_args = vec![
+            "build".to_string(),
+            "-f".to_string(),
+            dockerfile.to_string(),
+            "-t".to_string(),
+            tag.to_string(),
+        ];
+        for (key, value) in args {
+            cli_args.push("--build-arg".to_string());
+            cli_args.push(format!("{key}={value}"));
+        }
+        cli_args.push(context.to_string_lossy().into_owned());
+
+        let output = run_cli_owned(&self.binary_path, &cli_args).await?;
+        if output.exit_code != 0 {
+            return Err(BackendError::ImageBuildFailed {
+                message: output.stderr,
+            });
+        }
+        Ok(tag.to_string())
+    }
+
+    /// Check whether an image exists locally.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the CLI cannot be spawned.
+    pub async fn image_exists(&self, image: &str) -> Result<bool, BackendError> {
+        let output = run_cli(&self.binary_path, &["image", "inspect", image]).await?;
+        Ok(output.exit_code == 0)
+    }
+
+    /// Inspect an image and return raw JSON output.
+    ///
+    /// # Errors
+    ///
+    /// Returns `BackendError::ImageNotFound` if the image does not exist.
+    pub async fn image_inspect(&self, image: &str) -> Result<String, BackendError> {
+        let output = run_cli(
+            &self.binary_path,
+            &["image", "inspect", image, "--format", "json"],
+        )
+        .await?;
+        if output.exit_code != 0 {
+            return Err(BackendError::ImageNotFound {
+                image: image.to_string(),
+            });
+        }
+        Ok(output.stdout)
+    }
+
+    /// Create a named volume.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the CLI exits non-zero or cannot be spawned.
+    pub async fn volume_create(&self, name: &str) -> Result<(), BackendError> {
+        let output = run_cli(&self.binary_path, &["volume", "create", name]).await?;
+        if output.exit_code != 0 {
+            return Err(BackendError::Runtime(output.stderr.into()));
+        }
+        Ok(())
+    }
+}

--- a/crates/cella-container/src/sdk/run.rs
+++ b/crates/cella-container/src/sdk/run.rs
@@ -1,0 +1,139 @@
+//! Command execution helpers for the Apple `container` CLI.
+
+use std::path::Path;
+use std::process::Stdio;
+
+use cella_backend::BackendError;
+use tokio::process::Command;
+use tracing::debug;
+
+/// Captured output from a CLI invocation.
+#[derive(Debug)]
+pub struct CommandOutput {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+}
+
+/// Run the `container` CLI binary with the given arguments and capture output.
+///
+/// # Errors
+///
+/// Returns `BackendError::HostCommandFailed` if the binary cannot be spawned.
+pub async fn run_cli(binary: &Path, args: &[&str]) -> Result<CommandOutput, BackendError> {
+    debug!(binary = %binary.display(), ?args, "running container CLI");
+
+    let output = Command::new(binary)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await
+        .map_err(|e| BackendError::HostCommandFailed {
+            command: format!("{} {}", binary.display(), args.join(" ")),
+            source: e,
+        })?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let exit_code = output.status.code().unwrap_or(-1);
+
+    debug!(
+        exit_code,
+        stdout_len = stdout.len(),
+        stderr_len = stderr.len(),
+        "CLI output"
+    );
+
+    Ok(CommandOutput {
+        stdout,
+        stderr,
+        exit_code,
+    })
+}
+
+/// Run the CLI with the given `String` args (owned version of [`run_cli`]).
+///
+/// # Errors
+///
+/// Returns `BackendError::HostCommandFailed` if the binary cannot be spawned.
+pub async fn run_cli_owned(binary: &Path, args: &[String]) -> Result<CommandOutput, BackendError> {
+    let refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    run_cli(binary, &refs).await
+}
+
+/// Run the CLI and parse the JSON stdout into `T`.
+///
+/// # Errors
+///
+/// Returns an error if the CLI exits non-zero, cannot be spawned, or the
+/// output is not valid JSON for `T`.
+pub async fn run_cli_json<T: serde::de::DeserializeOwned>(
+    binary: &Path,
+    args: &[&str],
+) -> Result<T, BackendError> {
+    let output = run_cli(binary, args).await?;
+    if output.exit_code != 0 {
+        return Err(BackendError::Runtime(output.stderr.into()));
+    }
+    serde_json::from_str(&output.stdout).map_err(|e| BackendError::Runtime(Box::new(e)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn run_cli_missing_binary() {
+        let result = run_cli(Path::new("/nonexistent/binary"), &["version"]).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, BackendError::HostCommandFailed { .. }),
+            "expected HostCommandFailed, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_cli_captures_output() {
+        // Use `echo` as a trivially available binary.
+        let result = run_cli(Path::new("/bin/echo"), &["hello", "world"]).await;
+        let output = result.unwrap();
+        assert_eq!(output.exit_code, 0);
+        assert_eq!(output.stdout.trim(), "hello world");
+        assert!(output.stderr.is_empty());
+    }
+
+    #[tokio::test]
+    async fn run_cli_json_parses_output() {
+        // Use printf via sh to produce valid JSON.
+        let result: Result<Vec<String>, _> =
+            run_cli_json(Path::new("/bin/sh"), &["-c", r#"echo '["a","b"]'"#]).await;
+        let parsed = result.unwrap();
+        assert_eq!(parsed, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn run_cli_json_error_on_nonzero_exit() {
+        let result: Result<serde_json::Value, _> =
+            run_cli_json(Path::new("/bin/sh"), &["-c", "echo 'boom' >&2; exit 1"]).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn run_cli_json_error_on_invalid_json() {
+        let result: Result<serde_json::Value, _> =
+            run_cli_json(Path::new("/bin/sh"), &["-c", "echo 'not json'"]).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn run_cli_owned_works() {
+        let args = vec!["hello".to_string(), "world".to_string()];
+        let result = run_cli_owned(Path::new("/bin/echo"), &args).await;
+        let output = result.unwrap();
+        assert_eq!(output.exit_code, 0);
+        assert_eq!(output.stdout.trim(), "hello world");
+    }
+}

--- a/crates/cella-container/src/sdk/types.rs
+++ b/crates/cella-container/src/sdk/types.rs
@@ -1,0 +1,200 @@
+//! Typed structs for JSON output from the Apple `container` CLI.
+//!
+//! The CLI output format is pre-1.0 and subject to change.
+//! All optional fields use `#[serde(default)]` so missing keys
+//! are silently skipped rather than causing parse failures.
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+/// Entry returned by `container ls --format json --all`.
+#[derive(Debug, Deserialize)]
+pub struct ContainerListEntry {
+    #[serde(default)]
+    pub status: Option<ContainerStatus>,
+    #[serde(default)]
+    pub configuration: Option<ContainerConfiguration>,
+}
+
+/// Runtime status of a container.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContainerStatus {
+    /// One of `"running"`, `"stopped"`, `"created"`, etc.
+    #[serde(default)]
+    pub state: Option<String>,
+    #[serde(default)]
+    pub exit_code: Option<i64>,
+}
+
+/// Container configuration / metadata.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContainerConfiguration {
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub image: Option<String>,
+    #[serde(default)]
+    pub labels: Option<HashMap<String, String>>,
+    #[serde(default)]
+    pub published_ports: Option<Vec<PublishedPort>>,
+    #[serde(default)]
+    pub mounts: Option<Vec<MountEntry>>,
+}
+
+/// A port mapping exposed by the container.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PublishedPort {
+    #[serde(default)]
+    pub container_port: Option<u16>,
+    #[serde(default)]
+    pub host_port: Option<u16>,
+    #[serde(default)]
+    pub protocol: Option<String>,
+}
+
+/// A mount/volume attached to the container.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MountEntry {
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
+    pub destination: Option<String>,
+    #[serde(default, rename = "type")]
+    pub mount_type: Option<String>,
+}
+
+/// `container inspect <id>` returns the same structure as a list entry
+/// but may include additional detail.
+pub type ContainerInspect = ContainerListEntry;
+
+/// Entry returned by `container image ls --format json`.
+#[derive(Debug, Deserialize)]
+pub struct ImageListEntry {
+    #[serde(default)]
+    pub reference: Option<String>,
+}
+
+/// A single entry from `container version --format json` (returns an array).
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VersionInfo {
+    #[serde(default)]
+    pub version: Option<String>,
+    #[serde(default)]
+    pub app_name: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_container_list_entry() {
+        let json = r#"{
+            "status": { "state": "running", "exitCode": 0 },
+            "configuration": {
+                "id": "abc123",
+                "name": "test-container",
+                "image": "ubuntu:latest",
+                "labels": { "dev.cella.tool": "cella" },
+                "publishedPorts": [
+                    { "containerPort": 8080, "hostPort": 8080, "protocol": "tcp" }
+                ],
+                "mounts": [
+                    { "source": "/host/path", "destination": "/container/path", "type": "bind" }
+                ]
+            }
+        }"#;
+
+        let entry: ContainerListEntry = serde_json::from_str(json).unwrap();
+        let status = entry.status.unwrap();
+        assert_eq!(status.state.as_deref(), Some("running"));
+        assert_eq!(status.exit_code, Some(0));
+
+        let config = entry.configuration.unwrap();
+        assert_eq!(config.id.as_deref(), Some("abc123"));
+        assert_eq!(config.name.as_deref(), Some("test-container"));
+        assert_eq!(config.image.as_deref(), Some("ubuntu:latest"));
+
+        let labels = config.labels.unwrap();
+        assert_eq!(labels.get("dev.cella.tool").unwrap(), "cella");
+
+        let ports = config.published_ports.unwrap();
+        assert_eq!(ports.len(), 1);
+        assert_eq!(ports[0].container_port, Some(8080));
+
+        let mounts = config.mounts.unwrap();
+        assert_eq!(mounts.len(), 1);
+        assert_eq!(mounts[0].source.as_deref(), Some("/host/path"));
+    }
+
+    #[test]
+    fn deserialize_minimal_container_entry() {
+        let json = r"{}";
+        let entry: ContainerListEntry = serde_json::from_str(json).unwrap();
+        assert!(entry.status.is_none());
+        assert!(entry.configuration.is_none());
+    }
+
+    #[test]
+    fn deserialize_partial_status() {
+        let json = r#"{ "status": { "state": "stopped" } }"#;
+        let entry: ContainerListEntry = serde_json::from_str(json).unwrap();
+        let status = entry.status.unwrap();
+        assert_eq!(status.state.as_deref(), Some("stopped"));
+        assert!(status.exit_code.is_none());
+    }
+
+    #[test]
+    fn deserialize_image_list_entry() {
+        let json = r#"{ "reference": "ubuntu:latest" }"#;
+        let entry: ImageListEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.reference.as_deref(), Some("ubuntu:latest"));
+    }
+
+    #[test]
+    fn deserialize_version_info() {
+        let json = r#"[{ "version": "1.0.0", "appName": "container" }]"#;
+        let entries: Vec<VersionInfo> = serde_json::from_str(json).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].version.as_deref(), Some("1.0.0"));
+        assert_eq!(entries[0].app_name.as_deref(), Some("container"));
+    }
+
+    #[test]
+    fn deserialize_version_info_missing_fields() {
+        let json = r"[{}]";
+        let entries: Vec<VersionInfo> = serde_json::from_str(json).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].version.is_none());
+        assert!(entries[0].app_name.is_none());
+    }
+
+    #[test]
+    fn deserialize_container_list() {
+        let json = r#"[
+            { "status": { "state": "running" }, "configuration": { "id": "a" } },
+            { "status": { "state": "stopped" }, "configuration": { "id": "b" } }
+        ]"#;
+        let entries: Vec<ContainerListEntry> = serde_json::from_str(json).unwrap();
+        assert_eq!(entries.len(), 2);
+    }
+
+    #[test]
+    fn unknown_fields_are_ignored() {
+        let json = r#"{
+            "status": { "state": "running", "unknownField": 42 },
+            "configuration": { "id": "x", "futureField": true }
+        }"#;
+        let entry: ContainerListEntry = serde_json::from_str(json).unwrap();
+        assert!(entry.status.is_some());
+        assert!(entry.configuration.is_some());
+    }
+}


### PR DESCRIPTION
## Summary
- New `cella-container` crate implementing `ContainerBackend` for Apple's `container` CLI (`apple/container`)
- SDK module wrapping the CLI binary with typed JSON output parsing for all container lifecycle, exec, image, and volume operations
- CLI discovery via `CELLA_CONTAINER_PATH` env var or PATH search with version validation
- Wired into `resolve_backend()` as lowest-priority fallback with experimental warning on every use

## Design decisions
- **CLI shelling**: All operations shell out to the `container` binary and parse JSON output (no Swift FFI)
- **File injection**: Bind-mounted staging directory at `~/.cache/cella/containers/{name}/` since Apple Container has no `container cp`
- **SSH forwarding**: Native `--ssh` flag instead of manual socket mounting
- **Networking**: Port forwarding only (`-p` flags), no bridge network equivalent
- **Unsupported flags**: `--gpus`, `--privileged`, `--cap-add`, `--security-opt`, `--device` emit warnings and are skipped
- **Compose**: Not supported — returns clear error if `dockerComposeFile` is set

## Requirements
- macOS 26+ (Apple Silicon only)
- `container` CLI installed (`apple/container` v0.10.0+)
- Pre-1.0 CLI — output format may change between releases

## Test plan
- [x] 39 unit tests covering JSON deserialization, CLI arg building, entry conversion, discovery validation
- [x] All 1107 workspace tests pass (0 failures)
- [x] Clippy clean on `cella-backend`, `cella-docker`, `cella-container`
- [x] Manual: `cella --backend apple-container up` with image-based devcontainer.json (requires macOS + Apple Container)
- [x] Manual: `cella --backend apple-container exec` / `shell` / `down`
- [x] Manual: Cross-backend conflict detection (Docker container exists, Apple Container `up` refuses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)