### PR TITLE
ci: run clippy on macOS to catch platform-gated lints

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,10 +28,18 @@ jobs:
         run: cargo fmt --all -- --check
 
   clippy:
-    name: Clippy
-    runs-on: ubuntu-24.04-arm
+    name: Clippy (${{ matrix.os }})
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
+    strategy:
+      matrix:
+        include:
+          - os: Linux
+            runner: ubuntu-24.04-arm
+
+          - os: macOS
+            runner: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/crates/cella-cli/src/backend.rs
+++ b/crates/cella-cli/src/backend.rs
@@ -81,6 +81,20 @@ fn connect_docker_backend(
     Ok(Box::new(client))
 }
 
+#[cfg(target_os = "macos")]
+fn connect_apple_container_backend()
+-> Result<Box<dyn ContainerBackend>, Box<dyn std::error::Error + Send + Sync>> {
+    let cli = cella_container::discovery::discover()
+        .ok_or("Apple Container CLI not found. Install from https://github.com/apple/container")?;
+
+    eprintln!(
+        "warning: Apple Container backend is experimental. \
+         Report issues at https://github.com/eve0415/cella/issues"
+    );
+
+    Ok(Box::new(cella_container::AppleContainerBackend::new(cli)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -133,18 +147,4 @@ mod tests {
         // Either connect succeeds (unlikely) or fails - we just exercise the path
         let _ = result;
     }
-}
-
-#[cfg(target_os = "macos")]
-fn connect_apple_container_backend()
--> Result<Box<dyn ContainerBackend>, Box<dyn std::error::Error + Send + Sync>> {
-    let cli = cella_container::discovery::discover()
-        .ok_or("Apple Container CLI not found. Install from https://github.com/apple/container")?;
-
-    eprintln!(
-        "warning: Apple Container backend is experimental. \
-         Report issues at https://github.com/eve0415/cella/issues"
-    );
-
-    Ok(Box::new(cella_container::AppleContainerBackend::new(cli)))
 }

--- a/crates/cella-container/src/integration_tests.rs
+++ b/crates/cella-container/src/integration_tests.rs
@@ -25,7 +25,7 @@ struct ContainerGuard {
 }
 
 impl ContainerGuard {
-    fn new(cli_path: PathBuf) -> Self {
+    const fn new(cli_path: PathBuf) -> Self {
         Self {
             cli_path,
             container_id: None,


### PR DESCRIPTION
## Summary
- Add macOS matrix entry to the CI clippy job so `target_os = "macos"` gated code gets linted
- Fix `missing_const_for_fn` clippy warning in `cella-container` integration tests
- Move `connect_apple_container_backend` above `#[cfg(test)]` module for consistent ordering

## Test plan
- [x] CI clippy passes on both Linux and macOS runners
- [x] No new clippy warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)