### PR TITLE
feat: network proxy with path-level HTTPS blocking

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,7 +110,6 @@ jobs:
           cargo llvm-cov --no-report
           -p cella-features
           -p cella-daemon
-          -p cella-credential-proxy
           --features integration-tests
 
       - name: Generate combined coverage report

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,9 +301,11 @@ dependencies = [
 name = "cella-agent"
 version = "0.0.9"
 dependencies = [
+ "cella-network",
  "cella-port",
  "nix 0.31.2",
  "notify",
+ "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,6 +337,7 @@ dependencies = [
  "cella-env",
  "cella-features",
  "cella-git",
+ "cella-network",
  "cella-orchestrator",
  "cella-port",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,6 +532,7 @@ dependencies = [
  "cella-docker",
  "cella-features",
  "cella-git",
+ "cella-network",
  "hex",
  "serde_json",
  "sha2 0.11.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,6 +466,7 @@ dependencies = [
 name = "cella-env"
 version = "0.0.9"
 dependencies = [
+ "cella-network",
  "serde_json",
  "thiserror 2.0.18",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,8 +508,12 @@ dependencies = [
 name = "cella-network"
 version = "0.0.9"
 dependencies = [
+ "base64 0.22.1",
  "insta",
+ "rcgen",
+ "rustls-native-certs",
  "serde",
+ "tempfile",
  "thiserror 2.0.18",
  "toml",
  "tracing",
@@ -696,6 +739,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -1628,6 +1700,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1674,6 +1752,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1707,6 +1795,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1750,6 +1863,15 @@ dependencies = [
  "tokio",
  "tracing",
  "unicase",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -1814,6 +1936,16 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
 ]
 
 [[package]]
@@ -1918,6 +2050,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2051,6 +2189,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
 ]
 
 [[package]]
@@ -2212,6 +2364,15 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "rustix"
@@ -2711,6 +2872,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -3654,6 +3846,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3674,6 +3884,15 @@ dependencies = [
  "libyaml-rs",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,7 @@ name = "cella-config"
 version = "0.0.9"
 dependencies = [
  "cella-codegen",
+ "cella-network",
  "hex",
  "miette",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,6 +466,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cella-network"
+version = "0.0.9"
+dependencies = [
+ "insta",
+ "serde",
+ "thiserror 2.0.18",
+ "toml",
+ "tracing",
+]
+
+[[package]]
 name = "cella-orchestrator"
 version = "0.0.9"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,10 +305,15 @@ dependencies = [
  "cella-port",
  "nix 0.31.2",
  "notify",
+ "rcgen",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-rustls",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2400,6 +2405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2418,6 +2424,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,10 @@ glob = "0.3.3"
 
 # Certificate management
 rcgen = "0.14.7"
+rustls = { version = "0.23.27", default-features = false, features = ["ring", "std"] }
 rustls-native-certs = "0.8.3"
+rustls-pemfile = "2.2.0"
+tokio-rustls = "0.26.4"
 
 # File watching
 notify = "8.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,10 @@ reqwest = { version = "0.13.2", default-features = false, features = [
 regex = "1.12.3"
 glob = "0.3.3"
 
+# Certificate management
+rcgen = "0.14.7"
+rustls-native-certs = "0.8.3"
+
 # File watching
 notify = "8.2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/cella-port",
     "crates/cella-agent",
     "crates/cella-features",
+    "crates/cella-network",
     "crates/cella-orchestrator",
 ]
 
@@ -125,6 +126,7 @@ cella-docker = { path = "crates/cella-docker" }
 cella-env = { path = "crates/cella-env" }
 cella-features = { path = "crates/cella-features" }
 cella-git = { path = "crates/cella-git" }
+cella-network = { path = "crates/cella-network" }
 cella-orchestrator = { path = "crates/cella-orchestrator" }
 cella-port = { path = "crates/cella-port" }
 

--- a/crates/cella-agent/Cargo.toml
+++ b/crates/cella-agent/Cargo.toml
@@ -9,9 +9,11 @@ name = "cella-agent"
 path = "src/main.rs"
 
 [dependencies]
+cella-network.workspace = true
 cella-port.workspace = true
 nix.workspace = true
 notify.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/crates/cella-agent/Cargo.toml
+++ b/crates/cella-agent/Cargo.toml
@@ -13,10 +13,15 @@ cella-network.workspace = true
 cella-port.workspace = true
 nix.workspace = true
 notify.workspace = true
+rcgen.workspace = true
+rustls.workspace = true
+rustls-native-certs.workspace = true
+rustls-pemfile.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tokio-rustls.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 

--- a/crates/cella-agent/src/forward_proxy.rs
+++ b/crates/cella-agent/src/forward_proxy.rs
@@ -107,10 +107,23 @@ async fn handle_connect(mut client: TcpStream, target: &str, config: &AgentProxy
         return;
     }
 
-    // TODO: If path-level rules exist for this domain, MITM interception
-    // will be added in a follow-up commit. For now, domain-only blocking
-    // is enforced at the CONNECT stage.
+    // Check if path-level rules exist for this domain. If so, we need
+    // MITM TLS interception to inspect the URL path inside the encrypted
+    // connection.
+    if config.matcher.domain_needs_path_inspection(&host) && config.ca_cert_pem.is_some() {
+        // Send 200 first, then intercept the TLS handshake.
+        if client
+            .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+            .await
+            .is_err()
+        {
+            return;
+        }
+        crate::mitm::intercept_tls(client, &host, port, config).await;
+        return;
+    }
 
+    // No path-level rules — just tunnel without MITM.
     // Connect to upstream (or through upstream proxy).
     let upstream = match connect_upstream(&host, port, config).await {
         Ok(s) => s,
@@ -183,6 +196,16 @@ async fn handle_direct_http(
 
     // Bidirectional copy for the rest.
     let _ = copy_bidirectional(&mut client, &mut upstream).await;
+}
+
+/// Connect to the target, either directly or through an upstream proxy.
+/// Public for use by the MITM module.
+pub async fn connect_upstream_for_mitm(
+    host: &str,
+    port: u16,
+    config: &AgentProxyConfig,
+) -> Result<TcpStream, io::Error> {
+    connect_upstream(host, port, config).await
 }
 
 /// Connect to the target, either directly or through an upstream proxy.

--- a/crates/cella-agent/src/forward_proxy.rs
+++ b/crates/cella-agent/src/forward_proxy.rs
@@ -7,7 +7,7 @@
 use std::io;
 use std::sync::Arc;
 
-use tokio::io::{AsyncReadExt, AsyncWriteExt, copy_bidirectional};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader, copy_bidirectional};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
@@ -49,40 +49,50 @@ pub async fn start_forward_proxy(
 
 /// Handle a single proxy connection.
 ///
-/// Reads the first line to determine if it's a CONNECT request (HTTPS)
-/// or a direct HTTP request, then dispatches accordingly.
-async fn handle_connection(mut stream: TcpStream, config: Arc<AgentProxyConfig>) {
-    // Read the request line (e.g., "CONNECT host:443 HTTP/1.1\r\n" or "GET http://... HTTP/1.1\r\n")
-    let mut buf = [0u8; 8192];
-    let n = match stream.read(&mut buf).await {
-        Ok(0) => return,
-        Ok(n) => n,
-        Err(e) => {
-            debug!("Proxy read error: {e}");
-            return;
+/// Wraps the stream in a `BufReader` to avoid consuming bytes beyond the HTTP
+/// headers (e.g., the TLS `ClientHello` for CONNECT requests).
+async fn handle_connection(stream: TcpStream, config: Arc<AgentProxyConfig>) {
+    let mut reader = BufReader::new(stream);
+
+    // Read headers line by line until \r\n\r\n.
+    let mut header_bytes = Vec::new();
+    let mut first_line = String::new();
+    loop {
+        let mut line = String::new();
+        match reader.read_line(&mut line).await {
+            Ok(0) => return,
+            Ok(_) => {}
+            Err(e) => {
+                debug!("Proxy read error: {e}");
+                return;
+            }
         }
-    };
+        if first_line.is_empty() {
+            first_line = line.clone();
+        }
+        header_bytes.extend_from_slice(line.as_bytes());
+        if line == "\r\n" || line == "\n" {
+            break;
+        }
+    }
 
-    let request_bytes = &buf[..n];
-    let request_str = String::from_utf8_lossy(request_bytes);
-
-    // Parse the first line.
-    let Some(first_line) = request_str.lines().next() else {
-        return;
-    };
-    let parts: Vec<&str> = first_line.split_whitespace().collect();
+    let trimmed = first_line.trim_end();
+    let parts: Vec<&str> = trimmed.split_whitespace().collect();
     if parts.len() < 2 {
-        let _ = stream.write_all(b"HTTP/1.1 400 Bad Request\r\n\r\n").await;
+        let _ = reader
+            .get_mut()
+            .write_all(b"HTTP/1.1 400 Bad Request\r\n\r\n")
+            .await;
         return;
     }
 
-    let method = parts[0];
-    let target = parts[1];
+    let method = parts[0].to_string();
+    let target = parts[1].to_string();
 
     if method.eq_ignore_ascii_case("CONNECT") {
-        handle_connect(stream, target, &config).await;
+        handle_connect(reader, &target, &config).await;
     } else {
-        handle_direct_http(stream, request_bytes, method, target, &config).await;
+        handle_direct_http(reader, &header_bytes, &method, &target, &config).await;
     }
 }
 
@@ -90,52 +100,64 @@ async fn handle_connection(mut stream: TcpStream, config: Arc<AgentProxyConfig>)
 ///
 /// CONNECT requests look like: `CONNECT host:port HTTP/1.1`
 /// We evaluate domain blocking rules before establishing the tunnel.
-async fn handle_connect(mut client: TcpStream, target: &str, config: &AgentProxyConfig) {
+/// For domains with path-level rules, we defer to MITM TLS interception.
+async fn handle_connect(mut client: BufReader<TcpStream>, target: &str, config: &AgentProxyConfig) {
     // Parse host:port from CONNECT target.
     let Some((host, port)) = parse_host_port(target) else {
-        let _ = client.write_all(b"HTTP/1.1 400 Bad Request\r\n\r\n").await;
+        let _ = client
+            .get_mut()
+            .write_all(b"HTTP/1.1 400 Bad Request\r\n\r\n")
+            .await;
         return;
     };
 
-    // Evaluate domain-level rules.
-    let verdict = config.matcher.evaluate(&host, "/");
-    if !verdict.allowed {
-        info!("BLOCKED CONNECT to {host}:{port} - {}", verdict.reason);
-        config.log_blocked(&host, "/", &verdict.reason);
-        // Send 403 and close — this appears as "connection refused" to the client.
-        let _ = client.write_all(b"HTTP/1.1 403 Forbidden\r\n\r\n").await;
-        return;
-    }
+    let needs_path_inspection = config.matcher.domain_needs_path_inspection(&host);
+    let has_mitm = config.ca_cert_pem.is_some() && config.ca_key_pem.is_some();
 
-    // Check if path-level rules exist for this domain. If so, we need
-    // MITM TLS interception to inspect the URL path inside the encrypted
-    // connection.
-    if config.matcher.domain_needs_path_inspection(&host) && config.ca_cert_pem.is_some() {
-        // Send 200 first, then intercept the TLS handshake.
-        if client
+    if needs_path_inspection && has_mitm {
+        // Domain has path-level rules and MITM is available — allow the CONNECT
+        // and defer the actual allow/block decision to the MITM path where we
+        // can inspect request paths.
+        let mut client_tcp = client.into_inner();
+        if client_tcp
             .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
             .await
             .is_err()
         {
             return;
         }
-        crate::mitm::intercept_tls(client, &host, port, config).await;
+        crate::mitm::intercept_tls(client_tcp, &host, port, config).await;
+        return;
+    }
+
+    // No MITM available or no path-level rules — evaluate domain-level only.
+    let verdict = config.matcher.evaluate(&host, "/");
+    if !verdict.allowed {
+        info!("BLOCKED CONNECT to {host}:{port} - {}", verdict.reason);
+        config.log_blocked(&host, "/", &verdict.reason);
+        let _ = client
+            .get_mut()
+            .write_all(b"HTTP/1.1 403 Forbidden\r\n\r\n")
+            .await;
         return;
     }
 
     // No path-level rules — just tunnel without MITM.
-    // Connect to upstream (or through upstream proxy).
     let upstream = match connect_upstream(&host, port, config).await {
         Ok(s) => s,
         Err(e) => {
             warn!("Failed to connect to {host}:{port}: {e}");
-            let _ = client.write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n").await;
+            let _ = client
+                .get_mut()
+                .write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
+                .await;
             return;
         }
     };
 
-    // Send 200 Connection Established to the client.
-    if client
+    // Headers have been fully consumed by BufReader; safe to unwrap to raw TcpStream.
+    let mut client_tcp = client.into_inner();
+    if client_tcp
         .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
         .await
         .is_err()
@@ -144,13 +166,8 @@ async fn handle_connect(mut client: TcpStream, target: &str, config: &AgentProxy
     }
 
     // Tunnel bidirectionally.
-    let (mut client_r, mut client_w) = client.into_split();
-    let (mut upstream_r, mut upstream_w) = upstream.into_split();
-
-    let c2u = tokio::spawn(async move { tokio::io::copy(&mut client_r, &mut upstream_w).await });
-    let u2c = tokio::spawn(async move { tokio::io::copy(&mut upstream_r, &mut client_w).await });
-
-    let _ = tokio::try_join!(c2u, u2c);
+    let mut upstream = upstream;
+    let _ = copy_bidirectional(&mut client_tcp, &mut upstream).await;
 }
 
 /// Handle direct HTTP proxy request (non-CONNECT).
@@ -158,24 +175,30 @@ async fn handle_connect(mut client: TcpStream, target: &str, config: &AgentProxy
 /// Direct requests look like: `GET http://host/path HTTP/1.1`
 /// We evaluate both domain and path blocking rules.
 async fn handle_direct_http(
-    mut client: TcpStream,
-    first_chunk: &[u8],
+    mut client: BufReader<TcpStream>,
+    header_bytes: &[u8],
     _method: &str,
     target: &str,
     config: &AgentProxyConfig,
 ) {
     // Parse the URL to extract host and path.
     let Some((host, port, path)) = parse_http_url(target) else {
-        let _ = client.write_all(b"HTTP/1.1 400 Bad Request\r\n\r\n").await;
+        let _ = client
+            .get_mut()
+            .write_all(b"HTTP/1.1 400 Bad Request\r\n\r\n")
+            .await;
         return;
     };
 
-    // Evaluate rules with both domain and path.
-    let verdict = config.matcher.evaluate(&host, &path);
+    // Evaluate rules with both domain and path (strip query/fragment).
+    let verdict = config.matcher.evaluate(&host, strip_query(&path));
     if !verdict.allowed {
         info!("BLOCKED HTTP {target} - {}", verdict.reason);
         config.log_blocked(&host, &path, &verdict.reason);
-        let _ = client.write_all(b"HTTP/1.1 403 Forbidden\r\n\r\n").await;
+        let _ = client
+            .get_mut()
+            .write_all(b"HTTP/1.1 403 Forbidden\r\n\r\n")
+            .await;
         return;
     }
 
@@ -184,18 +207,22 @@ async fn handle_direct_http(
         Ok(s) => s,
         Err(e) => {
             warn!("Failed to connect to {host}:{port}: {e}");
-            let _ = client.write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n").await;
+            let _ = client
+                .get_mut()
+                .write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
+                .await;
             return;
         }
     };
 
-    // Forward the original request to upstream.
-    if upstream.write_all(first_chunk).await.is_err() {
+    // Forward the original request headers to upstream.
+    if upstream.write_all(header_bytes).await.is_err() {
         return;
     }
 
-    // Bidirectional copy for the rest.
-    let _ = copy_bidirectional(&mut client, &mut upstream).await;
+    // Bidirectional copy for the rest (request body + response).
+    let mut client_tcp = client.into_inner();
+    let _ = copy_bidirectional(&mut client_tcp, &mut upstream).await;
 }
 
 /// Connect to the target, either directly or through an upstream proxy.
@@ -253,6 +280,15 @@ async fn connect_via_upstream_proxy(
     }
 
     Ok(proxy_stream)
+}
+
+/// Strip query string and fragment from a URL path before rule evaluation.
+pub fn strip_query(path: &str) -> &str {
+    let end = path
+        .find('?')
+        .unwrap_or(path.len())
+        .min(path.find('#').unwrap_or(path.len()));
+    &path[..end]
 }
 
 /// Parse `host:port` from a CONNECT target.
@@ -351,6 +387,16 @@ mod tests {
             parse_proxy_url("http://user:pass@proxy:3128"),
             Some("proxy:3128".to_string())
         );
+    }
+
+    #[test]
+    fn strip_query_removes_query_string() {
+        assert_eq!(strip_query("/api/v1?foo=bar"), "/api/v1");
+        assert_eq!(strip_query("/api/v1#section"), "/api/v1");
+        assert_eq!(strip_query("/api/v1?foo=bar#section"), "/api/v1");
+        assert_eq!(strip_query("/api/v1#section?foo=bar"), "/api/v1");
+        assert_eq!(strip_query("/api/v1"), "/api/v1");
+        assert_eq!(strip_query("/"), "/");
     }
 
     #[test]

--- a/crates/cella-agent/src/forward_proxy.rs
+++ b/crates/cella-agent/src/forward_proxy.rs
@@ -7,7 +7,7 @@
 use std::io;
 use std::sync::Arc;
 
-use tokio::io::{copy_bidirectional, AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncReadExt, AsyncWriteExt, copy_bidirectional};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
@@ -22,7 +22,9 @@ use crate::proxy_config::AgentProxyConfig;
 /// # Errors
 ///
 /// Returns an error if binding fails.
-pub async fn start_forward_proxy(config: Arc<AgentProxyConfig>) -> Result<JoinHandle<()>, io::Error> {
+pub async fn start_forward_proxy(
+    config: Arc<AgentProxyConfig>,
+) -> Result<JoinHandle<()>, io::Error> {
     let port = config.listen_port;
     let listener = TcpListener::bind(("127.0.0.1", port)).await?;
     info!("Forward proxy listening on 127.0.0.1:{port}");
@@ -91,9 +93,7 @@ async fn handle_connection(mut stream: TcpStream, config: Arc<AgentProxyConfig>)
 async fn handle_connect(mut client: TcpStream, target: &str, config: &AgentProxyConfig) {
     // Parse host:port from CONNECT target.
     let Some((host, port)) = parse_host_port(target) else {
-        let _ = client
-            .write_all(b"HTTP/1.1 400 Bad Request\r\n\r\n")
-            .await;
+        let _ = client.write_all(b"HTTP/1.1 400 Bad Request\r\n\r\n").await;
         return;
     };
 
@@ -103,9 +103,7 @@ async fn handle_connect(mut client: TcpStream, target: &str, config: &AgentProxy
         info!("BLOCKED CONNECT to {host}:{port} - {}", verdict.reason);
         config.log_blocked(&host, "/", &verdict.reason);
         // Send 403 and close — this appears as "connection refused" to the client.
-        let _ = client
-            .write_all(b"HTTP/1.1 403 Forbidden\r\n\r\n")
-            .await;
+        let _ = client.write_all(b"HTTP/1.1 403 Forbidden\r\n\r\n").await;
         return;
     }
 
@@ -118,9 +116,7 @@ async fn handle_connect(mut client: TcpStream, target: &str, config: &AgentProxy
         Ok(s) => s,
         Err(e) => {
             warn!("Failed to connect to {host}:{port}: {e}");
-            let _ = client
-                .write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
-                .await;
+            let _ = client.write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n").await;
             return;
         }
     };
@@ -157,9 +153,7 @@ async fn handle_direct_http(
 ) {
     // Parse the URL to extract host and path.
     let Some((host, port, path)) = parse_http_url(target) else {
-        let _ = client
-            .write_all(b"HTTP/1.1 400 Bad Request\r\n\r\n")
-            .await;
+        let _ = client.write_all(b"HTTP/1.1 400 Bad Request\r\n\r\n").await;
         return;
     };
 
@@ -168,9 +162,7 @@ async fn handle_direct_http(
     if !verdict.allowed {
         info!("BLOCKED HTTP {target} - {}", verdict.reason);
         config.log_blocked(&host, &path, &verdict.reason);
-        let _ = client
-            .write_all(b"HTTP/1.1 403 Forbidden\r\n\r\n")
-            .await;
+        let _ = client.write_all(b"HTTP/1.1 403 Forbidden\r\n\r\n").await;
         return;
     }
 
@@ -179,9 +171,7 @@ async fn handle_direct_http(
         Ok(s) => s,
         Err(e) => {
             warn!("Failed to connect to {host}:{port}: {e}");
-            let _ = client
-                .write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
-                .await;
+            let _ = client.write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n").await;
             return;
         }
     };
@@ -215,9 +205,8 @@ async fn connect_via_upstream_proxy(
     proxy_url: &str,
 ) -> Result<TcpStream, io::Error> {
     // Parse proxy URL to get host:port.
-    let proxy_addr = parse_proxy_url(proxy_url).ok_or_else(|| {
-        io::Error::new(io::ErrorKind::InvalidInput, "invalid upstream proxy URL")
-    })?;
+    let proxy_addr = parse_proxy_url(proxy_url)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "invalid upstream proxy URL"))?;
 
     let mut proxy_stream = TcpStream::connect(proxy_addr.as_str()).await?;
 
@@ -233,7 +222,10 @@ async fn connect_via_upstream_proxy(
     if !resp.starts_with("HTTP/1.1 200") && !resp.starts_with("HTTP/1.0 200") {
         return Err(io::Error::new(
             io::ErrorKind::ConnectionRefused,
-            format!("upstream proxy rejected CONNECT: {}", resp.lines().next().unwrap_or("")),
+            format!(
+                "upstream proxy rejected CONNECT: {}",
+                resp.lines().next().unwrap_or("")
+            ),
         ));
     }
 

--- a/crates/cella-agent/src/forward_proxy.rs
+++ b/crates/cella-agent/src/forward_proxy.rs
@@ -1,0 +1,348 @@
+//! HTTP forward proxy for domain and path blocking.
+//!
+//! Implements an HTTP CONNECT proxy that runs inside the container.
+//! For HTTPS, uses CONNECT tunneling. For HTTP, proxies directly.
+//! Evaluates blocking rules against each request.
+
+use std::io;
+use std::sync::Arc;
+
+use tokio::io::{copy_bidirectional, AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::task::JoinHandle;
+use tracing::{debug, info, warn};
+
+use crate::proxy_config::AgentProxyConfig;
+
+/// Start the forward proxy server.
+///
+/// Listens on `127.0.0.1:<port>` and handles HTTP CONNECT and direct HTTP
+/// proxy requests. Returns the task handle.
+///
+/// # Errors
+///
+/// Returns an error if binding fails.
+pub async fn start_forward_proxy(config: Arc<AgentProxyConfig>) -> Result<JoinHandle<()>, io::Error> {
+    let port = config.listen_port;
+    let listener = TcpListener::bind(("127.0.0.1", port)).await?;
+    info!("Forward proxy listening on 127.0.0.1:{port}");
+
+    let handle = tokio::spawn(async move {
+        loop {
+            match listener.accept().await {
+                Ok((stream, peer)) => {
+                    debug!("Proxy connection from {peer}");
+                    let cfg = config.clone();
+                    tokio::spawn(handle_connection(stream, cfg));
+                }
+                Err(e) => {
+                    warn!("Proxy accept error: {e}");
+                }
+            }
+        }
+    });
+
+    Ok(handle)
+}
+
+/// Handle a single proxy connection.
+///
+/// Reads the first line to determine if it's a CONNECT request (HTTPS)
+/// or a direct HTTP request, then dispatches accordingly.
+async fn handle_connection(mut stream: TcpStream, config: Arc<AgentProxyConfig>) {
+    // Read the request line (e.g., "CONNECT host:443 HTTP/1.1\r\n" or "GET http://... HTTP/1.1\r\n")
+    let mut buf = [0u8; 8192];
+    let n = match stream.read(&mut buf).await {
+        Ok(0) => return,
+        Ok(n) => n,
+        Err(e) => {
+            debug!("Proxy read error: {e}");
+            return;
+        }
+    };
+
+    let request_bytes = &buf[..n];
+    let request_str = String::from_utf8_lossy(request_bytes);
+
+    // Parse the first line.
+    let Some(first_line) = request_str.lines().next() else {
+        return;
+    };
+    let parts: Vec<&str> = first_line.split_whitespace().collect();
+    if parts.len() < 2 {
+        let _ = stream.write_all(b"HTTP/1.1 400 Bad Request\r\n\r\n").await;
+        return;
+    }
+
+    let method = parts[0];
+    let target = parts[1];
+
+    if method.eq_ignore_ascii_case("CONNECT") {
+        handle_connect(stream, target, &config).await;
+    } else {
+        handle_direct_http(stream, request_bytes, method, target, &config).await;
+    }
+}
+
+/// Handle CONNECT tunneling (for HTTPS).
+///
+/// CONNECT requests look like: `CONNECT host:port HTTP/1.1`
+/// We evaluate domain blocking rules before establishing the tunnel.
+async fn handle_connect(mut client: TcpStream, target: &str, config: &AgentProxyConfig) {
+    // Parse host:port from CONNECT target.
+    let Some((host, port)) = parse_host_port(target) else {
+        let _ = client
+            .write_all(b"HTTP/1.1 400 Bad Request\r\n\r\n")
+            .await;
+        return;
+    };
+
+    // Evaluate domain-level rules.
+    let verdict = config.matcher.evaluate(&host, "/");
+    if !verdict.allowed {
+        info!("BLOCKED CONNECT to {host}:{port} - {}", verdict.reason);
+        config.log_blocked(&host, "/", &verdict.reason);
+        // Send 403 and close — this appears as "connection refused" to the client.
+        let _ = client
+            .write_all(b"HTTP/1.1 403 Forbidden\r\n\r\n")
+            .await;
+        return;
+    }
+
+    // TODO: If path-level rules exist for this domain, MITM interception
+    // will be added in a follow-up commit. For now, domain-only blocking
+    // is enforced at the CONNECT stage.
+
+    // Connect to upstream (or through upstream proxy).
+    let upstream = match connect_upstream(&host, port, config).await {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("Failed to connect to {host}:{port}: {e}");
+            let _ = client
+                .write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
+                .await;
+            return;
+        }
+    };
+
+    // Send 200 Connection Established to the client.
+    if client
+        .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+        .await
+        .is_err()
+    {
+        return;
+    }
+
+    // Tunnel bidirectionally.
+    let (mut client_r, mut client_w) = client.into_split();
+    let (mut upstream_r, mut upstream_w) = upstream.into_split();
+
+    let c2u = tokio::spawn(async move { tokio::io::copy(&mut client_r, &mut upstream_w).await });
+    let u2c = tokio::spawn(async move { tokio::io::copy(&mut upstream_r, &mut client_w).await });
+
+    let _ = tokio::try_join!(c2u, u2c);
+}
+
+/// Handle direct HTTP proxy request (non-CONNECT).
+///
+/// Direct requests look like: `GET http://host/path HTTP/1.1`
+/// We evaluate both domain and path blocking rules.
+async fn handle_direct_http(
+    mut client: TcpStream,
+    first_chunk: &[u8],
+    _method: &str,
+    target: &str,
+    config: &AgentProxyConfig,
+) {
+    // Parse the URL to extract host and path.
+    let Some((host, port, path)) = parse_http_url(target) else {
+        let _ = client
+            .write_all(b"HTTP/1.1 400 Bad Request\r\n\r\n")
+            .await;
+        return;
+    };
+
+    // Evaluate rules with both domain and path.
+    let verdict = config.matcher.evaluate(&host, &path);
+    if !verdict.allowed {
+        info!("BLOCKED HTTP {target} - {}", verdict.reason);
+        config.log_blocked(&host, &path, &verdict.reason);
+        let _ = client
+            .write_all(b"HTTP/1.1 403 Forbidden\r\n\r\n")
+            .await;
+        return;
+    }
+
+    // Connect to upstream and forward the request.
+    let mut upstream = match connect_upstream(&host, port, config).await {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("Failed to connect to {host}:{port}: {e}");
+            let _ = client
+                .write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
+                .await;
+            return;
+        }
+    };
+
+    // Forward the original request to upstream.
+    if upstream.write_all(first_chunk).await.is_err() {
+        return;
+    }
+
+    // Bidirectional copy for the rest.
+    let _ = copy_bidirectional(&mut client, &mut upstream).await;
+}
+
+/// Connect to the target, either directly or through an upstream proxy.
+async fn connect_upstream(
+    host: &str,
+    port: u16,
+    config: &AgentProxyConfig,
+) -> Result<TcpStream, io::Error> {
+    if let Some(ref upstream_proxy) = config.upstream_proxy {
+        connect_via_upstream_proxy(host, port, upstream_proxy).await
+    } else {
+        TcpStream::connect((host.to_string().as_str(), port)).await
+    }
+}
+
+/// Connect through an upstream HTTP proxy using CONNECT.
+async fn connect_via_upstream_proxy(
+    host: &str,
+    port: u16,
+    proxy_url: &str,
+) -> Result<TcpStream, io::Error> {
+    // Parse proxy URL to get host:port.
+    let proxy_addr = parse_proxy_url(proxy_url).ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidInput, "invalid upstream proxy URL")
+    })?;
+
+    let mut proxy_stream = TcpStream::connect(proxy_addr.as_str()).await?;
+
+    // Send CONNECT request to upstream proxy.
+    let connect_req = format!("CONNECT {host}:{port} HTTP/1.1\r\nHost: {host}:{port}\r\n\r\n");
+    proxy_stream.write_all(connect_req.as_bytes()).await?;
+
+    // Read the response (expect "HTTP/1.1 200").
+    let mut resp_buf = [0u8; 4096];
+    let n = proxy_stream.read(&mut resp_buf).await?;
+    let resp = String::from_utf8_lossy(&resp_buf[..n]);
+
+    if !resp.starts_with("HTTP/1.1 200") && !resp.starts_with("HTTP/1.0 200") {
+        return Err(io::Error::new(
+            io::ErrorKind::ConnectionRefused,
+            format!("upstream proxy rejected CONNECT: {}", resp.lines().next().unwrap_or("")),
+        ));
+    }
+
+    Ok(proxy_stream)
+}
+
+/// Parse `host:port` from a CONNECT target.
+fn parse_host_port(target: &str) -> Option<(String, u16)> {
+    if let Some((host, port_str)) = target.rsplit_once(':') {
+        let port: u16 = port_str.parse().ok()?;
+        Some((host.to_string(), port))
+    } else {
+        Some((target.to_string(), 443))
+    }
+}
+
+/// Parse an HTTP URL to extract host, port, and path.
+fn parse_http_url(url: &str) -> Option<(String, u16, String)> {
+    let rest = url.strip_prefix("http://")?;
+    let (host_port, path) = rest
+        .find('/')
+        .map_or((rest, "/"), |idx| (&rest[..idx], &rest[idx..]));
+
+    let (host, port) = if let Some((h, p)) = host_port.rsplit_once(':') {
+        (h.to_string(), p.parse().ok()?)
+    } else {
+        (host_port.to_string(), 80)
+    };
+
+    Some((host, port, path.to_string()))
+}
+
+/// Parse a proxy URL like `http://host:port` to `host:port`.
+fn parse_proxy_url(url: &str) -> Option<String> {
+    let rest = url
+        .strip_prefix("http://")
+        .or_else(|| url.strip_prefix("https://"))?;
+    // Strip trailing slash and path.
+    let host_port = rest.split('/').next()?;
+    // Strip auth (user:pass@host:port).
+    let host_port = host_port
+        .rfind('@')
+        .map_or(host_port, |idx| &host_port[idx + 1..]);
+    Some(host_port.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_connect_target() {
+        let (host, port) = parse_host_port("example.com:443").unwrap();
+        assert_eq!(host, "example.com");
+        assert_eq!(port, 443);
+    }
+
+    #[test]
+    fn parse_connect_target_no_port() {
+        let (host, port) = parse_host_port("example.com").unwrap();
+        assert_eq!(host, "example.com");
+        assert_eq!(port, 443);
+    }
+
+    #[test]
+    fn parse_http_url_with_path() {
+        let (host, port, path) = parse_http_url("http://example.com:8080/api/v1").unwrap();
+        assert_eq!(host, "example.com");
+        assert_eq!(port, 8080);
+        assert_eq!(path, "/api/v1");
+    }
+
+    #[test]
+    fn parse_http_url_default_port() {
+        let (host, port, path) = parse_http_url("http://example.com/index.html").unwrap();
+        assert_eq!(host, "example.com");
+        assert_eq!(port, 80);
+        assert_eq!(path, "/index.html");
+    }
+
+    #[test]
+    fn parse_http_url_no_path() {
+        let (host, port, path) = parse_http_url("http://example.com").unwrap();
+        assert_eq!(host, "example.com");
+        assert_eq!(port, 80);
+        assert_eq!(path, "/");
+    }
+
+    #[test]
+    fn parse_proxy_url_simple() {
+        assert_eq!(
+            parse_proxy_url("http://proxy:3128"),
+            Some("proxy:3128".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_proxy_url_with_auth() {
+        assert_eq!(
+            parse_proxy_url("http://user:pass@proxy:3128"),
+            Some("proxy:3128".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_proxy_url_with_path() {
+        assert_eq!(
+            parse_proxy_url("http://proxy:3128/"),
+            Some("proxy:3128".to_string())
+        );
+    }
+}

--- a/crates/cella-agent/src/main.rs
+++ b/crates/cella-agent/src/main.rs
@@ -16,9 +16,11 @@ mod browser;
 mod cli;
 mod control;
 mod credential;
+mod forward_proxy;
 mod plugin_sync;
 mod port_proxy;
 mod port_watcher;
+mod proxy_config;
 mod reconnecting_client;
 
 use std::time::Duration;
@@ -32,7 +34,10 @@ struct AgentArgs {
 
 enum AgentCommand {
     /// Run the agent daemon (port watching + credential helper).
-    Daemon { poll_interval_ms: u64 },
+    Daemon {
+        poll_interval_ms: u64,
+        proxy_config_json: Option<String>,
+    },
     /// Open a URL in the host browser.
     BrowserOpen { url: String },
     /// Handle a git credential request.
@@ -51,6 +56,7 @@ fn parse_args() -> Result<AgentArgs, String> {
     match args[1].as_str() {
         "daemon" => {
             let mut poll_interval_ms = 1000u64;
+            let mut proxy_config_json = None;
 
             let mut i = 2;
             while i < args.len() {
@@ -63,13 +69,24 @@ fn parse_args() -> Result<AgentArgs, String> {
                             .parse()
                             .map_err(|_| "invalid --poll-interval value")?;
                     }
+                    "--proxy-config" => {
+                        i += 1;
+                        proxy_config_json = Some(
+                            args.get(i)
+                                .ok_or("missing --proxy-config value")?
+                                .clone(),
+                        );
+                    }
                     other => return Err(format!("unknown flag: {other}")),
                 }
                 i += 1;
             }
 
             Ok(AgentArgs {
-                command: AgentCommand::Daemon { poll_interval_ms },
+                command: AgentCommand::Daemon {
+                    poll_interval_ms,
+                    proxy_config_json,
+                },
             })
         }
         "browser-open" => {
@@ -154,9 +171,12 @@ async fn main() {
     };
 
     match args.command {
-        AgentCommand::Daemon { poll_interval_ms } => {
+        AgentCommand::Daemon {
+            poll_interval_ms,
+            proxy_config_json,
+        } => {
             info!("cella-agent daemon starting (poll interval: {poll_interval_ms}ms)");
-            run_daemon(poll_interval_ms).await;
+            run_daemon(poll_interval_ms, proxy_config_json).await;
         }
         AgentCommand::BrowserOpen { url } => {
             if let Err(e) = browser::send_browser_open(&url).await {
@@ -173,9 +193,29 @@ async fn main() {
     }
 }
 
-async fn run_daemon(poll_interval_ms: u64) {
+async fn run_daemon(poll_interval_ms: u64, proxy_config_json: Option<String>) {
     let poll_interval = Duration::from_millis(poll_interval_ms);
     let connect_timeout = Duration::from_secs(30);
+
+    // Start forward proxy if config is provided.
+    if let Some(ref json) = proxy_config_json {
+        match proxy_config::AgentProxyConfig::from_json(json) {
+            Ok(config) => {
+                let config = std::sync::Arc::new(config);
+                match forward_proxy::start_forward_proxy(config).await {
+                    Ok(_handle) => {
+                        info!("Forward proxy started");
+                    }
+                    Err(e) => {
+                        error!("Failed to start forward proxy: {e}");
+                    }
+                }
+            }
+            Err(e) => {
+                error!("Invalid proxy config: {e}");
+            }
+        }
+    }
 
     // Read connection info from env vars
     let Ok(addr) = std::env::var("CELLA_DAEMON_ADDR") else {

--- a/crates/cella-agent/src/main.rs
+++ b/crates/cella-agent/src/main.rs
@@ -198,7 +198,15 @@ async fn run_daemon(poll_interval_ms: u64, proxy_config_json: Option<String>) {
     let connect_timeout = Duration::from_secs(30);
 
     // Start forward proxy if config is provided (via CLI arg or env var).
-    let proxy_json = proxy_config_json.or_else(|| std::env::var("CELLA_PROXY_CONFIG").ok());
+    // CELLA_NO_NETWORK_RULES=1 disables rule enforcement at runtime.
+    let rules_disabled = std::env::var("CELLA_NO_NETWORK_RULES")
+        .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"));
+    let proxy_json = if rules_disabled {
+        info!("Network rules disabled via CELLA_NO_NETWORK_RULES");
+        None
+    } else {
+        proxy_config_json.or_else(|| std::env::var("CELLA_PROXY_CONFIG").ok())
+    };
     if let Some(ref json) = proxy_json {
         match proxy_config::AgentProxyConfig::from_json(json) {
             Ok(config) => {

--- a/crates/cella-agent/src/main.rs
+++ b/crates/cella-agent/src/main.rs
@@ -197,8 +197,9 @@ async fn run_daemon(poll_interval_ms: u64, proxy_config_json: Option<String>) {
     let poll_interval = Duration::from_millis(poll_interval_ms);
     let connect_timeout = Duration::from_secs(30);
 
-    // Start forward proxy if config is provided.
-    if let Some(ref json) = proxy_config_json {
+    // Start forward proxy if config is provided (via CLI arg or env var).
+    let proxy_json = proxy_config_json.or_else(|| std::env::var("CELLA_PROXY_CONFIG").ok());
+    if let Some(ref json) = proxy_json {
         match proxy_config::AgentProxyConfig::from_json(json) {
             Ok(config) => {
                 let config = std::sync::Arc::new(config);

--- a/crates/cella-agent/src/main.rs
+++ b/crates/cella-agent/src/main.rs
@@ -17,6 +17,7 @@ mod cli;
 mod control;
 mod credential;
 mod forward_proxy;
+mod mitm;
 mod plugin_sync;
 mod port_proxy;
 mod port_watcher;

--- a/crates/cella-agent/src/main.rs
+++ b/crates/cella-agent/src/main.rs
@@ -203,7 +203,22 @@ async fn run_daemon(poll_interval_ms: u64, proxy_config_json: Option<String>) {
         info!("Network rules disabled via CELLA_NO_NETWORK_RULES");
         None
     } else {
-        proxy_config_json.or_else(|| std::env::var("CELLA_PROXY_CONFIG").ok())
+        proxy_config_json.or_else(|| {
+            let val = std::env::var("CELLA_PROXY_CONFIG").ok()?;
+            if val.starts_with('/') {
+                // File path — read the config from disk (contains sensitive CA key).
+                match std::fs::read_to_string(&val) {
+                    Ok(content) => Some(content),
+                    Err(e) => {
+                        tracing::warn!("Failed to read proxy config from {val}: {e}");
+                        None
+                    }
+                }
+            } else {
+                // Raw JSON (legacy / direct injection).
+                Some(val)
+            }
+        })
     };
     if let Some(ref json) = proxy_json {
         match proxy_config::AgentProxyConfig::from_json(json) {

--- a/crates/cella-agent/src/main.rs
+++ b/crates/cella-agent/src/main.rs
@@ -71,11 +71,8 @@ fn parse_args() -> Result<AgentArgs, String> {
                     }
                     "--proxy-config" => {
                         i += 1;
-                        proxy_config_json = Some(
-                            args.get(i)
-                                .ok_or("missing --proxy-config value")?
-                                .clone(),
-                        );
+                        proxy_config_json =
+                            Some(args.get(i).ok_or("missing --proxy-config value")?.clone());
                     }
                     other => return Err(format!("unknown flag: {other}")),
                 }

--- a/crates/cella-agent/src/mitm.rs
+++ b/crates/cella-agent/src/mitm.rs
@@ -4,16 +4,16 @@
 //! TLS connection:
 //! 1. Generate a per-domain certificate signed by the cella CA
 //! 2. Accept TLS from the client using that certificate
-//! 3. Parse the decrypted HTTP request to inspect the URL path
-//! 4. Evaluate blocking rules against domain + path
-//! 5. If allowed, establish TLS to the upstream and relay traffic
+//! 3. Parse decrypted HTTP requests to inspect URL paths
+//! 4. Evaluate blocking rules against domain + path for every request
+//! 5. If allowed, relay to upstream; if blocked, send 403
 
 use std::sync::Arc;
 
 use rcgen::{CertificateParams, DnType, DnValue, IsCa, Issuer, KeyPair, SanType};
 use rustls::ServerConfig;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
 use tokio_rustls::TlsAcceptor;
 use tracing::{debug, info, warn};
@@ -23,10 +23,9 @@ use crate::proxy_config::AgentProxyConfig;
 /// Perform MITM interception on a CONNECT tunnel.
 ///
 /// The client has already received "200 Connection Established" and expects
-/// to start a TLS handshake. We accept TLS with a generated cert, read the
-/// HTTP request inside, evaluate rules, and either block or forward.
+/// to start a TLS handshake. We accept TLS with a generated cert, then
+/// inspect every HTTP/1.1 request on the connection for rule evaluation.
 pub async fn intercept_tls(client: TcpStream, host: &str, port: u16, config: &AgentProxyConfig) {
-    // Generate a certificate for this domain.
     let tls_config = match generate_server_config(host, config) {
         Ok(cfg) => cfg,
         Err(e) => {
@@ -37,7 +36,6 @@ pub async fn intercept_tls(client: TcpStream, host: &str, port: u16, config: &Ag
 
     let acceptor = TlsAcceptor::from(Arc::new(tls_config));
 
-    // Accept TLS from the client.
     let tls_stream = match acceptor.accept(client).await {
         Ok(s) => s,
         Err(e) => {
@@ -49,35 +47,18 @@ pub async fn intercept_tls(client: TcpStream, host: &str, port: u16, config: &Ag
     let (reader, mut writer) = tokio::io::split(tls_stream);
     let mut reader = BufReader::new(reader);
 
-    // Read the HTTP request line (e.g., "GET /path HTTP/1.1\r\n").
-    let mut request_line = String::new();
-    if reader.read_line(&mut request_line).await.is_err() || request_line.is_empty() {
+    // Read first request headers.
+    let mut header_bytes = Vec::new();
+    if read_request_headers(&mut reader, &mut header_bytes)
+        .await
+        .is_err()
+    {
         return;
     }
 
-    // Read remaining headers.
-    let mut headers = Vec::new();
-    headers.push(request_line.clone());
-    loop {
-        let mut line = String::new();
-        match reader.read_line(&mut line).await {
-            Ok(0) => break,
-            Ok(_) => {
-                let is_end = line == "\r\n" || line == "\n";
-                headers.push(line);
-                if is_end {
-                    break;
-                }
-            }
-            Err(_) => return,
-        }
-    }
+    let (method, path) = parse_method_and_path(&header_bytes);
+    let path = super::forward_proxy::strip_query(path);
 
-    // Parse method and path from request line.
-    let parts: Vec<&str> = request_line.split_whitespace().collect();
-    let path = if parts.len() >= 2 { parts[1] } else { "/" };
-
-    // Evaluate rules with domain + path.
     let verdict = config.matcher.evaluate(host, path);
     if !verdict.allowed {
         info!("BLOCKED HTTPS {host}{path} - {}", verdict.reason);
@@ -109,7 +90,7 @@ pub async fn intercept_tls(client: TcpStream, host: &str, port: u16, config: &Ag
         }
     };
 
-    let mut upstream_tls = match connector.connect(server_name, upstream_tcp).await {
+    let upstream_tls = match connector.connect(server_name, upstream_tcp).await {
         Ok(s) => s,
         Err(e) => {
             warn!("Upstream TLS handshake failed for {host}: {e}");
@@ -118,15 +99,289 @@ pub async fn intercept_tls(client: TcpStream, host: &str, port: u16, config: &Ag
         }
     };
 
-    // Forward the original request to upstream.
-    let header_bytes: Vec<u8> = headers.iter().flat_map(|h| h.as_bytes().to_vec()).collect();
-    if upstream_tls.write_all(&header_bytes).await.is_err() {
+    let (upstream_reader, mut upstream_writer) = tokio::io::split(upstream_tls);
+    let mut upstream_reader = BufReader::new(upstream_reader);
+
+    // Request loop: evaluate rules on every request, relay if allowed.
+    let has_body = method_has_body(&method);
+    let content_length = parse_content_length(&header_bytes);
+    let is_chunked = is_chunked_transfer(&header_bytes);
+
+    // Forward first request headers to upstream.
+    if upstream_writer.write_all(&header_bytes).await.is_err() {
         return;
     }
 
-    // Bidirectional relay between client TLS and upstream TLS.
-    let mut client_tls = reader.into_inner().unsplit(writer);
-    let _ = tokio::io::copy_bidirectional(&mut client_tls, &mut upstream_tls).await;
+    // Relay first request body.
+    if has_body
+        && let Err(e) = relay_body(
+            &mut reader,
+            &mut upstream_writer,
+            content_length,
+            is_chunked,
+        )
+        .await
+    {
+        debug!("Error relaying request body: {e}");
+        return;
+    }
+
+    request_loop(
+        host,
+        config,
+        &mut reader,
+        &mut writer,
+        &mut upstream_reader,
+        &mut upstream_writer,
+        &mut header_bytes,
+    )
+    .await;
+}
+
+/// Process subsequent HTTP/1.1 requests on a keep-alive MITM connection.
+async fn request_loop<CR, CW, UR, UW>(
+    host: &str,
+    config: &AgentProxyConfig,
+    reader: &mut CR,
+    writer: &mut CW,
+    upstream_reader: &mut UR,
+    upstream_writer: &mut UW,
+    header_bytes: &mut Vec<u8>,
+) where
+    CR: AsyncBufRead + Unpin,
+    CW: AsyncWriteExt + Unpin,
+    UR: AsyncBufRead + Unpin,
+    UW: AsyncWriteExt + Unpin,
+{
+    loop {
+        // Read response from upstream and relay to client.
+        let mut resp_headers = Vec::new();
+        if read_request_headers(upstream_reader, &mut resp_headers)
+            .await
+            .is_err()
+        {
+            break;
+        }
+        if writer.write_all(&resp_headers).await.is_err() {
+            break;
+        }
+
+        let resp_content_length = parse_content_length(&resp_headers);
+        let resp_chunked = is_chunked_transfer(&resp_headers);
+        let keep_alive = !has_connection_close(&resp_headers);
+
+        // Relay response body.
+        if let Err(e) = relay_body(upstream_reader, writer, resp_content_length, resp_chunked).await
+        {
+            debug!("Error relaying response body: {e}");
+            break;
+        }
+
+        if !keep_alive {
+            break;
+        }
+
+        // Read next request from client.
+        header_bytes.clear();
+        if read_request_headers(reader, header_bytes).await.is_err() {
+            break;
+        }
+
+        let (next_method, next_path) = parse_method_and_path(header_bytes);
+        let next_path = super::forward_proxy::strip_query(next_path);
+
+        // Evaluate rules on this request.
+        let verdict = config.matcher.evaluate(host, next_path);
+        if !verdict.allowed {
+            info!(
+                "BLOCKED HTTPS {host}{next_path} (keep-alive) - {}",
+                verdict.reason
+            );
+            config.log_blocked(host, next_path, &verdict.reason);
+            let _ = writer
+                .write_all(b"HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n")
+                .await;
+            break;
+        }
+
+        // Forward allowed request to upstream.
+        if upstream_writer.write_all(header_bytes).await.is_err() {
+            break;
+        }
+
+        let has_body = method_has_body(&next_method);
+        let content_length = parse_content_length(header_bytes);
+        let is_chunked = is_chunked_transfer(header_bytes);
+
+        if has_body
+            && let Err(e) = relay_body(reader, upstream_writer, content_length, is_chunked).await
+        {
+            debug!("Error relaying request body: {e}");
+            break;
+        }
+    }
+}
+
+/// Read HTTP headers (request or response) into `buf` until `\r\n\r\n`.
+async fn read_request_headers<R: AsyncBufRead + Unpin>(
+    reader: &mut R,
+    buf: &mut Vec<u8>,
+) -> Result<(), ()> {
+    loop {
+        let mut line = String::new();
+        let n = reader.read_line(&mut line).await.map_err(|_| ())?;
+        if n == 0 {
+            return Err(());
+        }
+        let is_end = line == "\r\n" || line == "\n";
+        buf.extend_from_slice(line.as_bytes());
+        if is_end {
+            return Ok(());
+        }
+    }
+}
+
+/// Parse method and path from request line bytes.
+fn parse_method_and_path(header_bytes: &[u8]) -> (String, &str) {
+    let header_str = std::str::from_utf8(header_bytes).unwrap_or("");
+    let first_line = header_str.lines().next().unwrap_or("");
+    let parts: Vec<&str> = first_line.split_whitespace().collect();
+    let method = parts.first().copied().unwrap_or("GET").to_string();
+    let path = if parts.len() >= 2 { parts[1] } else { "/" };
+    (method, path)
+}
+
+/// Check if the HTTP method typically has a request body.
+fn method_has_body(method: &str) -> bool {
+    matches!(
+        method.to_ascii_uppercase().as_str(),
+        "POST" | "PUT" | "PATCH"
+    )
+}
+
+/// Parse Content-Length from raw header bytes.
+fn parse_content_length(headers: &[u8]) -> Option<u64> {
+    let headers_str = std::str::from_utf8(headers).ok()?;
+    for line in headers_str.lines() {
+        if let Some(val) = line
+            .strip_prefix("Content-Length:")
+            .or_else(|| line.strip_prefix("content-length:"))
+        {
+            return val.trim().parse().ok();
+        }
+        // Case-insensitive check.
+        if line.len() > 16 && line[..16].eq_ignore_ascii_case("content-length: ") {
+            return line[16..].trim().parse().ok();
+        }
+    }
+    None
+}
+
+/// Check if Transfer-Encoding: chunked is set.
+fn is_chunked_transfer(headers: &[u8]) -> bool {
+    let Ok(headers_str) = std::str::from_utf8(headers) else {
+        return false;
+    };
+    for line in headers_str.lines() {
+        let lower = line.to_ascii_lowercase();
+        if lower.starts_with("transfer-encoding:") && lower.contains("chunked") {
+            return true;
+        }
+    }
+    false
+}
+
+/// Check if Connection: close is set.
+fn has_connection_close(headers: &[u8]) -> bool {
+    let Ok(headers_str) = std::str::from_utf8(headers) else {
+        return false;
+    };
+    for line in headers_str.lines() {
+        let lower = line.to_ascii_lowercase();
+        if lower.starts_with("connection:") && lower.contains("close") {
+            return true;
+        }
+    }
+    false
+}
+
+/// Relay an HTTP message body between reader and writer.
+///
+/// Handles Content-Length, chunked transfer encoding, and no-body cases.
+async fn relay_body<R: AsyncBufRead + Unpin, W: AsyncWriteExt + Unpin>(
+    reader: &mut R,
+    writer: &mut W,
+    content_length: Option<u64>,
+    chunked: bool,
+) -> Result<(), std::io::Error> {
+    if chunked {
+        relay_chunked(reader, writer).await
+    } else if let Some(len) = content_length {
+        relay_fixed(reader, writer, len).await
+    } else {
+        // No body (GET, HEAD, or 204/304 response).
+        Ok(())
+    }
+}
+
+/// Relay a fixed-length body.
+async fn relay_fixed<R: AsyncRead + Unpin, W: AsyncWriteExt + Unpin>(
+    reader: &mut R,
+    writer: &mut W,
+    length: u64,
+) -> Result<(), std::io::Error> {
+    let mut remaining = length;
+    let mut buf = [0u8; 8192];
+    while remaining > 0 {
+        let to_read = usize::try_from(remaining)
+            .unwrap_or(buf.len())
+            .min(buf.len());
+        let n = reader.read(&mut buf[..to_read]).await?;
+        if n == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "connection closed mid-body",
+            ));
+        }
+        writer.write_all(&buf[..n]).await?;
+        remaining -= n as u64;
+    }
+    Ok(())
+}
+
+/// Relay a chunked transfer-encoded body.
+///
+/// Reads and forwards chunk headers + data + trailers verbatim.
+async fn relay_chunked<R: AsyncBufRead + Unpin, W: AsyncWriteExt + Unpin>(
+    reader: &mut R,
+    writer: &mut W,
+) -> Result<(), std::io::Error> {
+    loop {
+        // Read chunk size line.
+        let mut size_line = String::new();
+        reader.read_line(&mut size_line).await?;
+        writer.write_all(size_line.as_bytes()).await?;
+
+        let size_str = size_line.trim().split(';').next().unwrap_or("0");
+        let chunk_size = u64::from_str_radix(size_str, 16).unwrap_or(0);
+
+        if chunk_size == 0 {
+            // Terminal chunk. Read trailing \r\n (end of chunked body).
+            let mut trailer = String::new();
+            reader.read_line(&mut trailer).await?;
+            writer.write_all(trailer.as_bytes()).await?;
+            break;
+        }
+
+        // Relay chunk data.
+        relay_fixed(reader, writer, chunk_size).await?;
+
+        // Read and relay trailing \r\n after chunk data.
+        let mut crlf = String::new();
+        reader.read_line(&mut crlf).await?;
+        writer.write_all(crlf.as_bytes()).await?;
+    }
+    Ok(())
 }
 
 /// Generate a rustls `ServerConfig` with a certificate for the given domain,
@@ -135,7 +390,6 @@ fn generate_server_config(domain: &str, config: &AgentProxyConfig) -> Result<Ser
     let ca = load_ca_materials(config)?;
     let ca_issuer = Issuer::from_params(&ca.params, &ca.key_pair);
 
-    // Generate a key pair for this domain.
     let domain_key = KeyPair::generate().map_err(|e| format!("key generation: {e}"))?;
 
     let mut params = CertificateParams::default();
@@ -163,13 +417,11 @@ fn generate_server_config(domain: &str, config: &AgentProxyConfig) -> Result<Ser
         .map_err(|e| format!("server config: {e}"))
 }
 
-/// CA issuer materials for signing domain certs.
 struct CaIssuerMaterials {
     params: CertificateParams,
     key_pair: KeyPair,
 }
 
-/// Load the CA cert params and key from PEM strings.
 fn load_ca_materials(config: &AgentProxyConfig) -> Result<CaIssuerMaterials, String> {
     let ca_key_pem = config
         .ca_key_pem
@@ -190,7 +442,6 @@ fn load_ca_materials(config: &AgentProxyConfig) -> Result<CaIssuerMaterials, Str
     })
 }
 
-/// Build a TLS client config for connecting to upstream servers.
 fn upstream_tls_config() -> rustls::ClientConfig {
     let mut root_store = rustls::RootCertStore::empty();
 
@@ -202,4 +453,70 @@ fn upstream_tls_config() -> rustls::ClientConfig {
     rustls::ClientConfig::builder()
         .with_root_certificates(root_store)
         .with_no_client_auth()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_content_length_header() {
+        let headers = b"GET / HTTP/1.1\r\nContent-Length: 42\r\n\r\n";
+        assert_eq!(parse_content_length(headers), Some(42));
+    }
+
+    #[test]
+    fn parse_content_length_case_insensitive() {
+        let headers = b"POST / HTTP/1.1\r\ncontent-length: 100\r\n\r\n";
+        assert_eq!(parse_content_length(headers), Some(100));
+    }
+
+    #[test]
+    fn parse_content_length_absent() {
+        let headers = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
+        assert_eq!(parse_content_length(headers), None);
+    }
+
+    #[test]
+    fn detect_chunked_transfer() {
+        let headers = b"POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n";
+        assert!(is_chunked_transfer(headers));
+    }
+
+    #[test]
+    fn detect_connection_close() {
+        let headers = b"HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n";
+        assert!(has_connection_close(headers));
+
+        let headers = b"HTTP/1.1 200 OK\r\nConnection: keep-alive\r\n\r\n";
+        assert!(!has_connection_close(headers));
+    }
+
+    #[test]
+    fn parse_method_and_path_basic() {
+        let headers = b"GET /api/v1 HTTP/1.1\r\nHost: example.com\r\n\r\n";
+        let (method, path) = parse_method_and_path(headers);
+        assert_eq!(method, "GET");
+        assert_eq!(path, "/api/v1");
+    }
+
+    #[test]
+    fn parse_method_and_path_with_query() {
+        let headers = b"GET /api/v1?foo=bar HTTP/1.1\r\nHost: example.com\r\n\r\n";
+        let (method, path) = parse_method_and_path(headers);
+        assert_eq!(method, "GET");
+        assert_eq!(path, "/api/v1?foo=bar");
+        // strip_query is applied by the caller
+        assert_eq!(super::super::forward_proxy::strip_query(path), "/api/v1");
+    }
+
+    #[test]
+    fn method_body_detection() {
+        assert!(method_has_body("POST"));
+        assert!(method_has_body("PUT"));
+        assert!(method_has_body("PATCH"));
+        assert!(!method_has_body("GET"));
+        assert!(!method_has_body("HEAD"));
+        assert!(!method_has_body("DELETE"));
+    }
 }

--- a/crates/cella-agent/src/mitm.rs
+++ b/crates/cella-agent/src/mitm.rs
@@ -1,0 +1,205 @@
+//! TLS MITM interception for HTTPS path-level blocking.
+//!
+//! When a domain has path-level blocking rules, the proxy intercepts the
+//! TLS connection:
+//! 1. Generate a per-domain certificate signed by the cella CA
+//! 2. Accept TLS from the client using that certificate
+//! 3. Parse the decrypted HTTP request to inspect the URL path
+//! 4. Evaluate blocking rules against domain + path
+//! 5. If allowed, establish TLS to the upstream and relay traffic
+
+use std::sync::Arc;
+
+use rcgen::{CertificateParams, DnType, DnValue, IsCa, Issuer, KeyPair, SanType};
+use rustls::ServerConfig;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpStream;
+use tokio_rustls::TlsAcceptor;
+use tracing::{debug, info, warn};
+
+use crate::proxy_config::AgentProxyConfig;
+
+/// Perform MITM interception on a CONNECT tunnel.
+///
+/// The client has already received "200 Connection Established" and expects
+/// to start a TLS handshake. We accept TLS with a generated cert, read the
+/// HTTP request inside, evaluate rules, and either block or forward.
+pub async fn intercept_tls(client: TcpStream, host: &str, port: u16, config: &AgentProxyConfig) {
+    // Generate a certificate for this domain.
+    let tls_config = match generate_server_config(host, config) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            warn!("Failed to generate MITM cert for {host}: {e}");
+            return;
+        }
+    };
+
+    let acceptor = TlsAcceptor::from(Arc::new(tls_config));
+
+    // Accept TLS from the client.
+    let tls_stream = match acceptor.accept(client).await {
+        Ok(s) => s,
+        Err(e) => {
+            debug!("TLS handshake failed for {host}: {e}");
+            return;
+        }
+    };
+
+    let (reader, mut writer) = tokio::io::split(tls_stream);
+    let mut reader = BufReader::new(reader);
+
+    // Read the HTTP request line (e.g., "GET /path HTTP/1.1\r\n").
+    let mut request_line = String::new();
+    if reader.read_line(&mut request_line).await.is_err() || request_line.is_empty() {
+        return;
+    }
+
+    // Read remaining headers.
+    let mut headers = Vec::new();
+    headers.push(request_line.clone());
+    loop {
+        let mut line = String::new();
+        match reader.read_line(&mut line).await {
+            Ok(0) => break,
+            Ok(_) => {
+                let is_end = line == "\r\n" || line == "\n";
+                headers.push(line);
+                if is_end {
+                    break;
+                }
+            }
+            Err(_) => return,
+        }
+    }
+
+    // Parse method and path from request line.
+    let parts: Vec<&str> = request_line.split_whitespace().collect();
+    let path = if parts.len() >= 2 { parts[1] } else { "/" };
+
+    // Evaluate rules with domain + path.
+    let verdict = config.matcher.evaluate(host, path);
+    if !verdict.allowed {
+        info!("BLOCKED HTTPS {host}{path} - {}", verdict.reason);
+        config.log_blocked(host, path, &verdict.reason);
+        let _ = writer
+            .write_all(b"HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n")
+            .await;
+        return;
+    }
+
+    // Connect to upstream server.
+    let upstream_tcp =
+        match super::forward_proxy::connect_upstream_for_mitm(host, port, config).await {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("Failed to connect to {host}:{port} for MITM relay: {e}");
+                let _ = writer.write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n").await;
+                return;
+            }
+        };
+
+    // Establish TLS to upstream.
+    let connector = tokio_rustls::TlsConnector::from(Arc::new(upstream_tls_config()));
+    let server_name = match rustls::pki_types::ServerName::try_from(host.to_string()) {
+        Ok(sn) => sn,
+        Err(e) => {
+            warn!("Invalid server name {host}: {e}");
+            return;
+        }
+    };
+
+    let mut upstream_tls = match connector.connect(server_name, upstream_tcp).await {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("Upstream TLS handshake failed for {host}: {e}");
+            let _ = writer.write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n").await;
+            return;
+        }
+    };
+
+    // Forward the original request to upstream.
+    let header_bytes: Vec<u8> = headers.iter().flat_map(|h| h.as_bytes().to_vec()).collect();
+    if upstream_tls.write_all(&header_bytes).await.is_err() {
+        return;
+    }
+
+    // Bidirectional relay between client TLS and upstream TLS.
+    let mut client_tls = reader.into_inner().unsplit(writer);
+    let _ = tokio::io::copy_bidirectional(&mut client_tls, &mut upstream_tls).await;
+}
+
+/// Generate a rustls `ServerConfig` with a certificate for the given domain,
+/// signed by the cella CA.
+fn generate_server_config(domain: &str, config: &AgentProxyConfig) -> Result<ServerConfig, String> {
+    let ca = load_ca_materials(config)?;
+    let ca_issuer = Issuer::from_params(&ca.params, &ca.key_pair);
+
+    // Generate a key pair for this domain.
+    let domain_key = KeyPair::generate().map_err(|e| format!("key generation: {e}"))?;
+
+    let mut params = CertificateParams::default();
+    params.is_ca = IsCa::NoCa;
+    params
+        .distinguished_name
+        .push(DnType::CommonName, DnValue::Utf8String(domain.to_string()));
+    params.subject_alt_names.push(SanType::DnsName(
+        domain
+            .to_string()
+            .try_into()
+            .map_err(|e| format!("invalid domain for SAN: {e}"))?,
+    ));
+
+    let domain_cert = params
+        .signed_by(&domain_key, &ca_issuer)
+        .map_err(|e| format!("cert signing: {e}"))?;
+
+    let cert_der = CertificateDer::from(domain_cert.der().to_vec());
+    let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(domain_key.serialize_der()));
+
+    ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(vec![cert_der], key_der)
+        .map_err(|e| format!("server config: {e}"))
+}
+
+/// CA issuer materials for signing domain certs.
+struct CaIssuerMaterials {
+    params: CertificateParams,
+    key_pair: KeyPair,
+}
+
+/// Load the CA cert params and key from PEM strings.
+fn load_ca_materials(config: &AgentProxyConfig) -> Result<CaIssuerMaterials, String> {
+    let ca_key_pem = config
+        .ca_key_pem
+        .as_deref()
+        .ok_or("no CA key available for MITM")?;
+
+    let ca_key_pair = KeyPair::from_pem(ca_key_pem).map_err(|e| format!("parse CA key: {e}"))?;
+
+    let mut ca_params = CertificateParams::default();
+    ca_params.is_ca = IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+    ca_params
+        .distinguished_name
+        .push(DnType::CommonName, "Cella Dev Container CA");
+
+    Ok(CaIssuerMaterials {
+        params: ca_params,
+        key_pair: ca_key_pair,
+    })
+}
+
+/// Build a TLS client config for connecting to upstream servers.
+fn upstream_tls_config() -> rustls::ClientConfig {
+    let mut root_store = rustls::RootCertStore::empty();
+
+    let native = rustls_native_certs::load_native_certs();
+    for cert in native.certs {
+        let _ = root_store.add(cert);
+    }
+
+    rustls::ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_no_client_auth()
+}

--- a/crates/cella-agent/src/proxy_config.rs
+++ b/crates/cella-agent/src/proxy_config.rs
@@ -1,0 +1,110 @@
+//! Agent-side proxy configuration.
+//!
+//! Deserializes the proxy config passed via `--proxy-config` JSON argument
+//! and builds the rule matcher for request evaluation.
+
+use std::io::Write;
+use std::sync::Mutex;
+
+use cella_network::config::{NetworkConfig, NetworkMode, NetworkRule, RuleAction};
+use cella_network::rules::RuleMatcher;
+
+/// Runtime configuration for the forward proxy.
+pub struct AgentProxyConfig {
+    /// Port to listen on.
+    pub listen_port: u16,
+
+    /// Rule matcher for evaluating requests.
+    pub matcher: RuleMatcher,
+
+    /// Upstream proxy URL (if chaining through a corporate proxy).
+    pub upstream_proxy: Option<String>,
+
+    /// Log file for blocked requests.
+    log_file: Mutex<Option<std::fs::File>>,
+}
+
+impl AgentProxyConfig {
+    /// Create proxy config from the serialized JSON passed by cella-cli.
+    pub fn from_json(json: &str) -> Result<Self, String> {
+        let raw: ProxyConfigJson =
+            serde_json::from_str(json).map_err(|e| format!("invalid proxy config: {e}"))?;
+
+        let net_config = NetworkConfig {
+            mode: match raw.mode.as_str() {
+                "allowlist" => NetworkMode::Allowlist,
+                _ => NetworkMode::Denylist,
+            },
+            rules: raw
+                .rules
+                .into_iter()
+                .map(|r| NetworkRule {
+                    domain: r.domain,
+                    paths: r.paths,
+                    action: if r.action == "allow" {
+                        RuleAction::Allow
+                    } else {
+                        RuleAction::Block
+                    },
+                })
+                .collect(),
+            ..Default::default()
+        };
+
+        let matcher = RuleMatcher::new(&net_config);
+
+        // Open log file.
+        let log_file = open_log_file();
+
+        Ok(Self {
+            listen_port: raw.listen_port,
+            matcher,
+            upstream_proxy: raw.upstream_proxy,
+            log_file: Mutex::new(log_file),
+        })
+    }
+
+    /// Log a blocked request to the proxy log file.
+    pub fn log_blocked(&self, domain: &str, path: &str, reason: &str) {
+        let Ok(mut guard) = self.log_file.lock() else {
+            return;
+        };
+        let Some(ref mut file) = *guard else {
+            return;
+        };
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let _ = writeln!(file, "{timestamp}\tBLOCKED\t{domain}\t{path}\t{reason}");
+    }
+}
+
+fn open_log_file() -> Option<std::fs::File> {
+    let log_dir = "/tmp/.cella";
+    let _ = std::fs::create_dir_all(log_dir);
+    let path = format!("{log_dir}/proxy.log");
+    std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .ok()
+}
+
+/// JSON structure passed via `--proxy-config`.
+#[derive(serde::Deserialize)]
+struct ProxyConfigJson {
+    listen_port: u16,
+    mode: String,
+    rules: Vec<RuleJson>,
+    upstream_proxy: Option<String>,
+}
+
+/// A rule in the JSON config.
+#[derive(serde::Deserialize)]
+struct RuleJson {
+    domain: String,
+    #[serde(default)]
+    paths: Vec<String>,
+    action: String,
+}

--- a/crates/cella-agent/src/proxy_config.rs
+++ b/crates/cella-agent/src/proxy_config.rs
@@ -20,6 +20,12 @@ pub struct AgentProxyConfig {
     /// Upstream proxy URL (if chaining through a corporate proxy).
     pub upstream_proxy: Option<String>,
 
+    /// PEM-encoded CA certificate for MITM TLS interception.
+    pub ca_cert_pem: Option<String>,
+
+    /// PEM-encoded CA private key for MITM TLS interception.
+    pub ca_key_pem: Option<String>,
+
     /// Log file for blocked requests.
     log_file: Mutex<Option<std::fs::File>>,
 }
@@ -60,6 +66,8 @@ impl AgentProxyConfig {
             listen_port: raw.listen_port,
             matcher,
             upstream_proxy: raw.upstream_proxy,
+            ca_cert_pem: raw.ca_cert_pem,
+            ca_key_pem: raw.ca_key_pem,
             log_file: Mutex::new(log_file),
         })
     }
@@ -98,6 +106,8 @@ struct ProxyConfigJson {
     mode: String,
     rules: Vec<RuleJson>,
     upstream_proxy: Option<String>,
+    ca_cert_pem: Option<String>,
+    ca_key_pem: Option<String>,
 }
 
 /// A rule in the JSON config.

--- a/crates/cella-cli/Cargo.toml
+++ b/crates/cella-cli/Cargo.toml
@@ -19,6 +19,7 @@ cella-docker.workspace = true
 cella-orchestrator.workspace = true
 cella-env.workspace = true
 cella-features.workspace = true
+cella-network.workspace = true
 cella-git.workspace = true
 cella-port.workspace = true
 chrono.workspace = true

--- a/crates/cella-cli/src/commands/compose_up.rs
+++ b/crates/cella-cli/src/commands/compose_up.rs
@@ -145,7 +145,7 @@ async fn prepare_and_start(
 
     // 8. Resolve remote user from config
     let remote_user = resolve_remote_user(config, None, "root");
-    let env_fwd = cella_env::prepare_env_forwarding(config, &remote_user);
+    let env_fwd = cella_env::prepare_env_forwarding(config, &remote_user, None);
 
     // 9. Build extra environment variables
     let mut extra_env = daemon_env;
@@ -233,7 +233,7 @@ async fn finalize_compose(
     ctx.register_with_daemon(&primary.id).await;
 
     // 17. Post-create setup (UID, env, credentials, tools, userEnvProbe)
-    let env_fwd = cella_env::prepare_env_forwarding(config, remote_user);
+    let env_fwd = cella_env::prepare_env_forwarding(config, remote_user, None);
     let settings = cella_config::Settings::load(&ctx.resolved.workspace_root);
     let (_probed_env, lifecycle_env) = ctx
         .post_create_setup(

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -14,6 +14,7 @@ pub mod image;
 mod init;
 mod list;
 mod logs;
+mod network;
 mod nvim;
 mod ports;
 mod prune;
@@ -76,6 +77,8 @@ pub enum Command {
     Nvim(nvim::NvimArgs),
     /// Open a persistent tmux session inside the dev container.
     Tmux(tmux::TmuxArgs),
+    /// Inspect network proxy and blocking configuration.
+    Network(network::NetworkArgs),
     /// View port forwarding status for dev containers.
     Ports(ports::PortsArgs),
     /// Manage credential forwarding for dev containers.
@@ -150,6 +153,7 @@ impl Command {
             Self::Nvim(args) => args.execute(progress).await,
             Self::Tmux(args) => args.execute(progress).await,
             Self::Credential(args) => args.execute().await,
+            Self::Network(args) => args.execute(),
             Self::Ports(args) => args.execute().await,
             Self::Daemon(args) => args.execute().await,
         }

--- a/crates/cella-cli/src/commands/network.rs
+++ b/crates/cella-cli/src/commands/network.rs
@@ -45,13 +45,12 @@ fn execute_status() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let proxy_vars = cella_network::proxy_env::ProxyEnvVars::detect(&net_config.proxy);
-    let has_proxy = proxy_vars.as_ref().is_some_and(cella_network::ProxyEnvVars::has_proxy);
+    let has_proxy = proxy_vars
+        .as_ref()
+        .is_some_and(cella_network::ProxyEnvVars::has_proxy);
 
     if net_config.has_rules() {
-        println!(
-            "Proxy: active (localhost:{})",
-            net_config.proxy.proxy_port
-        );
+        println!("Proxy: active (localhost:{})", net_config.proxy.proxy_port);
     } else if has_proxy {
         println!("Proxy: forwarding (passthrough)");
     } else {
@@ -80,10 +79,7 @@ fn execute_status() -> Result<(), Box<dyn std::error::Error>> {
         cella_network::NetworkMode::Denylist => "denylist",
         cella_network::NetworkMode::Allowlist => "allowlist",
     };
-    println!(
-        "Mode: {mode_str} ({} rules)",
-        net_config.rules.len()
-    );
+    println!("Mode: {mode_str} ({} rules)", net_config.rules.len());
 
     for rule in &net_config.rules {
         let action = match rule.action {
@@ -93,11 +89,7 @@ fn execute_status() -> Result<(), Box<dyn std::error::Error>> {
         if rule.paths.is_empty() {
             println!("  {action}: {}", rule.domain);
         } else {
-            println!(
-                "  {action}: {} [{}]",
-                rule.domain,
-                rule.paths.join(", ")
-            );
+            println!("  {action}: {} [{}]", rule.domain, rule.paths.join(", "));
         }
     }
 

--- a/crates/cella-cli/src/commands/network.rs
+++ b/crates/cella-cli/src/commands/network.rs
@@ -1,0 +1,193 @@
+//! `cella network` subcommands for inspecting proxy and blocking state.
+
+use clap::{Args, Subcommand};
+
+#[derive(Args)]
+pub struct NetworkArgs {
+    #[command(subcommand)]
+    command: NetworkCommand,
+}
+
+#[derive(Subcommand)]
+enum NetworkCommand {
+    /// Show network proxy and blocking status.
+    Status,
+    /// Test whether a URL would be blocked or allowed.
+    Test {
+        /// The URL to test (e.g., `https://api.prod.internal/v1/data`).
+        url: String,
+    },
+    /// Tail the proxy blocked-request log from a running container.
+    Log,
+}
+
+impl NetworkArgs {
+    pub fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+        match self.command {
+            NetworkCommand::Status => execute_status(),
+            NetworkCommand::Test { url } => execute_test(&url),
+            NetworkCommand::Log => {
+                execute_log();
+                Ok(())
+            }
+        }
+    }
+}
+
+fn execute_status() -> Result<(), Box<dyn std::error::Error>> {
+    let workspace_root = std::env::current_dir()?;
+    let settings = cella_config::Settings::load(&workspace_root);
+    let net_config = settings.network.to_network_config();
+
+    if !net_config.proxy.enabled {
+        println!("Proxy: disabled");
+        return Ok(());
+    }
+
+    let proxy_vars = cella_network::proxy_env::ProxyEnvVars::detect(&net_config.proxy);
+    let has_proxy = proxy_vars.as_ref().is_some_and(cella_network::ProxyEnvVars::has_proxy);
+
+    if net_config.has_rules() {
+        println!(
+            "Proxy: active (localhost:{})",
+            net_config.proxy.proxy_port
+        );
+    } else if has_proxy {
+        println!("Proxy: forwarding (passthrough)");
+    } else {
+        println!("Proxy: inactive (no proxy detected, no rules)");
+    }
+
+    if let Some(ref vars) = proxy_vars {
+        if let Some(ref http) = vars.http_proxy {
+            println!("Upstream HTTP: {http}");
+        }
+        if let Some(ref https) = vars.https_proxy {
+            println!("Upstream HTTPS: {https}");
+        }
+    }
+
+    // CA status.
+    let ca_dir = dirs_home().join(".cella/proxy/ca.pem");
+    if ca_dir.exists() {
+        println!("CA: auto-generated (~/.cella/proxy/ca.pem)");
+    } else {
+        println!("CA: not generated");
+    }
+
+    // Rules.
+    let mode_str = match net_config.mode {
+        cella_network::NetworkMode::Denylist => "denylist",
+        cella_network::NetworkMode::Allowlist => "allowlist",
+    };
+    println!(
+        "Mode: {mode_str} ({} rules)",
+        net_config.rules.len()
+    );
+
+    for rule in &net_config.rules {
+        let action = match rule.action {
+            cella_network::RuleAction::Block => "block",
+            cella_network::RuleAction::Allow => "allow",
+        };
+        if rule.paths.is_empty() {
+            println!("  {action}: {}", rule.domain);
+        } else {
+            println!(
+                "  {action}: {} [{}]",
+                rule.domain,
+                rule.paths.join(", ")
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn execute_test(url: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let workspace_root = std::env::current_dir()?;
+    let settings = cella_config::Settings::load(&workspace_root);
+    let net_config = settings.network.to_network_config();
+
+    if !net_config.has_rules() {
+        println!("No blocking rules configured. All traffic is allowed.");
+        return Ok(());
+    }
+
+    // Parse URL to extract domain and path.
+    let (domain, path) = parse_url_parts(url);
+
+    let matcher = cella_network::RuleMatcher::new(&net_config);
+    let verdict = matcher.evaluate(&domain, &path);
+
+    if verdict.allowed {
+        println!("\u{2713} ALLOWED: {url}");
+    } else {
+        println!("\u{2717} BLOCKED: {url}");
+    }
+    println!("  {}", verdict.reason);
+
+    Ok(())
+}
+
+fn execute_log() {
+    // This runs on the host — it needs to exec into the container to read the log.
+    // For now, print instructions.
+    println!("To view the proxy log, run inside the container:");
+    println!("  cat /tmp/.cella/proxy.log");
+    println!();
+    println!("Or from the host:");
+    println!("  cella exec -- cat /tmp/.cella/proxy.log");
+}
+
+/// Parse a URL into (domain, path).
+fn parse_url_parts(url: &str) -> (String, String) {
+    // Strip scheme.
+    let rest = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))
+        .unwrap_or(url);
+
+    // Split host and path.
+    let (host_port, path) = rest
+        .find('/')
+        .map_or((rest, "/"), |idx| (&rest[..idx], &rest[idx..]));
+
+    // Strip port from host.
+    let host = host_port
+        .rfind(':')
+        .map_or(host_port, |idx| &host_port[..idx]);
+
+    (host.to_string(), path.to_string())
+}
+
+fn dirs_home() -> std::path::PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
+    std::path::PathBuf::from(home)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_https_url() {
+        let (domain, path) = parse_url_parts("https://api.prod.internal/v1/data");
+        assert_eq!(domain, "api.prod.internal");
+        assert_eq!(path, "/v1/data");
+    }
+
+    #[test]
+    fn parse_http_url_with_port() {
+        let (domain, path) = parse_url_parts("http://example.com:8080/api");
+        assert_eq!(domain, "example.com");
+        assert_eq!(path, "/api");
+    }
+
+    #[test]
+    fn parse_bare_domain() {
+        let (domain, path) = parse_url_parts("example.com");
+        assert_eq!(domain, "example.com");
+        assert_eq!(path, "/");
+    }
+}

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -64,6 +64,10 @@ pub struct UpArgs {
     /// Target a worktree branch's container by branch name.
     #[arg(long)]
     pub(crate) branch: Option<String>,
+
+    /// Start container without network blocking rules (proxy forwarding still active).
+    #[arg(long)]
+    pub(crate) no_network_rules: bool,
 }
 
 /// Output format for container commands.
@@ -77,6 +81,15 @@ impl UpArgs {
     pub const fn is_text_output(&self) -> bool {
         matches!(self.output, OutputFormat::Text)
     }
+}
+
+/// Whether network blocking rules are enforced.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum NetworkRulePolicy {
+    /// Enforce blocking rules from config.
+    Enforce,
+    /// Skip blocking rules (`--no-network-rules`).
+    Skip,
 }
 
 /// Holds resolved state for an `up` invocation, shared across all code paths.
@@ -94,6 +107,8 @@ pub struct UpContext {
     pub(crate) skip_checksum: bool,
     /// Extra Docker labels to merge into the container (e.g., worktree labels).
     extra_labels: std::collections::HashMap<String, String>,
+    /// Network rule enforcement policy.
+    network_rules: NetworkRulePolicy,
 }
 
 /// Resolved image configuration for container creation.
@@ -156,6 +171,11 @@ impl UpContext {
             build_no_cache: args.build_no_cache,
             skip_checksum: args.skip_checksum,
             extra_labels: std::collections::HashMap::new(),
+            network_rules: if args.no_network_rules {
+                NetworkRulePolicy::Skip
+            } else {
+                NetworkRulePolicy::Enforce
+            },
         })
     }
 
@@ -216,6 +236,7 @@ impl UpContext {
             build_no_cache: false,
             skip_checksum: false,
             extra_labels,
+            network_rules: NetworkRulePolicy::Enforce,
         })
     }
 
@@ -1060,7 +1081,11 @@ impl UpContext {
         // Build network proxy forwarding config from settings.
         let settings = cella_config::Settings::load(&self.resolved.workspace_root);
         let net_config = settings.network.to_network_config();
-        let has_rules = net_config.has_rules();
+        let skip_rules = self.network_rules == NetworkRulePolicy::Skip;
+        let has_rules = net_config.has_rules() && !skip_rules;
+        if skip_rules && net_config.has_rules() {
+            tracing::info!("Network blocking rules disabled via --no-network-rules");
+        }
         let proxy_fwd = cella_env::ProxyForwardingConfig {
             proxy: net_config.proxy.clone(),
             has_blocking_rules: has_rules,
@@ -1360,6 +1385,11 @@ impl UpArgs {
         ctx.remove_container = self.rebuild || self.remove_existing_container;
         ctx.build_no_cache = self.build_no_cache;
         ctx.skip_checksum = self.skip_checksum;
+        ctx.network_rules = if self.no_network_rules {
+            NetworkRulePolicy::Skip
+        } else {
+            NetworkRulePolicy::Enforce
+        };
 
         let result = ctx.ensure_up(self.build_no_cache, &self.strict).await?;
         output_result(

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -1081,6 +1081,7 @@ impl UpContext {
         // Build network proxy forwarding config from settings + devcontainer.json.
         let settings = cella_config::Settings::load(&self.resolved.workspace_root);
         let toml_net = settings.network.to_network_config();
+        let toml_mode_override = settings.network.mode_override();
 
         // Extract customizations.cella.network from devcontainer.json.
         let dc_net = config
@@ -1089,8 +1090,12 @@ impl UpContext {
             .and_then(|c| c.get("network"))
             .and_then(|n| serde_json::from_value::<cella_network::NetworkConfig>(n.clone()).ok());
 
-        // Merge: devcontainer.json is base, cella.toml overrides.
-        let merged = cella_network::merge_network_configs(dc_net.as_ref(), Some(&toml_net));
+        // Merge: devcontainer.json is base, cella.toml overrides (only when explicit).
+        let merged = cella_network::merge_network_configs(
+            dc_net.as_ref(),
+            Some(&toml_net),
+            toml_mode_override,
+        );
         let net_config = cella_network::NetworkConfig {
             mode: merged.mode,
             proxy: merged.proxy,
@@ -1106,6 +1111,7 @@ impl UpContext {
             proxy: net_config.proxy.clone(),
             has_blocking_rules: has_rules,
             full_config: if has_rules { Some(net_config) } else { None },
+            container_distro: cella_env::ca_bundle::ContainerDistro::Unknown,
         };
         let env_fwd = cella_env::prepare_env_forwarding(config, &remote_user, Some(&proxy_fwd));
 
@@ -1645,6 +1651,34 @@ pub async fn inject_post_start(
         remote_user,
     )
     .await;
+
+    // Execute privileged commands (e.g., CA trust store updates) as root.
+    for cmd in &post_start.root_commands {
+        let result = client
+            .exec_command(
+                container_id,
+                &ExecOptions {
+                    cmd: cmd.clone(),
+                    user: Some("root".to_string()),
+                    env: None,
+                    working_dir: None,
+                },
+            )
+            .await;
+        match result {
+            Ok(r) if r.exit_code != 0 => {
+                warn!(
+                    "Root command failed (exit {}): {}",
+                    r.exit_code,
+                    r.stderr.trim()
+                );
+            }
+            Err(e) => {
+                warn!("Failed to exec root command: {e}");
+            }
+            _ => {}
+        }
+    }
 }
 
 /// Add `/cella/bin` to PATH in the container's shell profile.

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -1090,10 +1090,7 @@ impl UpContext {
             .and_then(|n| serde_json::from_value::<cella_network::NetworkConfig>(n.clone()).ok());
 
         // Merge: devcontainer.json is base, cella.toml overrides.
-        let merged = cella_network::merge_network_configs(
-            dc_net.as_ref(),
-            Some(&toml_net),
-        );
+        let merged = cella_network::merge_network_configs(dc_net.as_ref(), Some(&toml_net));
         let net_config = cella_network::NetworkConfig {
             mode: merged.mode,
             proxy: merged.proxy,
@@ -1108,11 +1105,7 @@ impl UpContext {
         let proxy_fwd = cella_env::ProxyForwardingConfig {
             proxy: net_config.proxy.clone(),
             has_blocking_rules: has_rules,
-            full_config: if has_rules {
-                Some(net_config)
-            } else {
-                None
-            },
+            full_config: if has_rules { Some(net_config) } else { None },
         };
         let env_fwd = cella_env::prepare_env_forwarding(config, &remote_user, Some(&proxy_fwd));
 

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -327,7 +327,7 @@ impl UpContext {
         let config = self.config();
 
         // Re-inject env forwarding (git config + SSH files may have changed)
-        let env_fwd = cella_env::prepare_env_forwarding(config, remote_user);
+        let env_fwd = cella_env::prepare_env_forwarding(config, remote_user, None);
         self.progress
             .run_step(
                 "Configuring environment...",
@@ -1056,7 +1056,7 @@ impl UpContext {
             resolve_remote_user(config, image_meta_user.as_ref(), &base_image_details.user);
 
         super::ensure_cella_daemon().await;
-        let env_fwd = cella_env::prepare_env_forwarding(config, &remote_user);
+        let env_fwd = cella_env::prepare_env_forwarding(config, &remote_user, None);
 
         let labels = self.build_labels(
             resolved_features,

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -1078,9 +1078,28 @@ impl UpContext {
 
         super::ensure_cella_daemon().await;
 
-        // Build network proxy forwarding config from settings.
+        // Build network proxy forwarding config from settings + devcontainer.json.
         let settings = cella_config::Settings::load(&self.resolved.workspace_root);
-        let net_config = settings.network.to_network_config();
+        let toml_net = settings.network.to_network_config();
+
+        // Extract customizations.cella.network from devcontainer.json.
+        let dc_net = config
+            .get("customizations")
+            .and_then(|c| c.get("cella"))
+            .and_then(|c| c.get("network"))
+            .and_then(|n| serde_json::from_value::<cella_network::NetworkConfig>(n.clone()).ok());
+
+        // Merge: devcontainer.json is base, cella.toml overrides.
+        let merged = cella_network::merge_network_configs(
+            dc_net.as_ref(),
+            Some(&toml_net),
+        );
+        let net_config = cella_network::NetworkConfig {
+            mode: merged.mode,
+            proxy: merged.proxy,
+            rules: merged.rules.into_iter().map(|lr| lr.rule).collect(),
+        };
+
         let skip_rules = self.network_rules == NetworkRulePolicy::Skip;
         let has_rules = net_config.has_rules() && !skip_rules;
         if skip_rules && net_config.has_rules() {

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -1056,7 +1056,21 @@ impl UpContext {
             resolve_remote_user(config, image_meta_user.as_ref(), &base_image_details.user);
 
         super::ensure_cella_daemon().await;
-        let env_fwd = cella_env::prepare_env_forwarding(config, &remote_user, None);
+
+        // Build network proxy forwarding config from settings.
+        let settings = cella_config::Settings::load(&self.resolved.workspace_root);
+        let net_config = settings.network.to_network_config();
+        let has_rules = net_config.has_rules();
+        let proxy_fwd = cella_env::ProxyForwardingConfig {
+            proxy: net_config.proxy.clone(),
+            has_blocking_rules: has_rules,
+            full_config: if has_rules {
+                Some(net_config)
+            } else {
+                None
+            },
+        };
+        let env_fwd = cella_env::prepare_env_forwarding(config, &remote_user, Some(&proxy_fwd));
 
         let labels = self.build_labels(
             resolved_features,

--- a/crates/cella-config/Cargo.toml
+++ b/crates/cella-config/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+cella-network.workspace = true
 hex.workspace = true
 miette.workspace = true
 serde.workspace = true

--- a/crates/cella-config/src/settings/mod.rs
+++ b/crates/cella-config/src/settings/mod.rs
@@ -2,6 +2,7 @@ mod claude_code;
 mod codex;
 mod credentials;
 mod gemini;
+pub mod network;
 mod nvim;
 mod tmux;
 
@@ -14,6 +15,7 @@ pub use claude_code::ClaudeCode;
 pub use codex::Codex;
 pub use credentials::Credentials;
 pub use gemini::Gemini;
+pub use network::Network;
 pub use nvim::Nvim;
 pub use tmux::Tmux;
 
@@ -56,6 +58,10 @@ pub struct Settings {
     /// Tool installation and forwarding settings.
     #[serde(default)]
     pub tools: Tools,
+
+    /// Network proxy and blocking settings.
+    #[serde(default)]
+    pub network: Network,
 }
 
 impl Settings {
@@ -109,6 +115,7 @@ impl Settings {
                 let Self {
                     credentials: pc,
                     tools: pt,
+                    network: pn,
                 } = p;
                 let Tools {
                     claude_code: pt_claude,
@@ -126,6 +133,7 @@ impl Settings {
                         nvim: pt_nvim,
                         tmux: pt_tmux,
                     },
+                    network: pn,
                 }
             }
         }

--- a/crates/cella-config/src/settings/network.rs
+++ b/crates/cella-config/src/settings/network.rs
@@ -13,8 +13,10 @@ use serde::Deserialize;
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct Network {
     /// Blocking mode: "denylist" or "allowlist".
+    /// `None` when the user didn't set `[network].mode` in their TOML config,
+    /// so it doesn't override devcontainer.json's mode during merge.
     #[serde(default)]
-    pub mode: NetworkMode,
+    pub mode: Option<NetworkMode>,
 
     /// Proxy configuration.
     #[serde(default)]
@@ -106,13 +108,22 @@ const fn default_proxy_port() -> u16 {
 }
 
 impl Network {
+    /// The mode explicitly set by the user, if any.
+    pub fn mode_override(&self) -> Option<cella_network::NetworkMode> {
+        self.mode.map(|m| match m {
+            NetworkMode::Denylist => cella_network::NetworkMode::Denylist,
+            NetworkMode::Allowlist => cella_network::NetworkMode::Allowlist,
+        })
+    }
+
     /// Convert to `cella_network::NetworkConfig` for use by the rule engine.
+    ///
+    /// When `mode` is `None` (not explicitly set), defaults to `Denylist`.
     pub fn to_network_config(&self) -> cella_network::NetworkConfig {
         cella_network::NetworkConfig {
-            mode: match self.mode {
-                NetworkMode::Denylist => cella_network::NetworkMode::Denylist,
-                NetworkMode::Allowlist => cella_network::NetworkMode::Allowlist,
-            },
+            mode: self
+                .mode_override()
+                .unwrap_or(cella_network::NetworkMode::Denylist),
             proxy: cella_network::ProxyConfig {
                 enabled: self.proxy.enabled,
                 http: self.proxy.http.clone(),
@@ -144,7 +155,7 @@ mod tests {
     #[test]
     fn default_network_settings() {
         let network = Network::default();
-        assert_eq!(network.mode, NetworkMode::Denylist);
+        assert!(network.mode.is_none());
         assert!(network.proxy.enabled);
         assert_eq!(network.proxy.proxy_port, 18080);
         assert!(network.rules.is_empty());
@@ -169,7 +180,7 @@ paths = ["/admin/**"]
 action = "block"
 "#;
         let network: Network = toml::from_str(toml_str).unwrap();
-        assert_eq!(network.mode, NetworkMode::Denylist);
+        assert_eq!(network.mode, Some(NetworkMode::Denylist));
         assert_eq!(network.proxy.http.as_deref(), Some("http://proxy:3128"));
         assert_eq!(network.proxy.proxy_port, 19090);
         assert_eq!(network.rules.len(), 2);
@@ -180,7 +191,7 @@ action = "block"
     #[test]
     fn convert_to_network_config() {
         let network = Network {
-            mode: NetworkMode::Allowlist,
+            mode: Some(NetworkMode::Allowlist),
             proxy: ProxySettings {
                 enabled: true,
                 http: Some("http://proxy:3128".to_string()),

--- a/crates/cella-config/src/settings/network.rs
+++ b/crates/cella-config/src/settings/network.rs
@@ -1,0 +1,202 @@
+//! Network and proxy configuration settings.
+//!
+//! Wraps `cella_network::NetworkConfig` for TOML deserialization
+//! within the cella settings system.
+
+use serde::Deserialize;
+
+/// Network settings section of `cella.toml`.
+///
+/// Maps to `[network]` in the TOML config.
+/// Thin wrapper around `cella_network::NetworkConfig` to keep
+/// the settings crate's deserialization self-contained.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct Network {
+    /// Blocking mode: "denylist" or "allowlist".
+    #[serde(default)]
+    pub mode: NetworkMode,
+
+    /// Proxy configuration.
+    #[serde(default)]
+    pub proxy: ProxySettings,
+
+    /// Network blocking rules.
+    #[serde(default)]
+    pub rules: Vec<NetworkRule>,
+}
+
+/// Blocking mode.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum NetworkMode {
+    #[default]
+    Denylist,
+    Allowlist,
+}
+
+/// Proxy settings.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ProxySettings {
+    /// Whether proxy forwarding is enabled.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+
+    /// HTTP proxy URL override.
+    #[serde(default)]
+    pub http: Option<String>,
+
+    /// HTTPS proxy URL override.
+    #[serde(default)]
+    pub https: Option<String>,
+
+    /// `NO_PROXY` override.
+    #[serde(default)]
+    pub no_proxy: Option<String>,
+
+    /// Path to additional CA certificate.
+    #[serde(default)]
+    pub ca_cert: Option<String>,
+
+    /// Cella-agent proxy listen port.
+    #[serde(default = "default_proxy_port")]
+    pub proxy_port: u16,
+}
+
+impl Default for ProxySettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            http: None,
+            https: None,
+            no_proxy: None,
+            ca_cert: None,
+            proxy_port: default_proxy_port(),
+        }
+    }
+}
+
+/// A network blocking rule.
+#[derive(Debug, Clone, Deserialize)]
+pub struct NetworkRule {
+    /// Domain glob pattern.
+    pub domain: String,
+
+    /// Optional path glob patterns.
+    #[serde(default)]
+    pub paths: Vec<String>,
+
+    /// Block or allow action.
+    pub action: RuleAction,
+}
+
+/// Rule action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RuleAction {
+    Block,
+    Allow,
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+const fn default_proxy_port() -> u16 {
+    18080
+}
+
+impl Network {
+    /// Convert to `cella_network::NetworkConfig` for use by the rule engine.
+    pub fn to_network_config(&self) -> cella_network::NetworkConfig {
+        cella_network::NetworkConfig {
+            mode: match self.mode {
+                NetworkMode::Denylist => cella_network::NetworkMode::Denylist,
+                NetworkMode::Allowlist => cella_network::NetworkMode::Allowlist,
+            },
+            proxy: cella_network::ProxyConfig {
+                enabled: self.proxy.enabled,
+                http: self.proxy.http.clone(),
+                https: self.proxy.https.clone(),
+                no_proxy: self.proxy.no_proxy.clone(),
+                ca_cert: self.proxy.ca_cert.clone(),
+                proxy_port: self.proxy.proxy_port,
+            },
+            rules: self
+                .rules
+                .iter()
+                .map(|r| cella_network::NetworkRule {
+                    domain: r.domain.clone(),
+                    paths: r.paths.clone(),
+                    action: match r.action {
+                        RuleAction::Block => cella_network::RuleAction::Block,
+                        RuleAction::Allow => cella_network::RuleAction::Allow,
+                    },
+                })
+                .collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_network_settings() {
+        let network = Network::default();
+        assert_eq!(network.mode, NetworkMode::Denylist);
+        assert!(network.proxy.enabled);
+        assert_eq!(network.proxy.proxy_port, 18080);
+        assert!(network.rules.is_empty());
+    }
+
+    #[test]
+    fn deserialize_network_section() {
+        let toml_str = r#"
+mode = "denylist"
+
+[proxy]
+http = "http://proxy:3128"
+proxy_port = 19090
+
+[[rules]]
+domain = "*.prod.internal"
+action = "block"
+
+[[rules]]
+domain = "api.example.com"
+paths = ["/admin/**"]
+action = "block"
+"#;
+        let network: Network = toml::from_str(toml_str).unwrap();
+        assert_eq!(network.mode, NetworkMode::Denylist);
+        assert_eq!(network.proxy.http.as_deref(), Some("http://proxy:3128"));
+        assert_eq!(network.proxy.proxy_port, 19090);
+        assert_eq!(network.rules.len(), 2);
+        assert_eq!(network.rules[0].domain, "*.prod.internal");
+        assert_eq!(network.rules[0].action, RuleAction::Block);
+    }
+
+    #[test]
+    fn convert_to_network_config() {
+        let network = Network {
+            mode: NetworkMode::Allowlist,
+            proxy: ProxySettings {
+                enabled: true,
+                http: Some("http://proxy:3128".to_string()),
+                ..Default::default()
+            },
+            rules: vec![NetworkRule {
+                domain: "*.example.com".to_string(),
+                paths: vec!["/api/*".to_string()],
+                action: RuleAction::Allow,
+            }],
+        };
+
+        let config = network.to_network_config();
+        assert_eq!(config.mode, cella_network::NetworkMode::Allowlist);
+        assert_eq!(config.proxy.http.as_deref(), Some("http://proxy:3128"));
+        assert_eq!(config.rules.len(), 1);
+        assert_eq!(config.rules[0].action, cella_network::RuleAction::Allow);
+    }
+}

--- a/crates/cella-env/Cargo.toml
+++ b/crates/cella-env/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+cella-network.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/cella-env/src/ca_bundle.rs
+++ b/crates/cella-env/src/ca_bundle.rs
@@ -14,9 +14,7 @@ const CONTAINER_CA_PATH: &str = "/usr/local/share/ca-certificates/cella-host-ca.
 ///
 /// Returns file uploads and commands to update the container's trust store.
 /// Returns `None` if no CA bundle can be detected from the host.
-pub fn prepare_ca_injection(
-    additional_ca_path: Option<&str>,
-) -> Option<CaInjection> {
+pub fn prepare_ca_injection(additional_ca_path: Option<&str>) -> Option<CaInjection> {
     let mut pem_bundle = String::new();
 
     // Detect host CA bundle.
@@ -78,8 +76,7 @@ impl CaInjection {
         post_start.git_config_commands.push(vec![
             "sh".to_string(),
             "-c".to_string(),
-            "update-ca-certificates 2>/dev/null || update-ca-trust 2>/dev/null || true"
-                .to_string(),
+            "update-ca-certificates 2>/dev/null || update-ca-trust 2>/dev/null || true".to_string(),
         ]);
     }
 }

--- a/crates/cella-env/src/ca_bundle.rs
+++ b/crates/cella-env/src/ca_bundle.rs
@@ -7,8 +7,81 @@ use cella_network::ca::{detect_host_ca_bundle, read_additional_ca_cert};
 
 use crate::{FileUpload, PostStartInjection};
 
-/// CA bundle file path inside the container.
-const CONTAINER_CA_PATH: &str = "/usr/local/share/ca-certificates/cella-host-ca.crt";
+/// Container OS family, detected via `/etc/os-release`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContainerDistro {
+    Debian,
+    Rhel,
+    Unknown,
+}
+
+impl ContainerDistro {
+    /// Detect the container OS family from the output of `cat /etc/os-release`.
+    pub fn from_os_release(content: &str) -> Self {
+        let lower = content.to_ascii_lowercase();
+        // Check ID= and ID_LIKE= lines for known families.
+        for line in lower.lines() {
+            if let Some(id) = line
+                .strip_prefix("id=")
+                .or_else(|| line.strip_prefix("id_like="))
+            {
+                let id = id.trim_matches('"');
+                if id.contains("debian")
+                    || id.contains("ubuntu")
+                    || id.contains("alpine")
+                    || id.contains("mint")
+                {
+                    return Self::Debian;
+                }
+                if id.contains("rhel")
+                    || id.contains("fedora")
+                    || id.contains("centos")
+                    || id.contains("rocky")
+                    || id.contains("alma")
+                    || id.contains("oracle")
+                    || id.contains("amzn")
+                    || id.contains("suse")
+                {
+                    return Self::Rhel;
+                }
+            }
+        }
+        Self::Unknown
+    }
+
+    /// The CA certificate path for this distro family.
+    pub fn ca_cert_path(&self, filename: &str) -> String {
+        match self {
+            Self::Debian | Self::Unknown => {
+                format!("/usr/local/share/ca-certificates/{filename}")
+            }
+            Self::Rhel => format!("/etc/pki/ca-trust/source/anchors/{filename}"),
+        }
+    }
+
+    /// The trust store update command for this distro family.
+    /// Returns a shell command that runs the appropriate tool.
+    pub fn trust_store_update_command(&self) -> Vec<String> {
+        match self {
+            Self::Debian => vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                "update-ca-certificates 2>/dev/null || true".to_string(),
+            ],
+            Self::Rhel => vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                "update-ca-trust 2>/dev/null || true".to_string(),
+            ],
+            Self::Unknown => vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                "update-ca-certificates 2>/dev/null || update-ca-trust 2>/dev/null || true"
+                    .to_string(),
+            ],
+        }
+    }
+}
 
 /// Prepare CA bundle injection for a container.
 ///
@@ -46,37 +119,117 @@ pub fn prepare_ca_injection(additional_ca_path: Option<&str>) -> Option<CaInject
     tracing::info!("Preparing CA bundle injection ({} bytes)", pem_bundle.len());
 
     Some(CaInjection {
-        file_upload: FileUpload {
-            container_path: CONTAINER_CA_PATH.to_string(),
-            content: pem_bundle.into_bytes(),
-            mode: 0o644,
-        },
+        pem_content: pem_bundle.into_bytes(),
     })
 }
 
 /// Prepared CA injection data.
 pub struct CaInjection {
-    /// The CA bundle file to upload.
-    pub file_upload: FileUpload,
+    /// The CA bundle PEM content to upload.
+    pub pem_content: Vec<u8>,
 }
 
 impl CaInjection {
     /// Apply the CA injection to post-start commands.
     ///
-    /// Adds the file upload and `update-ca-certificates` command to the
-    /// post-start injection. The command is distro-agnostic: tries
-    /// `update-ca-certificates` (Debian/Ubuntu/Alpine) first, falls back
-    /// to `update-ca-trust` (RHEL/Fedora).
-    pub fn apply_to(&self, post_start: &mut PostStartInjection) {
-        post_start.file_uploads.push(self.file_upload.clone());
+    /// Uploads the CA bundle to the distro-appropriate path and adds
+    /// the trust store update command to `root_commands` (requires root).
+    pub fn apply_to(&self, post_start: &mut PostStartInjection, distro: &ContainerDistro) {
+        let ca_path = distro.ca_cert_path("cella-host-ca.crt");
+        post_start.file_uploads.push(FileUpload {
+            container_path: ca_path,
+            content: self.pem_content.clone(),
+            mode: 0o644,
+        });
 
-        // Run update-ca-certificates (Debian/Ubuntu/Alpine) or
-        // update-ca-trust (RHEL/Fedora). Use a shell command that
-        // tries both.
-        post_start.git_config_commands.push(vec![
-            "sh".to_string(),
-            "-c".to_string(),
-            "update-ca-certificates 2>/dev/null || update-ca-trust 2>/dev/null || true".to_string(),
-        ]);
+        // For unknown distro, also upload to the other path.
+        if *distro == ContainerDistro::Unknown {
+            post_start.file_uploads.push(FileUpload {
+                container_path: "/etc/pki/ca-trust/source/anchors/cella-host-ca.crt".to_string(),
+                content: self.pem_content.clone(),
+                mode: 0o644,
+            });
+        }
+
+        post_start
+            .root_commands
+            .push(distro.trust_store_update_command());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_debian() {
+        let os_release = r#"NAME="Ubuntu"
+ID=ubuntu
+ID_LIKE=debian
+VERSION_ID="22.04"
+"#;
+        assert_eq!(
+            ContainerDistro::from_os_release(os_release),
+            ContainerDistro::Debian
+        );
+    }
+
+    #[test]
+    fn detect_rhel() {
+        let os_release = r#"NAME="Rocky Linux"
+ID="rocky"
+ID_LIKE="rhel centos fedora"
+"#;
+        assert_eq!(
+            ContainerDistro::from_os_release(os_release),
+            ContainerDistro::Rhel
+        );
+    }
+
+    #[test]
+    fn detect_alpine() {
+        let os_release = r#"NAME="Alpine Linux"
+ID=alpine
+"#;
+        assert_eq!(
+            ContainerDistro::from_os_release(os_release),
+            ContainerDistro::Debian
+        );
+    }
+
+    #[test]
+    fn detect_unknown() {
+        let os_release = r#"NAME="Custom OS"
+ID=custom
+"#;
+        assert_eq!(
+            ContainerDistro::from_os_release(os_release),
+            ContainerDistro::Unknown
+        );
+    }
+
+    #[test]
+    fn ca_cert_paths() {
+        assert_eq!(
+            ContainerDistro::Debian.ca_cert_path("test.crt"),
+            "/usr/local/share/ca-certificates/test.crt"
+        );
+        assert_eq!(
+            ContainerDistro::Rhel.ca_cert_path("test.crt"),
+            "/etc/pki/ca-trust/source/anchors/test.crt"
+        );
+    }
+
+    #[test]
+    fn trust_store_commands() {
+        let cmd = ContainerDistro::Debian.trust_store_update_command();
+        assert!(cmd[2].contains("update-ca-certificates"));
+
+        let cmd = ContainerDistro::Rhel.trust_store_update_command();
+        assert!(cmd[2].contains("update-ca-trust"));
+
+        let cmd = ContainerDistro::Unknown.trust_store_update_command();
+        assert!(cmd[2].contains("update-ca-certificates"));
+        assert!(cmd[2].contains("update-ca-trust"));
     }
 }

--- a/crates/cella-env/src/ca_bundle.rs
+++ b/crates/cella-env/src/ca_bundle.rs
@@ -1,0 +1,85 @@
+//! Host CA bundle detection and container trust store injection.
+//!
+//! Detects the host's CA trust store and prepares file uploads and commands
+//! to inject it into containers, supporting multiple Linux distributions.
+
+use cella_network::ca::{detect_host_ca_bundle, read_additional_ca_cert};
+
+use crate::{FileUpload, PostStartInjection};
+
+/// CA bundle file path inside the container.
+const CONTAINER_CA_PATH: &str = "/usr/local/share/ca-certificates/cella-host-ca.crt";
+
+/// Prepare CA bundle injection for a container.
+///
+/// Returns file uploads and commands to update the container's trust store.
+/// Returns `None` if no CA bundle can be detected from the host.
+pub fn prepare_ca_injection(
+    additional_ca_path: Option<&str>,
+) -> Option<CaInjection> {
+    let mut pem_bundle = String::new();
+
+    // Detect host CA bundle.
+    if let Some(host_bundle) = detect_host_ca_bundle() {
+        pem_bundle.push_str(&host_bundle.pem_bundle);
+    }
+
+    // Append additional CA cert if configured.
+    if let Some(ca_path) = additional_ca_path {
+        match read_additional_ca_cert(ca_path) {
+            Ok(extra_pem) => {
+                if !pem_bundle.is_empty() && !pem_bundle.ends_with('\n') {
+                    pem_bundle.push('\n');
+                }
+                pem_bundle.push_str(&extra_pem);
+                tracing::info!("Added additional CA cert from {ca_path}");
+            }
+            Err(e) => {
+                tracing::warn!("Failed to read additional CA cert: {e}");
+            }
+        }
+    }
+
+    if pem_bundle.is_empty() {
+        tracing::debug!("No CA bundle to inject");
+        return None;
+    }
+
+    tracing::info!("Preparing CA bundle injection ({} bytes)", pem_bundle.len());
+
+    Some(CaInjection {
+        file_upload: FileUpload {
+            container_path: CONTAINER_CA_PATH.to_string(),
+            content: pem_bundle.into_bytes(),
+            mode: 0o644,
+        },
+    })
+}
+
+/// Prepared CA injection data.
+pub struct CaInjection {
+    /// The CA bundle file to upload.
+    pub file_upload: FileUpload,
+}
+
+impl CaInjection {
+    /// Apply the CA injection to post-start commands.
+    ///
+    /// Adds the file upload and `update-ca-certificates` command to the
+    /// post-start injection. The command is distro-agnostic: tries
+    /// `update-ca-certificates` (Debian/Ubuntu/Alpine) first, falls back
+    /// to `update-ca-trust` (RHEL/Fedora).
+    pub fn apply_to(&self, post_start: &mut PostStartInjection) {
+        post_start.file_uploads.push(self.file_upload.clone());
+
+        // Run update-ca-certificates (Debian/Ubuntu/Alpine) or
+        // update-ca-trust (RHEL/Fedora). Use a shell command that
+        // tries both.
+        post_start.git_config_commands.push(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "update-ca-certificates 2>/dev/null || update-ca-trust 2>/dev/null || true"
+                .to_string(),
+        ]);
+    }
+}

--- a/crates/cella-env/src/lib.rs
+++ b/crates/cella-env/src/lib.rs
@@ -69,9 +69,12 @@ pub struct EnvForwarding {
 pub struct PostStartInjection {
     /// Files to upload into the container (SSH config, credential helper).
     pub file_uploads: Vec<FileUpload>,
-    /// Git config commands to execute inside the container.
+    /// Git config commands to execute inside the container as `remote_user`.
     /// Each entry is a full command (e.g., `["git", "config", "--global", "user.name", "John"]`).
     pub git_config_commands: Vec<Vec<String>>,
+    /// Commands that require root privileges (e.g., CA trust store updates).
+    /// Executed as root after file uploads.
+    pub root_commands: Vec<Vec<String>>,
 }
 
 /// Apply SSH agent forwarding to the environment.
@@ -152,6 +155,8 @@ pub struct ProxyForwardingConfig {
     pub has_blocking_rules: bool,
     /// Full network config (needed to build agent proxy config JSON).
     pub full_config: Option<cella_network::config::NetworkConfig>,
+    /// Detected container distro (for CA trust store paths).
+    pub container_distro: ca_bundle::ContainerDistro,
 }
 
 /// Prepare environment forwarding for a container.
@@ -180,22 +185,29 @@ pub fn prepare_env_forwarding(
         proxy::apply_proxy_env(&mut fwd, &net_config.proxy, net_config.has_blocking_rules);
 
         // If blocking rules are active, pass the proxy config to cella-agent
-        // via env var so it can start the forward proxy.
+        // via a file with restrictive permissions (contains CA private key).
         if net_config.has_blocking_rules
             && let Some(ref net_full) = net_config.full_config
         {
             let json = proxy::build_agent_proxy_config_json(net_full);
+            let config_path = "/tmp/.cella/proxy-config.json";
+            fwd.post_start.file_uploads.push(FileUpload {
+                container_path: config_path.to_string(),
+                content: json.into_bytes(),
+                mode: 0o600,
+            });
             fwd.env.push(ForwardEnv {
                 key: "CELLA_PROXY_CONFIG".to_string(),
-                value: json,
+                value: config_path.to_string(),
             });
         }
 
         // Inject host CA bundle into the container so TLS works behind
         // corporate proxies.
+        let distro = &net_config.container_distro;
         let additional_ca = net_config.proxy.ca_cert.as_deref();
         if let Some(ca_injection) = ca_bundle::prepare_ca_injection(additional_ca) {
-            ca_injection.apply_to(&mut fwd.post_start);
+            ca_injection.apply_to(&mut fwd.post_start, distro);
         }
 
         // If MITM CA was generated (for path-level blocking), also inject it
@@ -203,14 +215,29 @@ pub fn prepare_env_forwarding(
         if let Some(ref net_full) = net_config.full_config {
             let has_path_rules = net_full.rules.iter().any(|r| !r.paths.is_empty());
             if has_path_rules && let Ok(ca) = cella_network::ca::ensure_ca() {
+                let mitm_path = distro.ca_cert_path("cella-mitm-ca.crt");
                 let mitm_upload = FileUpload {
-                    container_path: "/usr/local/share/ca-certificates/cella-mitm-ca.crt"
-                        .to_string(),
-                    content: ca.cert_pem.into_bytes(),
+                    container_path: mitm_path,
+                    content: ca.cert_pem.clone().into_bytes(),
                     mode: 0o644,
                 };
                 fwd.post_start.file_uploads.push(mitm_upload);
-                // update-ca-certificates will be called by the host CA injection above
+
+                // For unknown distro, also upload to RHEL path.
+                if *distro == ca_bundle::ContainerDistro::Unknown {
+                    fwd.post_start.file_uploads.push(FileUpload {
+                        container_path: "/etc/pki/ca-trust/source/anchors/cella-mitm-ca.crt"
+                            .to_string(),
+                        content: ca.cert_pem.into_bytes(),
+                        mode: 0o644,
+                    });
+                }
+
+                // Always refresh trust store after MITM CA upload,
+                // even when host CA injection was None.
+                fwd.post_start
+                    .root_commands
+                    .push(distro.trust_store_update_command());
             }
         }
     }

--- a/crates/cella-env/src/lib.rs
+++ b/crates/cella-env/src/lib.rs
@@ -190,6 +190,29 @@ pub fn prepare_env_forwarding(
                 value: json,
             });
         }
+
+        // Inject host CA bundle into the container so TLS works behind
+        // corporate proxies.
+        let additional_ca = net_config.proxy.ca_cert.as_deref();
+        if let Some(ca_injection) = ca_bundle::prepare_ca_injection(additional_ca) {
+            ca_injection.apply_to(&mut fwd.post_start);
+        }
+
+        // If MITM CA was generated (for path-level blocking), also inject it
+        // so the container trusts cella's intercepted certificates.
+        if let Some(ref net_full) = net_config.full_config {
+            let has_path_rules = net_full.rules.iter().any(|r| !r.paths.is_empty());
+            if has_path_rules && let Ok(ca) = cella_network::ca::ensure_ca() {
+                let mitm_upload = FileUpload {
+                    container_path: "/usr/local/share/ca-certificates/cella-mitm-ca.crt"
+                        .to_string(),
+                    content: ca.cert_pem.into_bytes(),
+                    mode: 0o644,
+                };
+                fwd.post_start.file_uploads.push(mitm_upload);
+                // update-ca-certificates will be called by the host CA injection above
+            }
+        }
     }
 
     fwd

--- a/crates/cella-env/src/lib.rs
+++ b/crates/cella-env/src/lib.rs
@@ -13,6 +13,7 @@ pub mod git_config;
 pub mod nvim;
 pub mod paths;
 pub mod platform;
+pub mod proxy;
 pub mod ssh_agent;
 pub mod ssh_config;
 pub mod tmux;

--- a/crates/cella-env/src/lib.rs
+++ b/crates/cella-env/src/lib.rs
@@ -150,6 +150,8 @@ pub struct ProxyForwardingConfig {
     /// Whether blocking rules are active (determines if proxy env vars
     /// point to cella-agent proxy or directly to upstream).
     pub has_blocking_rules: bool,
+    /// Full network config (needed to build agent proxy config JSON).
+    pub full_config: Option<cella_network::config::NetworkConfig>,
 }
 
 /// Prepare environment forwarding for a container.
@@ -176,6 +178,18 @@ pub fn prepare_env_forwarding(
 
     if let Some(net_config) = network {
         proxy::apply_proxy_env(&mut fwd, &net_config.proxy, net_config.has_blocking_rules);
+
+        // If blocking rules are active, pass the proxy config to cella-agent
+        // via env var so it can start the forward proxy.
+        if net_config.has_blocking_rules
+            && let Some(ref net_full) = net_config.full_config
+        {
+            let json = proxy::build_agent_proxy_config_json(net_full);
+            fwd.env.push(ForwardEnv {
+                key: "CELLA_PROXY_CONFIG".to_string(),
+                value: json,
+            });
+        }
     }
 
     fwd

--- a/crates/cella-env/src/lib.rs
+++ b/crates/cella-env/src/lib.rs
@@ -142,6 +142,15 @@ fn apply_credential_forwarding(fwd: &mut EnvForwarding) {
     ]);
 }
 
+/// Network configuration for proxy forwarding.
+pub struct ProxyForwardingConfig {
+    /// Proxy configuration from cella settings.
+    pub proxy: cella_network::config::ProxyConfig,
+    /// Whether blocking rules are active (determines if proxy env vars
+    /// point to cella-agent proxy or directly to upstream).
+    pub has_blocking_rules: bool,
+}
+
 /// Prepare environment forwarding for a container.
 ///
 /// Detects the Docker runtime, probes host SSH agent and git config,
@@ -149,7 +158,11 @@ fn apply_credential_forwarding(fwd: &mut EnvForwarding) {
 ///
 /// Never fails — individual features log warnings and are skipped
 /// on error, per the design principle of never failing `cella up`.
-pub fn prepare_env_forwarding(config: &serde_json::Value, remote_user: &str) -> EnvForwarding {
+pub fn prepare_env_forwarding(
+    config: &serde_json::Value,
+    remote_user: &str,
+    network: Option<&ProxyForwardingConfig>,
+) -> EnvForwarding {
     let runtime = platform::detect_runtime();
     tracing::debug!("Detected Docker runtime: {runtime:?}");
 
@@ -159,6 +172,10 @@ pub fn prepare_env_forwarding(config: &serde_json::Value, remote_user: &str) -> 
     apply_ssh_config_files(&mut fwd, remote_user);
     apply_git_config(&mut fwd);
     apply_credential_forwarding(&mut fwd);
+
+    if let Some(net_config) = network {
+        proxy::apply_proxy_env(&mut fwd, &net_config.proxy, net_config.has_blocking_rules);
+    }
 
     fwd
 }

--- a/crates/cella-env/src/lib.rs
+++ b/crates/cella-env/src/lib.rs
@@ -4,6 +4,7 @@
 //! then produces mounts, env vars, and post-start injection commands
 //! for the container.
 
+pub mod ca_bundle;
 pub mod claude_code;
 pub mod codex;
 mod error;

--- a/crates/cella-env/src/proxy.rs
+++ b/crates/cella-env/src/proxy.rs
@@ -3,7 +3,7 @@
 //! Detects host proxy env vars and builds the env var set for injection
 //! into containers, respecting cella network config overrides.
 
-use cella_network::config::ProxyConfig;
+use cella_network::config::{NetworkConfig, ProxyConfig};
 use cella_network::proxy_env::ProxyEnvVars;
 
 use crate::{EnvForwarding, ForwardEnv};
@@ -42,4 +42,43 @@ pub fn apply_proxy_env(
     for (key, value) in pairs {
         fwd.env.push(ForwardEnv { key, value });
     }
+}
+
+/// Build the JSON config string for the cella-agent forward proxy.
+///
+/// This is set as `CELLA_PROXY_CONFIG` env var in the container so
+/// the agent can start its forward proxy with the right rules.
+pub fn build_agent_proxy_config_json(config: &NetworkConfig) -> String {
+    let proxy_env = ProxyEnvVars::detect(&config.proxy);
+    let upstream = proxy_env.and_then(|p| p.http_proxy.or(p.https_proxy));
+
+    let rules: Vec<serde_json::Value> = config
+        .rules
+        .iter()
+        .map(|r| {
+            let mut rule = serde_json::json!({
+                "domain": r.domain,
+                "action": match r.action {
+                    cella_network::RuleAction::Block => "block",
+                    cella_network::RuleAction::Allow => "allow",
+                },
+            });
+            if !r.paths.is_empty() {
+                rule["paths"] = serde_json::json!(r.paths);
+            }
+            rule
+        })
+        .collect();
+
+    let json = serde_json::json!({
+        "listen_port": config.proxy.proxy_port,
+        "mode": match config.mode {
+            cella_network::NetworkMode::Denylist => "denylist",
+            cella_network::NetworkMode::Allowlist => "allowlist",
+        },
+        "rules": rules,
+        "upstream_proxy": upstream,
+    });
+
+    json.to_string()
 }

--- a/crates/cella-env/src/proxy.rs
+++ b/crates/cella-env/src/proxy.rs
@@ -1,0 +1,45 @@
+//! Proxy environment variable forwarding for containers.
+//!
+//! Detects host proxy env vars and builds the env var set for injection
+//! into containers, respecting cella network config overrides.
+
+use cella_network::config::ProxyConfig;
+use cella_network::proxy_env::ProxyEnvVars;
+
+use crate::{EnvForwarding, ForwardEnv};
+
+/// Apply proxy environment forwarding to the container env.
+///
+/// When blocking rules are active, proxy env vars point to the cella-agent
+/// proxy inside the container. Otherwise, they point directly to the
+/// upstream proxy (or auto-detected host proxy).
+pub fn apply_proxy_env(
+    fwd: &mut EnvForwarding,
+    proxy_config: &ProxyConfig,
+    has_blocking_rules: bool,
+) {
+    let Some(proxy_vars) = ProxyEnvVars::detect(proxy_config) else {
+        tracing::debug!("Proxy forwarding disabled in config");
+        return;
+    };
+
+    if !proxy_vars.has_proxy() && !has_blocking_rules {
+        tracing::debug!("No proxy env vars detected and no blocking rules");
+        return;
+    }
+
+    let pairs = if has_blocking_rules {
+        tracing::info!(
+            "Blocking rules active: proxy env vars point to cella-agent proxy (port {})",
+            proxy_config.proxy_port,
+        );
+        proxy_vars.to_agent_proxy_env_pairs(proxy_config.proxy_port)
+    } else {
+        tracing::info!("Forwarding host proxy env vars to container");
+        proxy_vars.to_env_pairs(None)
+    };
+
+    for (key, value) in pairs {
+        fwd.env.push(ForwardEnv { key, value });
+    }
+}

--- a/crates/cella-env/src/proxy.rs
+++ b/crates/cella-env/src/proxy.rs
@@ -70,6 +70,23 @@ pub fn build_agent_proxy_config_json(config: &NetworkConfig) -> String {
         })
         .collect();
 
+    // Check if any rules require path-level inspection (MITM).
+    // If so, ensure the CA cert/key are available and include them.
+    let has_path_rules = config.rules.iter().any(|r| !r.paths.is_empty());
+    let (ca_cert_pem, ca_key_pem) = if has_path_rules {
+        match cella_network::ca::ensure_ca() {
+            Ok(ca) => (Some(ca.cert_pem), Some(ca.key_pem)),
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to generate CA for MITM: {e}. Path-level blocking will be domain-only."
+                );
+                (None, None)
+            }
+        }
+    } else {
+        (None, None)
+    };
+
     let json = serde_json::json!({
         "listen_port": config.proxy.proxy_port,
         "mode": match config.mode {
@@ -78,6 +95,8 @@ pub fn build_agent_proxy_config_json(config: &NetworkConfig) -> String {
         },
         "rules": rules,
         "upstream_proxy": upstream,
+        "ca_cert_pem": ca_cert_pem,
+        "ca_key_pem": ca_key_pem,
     });
 
     json.to_string()

--- a/crates/cella-network/CLAUDE.md
+++ b/crates/cella-network/CLAUDE.md
@@ -1,0 +1,9 @@
+# cella-network
+
+- Network proxy configuration, domain/path blocking rules, and CA certificate management
+- `config.rs`: Types deserialize from both TOML (`cella.toml`) and JSON (`customizations.cella.network`)
+- `rules.rs`: Glob-based matching engine; `*` matches one segment, `**` matches zero or more (paths only)
+- Domain matching is case-insensitive; path matching is case-sensitive
+- `ca.rs`: Auto-generated CA stored at `~/.cella/proxy/`; uses `rcgen` for X.509 generation
+- `merge.rs`: Union merge from devcontainer.json + cella.toml; cella.toml wins on conflict
+- `proxy_env.rs`: Auto-detects `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` from host env, builds container env pairs

--- a/crates/cella-network/Cargo.toml
+++ b/crates/cella-network/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "cella-network"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+serde.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+insta.workspace = true
+toml.workspace = true
+
+[lints]
+workspace = true

--- a/crates/cella-network/Cargo.toml
+++ b/crates/cella-network/Cargo.toml
@@ -5,12 +5,16 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+base64.workspace = true
+rcgen.workspace = true
+rustls-native-certs.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
 insta.workspace = true
+tempfile.workspace = true
 toml.workspace = true
 
 [lints]

--- a/crates/cella-network/src/ca.rs
+++ b/crates/cella-network/src/ca.rs
@@ -180,11 +180,11 @@ fn detect_via_native_certs() -> Option<HostCaBundle> {
 /// Try to read CA bundle from well-known filesystem paths.
 fn detect_from_known_paths() -> Option<HostCaBundle> {
     let known_paths = [
-        "/etc/ssl/certs/ca-certificates.crt",                   // Debian/Ubuntu
-        "/etc/pki/tls/certs/ca-bundle.crt",                     // RHEL/CentOS
-        "/etc/ssl/ca-bundle.pem",                                // openSUSE
-        "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",    // Fedora
-        "/etc/ssl/cert.pem",                                     // macOS / Alpine
+        "/etc/ssl/certs/ca-certificates.crt", // Debian/Ubuntu
+        "/etc/pki/tls/certs/ca-bundle.crt",   // RHEL/CentOS
+        "/etc/ssl/ca-bundle.pem",             // openSUSE
+        "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // Fedora
+        "/etc/ssl/cert.pem",                  // macOS / Alpine
     ];
 
     for path_str in &known_paths {

--- a/crates/cella-network/src/ca.rs
+++ b/crates/cella-network/src/ca.rs
@@ -1,0 +1,255 @@
+//! CA certificate generation and host CA bundle detection.
+//!
+//! Generates a self-signed CA certificate for MITM TLS interception and
+//! detects the host's CA trust store for forwarding into containers.
+
+use std::path::{Path, PathBuf};
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use rcgen::{CertificateParams, DnType, IsCa, KeyPair};
+use thiserror::Error;
+
+/// Default storage location for the auto-generated CA.
+const CA_DIR: &str = ".cella/proxy";
+const CA_CERT_FILE: &str = "ca.pem";
+const CA_KEY_FILE: &str = "ca.key";
+
+#[derive(Debug, Error)]
+pub enum CaError {
+    #[error("failed to generate CA key pair: {0}")]
+    KeyGeneration(#[source] rcgen::Error),
+
+    #[error("failed to generate CA certificate: {0}")]
+    CertGeneration(#[source] rcgen::Error),
+
+    #[error("failed to write CA files: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("failed to read CA certificate: {0}")]
+    ReadCert(String),
+}
+
+/// A generated or loaded CA certificate and key pair.
+#[derive(Debug, Clone)]
+pub struct CaCertificate {
+    /// PEM-encoded CA certificate.
+    pub cert_pem: String,
+    /// PEM-encoded CA private key.
+    pub key_pem: String,
+    /// Path where the CA cert is stored.
+    pub cert_path: PathBuf,
+    /// Path where the CA key is stored.
+    pub key_path: PathBuf,
+}
+
+/// Ensure the auto-generated CA exists. Creates it if missing.
+///
+/// The CA is stored at `~/.cella/proxy/ca.pem` and `~/.cella/proxy/ca.key`.
+/// Returns the certificate and key pair.
+///
+/// # Errors
+///
+/// Returns `CaError` if CA generation fails or files cannot be read/written.
+pub fn ensure_ca() -> Result<CaCertificate, CaError> {
+    let ca_dir = ca_directory();
+    let cert_path = ca_dir.join(CA_CERT_FILE);
+    let key_path = ca_dir.join(CA_KEY_FILE);
+
+    // If both files exist, load and return them.
+    if cert_path.exists() && key_path.exists() {
+        tracing::debug!("Loading existing CA from {}", ca_dir.display());
+        let cert_pem = std::fs::read_to_string(&cert_path)?;
+        let key_pem = std::fs::read_to_string(&key_path)?;
+        return Ok(CaCertificate {
+            cert_pem,
+            key_pem,
+            cert_path,
+            key_path,
+        });
+    }
+
+    // Generate a new CA.
+    tracing::info!("Generating new CA certificate at {}", ca_dir.display());
+    generate_ca(&ca_dir)
+}
+
+/// Generate a new CA certificate and save to disk.
+fn generate_ca(ca_dir: &Path) -> Result<CaCertificate, CaError> {
+    std::fs::create_dir_all(ca_dir)?;
+
+    let key_pair = KeyPair::generate().map_err(CaError::KeyGeneration)?;
+
+    let mut params = CertificateParams::default();
+    params.is_ca = IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+    params
+        .distinguished_name
+        .push(DnType::CommonName, "Cella Dev Container CA");
+    params
+        .distinguished_name
+        .push(DnType::OrganizationName, "Cella");
+
+    let cert = params
+        .self_signed(&key_pair)
+        .map_err(CaError::CertGeneration)?;
+
+    let cert_pem = cert.pem();
+    let key_pem = key_pair.serialize_pem();
+
+    let cert_path = ca_dir.join(CA_CERT_FILE);
+    let key_path = ca_dir.join(CA_KEY_FILE);
+
+    std::fs::write(&cert_path, &cert_pem)?;
+    std::fs::write(&key_path, &key_pem)?;
+
+    // Restrict key file permissions on Unix.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o600))?;
+    }
+
+    tracing::info!("CA certificate generated: {}", cert_path.display());
+
+    Ok(CaCertificate {
+        cert_pem,
+        key_pem,
+        cert_path,
+        key_path,
+    })
+}
+
+/// Get the CA storage directory (`~/.cella/proxy/`).
+fn ca_directory() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
+    Path::new(&home).join(CA_DIR)
+}
+
+/// Detected host CA bundle for injection into containers.
+#[derive(Debug, Clone)]
+pub struct HostCaBundle {
+    /// PEM-encoded certificate bundle (concatenated PEM blocks).
+    pub pem_bundle: String,
+}
+
+/// Detect and read the host's CA trust store.
+///
+/// Tries multiple platform-specific locations. Returns `None` if
+/// no CA bundle can be found.
+pub fn detect_host_ca_bundle() -> Option<HostCaBundle> {
+    // Try platform-native detection first (handles macOS Keychain, etc.)
+    if let Some(bundle) = detect_via_native_certs() {
+        return Some(bundle);
+    }
+
+    // Fallback to well-known file paths.
+    detect_from_known_paths()
+}
+
+/// Use `rustls-native-certs` to read the platform's trust store.
+fn detect_via_native_certs() -> Option<HostCaBundle> {
+    let certs = rustls_native_certs::load_native_certs();
+
+    if !certs.errors.is_empty() {
+        for err in &certs.errors {
+            tracing::warn!("Error loading native cert: {err}");
+        }
+    }
+
+    if certs.certs.is_empty() {
+        return None;
+    }
+
+    let mut pem_bundle = String::new();
+    for cert in &certs.certs {
+        // Convert DER to PEM.
+        let b64 = BASE64.encode(cert.as_ref());
+        pem_bundle.push_str("-----BEGIN CERTIFICATE-----\n");
+        // Wrap at 76 characters per PEM spec.
+        for chunk in b64.as_bytes().chunks(76) {
+            pem_bundle.push_str(std::str::from_utf8(chunk).unwrap_or(""));
+            pem_bundle.push('\n');
+        }
+        pem_bundle.push_str("-----END CERTIFICATE-----\n");
+    }
+
+    tracing::info!("Detected {} host CA certificates", certs.certs.len());
+    Some(HostCaBundle { pem_bundle })
+}
+
+/// Try to read CA bundle from well-known filesystem paths.
+fn detect_from_known_paths() -> Option<HostCaBundle> {
+    let known_paths = [
+        "/etc/ssl/certs/ca-certificates.crt",                   // Debian/Ubuntu
+        "/etc/pki/tls/certs/ca-bundle.crt",                     // RHEL/CentOS
+        "/etc/ssl/ca-bundle.pem",                                // openSUSE
+        "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",    // Fedora
+        "/etc/ssl/cert.pem",                                     // macOS / Alpine
+    ];
+
+    for path_str in &known_paths {
+        let path = Path::new(path_str);
+        if path.exists() {
+            match std::fs::read_to_string(path) {
+                Ok(content) if !content.is_empty() => {
+                    tracing::info!("Read host CA bundle from {}", path.display());
+                    return Some(HostCaBundle {
+                        pem_bundle: content,
+                    });
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::debug!("Could not read {}: {e}", path.display());
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Read an additional CA certificate file specified by the user.
+///
+/// # Errors
+///
+/// Returns `CaError::ReadCert` if the file cannot be read.
+pub fn read_additional_ca_cert(path: &str) -> Result<String, CaError> {
+    let path = Path::new(path);
+    std::fs::read_to_string(path).map_err(|e| {
+        CaError::ReadCert(format!(
+            "failed to read CA cert from {}: {e}",
+            path.display()
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ca_directory_uses_home() {
+        let dir = ca_directory();
+        assert!(dir.to_string_lossy().contains(".cella/proxy"));
+    }
+
+    #[test]
+    fn detect_from_known_paths_doesnt_panic() {
+        let _ = detect_from_known_paths();
+    }
+
+    #[test]
+    fn generate_and_load_ca() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let ca = generate_ca(tmp.path()).unwrap();
+
+        assert!(ca.cert_pem.contains("BEGIN CERTIFICATE"));
+        assert!(ca.key_pem.contains("BEGIN"));
+        assert!(ca.cert_path.exists());
+        assert!(ca.key_path.exists());
+
+        // Loading should return the same cert.
+        let cert_pem = std::fs::read_to_string(&ca.cert_path).unwrap();
+        assert_eq!(cert_pem, ca.cert_pem);
+    }
+}

--- a/crates/cella-network/src/config.rs
+++ b/crates/cella-network/src/config.rs
@@ -1,0 +1,209 @@
+//! Network configuration types for proxy and blocking rules.
+
+use serde::Deserialize;
+
+/// Top-level network configuration.
+///
+/// Loaded from `[network]` in `cella.toml` or `customizations.cella.network`
+/// in `devcontainer.json`.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct NetworkConfig {
+    /// Blocking mode: `denylist` (block matching, allow rest) or
+    /// `allowlist` (allow matching, block rest).
+    #[serde(default)]
+    pub mode: NetworkMode,
+
+    /// Proxy configuration.
+    #[serde(default)]
+    pub proxy: ProxyConfig,
+
+    /// Network blocking rules.
+    #[serde(default)]
+    pub rules: Vec<NetworkRule>,
+}
+
+impl NetworkConfig {
+    /// Returns `true` if any blocking rules are configured.
+    pub const fn has_rules(&self) -> bool {
+        !self.rules.is_empty()
+    }
+}
+
+/// Blocking mode determines the default disposition of traffic.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum NetworkMode {
+    /// Everything is allowed unless a rule explicitly blocks it.
+    #[default]
+    Denylist,
+    /// Everything is blocked unless a rule explicitly allows it.
+    Allowlist,
+}
+
+/// Proxy configuration for upstream proxy servers.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ProxyConfig {
+    /// Whether proxy forwarding is enabled. Defaults to `true`.
+    /// When `true`, host proxy env vars are auto-detected and forwarded.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+
+    /// HTTP proxy URL (overrides `HTTP_PROXY` env var).
+    #[serde(default)]
+    pub http: Option<String>,
+
+    /// HTTPS proxy URL (overrides `HTTPS_PROXY` env var).
+    #[serde(default)]
+    pub https: Option<String>,
+
+    /// Comma-separated list of hosts that bypass the proxy
+    /// (overrides `NO_PROXY` env var).
+    #[serde(default)]
+    pub no_proxy: Option<String>,
+
+    /// Path to an additional CA certificate file to inject into containers.
+    #[serde(default)]
+    pub ca_cert: Option<String>,
+
+    /// Port for the cella-agent forward proxy inside containers.
+    /// Only used when blocking rules are active.
+    #[serde(default = "default_proxy_port")]
+    pub proxy_port: u16,
+}
+
+impl Default for ProxyConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            http: None,
+            https: None,
+            no_proxy: None,
+            ca_cert: None,
+            proxy_port: default_proxy_port(),
+        }
+    }
+}
+
+/// A network blocking rule matching a domain and optional paths.
+#[derive(Debug, Clone, Deserialize)]
+pub struct NetworkRule {
+    /// Domain glob pattern (e.g., `*.example.com`, `exact.domain.com`).
+    pub domain: String,
+
+    /// Optional path glob patterns (e.g., `["/api/*", "/internal/**"]`).
+    /// If empty, the rule applies to all paths on the domain.
+    #[serde(default)]
+    pub paths: Vec<String>,
+
+    /// Whether this rule blocks or allows traffic.
+    pub action: RuleAction,
+}
+
+/// Action to take when a rule matches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RuleAction {
+    Block,
+    Allow,
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+const fn default_proxy_port() -> u16 {
+    18080
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_full_config() {
+        let toml_str = r#"
+mode = "denylist"
+
+[proxy]
+enabled = true
+http = "http://proxy.corp:3128"
+https = "http://proxy.corp:3128"
+no_proxy = "localhost,.internal"
+proxy_port = 19090
+
+[[rules]]
+domain = "*.production.example.com"
+action = "block"
+
+[[rules]]
+domain = "api.example.com"
+paths = ["/v1/admin/*", "/internal/*"]
+action = "block"
+
+[[rules]]
+domain = "registry.npmjs.org"
+action = "allow"
+"#;
+        let config: NetworkConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.mode, NetworkMode::Denylist);
+        assert!(config.proxy.enabled);
+        assert_eq!(config.proxy.http.as_deref(), Some("http://proxy.corp:3128"));
+        assert_eq!(config.proxy.proxy_port, 19090);
+        assert_eq!(config.rules.len(), 3);
+        assert_eq!(config.rules[0].domain, "*.production.example.com");
+        assert_eq!(config.rules[0].action, RuleAction::Block);
+        assert!(config.rules[0].paths.is_empty());
+        assert_eq!(config.rules[1].paths.len(), 2);
+        assert_eq!(config.rules[2].action, RuleAction::Allow);
+    }
+
+    #[test]
+    fn deserialize_minimal_config() {
+        let toml_str = r#"
+[[rules]]
+domain = "*.prod.internal"
+action = "block"
+"#;
+        let config: NetworkConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.mode, NetworkMode::Denylist);
+        assert!(config.proxy.enabled);
+        assert_eq!(config.proxy.proxy_port, 18080);
+        assert_eq!(config.rules.len(), 1);
+    }
+
+    #[test]
+    fn deserialize_allowlist_mode() {
+        let toml_str = r#"
+mode = "allowlist"
+
+[[rules]]
+domain = "registry.npmjs.org"
+action = "allow"
+
+[[rules]]
+domain = "github.com"
+action = "allow"
+"#;
+        let config: NetworkConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.mode, NetworkMode::Allowlist);
+        assert_eq!(config.rules.len(), 2);
+    }
+
+    #[test]
+    fn default_config() {
+        let config = NetworkConfig::default();
+        assert_eq!(config.mode, NetworkMode::Denylist);
+        assert!(config.proxy.enabled);
+        assert!(!config.has_rules());
+    }
+
+    #[test]
+    fn proxy_disabled() {
+        let toml_str = r"
+[proxy]
+enabled = false
+";
+        let config: NetworkConfig = toml::from_str(toml_str).unwrap();
+        assert!(!config.proxy.enabled);
+    }
+}

--- a/crates/cella-network/src/lib.rs
+++ b/crates/cella-network/src/lib.rs
@@ -1,0 +1,17 @@
+//! Network configuration, proxy environment detection, and rule matching for cella.
+//!
+//! This crate provides:
+//! - Configuration types for proxy settings and network blocking rules
+//! - A glob-based rule matching engine for domain and path filtering
+//! - Host proxy environment variable auto-detection
+//! - Rule merging from multiple configuration sources
+
+pub mod config;
+pub mod merge;
+pub mod proxy_env;
+pub mod rules;
+
+pub use config::{NetworkConfig, NetworkMode, NetworkRule, ProxyConfig, RuleAction};
+pub use merge::merge_network_configs;
+pub use proxy_env::ProxyEnvVars;
+pub use rules::RuleMatcher;

--- a/crates/cella-network/src/lib.rs
+++ b/crates/cella-network/src/lib.rs
@@ -6,6 +6,7 @@
 //! - Host proxy environment variable auto-detection
 //! - Rule merging from multiple configuration sources
 
+pub mod ca;
 pub mod config;
 pub mod merge;
 pub mod proxy_env;

--- a/crates/cella-network/src/merge.rs
+++ b/crates/cella-network/src/merge.rs
@@ -1,0 +1,247 @@
+//! Merge network configurations from multiple sources.
+//!
+//! Rules from `cella.toml` and `devcontainer.json` `customizations.cella.network`
+//! are combined (union). On conflict, `cella.toml` wins for mode and per-domain
+//! rule precedence.
+
+use crate::config::{NetworkConfig, NetworkMode, NetworkRule};
+
+/// Source label for rules from `cella.toml`.
+pub const SOURCE_CELLA_TOML: &str = "cella.toml";
+
+/// Source label for rules from `devcontainer.json` customizations.
+pub const SOURCE_DEVCONTAINER: &str = "devcontainer.json";
+
+/// A network rule tagged with its source location.
+#[derive(Debug, Clone)]
+pub struct LabeledRule {
+    pub rule: NetworkRule,
+    pub source: String,
+}
+
+/// Merge network configs from `devcontainer.json` (base) and `cella.toml` (override).
+///
+/// - Mode: `cella.toml` wins if set, otherwise `devcontainer.json`
+/// - Proxy: `cella.toml` wins entirely if its proxy section has any explicit values
+/// - Rules: union of both sources; if the same exact domain string appears in both,
+///   the `cella.toml` rule takes precedence
+pub fn merge_network_configs(
+    devcontainer: Option<&NetworkConfig>,
+    cella_toml: Option<&NetworkConfig>,
+) -> MergedNetworkConfig {
+    match (devcontainer, cella_toml) {
+        (None, None) => MergedNetworkConfig::default(),
+        (Some(dc), None) => MergedNetworkConfig {
+            mode: dc.mode,
+            proxy: dc.proxy.clone(),
+            rules: dc
+                .rules
+                .iter()
+                .map(|r| LabeledRule {
+                    rule: r.clone(),
+                    source: SOURCE_DEVCONTAINER.to_string(),
+                })
+                .collect(),
+        },
+        (None, Some(ct)) => MergedNetworkConfig {
+            mode: ct.mode,
+            proxy: ct.proxy.clone(),
+            rules: ct
+                .rules
+                .iter()
+                .map(|r| LabeledRule {
+                    rule: r.clone(),
+                    source: SOURCE_CELLA_TOML.to_string(),
+                })
+                .collect(),
+        },
+        (Some(dc), Some(ct)) => {
+            // Mode: cella.toml wins
+            let mode = ct.mode;
+
+            // Proxy: cella.toml wins if it has any explicit values
+            let proxy = if ct.proxy.http.is_some()
+                || ct.proxy.https.is_some()
+                || ct.proxy.no_proxy.is_some()
+                || ct.proxy.ca_cert.is_some()
+                || !ct.proxy.enabled
+            {
+                ct.proxy.clone()
+            } else {
+                dc.proxy.clone()
+            };
+
+            // Rules: union, cella.toml wins per exact domain string
+            let mut rules: Vec<LabeledRule> = Vec::new();
+
+            // Collect cella.toml domains for dedup
+            let toml_domains: std::collections::HashSet<&str> =
+                ct.rules.iter().map(|r| r.domain.as_str()).collect();
+
+            // Add devcontainer rules (skip if same domain exists in cella.toml)
+            for r in &dc.rules {
+                if !toml_domains.contains(r.domain.as_str()) {
+                    rules.push(LabeledRule {
+                        rule: r.clone(),
+                        source: SOURCE_DEVCONTAINER.to_string(),
+                    });
+                }
+            }
+
+            // Add all cella.toml rules
+            for r in &ct.rules {
+                rules.push(LabeledRule {
+                    rule: r.clone(),
+                    source: SOURCE_CELLA_TOML.to_string(),
+                });
+            }
+
+            MergedNetworkConfig { mode, proxy, rules }
+        }
+    }
+}
+
+/// Result of merging network configs from multiple sources.
+#[derive(Debug, Clone, Default)]
+pub struct MergedNetworkConfig {
+    pub mode: NetworkMode,
+    pub proxy: crate::config::ProxyConfig,
+    pub rules: Vec<LabeledRule>,
+}
+
+impl MergedNetworkConfig {
+    /// Returns `true` if any blocking rules are configured.
+    pub const fn has_rules(&self) -> bool {
+        !self.rules.is_empty()
+    }
+
+    /// Build a `RuleMatcher` from the merged config.
+    pub fn build_matcher(&self) -> crate::rules::RuleMatcher {
+        let labeled: Vec<(NetworkRule, String)> = self
+            .rules
+            .iter()
+            .map(|lr| (lr.rule.clone(), lr.source.clone()))
+            .collect();
+        crate::rules::RuleMatcher::from_labeled_rules(self.mode, &labeled)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::{ProxyConfig, RuleAction};
+
+    use super::*;
+
+    #[test]
+    fn merge_none_returns_default() {
+        let merged = merge_network_configs(None, None);
+        assert_eq!(merged.mode, NetworkMode::Denylist);
+        assert!(!merged.has_rules());
+    }
+
+    #[test]
+    fn merge_devcontainer_only() {
+        let dc = NetworkConfig {
+            mode: NetworkMode::Allowlist,
+            rules: vec![NetworkRule {
+                domain: "*.prod.internal".to_string(),
+                paths: vec![],
+                action: RuleAction::Block,
+            }],
+            ..Default::default()
+        };
+        let merged = merge_network_configs(Some(&dc), None);
+        assert_eq!(merged.mode, NetworkMode::Allowlist);
+        assert_eq!(merged.rules.len(), 1);
+        assert_eq!(merged.rules[0].source, SOURCE_DEVCONTAINER);
+    }
+
+    #[test]
+    fn merge_toml_wins_mode() {
+        let dc = NetworkConfig {
+            mode: NetworkMode::Allowlist,
+            ..Default::default()
+        };
+        let ct = NetworkConfig {
+            mode: NetworkMode::Denylist,
+            ..Default::default()
+        };
+        let merged = merge_network_configs(Some(&dc), Some(&ct));
+        assert_eq!(merged.mode, NetworkMode::Denylist);
+    }
+
+    #[test]
+    fn merge_union_rules_dedup_by_domain() {
+        let dc = NetworkConfig {
+            rules: vec![
+                NetworkRule {
+                    domain: "*.prod.internal".to_string(),
+                    paths: vec![],
+                    action: RuleAction::Block,
+                },
+                NetworkRule {
+                    domain: "api.example.com".to_string(),
+                    paths: vec![],
+                    action: RuleAction::Block,
+                },
+            ],
+            ..Default::default()
+        };
+        let ct = NetworkConfig {
+            rules: vec![NetworkRule {
+                // Same domain as devcontainer — toml wins
+                domain: "api.example.com".to_string(),
+                paths: vec!["/admin/**".to_string()],
+                action: RuleAction::Allow,
+            }],
+            ..Default::default()
+        };
+        let merged = merge_network_configs(Some(&dc), Some(&ct));
+
+        // *.prod.internal from devcontainer + api.example.com from toml
+        assert_eq!(merged.rules.len(), 2);
+
+        let prod_rule = merged.rules.iter().find(|r| r.rule.domain == "*.prod.internal");
+        assert!(prod_rule.is_some());
+        assert_eq!(prod_rule.unwrap().source, SOURCE_DEVCONTAINER);
+
+        let api_rule = merged.rules.iter().find(|r| r.rule.domain == "api.example.com");
+        assert!(api_rule.is_some());
+        assert_eq!(api_rule.unwrap().source, SOURCE_CELLA_TOML);
+        assert_eq!(api_rule.unwrap().rule.action, RuleAction::Allow);
+    }
+
+    #[test]
+    fn merge_proxy_toml_overrides() {
+        let dc = NetworkConfig {
+            proxy: ProxyConfig {
+                http: Some("http://dc-proxy:3128".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let ct = NetworkConfig {
+            proxy: ProxyConfig {
+                http: Some("http://toml-proxy:3128".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let merged = merge_network_configs(Some(&dc), Some(&ct));
+        assert_eq!(merged.proxy.http.as_deref(), Some("http://toml-proxy:3128"));
+    }
+
+    #[test]
+    fn merge_proxy_devcontainer_when_toml_empty() {
+        let dc = NetworkConfig {
+            proxy: ProxyConfig {
+                http: Some("http://dc-proxy:3128".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let ct = NetworkConfig::default();
+        let merged = merge_network_configs(Some(&dc), Some(&ct));
+        assert_eq!(merged.proxy.http.as_deref(), Some("http://dc-proxy:3128"));
+    }
+}

--- a/crates/cella-network/src/merge.rs
+++ b/crates/cella-network/src/merge.rs
@@ -21,13 +21,14 @@ pub struct LabeledRule {
 
 /// Merge network configs from `devcontainer.json` (base) and `cella.toml` (override).
 ///
-/// - Mode: `cella.toml` wins if set, otherwise `devcontainer.json`
+/// - Mode: `cella_toml_mode` wins if `Some`, otherwise `devcontainer.json`'s mode
 /// - Proxy: `cella.toml` wins entirely if its proxy section has any explicit values
 /// - Rules: union of both sources; if the same exact domain string appears in both,
 ///   the `cella.toml` rule takes precedence
 pub fn merge_network_configs(
     devcontainer: Option<&NetworkConfig>,
     cella_toml: Option<&NetworkConfig>,
+    cella_toml_mode: Option<NetworkMode>,
 ) -> MergedNetworkConfig {
     match (devcontainer, cella_toml) {
         (None, None) => MergedNetworkConfig::default(),
@@ -56,8 +57,8 @@ pub fn merge_network_configs(
                 .collect(),
         },
         (Some(dc), Some(ct)) => {
-            // Mode: cella.toml wins
-            let mode = ct.mode;
+            // Mode: cella.toml wins only if explicitly set
+            let mode = cella_toml_mode.unwrap_or(dc.mode);
 
             // Proxy: cella.toml wins if it has any explicit values
             let proxy = if ct.proxy.http.is_some()
@@ -134,7 +135,7 @@ mod tests {
 
     #[test]
     fn merge_none_returns_default() {
-        let merged = merge_network_configs(None, None);
+        let merged = merge_network_configs(None, None, None);
         assert_eq!(merged.mode, NetworkMode::Denylist);
         assert!(!merged.has_rules());
     }
@@ -150,14 +151,14 @@ mod tests {
             }],
             ..Default::default()
         };
-        let merged = merge_network_configs(Some(&dc), None);
+        let merged = merge_network_configs(Some(&dc), None, None);
         assert_eq!(merged.mode, NetworkMode::Allowlist);
         assert_eq!(merged.rules.len(), 1);
         assert_eq!(merged.rules[0].source, SOURCE_DEVCONTAINER);
     }
 
     #[test]
-    fn merge_toml_wins_mode() {
+    fn merge_toml_wins_mode_when_explicit() {
         let dc = NetworkConfig {
             mode: NetworkMode::Allowlist,
             ..Default::default()
@@ -166,8 +167,21 @@ mod tests {
             mode: NetworkMode::Denylist,
             ..Default::default()
         };
-        let merged = merge_network_configs(Some(&dc), Some(&ct));
+        // Explicit toml mode overrides devcontainer.
+        let merged = merge_network_configs(Some(&dc), Some(&ct), Some(NetworkMode::Denylist));
         assert_eq!(merged.mode, NetworkMode::Denylist);
+    }
+
+    #[test]
+    fn merge_devcontainer_mode_preserved_when_toml_unset() {
+        let dc = NetworkConfig {
+            mode: NetworkMode::Allowlist,
+            ..Default::default()
+        };
+        let ct = NetworkConfig::default();
+        // No explicit toml mode — devcontainer.json's mode is preserved.
+        let merged = merge_network_configs(Some(&dc), Some(&ct), None);
+        assert_eq!(merged.mode, NetworkMode::Allowlist);
     }
 
     #[test]
@@ -196,7 +210,7 @@ mod tests {
             }],
             ..Default::default()
         };
-        let merged = merge_network_configs(Some(&dc), Some(&ct));
+        let merged = merge_network_configs(Some(&dc), Some(&ct), None);
 
         // *.prod.internal from devcontainer + api.example.com from toml
         assert_eq!(merged.rules.len(), 2);
@@ -233,7 +247,7 @@ mod tests {
             },
             ..Default::default()
         };
-        let merged = merge_network_configs(Some(&dc), Some(&ct));
+        let merged = merge_network_configs(Some(&dc), Some(&ct), None);
         assert_eq!(merged.proxy.http.as_deref(), Some("http://toml-proxy:3128"));
     }
 
@@ -247,7 +261,7 @@ mod tests {
             ..Default::default()
         };
         let ct = NetworkConfig::default();
-        let merged = merge_network_configs(Some(&dc), Some(&ct));
+        let merged = merge_network_configs(Some(&dc), Some(&ct), None);
         assert_eq!(merged.proxy.http.as_deref(), Some("http://dc-proxy:3128"));
     }
 }

--- a/crates/cella-network/src/merge.rs
+++ b/crates/cella-network/src/merge.rs
@@ -201,11 +201,17 @@ mod tests {
         // *.prod.internal from devcontainer + api.example.com from toml
         assert_eq!(merged.rules.len(), 2);
 
-        let prod_rule = merged.rules.iter().find(|r| r.rule.domain == "*.prod.internal");
+        let prod_rule = merged
+            .rules
+            .iter()
+            .find(|r| r.rule.domain == "*.prod.internal");
         assert!(prod_rule.is_some());
         assert_eq!(prod_rule.unwrap().source, SOURCE_DEVCONTAINER);
 
-        let api_rule = merged.rules.iter().find(|r| r.rule.domain == "api.example.com");
+        let api_rule = merged
+            .rules
+            .iter()
+            .find(|r| r.rule.domain == "api.example.com");
         assert!(api_rule.is_some());
         assert_eq!(api_rule.unwrap().source, SOURCE_CELLA_TOML);
         assert_eq!(api_rule.unwrap().rule.action, RuleAction::Allow);

--- a/crates/cella-network/src/proxy_env.rs
+++ b/crates/cella-network/src/proxy_env.rs
@@ -118,6 +118,27 @@ impl ProxyEnvVars {
         entries.join(",")
     }
 
+    /// Build args to inject into Docker builds for proxy support.
+    ///
+    /// Docker automatically recognizes `HTTP_PROXY`, `HTTPS_PROXY`, and
+    /// `NO_PROXY` as build args without requiring explicit `ARG` declarations.
+    pub fn to_build_args(&self) -> Vec<(String, String)> {
+        let mut args = Vec::new();
+        if let Some(ref url) = self.http_proxy {
+            args.push(("HTTP_PROXY".to_string(), url.clone()));
+            args.push(("http_proxy".to_string(), url.clone()));
+        }
+        if let Some(ref url) = self.https_proxy {
+            args.push(("HTTPS_PROXY".to_string(), url.clone()));
+            args.push(("https_proxy".to_string(), url.clone()));
+        }
+        if let Some(ref np) = self.no_proxy {
+            args.push(("NO_PROXY".to_string(), np.clone()));
+            args.push(("no_proxy".to_string(), np.clone()));
+        }
+        args
+    }
+
     /// Build the env var pairs for the cella-agent proxy.
     ///
     /// When blocking rules are active, proxy env vars point to the local

--- a/crates/cella-network/src/proxy_env.rs
+++ b/crates/cella-network/src/proxy_env.rs
@@ -1,0 +1,226 @@
+//! Host proxy environment variable auto-detection and env var set building.
+//!
+//! Detects `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` (and lowercase variants)
+//! from the host environment and builds the env var set for containers.
+
+use crate::config::ProxyConfig;
+
+/// Proxy environment variables resolved for container injection.
+#[derive(Debug, Clone, Default)]
+pub struct ProxyEnvVars {
+    pub http_proxy: Option<String>,
+    pub https_proxy: Option<String>,
+    pub no_proxy: Option<String>,
+}
+
+impl ProxyEnvVars {
+    /// Detect proxy env vars from the current process environment,
+    /// then apply overrides from the proxy config.
+    ///
+    /// Returns `None` if proxy is disabled in config.
+    pub fn detect(config: &ProxyConfig) -> Option<Self> {
+        if !config.enabled {
+            return None;
+        }
+
+        let http_proxy = config
+            .http
+            .clone()
+            .or_else(|| std::env::var("HTTP_PROXY").ok())
+            .or_else(|| std::env::var("http_proxy").ok());
+
+        let https_proxy = config
+            .https
+            .clone()
+            .or_else(|| std::env::var("HTTPS_PROXY").ok())
+            .or_else(|| std::env::var("https_proxy").ok());
+
+        let no_proxy = config
+            .no_proxy
+            .clone()
+            .or_else(|| std::env::var("NO_PROXY").ok())
+            .or_else(|| std::env::var("no_proxy").ok());
+
+        // If nothing detected and nothing configured, return empty.
+        if http_proxy.is_none() && https_proxy.is_none() {
+            return Some(Self::default());
+        }
+
+        Some(Self {
+            http_proxy,
+            https_proxy,
+            no_proxy,
+        })
+    }
+
+    /// Returns `true` if any proxy URL is set.
+    pub const fn has_proxy(&self) -> bool {
+        self.http_proxy.is_some() || self.https_proxy.is_some()
+    }
+
+    /// Build the env var key-value pairs to inject into a container.
+    ///
+    /// Sets both uppercase and lowercase variants for maximum compatibility.
+    /// Appends safety entries to `NO_PROXY` to prevent proxy loops.
+    pub fn to_env_pairs(&self, cella_proxy_port: Option<u16>) -> Vec<(String, String)> {
+        let mut pairs = Vec::new();
+
+        if let Some(ref url) = self.http_proxy {
+            pairs.push(("HTTP_PROXY".to_string(), url.clone()));
+            pairs.push(("http_proxy".to_string(), url.clone()));
+        }
+
+        if let Some(ref url) = self.https_proxy {
+            pairs.push(("HTTPS_PROXY".to_string(), url.clone()));
+            pairs.push(("https_proxy".to_string(), url.clone()));
+        }
+
+        // Build NO_PROXY with safety entries to prevent proxy loops.
+        let no_proxy = self.build_no_proxy(cella_proxy_port);
+        if !no_proxy.is_empty() {
+            pairs.push(("NO_PROXY".to_string(), no_proxy.clone()));
+            pairs.push(("no_proxy".to_string(), no_proxy));
+        }
+
+        pairs
+    }
+
+    /// Build the `NO_PROXY` value, appending localhost entries to prevent loops.
+    fn build_no_proxy(&self, cella_proxy_port: Option<u16>) -> String {
+        let mut entries: Vec<String> = Vec::new();
+
+        if let Some(ref existing) = self.no_proxy {
+            for entry in existing.split(',') {
+                let trimmed = entry.trim();
+                if !trimmed.is_empty() {
+                    entries.push(trimmed.to_string());
+                }
+            }
+        }
+
+        // Always add localhost entries to prevent proxy loops.
+        let safety = ["localhost", "127.0.0.1", "::1"];
+        for s in &safety {
+            let s_str = (*s).to_string();
+            if !entries.iter().any(|e| e.eq_ignore_ascii_case(&s_str)) {
+                entries.push(s_str);
+            }
+        }
+
+        // If cella-agent proxy is active, add its address too.
+        if let Some(port) = cella_proxy_port {
+            let addr = format!("127.0.0.1:{port}");
+            if !entries.contains(&addr) {
+                entries.push(addr);
+            }
+        }
+
+        entries.join(",")
+    }
+
+    /// Build the env var pairs for the cella-agent proxy.
+    ///
+    /// When blocking rules are active, proxy env vars point to the local
+    /// cella-agent proxy instead of the upstream proxy.
+    pub fn to_agent_proxy_env_pairs(&self, proxy_port: u16) -> Vec<(String, String)> {
+        let proxy_url = format!("http://127.0.0.1:{proxy_port}");
+        let no_proxy = self.build_no_proxy(Some(proxy_port));
+
+        let mut pairs = vec![
+            ("HTTP_PROXY".to_string(), proxy_url.clone()),
+            ("http_proxy".to_string(), proxy_url.clone()),
+            ("HTTPS_PROXY".to_string(), proxy_url.clone()),
+            ("https_proxy".to_string(), proxy_url),
+        ];
+
+        if !no_proxy.is_empty() {
+            pairs.push(("NO_PROXY".to_string(), no_proxy.clone()));
+            pairs.push(("no_proxy".to_string(), no_proxy));
+        }
+
+        pairs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_returns_none_when_disabled() {
+        let config = ProxyConfig {
+            enabled: false,
+            ..Default::default()
+        };
+        assert!(ProxyEnvVars::detect(&config).is_none());
+    }
+
+    #[test]
+    fn detect_with_explicit_config() {
+        let config = ProxyConfig {
+            http: Some("http://proxy:3128".to_string()),
+            https: Some("http://proxy:3128".to_string()),
+            no_proxy: Some("localhost,.internal".to_string()),
+            ..Default::default()
+        };
+        let vars = ProxyEnvVars::detect(&config).unwrap();
+        assert_eq!(vars.http_proxy.as_deref(), Some("http://proxy:3128"));
+        assert_eq!(vars.https_proxy.as_deref(), Some("http://proxy:3128"));
+        assert!(vars.has_proxy());
+    }
+
+    #[test]
+    fn to_env_pairs_sets_both_cases() {
+        let vars = ProxyEnvVars {
+            http_proxy: Some("http://proxy:3128".to_string()),
+            https_proxy: Some("http://proxy:3128".to_string()),
+            no_proxy: None,
+        };
+        let pairs = vars.to_env_pairs(None);
+        assert!(pairs.iter().any(|(k, _)| k == "HTTP_PROXY"));
+        assert!(pairs.iter().any(|(k, _)| k == "http_proxy"));
+        assert!(pairs.iter().any(|(k, _)| k == "HTTPS_PROXY"));
+        assert!(pairs.iter().any(|(k, _)| k == "https_proxy"));
+        // NO_PROXY should have safety entries
+        assert!(pairs.iter().any(|(k, _)| k == "NO_PROXY"));
+    }
+
+    #[test]
+    fn no_proxy_includes_safety_entries() {
+        let vars = ProxyEnvVars {
+            http_proxy: Some("http://proxy:3128".to_string()),
+            no_proxy: Some(".internal".to_string()),
+            ..Default::default()
+        };
+        let no_proxy = vars.build_no_proxy(None);
+        assert!(no_proxy.contains(".internal"));
+        assert!(no_proxy.contains("localhost"));
+        assert!(no_proxy.contains("127.0.0.1"));
+        assert!(no_proxy.contains("::1"));
+    }
+
+    #[test]
+    fn no_proxy_deduplicates_safety_entries() {
+        let vars = ProxyEnvVars {
+            http_proxy: Some("http://proxy:3128".to_string()),
+            no_proxy: Some("localhost,127.0.0.1,.corp".to_string()),
+            ..Default::default()
+        };
+        let no_proxy = vars.build_no_proxy(None);
+        let count = no_proxy.matches("localhost").count();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn agent_proxy_env_pairs() {
+        let vars = ProxyEnvVars {
+            no_proxy: Some(".internal".to_string()),
+            ..Default::default()
+        };
+        let pairs = vars.to_agent_proxy_env_pairs(18080);
+        let http = pairs.iter().find(|(k, _)| k == "HTTP_PROXY").unwrap();
+        assert_eq!(http.1, "http://127.0.0.1:18080");
+        let no_proxy = pairs.iter().find(|(k, _)| k == "NO_PROXY").unwrap();
+        assert!(no_proxy.1.contains("127.0.0.1:18080"));
+    }
+}

--- a/crates/cella-network/src/proxy_env.rs
+++ b/crates/cella-network/src/proxy_env.rs
@@ -41,11 +41,6 @@ impl ProxyEnvVars {
             .or_else(|| std::env::var("NO_PROXY").ok())
             .or_else(|| std::env::var("no_proxy").ok());
 
-        // If nothing detected and nothing configured, return empty.
-        if http_proxy.is_none() && https_proxy.is_none() {
-            return Some(Self::default());
-        }
-
         Some(Self {
             http_proxy,
             https_proxy,
@@ -230,6 +225,17 @@ mod tests {
         let no_proxy = vars.build_no_proxy(None);
         let count = no_proxy.matches("localhost").count();
         assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn detect_preserves_no_proxy_when_http_https_absent() {
+        let config = ProxyConfig {
+            no_proxy: Some(".internal,.corp".to_string()),
+            ..Default::default()
+        };
+        let vars = ProxyEnvVars::detect(&config).unwrap();
+        assert!(!vars.has_proxy());
+        assert_eq!(vars.no_proxy.as_deref(), Some(".internal,.corp"));
     }
 
     #[test]

--- a/crates/cella-network/src/rules.rs
+++ b/crates/cella-network/src/rules.rs
@@ -62,10 +62,7 @@ impl RuleMatcher {
 
     /// Build a matcher from rules that already have source labels.
     pub fn from_labeled_rules(mode: NetworkMode, rules: &[(NetworkRule, String)]) -> Self {
-        let rules = rules
-            .iter()
-            .map(|(r, src)| compile_rule(r, src))
-            .collect();
+        let rules = rules.iter().map(|(r, src)| compile_rule(r, src)).collect();
         Self { mode, rules }
     }
 
@@ -85,9 +82,7 @@ impl RuleMatcher {
             let path_matched = if rule.path_patterns.is_empty() {
                 true
             } else {
-                rule.path_patterns
-                    .iter()
-                    .any(|pp| match_path(pp, path))
+                rule.path_patterns.iter().any(|pp| match_path(pp, path))
             };
 
             if path_matched {
@@ -211,12 +206,7 @@ fn match_segments_with_doublestar(pattern: &[PatternPart], segments: &[&str]) ->
     match_recursive(pattern, segments, 0, 0)
 }
 
-fn match_recursive(
-    pattern: &[PatternPart],
-    segments: &[&str],
-    pi: usize,
-    si: usize,
-) -> bool {
+fn match_recursive(pattern: &[PatternPart], segments: &[&str], pi: usize, si: usize) -> bool {
     // Both exhausted: match.
     if pi == pattern.len() && si == segments.len() {
         return true;

--- a/crates/cella-network/src/rules.rs
+++ b/crates/cella-network/src/rules.rs
@@ -16,6 +16,8 @@ struct CompiledRule {
     path_patterns: Vec<Vec<PatternPart>>,
     action: RuleAction,
     source: String,
+    /// Human-readable display of the original rule (e.g., "*.example.com /admin/** (block)").
+    pattern_display: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -92,9 +94,9 @@ impl RuleMatcher {
                     reason: format!(
                         "{} by rule: {}",
                         if allowed { "allowed" } else { "blocked" },
-                        rule.source,
+                        rule.pattern_display,
                     ),
-                    matched_rule: Some(rule.source.clone()),
+                    matched_rule: Some(rule.pattern_display.clone()),
                     source: Some(rule.source.clone()),
                 };
             }
@@ -132,11 +134,23 @@ impl RuleMatcher {
 fn compile_rule(rule: &NetworkRule, source: &str) -> CompiledRule {
     let domain_parts = parse_domain_pattern(&rule.domain);
     let path_patterns = rule.paths.iter().map(|p| parse_path_pattern(p)).collect();
+
+    let action_str = match rule.action {
+        RuleAction::Block => "block",
+        RuleAction::Allow => "allow",
+    };
+    let pattern_display = if rule.paths.is_empty() {
+        format!("{} ({})", rule.domain, action_str)
+    } else {
+        format!("{} {} ({})", rule.domain, rule.paths.join(", "), action_str)
+    };
+
     CompiledRule {
         domain_parts,
         path_patterns,
         action: rule.action,
         source: source.to_string(),
+        pattern_display,
     }
 }
 
@@ -202,11 +216,21 @@ fn match_segments(pattern: &[PatternPart], segments: &[&str]) -> bool {
 
 /// Segment matching with `**` support (for paths).
 fn match_segments_with_doublestar(pattern: &[PatternPart], segments: &[&str]) -> bool {
-    // Use a recursive approach with memoization-friendly structure.
-    match_recursive(pattern, segments, 0, 0)
+    let mut visited = std::collections::HashSet::new();
+    match_recursive(pattern, segments, 0, 0, &mut visited)
 }
 
-fn match_recursive(pattern: &[PatternPart], segments: &[&str], pi: usize, si: usize) -> bool {
+fn match_recursive(
+    pattern: &[PatternPart],
+    segments: &[&str],
+    pi: usize,
+    si: usize,
+    visited: &mut std::collections::HashSet<(usize, usize)>,
+) -> bool {
+    if !visited.insert((pi, si)) {
+        return false;
+    }
+
     // Both exhausted: match.
     if pi == pattern.len() && si == segments.len() {
         return true;
@@ -220,25 +244,23 @@ fn match_recursive(pattern: &[PatternPart], segments: &[&str], pi: usize, si: us
     match &pattern[pi] {
         PatternPart::DoubleStar => {
             // `**` matches zero or more segments.
-            // Try matching zero segments, then one, then two, etc.
             for skip in 0..=(segments.len() - si) {
-                if match_recursive(pattern, segments, pi + 1, si + skip) {
+                if match_recursive(pattern, segments, pi + 1, si + skip, visited) {
                     return true;
                 }
             }
             false
         }
         PatternPart::Star => {
-            // `*` matches exactly one segment.
             if si < segments.len() {
-                match_recursive(pattern, segments, pi + 1, si + 1)
+                match_recursive(pattern, segments, pi + 1, si + 1, visited)
             } else {
                 false
             }
         }
         PatternPart::Literal(lit) => {
             if si < segments.len() && lit == segments[si] {
-                match_recursive(pattern, segments, pi + 1, si + 1)
+                match_recursive(pattern, segments, pi + 1, si + 1, visited)
             } else {
                 false
             }
@@ -458,6 +480,42 @@ mod tests {
         // /secret matches second rule (block)
         let v = matcher.evaluate("api.example.com", "/secret");
         assert!(!v.allowed);
+    }
+
+    #[test]
+    fn rule_verdict_shows_pattern_not_source() {
+        let config = NetworkConfig {
+            mode: NetworkMode::Denylist,
+            rules: vec![NetworkRule {
+                domain: "*.prod.internal".to_string(),
+                paths: vec!["/admin/**".to_string()],
+                action: RuleAction::Block,
+            }],
+            ..Default::default()
+        };
+        let matcher = RuleMatcher::with_source(&config, "cella.toml");
+
+        let v = matcher.evaluate("api.prod.internal", "/admin/users");
+        assert!(!v.allowed);
+        assert_eq!(
+            v.matched_rule.as_deref(),
+            Some("*.prod.internal /admin/** (block)")
+        );
+        assert_eq!(v.source.as_deref(), Some("cella.toml"));
+        assert!(v.reason.contains("*.prod.internal"));
+    }
+
+    #[test]
+    fn memoization_handles_pathological_pattern() {
+        // Multiple ** patterns that could cause exponential blowup without memoization.
+        let parts = parse_path_pattern("/**/a/**/b/**/c");
+        // Should complete quickly (not hang) regardless of match result.
+        assert!(match_path(&parts, "/x/y/a/z/b/w/c"));
+        assert!(!match_path(&parts, "/x/y/a/z/b/w/d"));
+
+        // Long path with multiple ** — tests memoization prevents exponential time.
+        let parts = parse_path_pattern("/**/x/**/y/**/z");
+        assert!(match_path(&parts, "/a/b/c/x/d/e/f/y/g/h/i/j/k/l/m/z"));
     }
 
     #[test]

--- a/crates/cella-network/src/rules.rs
+++ b/crates/cella-network/src/rules.rs
@@ -1,0 +1,489 @@
+//! Glob-based rule matching engine for domain and path filtering.
+//!
+//! Supports domain patterns like `*.example.com` and path patterns like `/api/**`.
+//! Domain matching is case-insensitive; path matching is case-sensitive.
+
+use crate::config::{NetworkConfig, NetworkMode, NetworkRule, RuleAction};
+
+/// Evaluates network rules against request URLs.
+pub struct RuleMatcher {
+    mode: NetworkMode,
+    rules: Vec<CompiledRule>,
+}
+
+struct CompiledRule {
+    domain_parts: Vec<PatternPart>,
+    path_patterns: Vec<Vec<PatternPart>>,
+    action: RuleAction,
+    source: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PatternPart {
+    /// Match exactly this literal string.
+    Literal(String),
+    /// `*` — match exactly one segment.
+    Star,
+    /// `**` — match zero or more segments.
+    DoubleStar,
+}
+
+/// Result of evaluating a URL against the rule set.
+#[derive(Debug, Clone)]
+pub struct RuleVerdict {
+    /// Whether the request is allowed.
+    pub allowed: bool,
+    /// Human-readable explanation (e.g., "blocked by rule: *.prod.internal").
+    pub reason: String,
+    /// The original rule pattern that matched, if any.
+    pub matched_rule: Option<String>,
+    /// Source of the matching rule (e.g., "cella.toml" or "devcontainer.json").
+    pub source: Option<String>,
+}
+
+impl RuleMatcher {
+    /// Build a matcher from a network configuration.
+    pub fn new(config: &NetworkConfig) -> Self {
+        Self::with_source(config, "config")
+    }
+
+    /// Build a matcher from config with a source label for all rules.
+    pub fn with_source(config: &NetworkConfig, source: &str) -> Self {
+        let rules = config
+            .rules
+            .iter()
+            .map(|r| compile_rule(r, source))
+            .collect();
+        Self {
+            mode: config.mode,
+            rules,
+        }
+    }
+
+    /// Build a matcher from rules that already have source labels.
+    pub fn from_labeled_rules(mode: NetworkMode, rules: &[(NetworkRule, String)]) -> Self {
+        let rules = rules
+            .iter()
+            .map(|(r, src)| compile_rule(r, src))
+            .collect();
+        Self { mode, rules }
+    }
+
+    /// Evaluate whether a request to the given domain and path is allowed.
+    ///
+    /// Domain matching is case-insensitive. Path matching is case-sensitive.
+    pub fn evaluate(&self, domain: &str, path: &str) -> RuleVerdict {
+        let domain_lower = domain.to_ascii_lowercase();
+        let path = if path.is_empty() { "/" } else { path };
+
+        for rule in &self.rules {
+            if !match_domain(&rule.domain_parts, &domain_lower) {
+                continue;
+            }
+
+            // Domain matched. Check paths if any are specified.
+            let path_matched = if rule.path_patterns.is_empty() {
+                true
+            } else {
+                rule.path_patterns
+                    .iter()
+                    .any(|pp| match_path(pp, path))
+            };
+
+            if path_matched {
+                let allowed = rule.action == RuleAction::Allow;
+                return RuleVerdict {
+                    allowed,
+                    reason: format!(
+                        "{} by rule: {}",
+                        if allowed { "allowed" } else { "blocked" },
+                        rule.source,
+                    ),
+                    matched_rule: Some(rule.source.clone()),
+                    source: Some(rule.source.clone()),
+                };
+            }
+        }
+
+        // No rule matched — use default disposition based on mode.
+        match self.mode {
+            NetworkMode::Denylist => RuleVerdict {
+                allowed: true,
+                reason: "allowed (no matching deny rule)".to_string(),
+                matched_rule: None,
+                source: None,
+            },
+            NetworkMode::Allowlist => RuleVerdict {
+                allowed: false,
+                reason: "blocked (no matching allow rule)".to_string(),
+                matched_rule: None,
+                source: None,
+            },
+        }
+    }
+
+    /// Check whether any rule for the given domain requires path inspection.
+    ///
+    /// If `true`, MITM TLS interception is needed for this domain.
+    /// If `false`, domain-level blocking is sufficient (no MITM).
+    pub fn domain_needs_path_inspection(&self, domain: &str) -> bool {
+        let domain_lower = domain.to_ascii_lowercase();
+        self.rules.iter().any(|rule| {
+            !rule.path_patterns.is_empty() && match_domain(&rule.domain_parts, &domain_lower)
+        })
+    }
+}
+
+fn compile_rule(rule: &NetworkRule, source: &str) -> CompiledRule {
+    let domain_parts = parse_domain_pattern(&rule.domain);
+    let path_patterns = rule.paths.iter().map(|p| parse_path_pattern(p)).collect();
+    CompiledRule {
+        domain_parts,
+        path_patterns,
+        action: rule.action,
+        source: source.to_string(),
+    }
+}
+
+/// Parse a domain pattern like `*.example.com` into parts.
+/// Splits on `.` and maps `*` to `Star`.
+fn parse_domain_pattern(pattern: &str) -> Vec<PatternPart> {
+    pattern
+        .to_ascii_lowercase()
+        .split('.')
+        .map(|segment| {
+            if segment == "*" {
+                PatternPart::Star
+            } else {
+                PatternPart::Literal(segment.to_string())
+            }
+        })
+        .collect()
+}
+
+/// Parse a path pattern like `/v1/admin/**` into parts.
+/// Splits on `/` (ignoring empty segments from leading slash) and maps
+/// `*` to `Star`, `**` to `DoubleStar`.
+fn parse_path_pattern(pattern: &str) -> Vec<PatternPart> {
+    pattern
+        .split('/')
+        .filter(|s| !s.is_empty())
+        .map(|segment| match segment {
+            "*" => PatternPart::Star,
+            "**" => PatternPart::DoubleStar,
+            other => PatternPart::Literal(other.to_string()),
+        })
+        .collect()
+}
+
+/// Match a domain (lowercase) against a compiled domain pattern.
+///
+/// `*` matches exactly one domain label.
+/// `*.example.com` matches `foo.example.com` but NOT `foo.bar.example.com`.
+fn match_domain(pattern: &[PatternPart], domain: &str) -> bool {
+    let labels: Vec<&str> = domain.split('.').collect();
+    match_segments(pattern, &labels)
+}
+
+/// Match a path against a compiled path pattern.
+///
+/// `*` matches exactly one path segment.
+/// `**` matches zero or more path segments.
+fn match_path(pattern: &[PatternPart], path: &str) -> bool {
+    let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+    match_segments_with_doublestar(pattern, &segments)
+}
+
+/// Exact segment matching (for domains): `*` matches one, no `**` support.
+fn match_segments(pattern: &[PatternPart], segments: &[&str]) -> bool {
+    if pattern.len() != segments.len() {
+        return false;
+    }
+    pattern.iter().zip(segments.iter()).all(|(p, s)| match p {
+        PatternPart::Literal(lit) => lit == s,
+        PatternPart::Star | PatternPart::DoubleStar => true,
+    })
+}
+
+/// Segment matching with `**` support (for paths).
+fn match_segments_with_doublestar(pattern: &[PatternPart], segments: &[&str]) -> bool {
+    // Use a recursive approach with memoization-friendly structure.
+    match_recursive(pattern, segments, 0, 0)
+}
+
+fn match_recursive(
+    pattern: &[PatternPart],
+    segments: &[&str],
+    pi: usize,
+    si: usize,
+) -> bool {
+    // Both exhausted: match.
+    if pi == pattern.len() && si == segments.len() {
+        return true;
+    }
+
+    // Pattern exhausted but segments remain: no match.
+    if pi == pattern.len() {
+        return false;
+    }
+
+    match &pattern[pi] {
+        PatternPart::DoubleStar => {
+            // `**` matches zero or more segments.
+            // Try matching zero segments, then one, then two, etc.
+            for skip in 0..=(segments.len() - si) {
+                if match_recursive(pattern, segments, pi + 1, si + skip) {
+                    return true;
+                }
+            }
+            false
+        }
+        PatternPart::Star => {
+            // `*` matches exactly one segment.
+            if si < segments.len() {
+                match_recursive(pattern, segments, pi + 1, si + 1)
+            } else {
+                false
+            }
+        }
+        PatternPart::Literal(lit) => {
+            if si < segments.len() && lit == segments[si] {
+                match_recursive(pattern, segments, pi + 1, si + 1)
+            } else {
+                false
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::{NetworkConfig, NetworkMode, NetworkRule, RuleAction};
+
+    use super::*;
+
+    // --- Domain pattern matching ---
+
+    #[test]
+    fn exact_domain_match() {
+        let parts = parse_domain_pattern("example.com");
+        assert!(match_domain(&parts, "example.com"));
+        assert!(!match_domain(&parts, "foo.example.com"));
+        assert!(!match_domain(&parts, "other.com"));
+    }
+
+    #[test]
+    fn wildcard_subdomain() {
+        let parts = parse_domain_pattern("*.example.com");
+        assert!(match_domain(&parts, "foo.example.com"));
+        assert!(match_domain(&parts, "bar.example.com"));
+        assert!(!match_domain(&parts, "foo.bar.example.com"));
+        assert!(!match_domain(&parts, "example.com"));
+    }
+
+    #[test]
+    fn wildcard_middle_segment() {
+        let parts = parse_domain_pattern("api.*.internal");
+        assert!(match_domain(&parts, "api.foo.internal"));
+        assert!(match_domain(&parts, "api.bar.internal"));
+        assert!(!match_domain(&parts, "api.foo.bar.internal"));
+        assert!(!match_domain(&parts, "web.foo.internal"));
+    }
+
+    #[test]
+    fn domain_case_insensitive() {
+        // Patterns are lowercased during parsing, domains are lowercased
+        // during evaluation (in `evaluate()`). Direct `match_domain` calls
+        // expect a pre-lowercased domain.
+        let parts = parse_domain_pattern("*.Example.COM");
+        assert!(match_domain(&parts, "foo.example.com"));
+
+        // Full evaluation path handles case normalization:
+        let config = NetworkConfig {
+            mode: NetworkMode::Denylist,
+            rules: vec![NetworkRule {
+                domain: "*.Example.COM".to_string(),
+                paths: vec![],
+                action: RuleAction::Block,
+            }],
+            ..Default::default()
+        };
+        let matcher = RuleMatcher::new(&config);
+        let v = matcher.evaluate("FOO.EXAMPLE.COM", "/");
+        assert!(!v.allowed);
+    }
+
+    // --- Path pattern matching ---
+
+    #[test]
+    fn exact_path_match() {
+        let parts = parse_path_pattern("/api/v1");
+        assert!(match_path(&parts, "/api/v1"));
+        assert!(!match_path(&parts, "/api/v2"));
+        assert!(!match_path(&parts, "/api/v1/extra"));
+    }
+
+    #[test]
+    fn single_star_path() {
+        let parts = parse_path_pattern("/api/*");
+        assert!(match_path(&parts, "/api/users"));
+        assert!(match_path(&parts, "/api/posts"));
+        assert!(!match_path(&parts, "/api/users/123"));
+        assert!(!match_path(&parts, "/api"));
+    }
+
+    #[test]
+    fn double_star_path() {
+        let parts = parse_path_pattern("/v1/admin/**");
+        assert!(match_path(&parts, "/v1/admin"));
+        assert!(match_path(&parts, "/v1/admin/users"));
+        assert!(match_path(&parts, "/v1/admin/users/123/roles"));
+        assert!(!match_path(&parts, "/v1/public"));
+        assert!(!match_path(&parts, "/v2/admin"));
+    }
+
+    #[test]
+    fn double_star_middle() {
+        let parts = parse_path_pattern("/api/**/delete");
+        assert!(match_path(&parts, "/api/delete"));
+        assert!(match_path(&parts, "/api/users/delete"));
+        assert!(match_path(&parts, "/api/users/123/delete"));
+        assert!(!match_path(&parts, "/api/users/update"));
+    }
+
+    // --- Rule evaluation ---
+
+    #[test]
+    fn denylist_blocks_matching() {
+        let config = NetworkConfig {
+            mode: NetworkMode::Denylist,
+            rules: vec![NetworkRule {
+                domain: "*.prod.internal".to_string(),
+                paths: vec![],
+                action: RuleAction::Block,
+            }],
+            ..Default::default()
+        };
+        let matcher = RuleMatcher::new(&config);
+
+        let v = matcher.evaluate("api.prod.internal", "/");
+        assert!(!v.allowed);
+
+        let v = matcher.evaluate("api.staging.internal", "/");
+        assert!(v.allowed);
+    }
+
+    #[test]
+    fn allowlist_blocks_unmatched() {
+        let config = NetworkConfig {
+            mode: NetworkMode::Allowlist,
+            rules: vec![NetworkRule {
+                domain: "registry.npmjs.org".to_string(),
+                paths: vec![],
+                action: RuleAction::Allow,
+            }],
+            ..Default::default()
+        };
+        let matcher = RuleMatcher::new(&config);
+
+        let v = matcher.evaluate("registry.npmjs.org", "/");
+        assert!(v.allowed);
+
+        let v = matcher.evaluate("evil.example.com", "/");
+        assert!(!v.allowed);
+    }
+
+    #[test]
+    fn path_level_blocking() {
+        let config = NetworkConfig {
+            mode: NetworkMode::Denylist,
+            rules: vec![NetworkRule {
+                domain: "api.example.com".to_string(),
+                paths: vec!["/v1/admin/*".to_string(), "/internal/**".to_string()],
+                action: RuleAction::Block,
+            }],
+            ..Default::default()
+        };
+        let matcher = RuleMatcher::new(&config);
+
+        let v = matcher.evaluate("api.example.com", "/v1/admin/delete");
+        assert!(!v.allowed);
+
+        let v = matcher.evaluate("api.example.com", "/internal/secrets/key");
+        assert!(!v.allowed);
+
+        let v = matcher.evaluate("api.example.com", "/v1/public/data");
+        assert!(v.allowed);
+    }
+
+    #[test]
+    fn domain_needs_path_inspection_check() {
+        let config = NetworkConfig {
+            mode: NetworkMode::Denylist,
+            rules: vec![
+                NetworkRule {
+                    domain: "*.prod.internal".to_string(),
+                    paths: vec![],
+                    action: RuleAction::Block,
+                },
+                NetworkRule {
+                    domain: "api.example.com".to_string(),
+                    paths: vec!["/admin/**".to_string()],
+                    action: RuleAction::Block,
+                },
+            ],
+            ..Default::default()
+        };
+        let matcher = RuleMatcher::new(&config);
+
+        assert!(!matcher.domain_needs_path_inspection("foo.prod.internal"));
+        assert!(matcher.domain_needs_path_inspection("api.example.com"));
+        assert!(!matcher.domain_needs_path_inspection("other.example.com"));
+    }
+
+    #[test]
+    fn first_matching_rule_wins() {
+        let config = NetworkConfig {
+            mode: NetworkMode::Denylist,
+            rules: vec![
+                NetworkRule {
+                    domain: "api.example.com".to_string(),
+                    paths: vec!["/public/**".to_string()],
+                    action: RuleAction::Allow,
+                },
+                NetworkRule {
+                    domain: "api.example.com".to_string(),
+                    paths: vec![],
+                    action: RuleAction::Block,
+                },
+            ],
+            ..Default::default()
+        };
+        let matcher = RuleMatcher::new(&config);
+
+        // /public/data matches first rule (allow)
+        let v = matcher.evaluate("api.example.com", "/public/data");
+        assert!(v.allowed);
+
+        // /secret matches second rule (block)
+        let v = matcher.evaluate("api.example.com", "/secret");
+        assert!(!v.allowed);
+    }
+
+    #[test]
+    fn empty_path_defaults_to_root() {
+        let config = NetworkConfig {
+            mode: NetworkMode::Denylist,
+            rules: vec![NetworkRule {
+                domain: "example.com".to_string(),
+                paths: vec![],
+                action: RuleAction::Block,
+            }],
+            ..Default::default()
+        };
+        let matcher = RuleMatcher::new(&config);
+
+        let v = matcher.evaluate("example.com", "");
+        assert!(!v.allowed);
+    }
+}

--- a/crates/cella-orchestrator/Cargo.toml
+++ b/crates/cella-orchestrator/Cargo.toml
@@ -9,6 +9,7 @@ cella-backend.workspace = true
 cella-docker.workspace = true
 cella-features.workspace = true
 cella-git.workspace = true
+cella-network.workspace = true
 hex.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/cella-orchestrator/src/image.rs
+++ b/crates/cella-orchestrator/src/image.rs
@@ -254,6 +254,24 @@ async fn resolve_and_build_features(
 }
 
 /// Parse build configuration from the `build` object in devcontainer.json.
+/// Inject host proxy env vars into build args so Dockerfile RUN steps
+/// work behind corporate proxies.
+///
+/// Docker automatically recognizes `HTTP_PROXY`, `HTTPS_PROXY`, and
+/// `NO_PROXY` as predefined build args without requiring `ARG` declarations.
+pub fn inject_proxy_build_args(opts: &mut BuildOptions, proxy: &cella_network::config::ProxyConfig) {
+    let Some(proxy_vars) = cella_network::proxy_env::ProxyEnvVars::detect(proxy) else {
+        return;
+    };
+    if !proxy_vars.has_proxy() {
+        return;
+    }
+    for (key, value) in proxy_vars.to_build_args() {
+        opts.args.entry(key).or_insert(value);
+    }
+    tracing::debug!("Injected proxy build args into Docker build");
+}
+
 pub fn parse_build_options(
     build: &serde_json::Map<String, serde_json::Value>,
     img_name: &str,

--- a/crates/cella-orchestrator/src/image.rs
+++ b/crates/cella-orchestrator/src/image.rs
@@ -259,7 +259,10 @@ async fn resolve_and_build_features(
 ///
 /// Docker automatically recognizes `HTTP_PROXY`, `HTTPS_PROXY`, and
 /// `NO_PROXY` as predefined build args without requiring `ARG` declarations.
-pub fn inject_proxy_build_args(opts: &mut BuildOptions, proxy: &cella_network::config::ProxyConfig) {
+pub fn inject_proxy_build_args(
+    opts: &mut BuildOptions,
+    proxy: &cella_network::config::ProxyConfig,
+) {
     let Some(proxy_vars) = cella_network::proxy_env::ProxyEnvVars::detect(proxy) else {
         return;
     };


### PR DESCRIPTION
## Summary

- Adds `cella-network` crate: network rules engine (allow/block by host, path, port), CA cert generation, host CA bundle detection, and proxy env var management
- Implements a forward proxy in `cella-agent` with HTTP CONNECT support and MITM TLS interception for path-level HTTPS blocking
- Wires network rules into `cella up`: proxy env injection, CA bundle injection, build ARGs, smart activation, and `cella network status/test/log` CLI commands
- Supports `customizations.cella.network` config in devcontainer.json and `--no-network-rules` opt-out

## Test plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings -D clippy::all` clean
- [x] Manual: `cella up` with network rules blocks/allows expected URLs
- [x] Manual: HTTPS path-level blocking works via MITM interception
- [x] Manual: `cella network status`, `cella network test`, `cella network log` work
- [x] Manual: `--no-network-rules` disables proxy injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)