### PR TITLE
feat: version skew resilience for daemon-agent connection

### DIFF
--- a/crates/cella-agent/src/browser.rs
+++ b/crates/cella-agent/src/browser.rs
@@ -24,16 +24,17 @@ pub async fn send_browser_open(url: &str) -> Result<(), CellaPortError> {
     client.send(&msg).await
 }
 
-/// Resolve daemon connection info from env vars or `.daemon_addr` file.
+/// Resolve daemon connection info: `.daemon_addr` file first (authoritative),
+/// env vars as fallback (may be stale after container restart).
 fn resolve_daemon_connection() -> Result<(String, String), CellaPortError> {
+    if let Some(info) = crate::control::read_daemon_addr_file() {
+        return Ok((info.addr, info.token));
+    }
     if let (Ok(addr), Ok(token)) = (
         std::env::var("CELLA_DAEMON_ADDR"),
         std::env::var("CELLA_DAEMON_TOKEN"),
     ) {
         return Ok((addr, token));
-    }
-    if let Some(info) = crate::control::read_daemon_addr_file() {
-        return Ok((info.addr, info.token));
     }
     Err(CellaPortError::ControlSocket {
         message: "no daemon connection info available (env vars not set, .daemon_addr not found)"

--- a/crates/cella-agent/src/browser.rs
+++ b/crates/cella-agent/src/browser.rs
@@ -7,27 +7,36 @@ use crate::control::ControlClient;
 
 /// Send a browser-open request to the host daemon.
 ///
-/// Reads connection info from `CELLA_DAEMON_ADDR`, `CELLA_DAEMON_TOKEN`,
-/// and `CELLA_CONTAINER_NAME` environment variables.
+/// Reads connection info from `CELLA_DAEMON_ADDR` / `CELLA_DAEMON_TOKEN`
+/// env vars, falling back to the `.daemon_addr` file on the shared volume.
 ///
 /// # Errors
 ///
-/// Returns error if env vars are missing or daemon is unreachable.
+/// Returns error if connection info is unavailable or daemon is unreachable.
 pub async fn send_browser_open(url: &str) -> Result<(), CellaPortError> {
-    let addr = std::env::var("CELLA_DAEMON_ADDR").map_err(|_| CellaPortError::ControlSocket {
-        message: "CELLA_DAEMON_ADDR not set".to_string(),
-    })?;
-    let token = std::env::var("CELLA_DAEMON_TOKEN").map_err(|_| CellaPortError::ControlSocket {
-        message: "CELLA_DAEMON_TOKEN not set".to_string(),
-    })?;
-    let name =
-        std::env::var("CELLA_CONTAINER_NAME").map_err(|_| CellaPortError::ControlSocket {
-            message: "CELLA_CONTAINER_NAME not set".to_string(),
-        })?;
+    let (addr, token) = resolve_daemon_connection()?;
+    let name = std::env::var("CELLA_CONTAINER_NAME").unwrap_or_default();
 
     let (mut client, _hello) = ControlClient::connect(&addr, &name, &token).await?;
     let msg = AgentMessage::BrowserOpen {
         url: url.to_string(),
     };
     client.send(&msg).await
+}
+
+/// Resolve daemon connection info from env vars or `.daemon_addr` file.
+fn resolve_daemon_connection() -> Result<(String, String), CellaPortError> {
+    if let (Ok(addr), Ok(token)) = (
+        std::env::var("CELLA_DAEMON_ADDR"),
+        std::env::var("CELLA_DAEMON_TOKEN"),
+    ) {
+        return Ok((addr, token));
+    }
+    if let Some(info) = crate::control::read_daemon_addr_file() {
+        return Ok((info.addr, info.token));
+    }
+    Err(CellaPortError::ControlSocket {
+        message: "no daemon connection info available (env vars not set, .daemon_addr not found)"
+            .to_string(),
+    })
 }

--- a/crates/cella-agent/src/cli.rs
+++ b/crates/cella-agent/src/cli.rs
@@ -74,6 +74,7 @@ pub enum CliCommand {
     Switch {
         branch: String,
     },
+    Doctor,
     Help,
     Unsupported {
         command: String,
@@ -163,6 +164,7 @@ pub fn parse_cli_args(args: &[String]) -> CliCommand {
             };
             CliCommand::Switch { branch }
         }
+        Some("doctor") => CliCommand::Doctor,
         Some("--help" | "-h") | None => CliCommand::Help,
         Some(cmd) => CliCommand::Unsupported {
             command: cmd.to_string(),
@@ -244,6 +246,7 @@ pub async fn run(command: CliCommand) -> Result<(), Box<dyn std::error::Error>> 
             print_help();
             Ok(())
         }
+        CliCommand::Doctor => run_doctor().await,
         CliCommand::Unsupported { command } => {
             print_unsupported(&command);
             std::process::exit(1);
@@ -292,6 +295,7 @@ Commands:
   task logs [-f] <branch>        Show output from a background task (-f to follow)
   task wait <branch>             Wait for a background task to complete
   task stop <branch>             Stop a running background task
+  doctor                         Check connectivity and version status
 
 Options:
   --help, -h                     Show this help message
@@ -319,10 +323,18 @@ Run `cella --help` on the host for all commands."
 }
 
 /// Connect to the host daemon for CLI commands.
+///
+/// Reads connection info from env vars, falling back to the `.daemon_addr`
+/// file on the shared agent volume.
 async fn connect_daemon() -> Result<ControlClient, Box<dyn std::error::Error>> {
-    let addr = std::env::var("CELLA_DAEMON_ADDR")
-        .map_err(|_| "CELLA_DAEMON_ADDR not set. Are you inside a cella dev container?")?;
-    let token = std::env::var("CELLA_DAEMON_TOKEN").unwrap_or_default();
+    let (addr, token) = if let Ok(addr) = std::env::var("CELLA_DAEMON_ADDR") {
+        let token = std::env::var("CELLA_DAEMON_TOKEN").unwrap_or_default();
+        (addr, token)
+    } else if let Some(info) = crate::control::read_daemon_addr_file() {
+        (info.addr, info.token)
+    } else {
+        return Err("No daemon connection info. Are you inside a cella dev container?".into());
+    };
     let container_name = std::env::var("CELLA_CONTAINER_NAME").unwrap_or_default();
 
     let (client, _hello) = ControlClient::connect(&addr, &container_name, &token)
@@ -338,6 +350,71 @@ fn request_id() -> String {
     static COUNTER: AtomicU64 = AtomicU64::new(1);
     let n = COUNTER.fetch_add(1, Ordering::Relaxed);
     format!("cli-{n}")
+}
+
+async fn run_doctor() -> Result<(), Box<dyn std::error::Error>> {
+    let agent_version = env!("CARGO_PKG_VERSION");
+    eprintln!("cella doctor (in-container, agent v{agent_version})\n");
+
+    // 1. .daemon_addr file
+    let daemon_addr_exists = std::path::Path::new("/cella/.daemon_addr").exists();
+    if daemon_addr_exists {
+        eprintln!("  \u{2713} daemon address file (/cella/.daemon_addr)");
+    } else {
+        eprintln!("  \u{2717} daemon address file not found (/cella/.daemon_addr)");
+        eprintln!("    Run `cella up` on the host to fix");
+    }
+
+    // 2. Resolve connection info
+    let (addr, token) = if let Ok(addr) = std::env::var("CELLA_DAEMON_ADDR") {
+        let token = std::env::var("CELLA_DAEMON_TOKEN").unwrap_or_default();
+        eprintln!("  \u{2713} connection info (from env vars)");
+        (addr, token)
+    } else if let Some(info) = crate::control::read_daemon_addr_file() {
+        eprintln!("  \u{2713} connection info (from .daemon_addr file)");
+        (info.addr, info.token)
+    } else {
+        eprintln!("  \u{2717} no connection info available");
+        eprintln!("    Set CELLA_DAEMON_ADDR or ensure .daemon_addr exists");
+        return Ok(());
+    };
+
+    // 3. Daemon connectivity
+    let container_name = std::env::var("CELLA_CONTAINER_NAME").unwrap_or_default();
+    match ControlClient::connect(&addr, &container_name, &token).await {
+        Ok((_client, hello)) => {
+            eprintln!("  \u{2713} daemon reachable at {addr}");
+            eprintln!(
+                "  \u{2713} protocol version: {} (matches)",
+                cella_port::protocol::PROTOCOL_VERSION
+            );
+
+            // 4. Version comparison
+            if hello.daemon_version == agent_version {
+                eprintln!("  \u{2713} version: {agent_version}");
+            } else {
+                eprintln!(
+                    "  \u{26a0} agent version {agent_version} != daemon version {}",
+                    hello.daemon_version
+                );
+                eprintln!("    Run `cella up` on the host to update");
+            }
+        }
+        Err(e) => {
+            eprintln!("  \u{2717} daemon unreachable at {addr}: {e}");
+        }
+    }
+
+    // 5. Credential helper
+    let browser = std::env::var("BROWSER").unwrap_or_default();
+    if browser.contains("cella") {
+        eprintln!("  \u{2713} browser helper configured");
+    } else {
+        eprintln!("  \u{26a0} browser helper not configured (BROWSER={browser})");
+    }
+
+    eprintln!();
+    Ok(())
 }
 
 async fn run_branch(name: &str, base: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {
@@ -766,8 +843,11 @@ async fn run_switch(branch: &str) -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    // Extract daemon host from CELLA_DAEMON_ADDR.
-    let daemon_addr = std::env::var("CELLA_DAEMON_ADDR").unwrap_or_default();
+    // Extract daemon host from env var or .daemon_addr file.
+    let daemon_addr = std::env::var("CELLA_DAEMON_ADDR")
+        .ok()
+        .or_else(|| crate::control::read_daemon_addr_file().map(|i| i.addr))
+        .unwrap_or_default();
     let host = daemon_addr
         .rsplit_once(':')
         .map_or(daemon_addr.as_str(), |(h, _)| h);

--- a/crates/cella-agent/src/cli.rs
+++ b/crates/cella-agent/src/cli.rs
@@ -327,11 +327,11 @@ Run `cella --help` on the host for all commands."
 /// Reads connection info from env vars, falling back to the `.daemon_addr`
 /// file on the shared agent volume.
 async fn connect_daemon() -> Result<ControlClient, Box<dyn std::error::Error>> {
-    let (addr, token) = if let Ok(addr) = std::env::var("CELLA_DAEMON_ADDR") {
+    let (addr, token) = if let Some(info) = crate::control::read_daemon_addr_file() {
+        (info.addr, info.token)
+    } else if let Ok(addr) = std::env::var("CELLA_DAEMON_ADDR") {
         let token = std::env::var("CELLA_DAEMON_TOKEN").unwrap_or_default();
         (addr, token)
-    } else if let Some(info) = crate::control::read_daemon_addr_file() {
-        (info.addr, info.token)
     } else {
         return Err("No daemon connection info. Are you inside a cella dev container?".into());
     };
@@ -365,14 +365,14 @@ async fn run_doctor() -> Result<(), Box<dyn std::error::Error>> {
         eprintln!("    Run `cella up` on the host to fix");
     }
 
-    // 2. Resolve connection info
-    let (addr, token) = if let Ok(addr) = std::env::var("CELLA_DAEMON_ADDR") {
+    // 2. Resolve connection info (file is authoritative, env vars are fallback)
+    let (addr, token) = if let Some(info) = crate::control::read_daemon_addr_file() {
+        eprintln!("  \u{2713} connection info (from .daemon_addr file)");
+        (info.addr, info.token)
+    } else if let Ok(addr) = std::env::var("CELLA_DAEMON_ADDR") {
         let token = std::env::var("CELLA_DAEMON_TOKEN").unwrap_or_default();
         eprintln!("  \u{2713} connection info (from env vars)");
         (addr, token)
-    } else if let Some(info) = crate::control::read_daemon_addr_file() {
-        eprintln!("  \u{2713} connection info (from .daemon_addr file)");
-        (info.addr, info.token)
     } else {
         eprintln!("  \u{2717} no connection info available");
         eprintln!("    Set CELLA_DAEMON_ADDR or ensure .daemon_addr exists");

--- a/crates/cella-agent/src/control.rs
+++ b/crates/cella-agent/src/control.rs
@@ -132,3 +132,26 @@ impl ControlClient {
         Ok(msg)
     }
 }
+
+/// Daemon connection info read from the shared volume file.
+pub struct DaemonAddrInfo {
+    pub addr: String,
+    pub token: String,
+}
+
+/// Read daemon connection info from `/cella/.daemon_addr`.
+///
+/// The file contains two lines: the daemon address (`host:port`) and the
+/// auth token. Written by the host CLI during `cella up`.
+///
+/// Returns `None` if the file doesn't exist or can't be parsed.
+pub fn read_daemon_addr_file() -> Option<DaemonAddrInfo> {
+    let content = std::fs::read_to_string("/cella/.daemon_addr").ok()?;
+    let mut lines = content.lines();
+    let addr = lines.next()?.trim().to_string();
+    let token = lines.next()?.trim().to_string();
+    if addr.is_empty() || token.is_empty() {
+        return None;
+    }
+    Some(DaemonAddrInfo { addr, token })
+}

--- a/crates/cella-agent/src/credential.rs
+++ b/crates/cella-agent/src/credential.rs
@@ -63,16 +63,17 @@ pub async fn handle_credential(operation: &str) -> Result<(), CellaPortError> {
     Ok(())
 }
 
-/// Resolve daemon connection info from env vars or `.daemon_addr` file.
+/// Resolve daemon connection info: `.daemon_addr` file first (authoritative),
+/// env vars as fallback (may be stale after container restart).
 fn resolve_daemon_connection() -> Result<(String, String), CellaPortError> {
+    if let Some(info) = crate::control::read_daemon_addr_file() {
+        return Ok((info.addr, info.token));
+    }
     if let (Ok(addr), Ok(token)) = (
         std::env::var("CELLA_DAEMON_ADDR"),
         std::env::var("CELLA_DAEMON_TOKEN"),
     ) {
         return Ok((addr, token));
-    }
-    if let Some(info) = crate::control::read_daemon_addr_file() {
-        return Ok((info.addr, info.token));
     }
     Err(CellaPortError::ControlSocket {
         message: "no daemon connection info available (env vars not set, .daemon_addr not found)"

--- a/crates/cella-agent/src/credential.rs
+++ b/crates/cella-agent/src/credential.rs
@@ -13,12 +13,12 @@ use crate::control::ControlClient;
 /// Reads credential fields from stdin (git credential protocol),
 /// sends to daemon, and writes response to stdout.
 ///
-/// Reads connection info from `CELLA_DAEMON_ADDR`, `CELLA_DAEMON_TOKEN`,
-/// and `CELLA_CONTAINER_NAME` environment variables.
+/// Reads connection info from `CELLA_DAEMON_ADDR` / `CELLA_DAEMON_TOKEN`
+/// env vars, falling back to the `.daemon_addr` file on the shared volume.
 ///
 /// # Errors
 ///
-/// Returns error if env vars are missing or control socket communication fails.
+/// Returns error if connection info is unavailable or control socket communication fails.
 pub async fn handle_credential(operation: &str) -> Result<(), CellaPortError> {
     // Read credential fields from stdin
     let mut stdin_data = String::new();
@@ -38,16 +38,8 @@ pub async fn handle_credential(operation: &str) -> Result<(), CellaPortError> {
             .as_millis()
     );
 
-    let addr = std::env::var("CELLA_DAEMON_ADDR").map_err(|_| CellaPortError::ControlSocket {
-        message: "CELLA_DAEMON_ADDR not set".to_string(),
-    })?;
-    let token = std::env::var("CELLA_DAEMON_TOKEN").map_err(|_| CellaPortError::ControlSocket {
-        message: "CELLA_DAEMON_TOKEN not set".to_string(),
-    })?;
-    let name =
-        std::env::var("CELLA_CONTAINER_NAME").map_err(|_| CellaPortError::ControlSocket {
-            message: "CELLA_CONTAINER_NAME not set".to_string(),
-        })?;
+    let (addr, token) = resolve_daemon_connection()?;
+    let name = std::env::var("CELLA_CONTAINER_NAME").unwrap_or_default();
 
     let (mut client, _hello) = ControlClient::connect(&addr, &name, &token).await?;
 
@@ -69,6 +61,23 @@ pub async fn handle_credential(operation: &str) -> Result<(), CellaPortError> {
     }
 
     Ok(())
+}
+
+/// Resolve daemon connection info from env vars or `.daemon_addr` file.
+fn resolve_daemon_connection() -> Result<(String, String), CellaPortError> {
+    if let (Ok(addr), Ok(token)) = (
+        std::env::var("CELLA_DAEMON_ADDR"),
+        std::env::var("CELLA_DAEMON_TOKEN"),
+    ) {
+        return Ok((addr, token));
+    }
+    if let Some(info) = crate::control::read_daemon_addr_file() {
+        return Ok((info.addr, info.token));
+    }
+    Err(CellaPortError::ControlSocket {
+        message: "no daemon connection info available (env vars not set, .daemon_addr not found)"
+            .to_string(),
+    })
 }
 
 /// Parse git credential protocol fields from stdin.

--- a/crates/cella-agent/src/main.rs
+++ b/crates/cella-agent/src/main.rs
@@ -213,13 +213,14 @@ async fn run_daemon(poll_interval_ms: u64, proxy_config_json: Option<String>) {
         }
     }
 
-    // Read connection info from env vars, falling back to .daemon_addr file
-    let (addr, token) = if let Ok(addr) = std::env::var("CELLA_DAEMON_ADDR") {
-        let token = std::env::var("CELLA_DAEMON_TOKEN").unwrap_or_default();
-        (addr, token)
-    } else if let Some(info) = control::read_daemon_addr_file() {
+    // Read connection info: .daemon_addr file is authoritative (updated on
+    // every `cella up`), env vars are fallback (may be stale after restart).
+    let (addr, token) = if let Some(info) = control::read_daemon_addr_file() {
         info!("Using daemon address from .daemon_addr file");
         (info.addr, info.token)
+    } else if let Ok(addr) = std::env::var("CELLA_DAEMON_ADDR") {
+        let token = std::env::var("CELLA_DAEMON_TOKEN").unwrap_or_default();
+        (addr, token)
     } else {
         info!("No daemon address available, running in standalone mode");
         port_watcher::run_standalone(poll_interval).await;

--- a/crates/cella-agent/src/main.rs
+++ b/crates/cella-agent/src/main.rs
@@ -213,13 +213,18 @@ async fn run_daemon(poll_interval_ms: u64, proxy_config_json: Option<String>) {
         }
     }
 
-    // Read connection info from env vars
-    let Ok(addr) = std::env::var("CELLA_DAEMON_ADDR") else {
-        info!("CELLA_DAEMON_ADDR not set, running in standalone mode");
+    // Read connection info from env vars, falling back to .daemon_addr file
+    let (addr, token) = if let Ok(addr) = std::env::var("CELLA_DAEMON_ADDR") {
+        let token = std::env::var("CELLA_DAEMON_TOKEN").unwrap_or_default();
+        (addr, token)
+    } else if let Some(info) = control::read_daemon_addr_file() {
+        info!("Using daemon address from .daemon_addr file");
+        (info.addr, info.token)
+    } else {
+        info!("No daemon address available, running in standalone mode");
         port_watcher::run_standalone(poll_interval).await;
         return;
     };
-    let token = std::env::var("CELLA_DAEMON_TOKEN").unwrap_or_default();
     let container_name = std::env::var("CELLA_CONTAINER_NAME").unwrap_or_default();
 
     // Wait for the host daemon to accept connections (race with cella up).

--- a/crates/cella-agent/src/reconnecting_client.rs
+++ b/crates/cella-agent/src/reconnecting_client.rs
@@ -89,6 +89,13 @@ impl ReconnectingClient {
         self.inner.is_some()
     }
 
+    /// Check if the given daemon info matches the current connection params.
+    fn matches_current(&self, info: &crate::control::DaemonAddrInfo) -> bool {
+        let addr_matches = info.addr == self.addr;
+        let token_matches = info.token == self.auth_token;
+        addr_matches && token_matches
+    }
+
     /// Returns and clears the `reconnected` flag.
     ///
     /// When a reconnection succeeds the flag is set to `true`. Callers should
@@ -145,22 +152,52 @@ impl ReconnectingClient {
     }
 
     /// Attempt a single reconnect to the daemon.
+    ///
+    /// Tries the current address first, then falls back to reading the
+    /// `.daemon_addr` file on the shared volume (which the host CLI
+    /// updates on every `cella up` and daemon restart).
     async fn try_reconnect(&mut self) -> Result<(), CellaPortError> {
+        // 1. Try the current address
         match ControlClient::connect(&self.addr, &self.container_name, &self.auth_token).await {
             Ok((client, hello)) => {
                 info!("Reconnected to daemon at {}", self.addr);
                 self.inner = Some(client);
                 self.daemon_hello = Some(hello);
                 self.reconnected = true;
-                Ok(())
+                return Ok(());
             }
             Err(e) => {
-                warn!("Reconnect failed: {e}");
-                Err(CellaPortError::ControlSocket {
-                    message: format!("reconnect to {} failed: {e}", self.addr),
-                })
+                debug!("Reconnect to {} failed: {e}", self.addr);
             }
         }
+
+        // 2. Fallback: read updated address from .daemon_addr file
+        if let Some(info) =
+            crate::control::read_daemon_addr_file().filter(|info| !self.matches_current(info))
+        {
+            info!(
+                "Daemon address changed ({} -> {}), trying new address",
+                self.addr, info.addr
+            );
+            match ControlClient::connect(&info.addr, &self.container_name, &info.token).await {
+                Ok((client, hello)) => {
+                    info!("Reconnected to daemon at {} (from .daemon_addr)", info.addr);
+                    self.addr = info.addr;
+                    self.auth_token = info.token;
+                    self.inner = Some(client);
+                    self.daemon_hello = Some(hello);
+                    self.reconnected = true;
+                    return Ok(());
+                }
+                Err(e) => {
+                    warn!("Reconnect to {} (from .daemon_addr) failed: {e}", info.addr);
+                }
+            }
+        }
+
+        Err(CellaPortError::ControlSocket {
+            message: format!("reconnect to {} failed", self.addr),
+        })
     }
 }
 

--- a/crates/cella-cli/src/commands/compose_up.rs
+++ b/crates/cella-cli/src/commands/compose_up.rs
@@ -390,9 +390,8 @@ fn build_compose_labels(
 ///
 /// Since compose's `overrideCommand` defaults to `false`, the container runs its
 /// own entrypoint. The agent is started via `exec` as a background daemon.
-async fn launch_agent(ctx: &UpContext, container_id: &str, agent_arch: &str) {
-    let version = env!("CARGO_PKG_VERSION");
-    let agent_path = format!("/cella/v{version}/{agent_arch}/cella-agent");
+async fn launch_agent(ctx: &UpContext, container_id: &str, _agent_arch: &str) {
+    let agent_path = cella_docker::volume::agent_symlink_path();
 
     let script = format!(
         "if [ -x \"{agent_path}\" ]; then \

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -442,6 +442,34 @@ impl UpContext {
                 .hint("Run `cella logs --lifecycle` for details.");
         }
 
+        // Always update .daemon_addr (daemon may have restarted)
+        write_daemon_addr_to_volume(&self.client).await;
+
+        // Version-aware agent restart: if the container was created with a
+        // different cella version, repopulate the volume and restart the agent.
+        let container_version = container
+            .labels
+            .get("dev.cella.version")
+            .map_or("unknown", String::as_str);
+        let current_version = env!("CARGO_PKG_VERSION");
+        if container_version != current_version {
+            info!(
+                "Version change detected ({container_version} -> {current_version}), updating agent"
+            );
+            let agent_arch = self.detect_arch().await;
+            if let Err(e) = cella_docker::volume::ensure_agent_volume_populated(
+                self.client.inner(),
+                &agent_arch,
+                self.skip_checksum,
+            )
+            .await
+            {
+                warn!("Failed to repopulate agent volume: {e}");
+            }
+            self.register_with_daemon(&container.id).await;
+            restart_agent_in_container(&self.client, &container.id).await;
+        }
+
         let (_probed_env, lifecycle_env) =
             self.prepare_container_env(&container.id, remote_user).await;
 
@@ -510,6 +538,24 @@ impl UpContext {
             }
         }
 
+        // Repopulate agent volume before starting (may have been updated since
+        // the container was created, and the old versioned binary path in CMD
+        // would fail if the volume was repopulated by another `cella up`).
+        let agent_arch = self.detect_arch().await;
+        self.progress
+            .run_step(
+                "Populating agent volume...",
+                cella_docker::volume::ensure_agent_volume_populated(
+                    self.client.inner(),
+                    &agent_arch,
+                    self.skip_checksum,
+                ),
+            )
+            .await?;
+
+        // Write .daemon_addr so the agent can discover the current daemon
+        write_daemon_addr_to_volume(&self.client).await;
+
         // Attempt to start directly -- let Docker validate mounts
         let step = self.progress.step("Starting container...");
         let start_result = self.client.start_container(&container.id).await;
@@ -522,6 +568,14 @@ impl UpContext {
         match start_result {
             Ok(()) => {
                 verify_container_running(&self.client, &container.id).await?;
+
+                // Register with daemon (missing from the original code —
+                // without this the daemon rejects the agent with "unknown container")
+                self.register_with_daemon(&container.id).await;
+
+                // Kill + restart agent so it picks up the new binary and
+                // daemon address from the updated .daemon_addr file
+                restart_agent_in_container(&self.client, &container.id).await;
 
                 let (_probed_env, lifecycle_env) =
                     self.prepare_container_env(&container.id, remote_user).await;
@@ -536,6 +590,15 @@ impl UpContext {
                         phase,
                     );
                     run_lifecycle_entries(&lc_ctx, phase, &entries, &self.progress).await?;
+                }
+
+                // Prune old agent versions from the volume (non-fatal)
+                let version = env!("CARGO_PKG_VERSION");
+                if let Err(e) =
+                    cella_docker::volume::prune_old_agent_versions(self.client.inner(), version)
+                        .await
+                {
+                    debug!("Agent version pruning failed: {e}");
                 }
 
                 Ok(Some(UpResult {
@@ -598,6 +661,10 @@ impl UpContext {
         );
 
         labels.insert("dev.cella.remote_user".to_string(), remote_user.to_string());
+        labels.insert(
+            "dev.cella.version".to_string(),
+            env!("CARGO_PKG_VERSION").to_string(),
+        );
         labels.insert(
             "dev.cella.workspace_folder".to_string(),
             self.workspace_folder_str().to_string(),
@@ -716,6 +783,9 @@ impl UpContext {
                     .hint(&format!("Agent volume population failed: {e}"));
             }
         }
+
+        // Write .daemon_addr to volume so agents can discover the daemon
+        write_daemon_addr_to_volume(&self.client).await;
 
         let agent_env = cella_docker::config_map::env::agent_env_vars();
         if create_opts.env.is_empty() {
@@ -1516,4 +1586,70 @@ async fn create_claude_home_symlink(client: &DockerClient, container_id: &str, r
 async fn setup_plugin_manifests(client: &DockerClient, container_id: &str, remote_user: &str) {
     cella_orchestrator::tool_install::setup_plugin_manifests(client, container_id, remote_user)
         .await;
+}
+
+// ── Version skew helpers ─────────────────────────────────────────────────
+
+/// Write the `.daemon_addr` file to the shared agent volume.
+///
+/// Queries the daemon for its current control port and auth token, then
+/// writes them to `/cella/.daemon_addr` on the volume so agents can
+/// discover the daemon on startup and reconnect after restarts.
+async fn write_daemon_addr_to_volume(client: &DockerClient) {
+    let Some(mgmt_sock) = cella_env::paths::daemon_socket_path() else {
+        return;
+    };
+    if !mgmt_sock.exists() {
+        return;
+    }
+
+    let Ok(cella_port::protocol::ManagementResponse::Status {
+        control_port,
+        control_token,
+        ..
+    }) = cella_daemon::management::send_management_request(
+        &mgmt_sock,
+        &cella_port::protocol::ManagementRequest::QueryStatus,
+    )
+    .await
+    else {
+        warn!("Failed to query daemon status for .daemon_addr write");
+        return;
+    };
+
+    let addr = format!("host.docker.internal:{control_port}");
+    if let Err(e) =
+        cella_docker::volume::write_daemon_addr_file(client.inner(), &addr, &control_token).await
+    {
+        warn!("Failed to write .daemon_addr to agent volume: {e}");
+    }
+}
+
+/// Kill the running cella-agent and restart it using the stable symlink.
+///
+/// Used after volume repopulation or daemon restart to ensure the agent
+/// connects to the current daemon with the latest binary.
+async fn restart_agent_in_container(client: &DockerClient, container_id: &str) {
+    let agent_path = cella_docker::volume::agent_symlink_path();
+    let script = format!(
+        "pkill -f 'cella-agent daemon' 2>/dev/null; \
+         \"{agent_path}\" daemon \
+         --poll-interval \"${{CELLA_PORT_POLL_INTERVAL:-1000}}\" &"
+    );
+
+    match client
+        .exec_detached(
+            container_id,
+            &ExecOptions {
+                cmd: vec!["sh".to_string(), "-c".to_string(), script],
+                user: Some("root".to_string()),
+                env: None,
+                working_dir: None,
+            },
+        )
+        .await
+    {
+        Ok(_) => info!("Agent restarted in container {container_id}"),
+        Err(e) => warn!("Failed to restart agent in container: {e}"),
+    }
 }

--- a/crates/cella-docker/src/volume.rs
+++ b/crates/cella-docker/src/volume.rs
@@ -75,6 +75,14 @@ pub fn browser_helper_path() -> String {
     format!("{AGENT_PATH_PREFIX}/bin/cella-browser")
 }
 
+/// Stable symlink path for the agent binary inside the container.
+///
+/// Points to the latest versioned agent binary. Survives version upgrades
+/// so containers with hardcoded CMD paths continue to work.
+pub fn agent_symlink_path() -> String {
+    format!("{AGENT_PATH_PREFIX}/bin/cella-agent")
+}
+
 /// Get the CLI symlink path inside the container.
 ///
 /// This symlink points to the agent binary. When invoked via this path,
@@ -85,9 +93,17 @@ pub fn cli_symlink_path() -> String {
 
 /// Get the credential helper path inside the container.
 ///
-/// Uses the agent binary directly with the `credential` subcommand.
+/// Uses the stable agent symlink with the `credential` subcommand.
 pub fn credential_helper_path() -> String {
     format!("{AGENT_PATH_PREFIX}/bin/cella-agent credential")
+}
+
+/// Path for the daemon address file on the shared agent volume.
+///
+/// Contains two lines: `host:port` and auth token. Read by agents to
+/// discover the daemon, enabling self-healing on daemon restarts.
+pub const fn daemon_addr_file_path() -> &'static str {
+    "/cella/.daemon_addr"
 }
 
 /// Generate the mount configuration for the agent volume.
@@ -151,8 +167,10 @@ pub async fn detect_container_arch(docker: &Docker) -> Result<String, CellaDocke
 /// This script is placed at `/cella/bin/cella-browser` and set as the
 /// `BROWSER` env var. When called, it forwards the URL to the agent
 /// which sends it to the host daemon via the control socket.
-pub fn browser_helper_script(version: &str, arch: &str) -> Vec<u8> {
-    let agent_path = agent_binary_path(version, arch);
+///
+/// Uses the stable symlink so the script survives version upgrades.
+pub fn browser_helper_script() -> Vec<u8> {
+    let agent_path = agent_symlink_path();
     let script = format!(
         r#"#!/bin/sh
 # cella browser helper — forwards URLs to host via cella-agent.
@@ -258,7 +276,7 @@ async fn populate_volume(
     skip_checksum: bool,
 ) -> Result<(), CellaDockerError> {
     let agent_bytes = get_agent_binary_bytes(docker, arch, skip_checksum).await?;
-    let browser_script = browser_helper_script(version, arch);
+    let browser_script = browser_helper_script();
 
     upload_to_volume(
         docker,
@@ -911,16 +929,29 @@ fn build_volume_tar(
                 message: format!("tar append browser: {e}"),
             })?;
 
-        // CLI symlink: /cella/bin/cella -> agent binary
-        // When invoked as "cella", the agent enters CLI mode for in-container commands.
+        // Stable agent symlink: /cella/bin/cella-agent -> versioned binary
+        // Survives version upgrades so CMD paths and credential helpers keep working.
+        let agent_link_target = format!("/cella/v{version}/{arch}/cella-agent");
         let mut header = tar::Header::new_gnu();
-        let link_target = format!("/cella/v{version}/{arch}/cella-agent");
         header.set_entry_type(tar::EntryType::Symlink);
         header.set_size(0);
         header.set_mode(0o755);
         header.set_cksum();
         archive
-            .append_link(&mut header, "cella/bin/cella", &link_target)
+            .append_link(&mut header, "cella/bin/cella-agent", &agent_link_target)
+            .map_err(|e| CellaDockerError::AgentVolume {
+                message: format!("tar append cella-agent symlink: {e}"),
+            })?;
+
+        // CLI symlink: /cella/bin/cella -> stable agent symlink
+        // When invoked as "cella", the agent enters CLI mode for in-container commands.
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Symlink);
+        header.set_size(0);
+        header.set_mode(0o755);
+        header.set_cksum();
+        archive
+            .append_link(&mut header, "cella/bin/cella", "/cella/bin/cella-agent")
             .map_err(|e| CellaDockerError::AgentVolume {
                 message: format!("tar append cella symlink: {e}"),
             })?;
@@ -944,6 +975,333 @@ fn build_volume_tar(
             })?;
     }
     Ok(buf)
+}
+
+/// Write the daemon address file to the agent volume.
+///
+/// The file contains two lines: the daemon address (`host:port`) and the
+/// auth token. Agents read this file on startup and reconnect to discover
+/// the current daemon, enabling self-healing after daemon restarts.
+///
+/// # Errors
+///
+/// Returns error if volume access or file upload fails.
+pub async fn write_daemon_addr_file(
+    docker: &Docker,
+    daemon_addr: &str,
+    daemon_token: &str,
+) -> Result<(), CellaDockerError> {
+    ensure_image_pulled(docker, "alpine:3").await?;
+
+    let container_name = "cella-daemon-addr-write";
+
+    let _ = docker
+        .remove_container(
+            container_name,
+            Some(RemoveContainerOptions {
+                force: true,
+                ..Default::default()
+            }),
+        )
+        .await;
+
+    let config = ContainerCreateBody {
+        image: Some("alpine:3".to_string()),
+        cmd: Some(vec!["sleep".to_string(), "10".to_string()]),
+        host_config: Some(bollard::models::HostConfig {
+            mounts: Some(vec![bollard::models::Mount {
+                target: Some("/cella".to_string()),
+                source: Some(AGENT_VOLUME_NAME.to_string()),
+                typ: Some(bollard::models::MountTypeEnum::VOLUME),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    docker
+        .create_container(
+            Some(BollardCreateOpts {
+                name: Some(container_name.to_string()),
+                ..Default::default()
+            }),
+            config,
+        )
+        .await?;
+
+    docker
+        .start_container(container_name, None::<StartContainerOptions>)
+        .await?;
+
+    // Build a tar with just the .daemon_addr file
+    let content = format!("{daemon_addr}\n{daemon_token}\n");
+    let content_bytes = content.as_bytes();
+    let mut buf = Vec::new();
+    {
+        let mut archive = tar::Builder::new(&mut buf);
+        let mut header = tar::Header::new_gnu();
+        header.set_size(content_bytes.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        archive
+            .append_data(&mut header, "cella/.daemon_addr", content_bytes)
+            .map_err(|e| CellaDockerError::AgentVolume {
+                message: format!("tar append .daemon_addr: {e}"),
+            })?;
+        archive
+            .finish()
+            .map_err(|e| CellaDockerError::AgentVolume {
+                message: format!("tar finish: {e}"),
+            })?;
+    }
+
+    docker
+        .upload_to_container(
+            container_name,
+            Some(bollard::query_parameters::UploadToContainerOptions {
+                path: "/".to_string(),
+                ..Default::default()
+            }),
+            bollard::body_full(buf.into()),
+        )
+        .await?;
+
+    let _ = docker
+        .stop_container(
+            container_name,
+            None::<bollard::query_parameters::StopContainerOptions>,
+        )
+        .await;
+    let _ = docker
+        .remove_container(
+            container_name,
+            Some(RemoveContainerOptions {
+                force: true,
+                ..Default::default()
+            }),
+        )
+        .await;
+
+    debug!("Wrote .daemon_addr file to agent volume");
+    Ok(())
+}
+
+/// Prune old agent versions from the volume, keeping the current version
+/// and any versions used by running containers.
+///
+/// # Errors
+///
+/// Returns error if Docker API calls fail.
+pub async fn prune_old_agent_versions(
+    docker: &Docker,
+    current_version: &str,
+) -> Result<(), CellaDockerError> {
+    ensure_image_pulled(docker, "alpine:3").await?;
+
+    // Find versions used by running cella containers
+    let mut versions_in_use = std::collections::HashSet::new();
+    versions_in_use.insert(current_version.to_string());
+
+    let filters: std::collections::HashMap<String, Vec<String>> = [
+        (
+            "label".to_string(),
+            vec!["dev.cella.tool=cella".to_string()],
+        ),
+        ("status".to_string(), vec!["running".to_string()]),
+    ]
+    .into_iter()
+    .collect();
+    if let Ok(containers) = docker
+        .list_containers(Some(bollard::query_parameters::ListContainersOptions {
+            filters: Some(filters),
+            ..Default::default()
+        }))
+        .await
+    {
+        for c in &containers {
+            if let Some(labels) = &c.labels
+                && let Some(ver) = labels.get("dev.cella.version")
+            {
+                versions_in_use.insert(ver.clone());
+            }
+        }
+    }
+
+    let versions_on_volume = list_volume_versions(docker).await?;
+
+    let to_delete: Vec<&String> = versions_on_volume
+        .iter()
+        .filter(|v| !versions_in_use.contains(v.as_str()))
+        .collect();
+
+    if to_delete.is_empty() {
+        return Ok(());
+    }
+
+    delete_version_dirs(docker, &to_delete).await
+}
+
+/// List agent version directories present on the volume.
+async fn list_volume_versions(docker: &Docker) -> Result<Vec<String>, CellaDockerError> {
+    let container_name = "cella-version-prune";
+    let _ = docker
+        .remove_container(
+            container_name,
+            Some(RemoveContainerOptions {
+                force: true,
+                ..Default::default()
+            }),
+        )
+        .await;
+
+    let config = ContainerCreateBody {
+        image: Some("alpine:3".to_string()),
+        cmd: Some(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "ls -d /cella/v*/ 2>/dev/null | sed 's|/cella/v||;s|/||g'".to_string(),
+        ]),
+        host_config: Some(bollard::models::HostConfig {
+            mounts: Some(vec![bollard::models::Mount {
+                target: Some("/cella".to_string()),
+                source: Some(AGENT_VOLUME_NAME.to_string()),
+                typ: Some(bollard::models::MountTypeEnum::VOLUME),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    docker
+        .create_container(
+            Some(BollardCreateOpts {
+                name: Some(container_name.to_string()),
+                ..Default::default()
+            }),
+            config,
+        )
+        .await?;
+
+    docker
+        .start_container(container_name, None::<StartContainerOptions>)
+        .await?;
+
+    let mut wait_stream =
+        docker.wait_container(container_name, Some(WaitContainerOptions::default()));
+    while let Some(result) = wait_stream.next().await {
+        if result.is_err() {
+            break;
+        }
+    }
+
+    let log_opts = bollard::query_parameters::LogsOptions {
+        stdout: true,
+        ..Default::default()
+    };
+    let mut log_stream = docker.logs(container_name, Some(log_opts));
+    let mut output = String::new();
+    while let Some(Ok(chunk)) = log_stream.next().await {
+        output.push_str(&chunk.to_string());
+    }
+
+    let _ = docker
+        .remove_container(
+            container_name,
+            Some(RemoveContainerOptions {
+                force: true,
+                ..Default::default()
+            }),
+        )
+        .await;
+
+    Ok(output
+        .lines()
+        .map(|l| l.trim().to_string())
+        .filter(|l| !l.is_empty())
+        .collect())
+}
+
+/// Delete specific version directories from the agent volume.
+async fn delete_version_dirs(
+    docker: &Docker,
+    versions: &[&String],
+) -> Result<(), CellaDockerError> {
+    let rm_cmds: Vec<String> = versions
+        .iter()
+        .map(|v| format!("rm -rf /cella/v{v}"))
+        .collect();
+    let rm_script = rm_cmds.join(" && ");
+
+    let container_name = "cella-version-prune-rm";
+    let _ = docker
+        .remove_container(
+            container_name,
+            Some(RemoveContainerOptions {
+                force: true,
+                ..Default::default()
+            }),
+        )
+        .await;
+
+    let config = ContainerCreateBody {
+        image: Some("alpine:3".to_string()),
+        cmd: Some(vec!["sh".to_string(), "-c".to_string(), rm_script]),
+        host_config: Some(bollard::models::HostConfig {
+            mounts: Some(vec![bollard::models::Mount {
+                target: Some("/cella".to_string()),
+                source: Some(AGENT_VOLUME_NAME.to_string()),
+                typ: Some(bollard::models::MountTypeEnum::VOLUME),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    docker
+        .create_container(
+            Some(BollardCreateOpts {
+                name: Some(container_name.to_string()),
+                ..Default::default()
+            }),
+            config,
+        )
+        .await?;
+
+    docker
+        .start_container(container_name, None::<StartContainerOptions>)
+        .await?;
+
+    let mut wait_stream =
+        docker.wait_container(container_name, Some(WaitContainerOptions::default()));
+    while let Some(result) = wait_stream.next().await {
+        if result.is_err() {
+            break;
+        }
+    }
+
+    info!(
+        "Pruned old agent versions: {}",
+        versions
+            .iter()
+            .map(|v| format!("v{v}"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+
+    let _ = docker
+        .remove_container(
+            container_name,
+            Some(RemoveContainerOptions {
+                force: true,
+                ..Default::default()
+            }),
+        )
+        .await;
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -972,10 +1330,15 @@ mod tests {
     }
 
     #[test]
-    fn browser_script_contains_agent_path() {
-        let script = browser_helper_script("0.1.0", "x86_64");
+    fn agent_symlink_path_format() {
+        assert_eq!(agent_symlink_path(), "/cella/bin/cella-agent");
+    }
+
+    #[test]
+    fn browser_script_uses_stable_symlink() {
+        let script = browser_helper_script();
         let content = String::from_utf8(script).unwrap();
-        assert!(content.contains("/cella/v0.1.0/x86_64/cella-agent"));
+        assert!(content.contains("/cella/bin/cella-agent"));
         assert!(content.contains("browser-open"));
     }
 
@@ -1034,7 +1397,7 @@ mod tests {
     }
 
     #[test]
-    fn build_volume_tar_cella_symlink_points_to_agent() {
+    fn build_volume_tar_agent_symlink_points_to_versioned() {
         let agent_bytes = b"fake-binary";
         let browser_bytes = b"#!/bin/sh";
         let marker = "0.1.0/x86_64\n";
@@ -1043,17 +1406,29 @@ mod tests {
             build_volume_tar("0.1.0", "x86_64", agent_bytes, browser_bytes, marker).unwrap();
 
         let mut archive = tar::Archive::new(tar_bytes.as_slice());
+        let mut found_agent_symlink = false;
+        let mut found_cella_symlink = false;
         for entry in archive.entries().unwrap() {
             let entry = entry.unwrap();
             let path = entry.path().unwrap().to_string_lossy().to_string();
-            if path == "cella/bin/cella" {
+            if path == "cella/bin/cella-agent" {
                 assert_eq!(entry.header().entry_type(), tar::EntryType::Symlink);
                 let link = entry.link_name().unwrap().unwrap();
                 assert_eq!(link.to_string_lossy(), "/cella/v0.1.0/x86_64/cella-agent");
-                return;
+                found_agent_symlink = true;
+            }
+            if path == "cella/bin/cella" {
+                assert_eq!(entry.header().entry_type(), tar::EntryType::Symlink);
+                let link = entry.link_name().unwrap().unwrap();
+                assert_eq!(link.to_string_lossy(), "/cella/bin/cella-agent");
+                found_cella_symlink = true;
             }
         }
-        panic!("cella/bin/cella symlink not found in tar");
+        assert!(
+            found_agent_symlink,
+            "cella/bin/cella-agent symlink not found"
+        );
+        assert!(found_cella_symlink, "cella/bin/cella symlink not found");
     }
 
     #[test]

--- a/crates/cella-doctor/src/checks/container.rs
+++ b/crates/cella-doctor/src/checks/container.rs
@@ -135,6 +135,9 @@ async fn check_single_container(
         fix_hint: None,
     });
 
+    // Version skew check
+    check_version_skew(client, container_id, &mut checks).await;
+
     // Agent connectivity via daemon
     check_agent_connectivity(&mut checks, container_name).await;
 
@@ -145,6 +148,38 @@ async fn check_single_container(
     check_ports(&mut checks, container_name).await;
 
     checks
+}
+
+async fn check_version_skew(
+    client: &DockerClient,
+    container_id: &str,
+    checks: &mut Vec<CheckResult>,
+) {
+    let Ok(info) = client.inspect_container(container_id).await else {
+        return;
+    };
+
+    let cli_version = env!("CARGO_PKG_VERSION");
+    let container_version = info
+        .labels
+        .get("dev.cella.version")
+        .map_or("unknown", String::as_str);
+
+    if container_version == cli_version {
+        checks.push(CheckResult {
+            name: "version".into(),
+            severity: Severity::Pass,
+            detail: container_version.to_string(),
+            fix_hint: None,
+        });
+    } else {
+        checks.push(CheckResult {
+            name: "version".into(),
+            severity: Severity::Warning,
+            detail: format!("container {container_version} != CLI {cli_version}"),
+            fix_hint: Some("Run `cella up` to update".into()),
+        });
+    }
 }
 
 async fn check_agent_connectivity(checks: &mut Vec<CheckResult>, container_name: &str) {

--- a/crates/cella-orchestrator/src/config_map/mod.rs
+++ b/crates/cella-orchestrator/src/config_map/mod.rs
@@ -155,7 +155,7 @@ fn map_merged_string_list(
 fn build_entrypoint_cmd(
     config: &serde_json::Value,
     feature_config: Option<&FeatureContainerConfig>,
-    agent_arch: &str,
+    _agent_arch: &str,
 ) -> (Option<Vec<String>>, Option<Vec<String>>) {
     use std::fmt::Write;
 
@@ -170,8 +170,7 @@ fn build_entrypoint_cmd(
 
     let mut script = String::from("echo Container started\ntrap \"exit 0\" 15\n");
 
-    let version = env!("CARGO_PKG_VERSION");
-    let agent_path = cella_docker::volume::agent_binary_path(version, agent_arch);
+    let agent_path = cella_docker::volume::agent_symlink_path();
     let _ = write!(
         script,
         "if [ -x \"{agent_path}\" ]; then\n  \


### PR DESCRIPTION
## Summary

- Fix agent connection failures after `cella down` → version update → `cella up` by writing a `.daemon_addr` file to the shared agent volume (authoritative source of daemon address + token)
- Add missing daemon registration in `handle_stopped()` path — previously the daemon rejected restarted agents with "unknown container"
- Add stable symlink `/cella/bin/cella-agent` so CMD paths and credential helpers survive version upgrades
- Agent self-healing: `try_reconnect()` falls back to `.daemon_addr` file when the original address fails, enabling automatic recovery after daemon restarts

### Additional changes
- Keep old agent versions on volume for running containers, prune stale versions on repopulation
- Kill + restart agent on version change in both stopped and running `cella up` paths
- Add `dev.cella.version` container label for version skew detection
- In-container `cella doctor` command for connectivity diagnostics
- Host-side doctor: per-container version skew check

## Test plan

- [x] `cella up` → verify agent connected via `cella doctor`
- [x] `cella down` → rebuild cella → `cella up` → verify agent connects (`.daemon_addr` file used)
- [x] While container running: rebuild cella → `cella up` → verify agent restarts with new version
- [x] Run `cella doctor` on host → verify version skew detection
- [x] Exec into container → `cella doctor` → verify all checks pass
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings -D clippy::all` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)