### PR TITLE
fix: make --backend flag work correctly across all commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,6 +325,7 @@ dependencies = [
  "chrono",
  "futures-util",
  "hex",
+ "serde",
  "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.18",

--- a/crates/cella-backend/Cargo.toml
+++ b/crates/cella-backend/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 chrono.workspace = true
 futures-util.workspace = true
 hex.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true

--- a/crates/cella-backend/src/lib.rs
+++ b/crates/cella-backend/src/lib.rs
@@ -12,8 +12,8 @@ pub use lifecycle::{
     LifecycleContext, OutputCallback, ParsedLifecycle, parse_lifecycle_command, run_lifecycle_phase,
 };
 pub use names::{
-    compose_labels, compose_project_name, container_labels, container_name, image_name,
-    image_name_with_features, worktree_labels,
+    BACKEND_LABEL, compose_labels, compose_project_name, container_labels, container_name,
+    image_name, image_name_with_features, worktree_labels,
 };
 pub use resolve::ContainerTarget;
 pub use traits::{BackendCapabilities, BoxFuture, ContainerBackend, Platform};

--- a/crates/cella-backend/src/names.rs
+++ b/crates/cella-backend/src/names.rs
@@ -89,6 +89,9 @@ pub fn image_name_with_features(
     format!("cella-img-{identifier}-{path_hash}-{feat_hash}")
 }
 
+/// Label key for the container backend kind.
+pub const BACKEND_LABEL: &str = "dev.cella.backend";
+
 /// Standard labels for cella containers.
 pub fn container_labels(
     workspace_root: &Path,

--- a/crates/cella-backend/src/types.rs
+++ b/crates/cella-backend/src/types.rs
@@ -3,13 +3,15 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::path::PathBuf;
+use std::str::FromStr;
 
 // ---------------------------------------------------------------------------
 // Backend kind
 // ---------------------------------------------------------------------------
 
 /// Which container backend is in use.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum BackendKind {
     Docker,
     Podman,
@@ -22,6 +24,19 @@ impl fmt::Display for BackendKind {
             Self::Docker => f.write_str("docker"),
             Self::Podman => f.write_str("podman"),
             Self::AppleContainer => f.write_str("apple-container"),
+        }
+    }
+}
+
+impl FromStr for BackendKind {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "docker" => Ok(Self::Docker),
+            "podman" => Ok(Self::Podman),
+            "apple-container" => Ok(Self::AppleContainer),
+            other => Err(format!("unknown backend kind: {other}")),
         }
     }
 }
@@ -255,6 +270,69 @@ mod tests {
     #[test]
     fn display_apple_container() {
         assert_eq!(BackendKind::AppleContainer.to_string(), "apple-container");
+    }
+
+    // -----------------------------------------------------------------------
+    // BackendKind::FromStr
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn from_str_docker() {
+        assert_eq!("docker".parse::<BackendKind>().unwrap(), BackendKind::Docker);
+    }
+
+    #[test]
+    fn from_str_podman() {
+        assert_eq!("podman".parse::<BackendKind>().unwrap(), BackendKind::Podman);
+    }
+
+    #[test]
+    fn from_str_apple_container() {
+        assert_eq!(
+            "apple-container".parse::<BackendKind>().unwrap(),
+            BackendKind::AppleContainer
+        );
+    }
+
+    #[test]
+    fn from_str_unknown() {
+        assert!("nope".parse::<BackendKind>().is_err());
+    }
+
+    #[test]
+    fn display_from_str_roundtrip() {
+        for kind in [
+            BackendKind::Docker,
+            BackendKind::Podman,
+            BackendKind::AppleContainer,
+        ] {
+            assert_eq!(kind.to_string().parse::<BackendKind>().unwrap(), kind);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // BackendKind serde
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn serde_roundtrip() {
+        for kind in [
+            BackendKind::Docker,
+            BackendKind::Podman,
+            BackendKind::AppleContainer,
+        ] {
+            let json = serde_json::to_string(&kind).unwrap();
+            let parsed: BackendKind = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, kind);
+        }
+    }
+
+    #[test]
+    fn serde_kebab_case() {
+        assert_eq!(
+            serde_json::to_string(&BackendKind::AppleContainer).unwrap(),
+            "\"apple-container\""
+        );
     }
 }
 

--- a/crates/cella-backend/src/types.rs
+++ b/crates/cella-backend/src/types.rs
@@ -278,12 +278,18 @@ mod tests {
 
     #[test]
     fn from_str_docker() {
-        assert_eq!("docker".parse::<BackendKind>().unwrap(), BackendKind::Docker);
+        assert_eq!(
+            "docker".parse::<BackendKind>().unwrap(),
+            BackendKind::Docker
+        );
     }
 
     #[test]
     fn from_str_podman() {
-        assert_eq!("podman".parse::<BackendKind>().unwrap(), BackendKind::Podman);
+        assert_eq!(
+            "podman".parse::<BackendKind>().unwrap(),
+            BackendKind::Podman
+        );
     }
 
     #[test]

--- a/crates/cella-cli/src/backend.rs
+++ b/crates/cella-cli/src/backend.rs
@@ -94,6 +94,12 @@ pub async fn resolve_backend(
 async fn auto_detect(
     docker_host: Option<&str>,
 ) -> Result<Box<dyn ContainerBackend>, Box<dyn std::error::Error + Send + Sync>> {
+    // Treat DOCKER_HOST env var the same as an explicit --docker-host: if the
+    // user configured a specific Docker endpoint, don't silently fall through
+    // to a different backend when it's unreachable.
+    let has_explicit_docker_target =
+        docker_host.is_some() || std::env::var_os("DOCKER_HOST").is_some();
+
     // Docker is highest priority.
     match connect_docker_backend(docker_host) {
         Ok(client) => {
@@ -103,7 +109,7 @@ async fn auto_detect(
             match client.ping().await {
                 Ok(()) => return Ok(client),
                 Err(e) => {
-                    if docker_host.is_some() {
+                    if has_explicit_docker_target {
                         return Err(e.into());
                     }
                     // Socket exists but daemon not responding — try next backend
@@ -113,7 +119,7 @@ async fn auto_detect(
         Err(e) => {
             // If the user explicitly targeted a Docker host, don't silently
             // fall back to a different backend — fail with the Docker error.
-            if docker_host.is_some() {
+            if has_explicit_docker_target {
                 return Err(e);
             }
         }

--- a/crates/cella-cli/src/backend.rs
+++ b/crates/cella-cli/src/backend.rs
@@ -55,6 +55,19 @@ impl BackendArgs {
         }
         resolve_backend(self.backend.as_ref(), self.docker_host.as_deref()).await
     }
+
+    /// Convenience wrapper that coerces the error to `Box<dyn Error>`.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if backend resolution fails (see [`resolve`](Self::resolve)).
+    pub async fn resolve_client(
+        &self,
+    ) -> Result<Box<dyn ContainerBackend>, Box<dyn std::error::Error>> {
+        self.resolve()
+            .await
+            .map_err(|e| e as Box<dyn std::error::Error>)
+    }
 }
 
 /// Resolve the container backend from user choice, auto-detecting if needed.

--- a/crates/cella-cli/src/backend.rs
+++ b/crates/cella-cli/src/backend.rs
@@ -214,4 +214,24 @@ mod tests {
         // Auto-detect: exercises the full path regardless of Docker availability
         let _ = args.resolve().await;
     }
+
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn backend_args_conflict_apple_container_docker_host() {
+        let args = BackendArgs {
+            backend: Some(BackendChoice::AppleContainer),
+            docker_host: Some("tcp://localhost:2375".to_string()),
+        };
+        let result = args.resolve().await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("--docker-host cannot be used"));
+    }
+
+    #[test]
+    fn backend_args_default_is_none() {
+        let args = BackendArgs::default();
+        assert!(args.backend.is_none());
+        assert!(args.docker_host.is_none());
+    }
 }

--- a/crates/cella-cli/src/backend.rs
+++ b/crates/cella-cli/src/backend.rs
@@ -222,10 +222,10 @@ mod tests {
             backend: Some(BackendChoice::AppleContainer),
             docker_host: Some("tcp://localhost:2375".to_string()),
         };
-        let result = args.resolve().await;
-        assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
-        assert!(err.contains("--docker-host cannot be used"));
+        match args.resolve().await {
+            Err(e) => assert!(e.to_string().contains("--docker-host cannot be used")),
+            Ok(_) => panic!("expected conflict error"),
+        }
     }
 
     #[test]

--- a/crates/cella-cli/src/backend.rs
+++ b/crates/cella-cli/src/backend.rs
@@ -22,15 +22,51 @@ impl BackendChoice {
     }
 }
 
+/// Shared CLI flags for backend selection.
+#[derive(clap::Args, Clone, Default)]
+pub struct BackendArgs {
+    /// Container backend to use (auto-detected if not specified).
+    #[arg(long, value_enum)]
+    pub backend: Option<BackendChoice>,
+
+    /// Explicit Docker host URL (overrides `DOCKER_HOST`).
+    #[arg(long)]
+    pub docker_host: Option<String>,
+}
+
+impl BackendArgs {
+    /// Resolve the container backend, validating flag combinations.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if `--backend apple-container` is combined with
+    /// `--docker-host`, or if no backend is available.
+    pub async fn resolve(
+        &self,
+    ) -> Result<Box<dyn ContainerBackend>, Box<dyn std::error::Error + Send + Sync>> {
+        #[cfg(target_os = "macos")]
+        if matches!(self.backend, Some(BackendChoice::AppleContainer)) && self.docker_host.is_some()
+        {
+            return Err(
+                "--docker-host cannot be used with --backend apple-container; \
+                 --docker-host is Docker-specific"
+                    .into(),
+            );
+        }
+        resolve_backend(self.backend.as_ref(), self.docker_host.as_deref()).await
+    }
+}
+
 /// Resolve the container backend from user choice, auto-detecting if needed.
 ///
-/// When `choice` is `None`, auto-detection tries Docker first. Apple Container
-/// is only attempted when Docker is unavailable and the host is macOS.
+/// When `choice` is `None`, auto-detection tries Docker first and pings to
+/// verify the daemon is responsive. Apple Container is only attempted when
+/// Docker is unavailable and the host is macOS.
 ///
 /// # Errors
 ///
 /// Returns error if no backend is available.
-pub fn resolve_backend(
+pub async fn resolve_backend(
     choice: Option<&BackendChoice>,
     docker_host: Option<&str>,
 ) -> Result<Box<dyn ContainerBackend>, Box<dyn std::error::Error + Send + Sync>> {
@@ -38,19 +74,29 @@ pub fn resolve_backend(
         Some(BackendChoice::Docker) => connect_docker_backend(docker_host),
         #[cfg(target_os = "macos")]
         Some(BackendChoice::AppleContainer) => connect_apple_container_backend(),
-        None => auto_detect(docker_host),
+        None => auto_detect(docker_host).await,
     }
 }
 
-fn auto_detect(
+async fn auto_detect(
     docker_host: Option<&str>,
 ) -> Result<Box<dyn ContainerBackend>, Box<dyn std::error::Error + Send + Sync>> {
     // Docker is highest priority.
-    // connect_docker_backend checks socket existence during discovery,
-    // so a successful connect means a socket was found (though the daemon
-    // may not be responding — that's caught later by ping() in commands).
     match connect_docker_backend(docker_host) {
-        Ok(client) => return Ok(client),
+        Ok(client) => {
+            // Verify the daemon is actually responding, not just that a socket
+            // exists. If Docker is installed but stopped, fall through to Apple
+            // Container instead of failing with a confusing error later.
+            match client.ping().await {
+                Ok(()) => return Ok(client),
+                Err(e) => {
+                    if docker_host.is_some() {
+                        return Err(e.into());
+                    }
+                    // Socket exists but daemon not responding — try next backend
+                }
+            }
+        }
         Err(e) => {
             // If the user explicitly targeted a Docker host, don't silently
             // fall back to a different backend — fail with the Docker error.
@@ -120,31 +166,39 @@ mod tests {
         assert!(matches!(choice.to_kind(), BackendKind::AppleContainer));
     }
 
-    #[test]
-    fn resolve_backend_explicit_docker() {
+    #[tokio::test]
+    async fn resolve_backend_explicit_docker() {
         // Explicit Docker choice should attempt Docker connection.
         // This will succeed or fail depending on Docker availability,
         // but the match arm is exercised either way.
-        let result = resolve_backend(Some(&BackendChoice::Docker), None);
+        let result = resolve_backend(Some(&BackendChoice::Docker), None).await;
         // We only care that it doesn't panic - Docker may or may not be available
         let _ = result;
     }
 
-    #[test]
-    fn resolve_backend_auto_detect() {
+    #[tokio::test]
+    async fn resolve_backend_auto_detect() {
         // Auto-detect with no choice should try Docker first.
-        let result = resolve_backend(None, None);
+        let result = resolve_backend(None, None).await;
         let _ = result;
     }
 
-    #[test]
-    fn resolve_backend_with_invalid_host() {
+    #[tokio::test]
+    async fn resolve_backend_with_invalid_host() {
         // A clearly invalid host should fail
         let result = resolve_backend(
             Some(&BackendChoice::Docker),
             Some("tcp://invalid-host-that-does-not-exist:99999"),
-        );
+        )
+        .await;
         // Either connect succeeds (unlikely) or fails - we just exercise the path
         let _ = result;
+    }
+
+    #[tokio::test]
+    async fn backend_args_resolve_exercises_path() {
+        let args = BackendArgs::default();
+        // Auto-detect: exercises the full path regardless of Docker availability
+        let _ = args.resolve().await;
     }
 }

--- a/crates/cella-cli/src/commands/branch.rs
+++ b/crates/cella-cli/src/commands/branch.rs
@@ -20,9 +20,8 @@ pub struct BranchArgs {
     #[arg(long = "exec")]
     pub exec_cmd: Option<String>,
 
-    /// Explicit Docker host URL (overrides `DOCKER_HOST`).
-    #[arg(long)]
-    docker_host: Option<String>,
+    #[command(flatten)]
+    backend: crate::backend::BackendArgs,
 
     /// Output format.
     #[arg(long, value_enum, default_value = "text")]
@@ -33,7 +32,6 @@ impl BranchArgs {
     pub async fn execute(
         self,
         progress: crate::progress::Progress,
-        backend: Option<&crate::backend::BackendChoice>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         // 1. Discover git repo
         let cwd = std::env::current_dir()?;
@@ -57,7 +55,7 @@ impl BranchArgs {
 
         // 3. Run container pipeline (with rollback on failure)
         let result = self
-            .run_container_pipeline(&wt_path, repo_root, &progress, backend)
+            .run_container_pipeline(&wt_path, repo_root, &progress)
             .await;
 
         if let Err(e) = &result {
@@ -80,7 +78,6 @@ impl BranchArgs {
         wt_path: &std::path::Path,
         repo_root: &std::path::Path,
         progress: &crate::progress::Progress,
-        backend: Option<&crate::backend::BackendChoice>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         // Prepare worktree-specific labels
         let extra_labels = worktree_labels(&self.name, repo_root);
@@ -88,11 +85,10 @@ impl BranchArgs {
         // Create the container using the up pipeline
         let ctx = UpContext::for_workspace(
             wt_path,
-            self.docker_host.as_deref(),
+            &self.backend,
             extra_labels,
             progress.clone(),
             self.output.clone(),
-            backend,
         )
         .await?;
 

--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -64,7 +64,7 @@ impl BuildArgs {
         let config = &resolved.config;
         let config_name = config.get("name").and_then(|v| v.as_str());
 
-        let client = super::resolve_backend_for_command(backend, self.docker_host.as_deref())?;
+        let client = super::resolve_backend_for_command(backend, self.docker_host.as_deref()).await?;
         client.ping().await?;
 
         // Docker Compose path: delegate to orchestrator

--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -26,9 +26,8 @@ pub struct BuildArgs {
     #[arg(long)]
     file: Option<PathBuf>,
 
-    /// Explicit Docker host URL (overrides `DOCKER_HOST`).
-    #[arg(long)]
-    docker_host: Option<String>,
+    #[command(flatten)]
+    backend: crate::backend::BackendArgs,
 
     /// Output format.
     #[arg(long, value_enum, default_value = "text")]
@@ -50,7 +49,6 @@ impl BuildArgs {
     pub async fn execute(
         self,
         progress: crate::progress::Progress,
-        backend: Option<&crate::backend::BackendChoice>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let cwd = super::resolve_workspace_folder(self.workspace_folder.as_deref())?;
 
@@ -64,7 +62,7 @@ impl BuildArgs {
         let config = &resolved.config;
         let config_name = config.get("name").and_then(|v| v.as_str());
 
-        let client = super::resolve_backend_for_command(backend, self.docker_host.as_deref()).await?;
+        let client = self.backend.resolve_client().await?;
         client.ping().await?;
 
         // Docker Compose path: delegate to orchestrator

--- a/crates/cella-cli/src/commands/code.rs
+++ b/crates/cella-cli/src/commands/code.rs
@@ -46,7 +46,6 @@ impl CodeArgs {
     pub async fn execute(
         self,
         progress: crate::progress::Progress,
-        backend: Option<&crate::backend::BackendChoice>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         // 1. Check for remote Docker (unsupported)
         check_local_docker()?;
@@ -61,7 +60,7 @@ impl CodeArgs {
         let output_format = self.up.output.clone();
         let mut up = self.up;
         picker::resolve_up_workspace(&mut up).await;
-        let ctx = UpContext::new(&up, progress, backend).await?;
+        let ctx = UpContext::new(&up, progress).await?;
 
         // Reject non-Docker backends — VS Code attach URI is Docker-specific
         if ctx.client.kind() != cella_backend::BackendKind::Docker {

--- a/crates/cella-cli/src/commands/credential.rs
+++ b/crates/cella-cli/src/commands/credential.rs
@@ -50,20 +50,18 @@ enum CredentialTool {
 }
 
 impl CredentialArgs {
-    pub async fn execute(
-        self,
-        backend: Option<&crate::backend::BackendChoice>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+        let backend = crate::backend::BackendArgs::default();
         match self.command {
-            CredentialCommand::Sync(args) => run_sync(args, backend).await,
-            CredentialCommand::Status(args) => run_status(args, backend).await,
+            CredentialCommand::Sync(args) => run_sync(args, &backend).await,
+            CredentialCommand::Status(args) => run_status(args, &backend).await,
         }
     }
 }
 
 async fn run_sync(
     args: SyncArgs,
-    backend: Option<&crate::backend::BackendChoice>,
+    backend: &crate::backend::BackendArgs,
 ) -> Result<(), Box<dyn std::error::Error>> {
     match args.tool {
         CredentialTool::Gh => sync_gh(args.container, args.workspace_folder, backend).await,
@@ -73,9 +71,9 @@ async fn run_sync(
 async fn sync_gh(
     container_id_override: Option<String>,
     workspace_folder: Option<PathBuf>,
-    backend: Option<&crate::backend::BackendChoice>,
+    backend: &crate::backend::BackendArgs,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let client = super::resolve_backend_for_command(backend, None).await?;
+    let client = backend.resolve_client().await?;
 
     let cwd = super::resolve_workspace_folder(workspace_folder.as_deref())?;
 
@@ -178,7 +176,7 @@ async fn sync_gh(
 
 async fn run_status(
     args: StatusArgs,
-    backend: Option<&crate::backend::BackendChoice>,
+    backend: &crate::backend::BackendArgs,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let redactor = cella_doctor::redact::Redactor::new();
 
@@ -222,7 +220,7 @@ async fn run_status(
     );
 
     // Container section
-    let client = super::resolve_backend_for_command(backend, None).await?;
+    let client = backend.resolve_client().await?;
     let target = ContainerTarget {
         container_id: args.container,
         container_name: None,

--- a/crates/cella-cli/src/commands/credential.rs
+++ b/crates/cella-cli/src/commands/credential.rs
@@ -8,6 +8,8 @@ use cella_backend::{ContainerTarget, ExecOptions, FileToUpload};
 /// Manage credential forwarding for dev containers.
 #[derive(Args)]
 pub struct CredentialArgs {
+    #[command(flatten)]
+    backend: crate::backend::BackendArgs,
     #[command(subcommand)]
     command: CredentialCommand,
 }
@@ -51,10 +53,9 @@ enum CredentialTool {
 
 impl CredentialArgs {
     pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
-        let backend = crate::backend::BackendArgs::default();
         match self.command {
-            CredentialCommand::Sync(args) => run_sync(args, &backend).await,
-            CredentialCommand::Status(args) => run_status(args, &backend).await,
+            CredentialCommand::Sync(args) => run_sync(args, &self.backend).await,
+            CredentialCommand::Status(args) => run_status(args, &self.backend).await,
         }
     }
 }

--- a/crates/cella-cli/src/commands/credential.rs
+++ b/crates/cella-cli/src/commands/credential.rs
@@ -75,7 +75,7 @@ async fn sync_gh(
     workspace_folder: Option<PathBuf>,
     backend: Option<&crate::backend::BackendChoice>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let client = super::resolve_backend_for_command(backend, None)?;
+    let client = super::resolve_backend_for_command(backend, None).await?;
 
     let cwd = super::resolve_workspace_folder(workspace_folder.as_deref())?;
 
@@ -222,7 +222,7 @@ async fn run_status(
     );
 
     // Container section
-    let client = super::resolve_backend_for_command(backend, None)?;
+    let client = super::resolve_backend_for_command(backend, None).await?;
     let target = ContainerTarget {
         container_id: args.container,
         container_name: None,

--- a/crates/cella-cli/src/commands/doctor.rs
+++ b/crates/cella-cli/src/commands/doctor.rs
@@ -24,7 +24,7 @@ impl DoctorArgs {
     ) -> Result<(), Box<dyn std::error::Error>> {
         let workspace_folder = std::env::current_dir().ok();
         let (backend_client, backend_error) =
-            match crate::commands::resolve_backend_for_command(backend, None) {
+            match crate::commands::resolve_backend_for_command(backend, None).await {
                 Ok(client) => (Some(client), None),
                 Err(e) => (None, Some(e.to_string())),
             };

--- a/crates/cella-cli/src/commands/doctor.rs
+++ b/crates/cella-cli/src/commands/doctor.rs
@@ -37,7 +37,8 @@ impl DoctorArgs {
         let mut report = checks::run_all_checks(&ctx).await;
 
         // Surface backend connection failure when explicitly requested
-        if let Some(err) = backend_error.filter(|_| self.backend.backend.is_some()) {
+        let explicit_backend = self.backend.backend.is_some() || self.backend.docker_host.is_some();
+        if let Some(err) = backend_error.filter(|_| explicit_backend) {
             report.categories.insert(
                 0,
                 CategoryReport::new(

--- a/crates/cella-cli/src/commands/doctor.rs
+++ b/crates/cella-cli/src/commands/doctor.rs
@@ -15,29 +15,30 @@ pub struct DoctorArgs {
     /// Disable redaction of sensitive information (home paths, tokens).
     #[arg(long)]
     no_redact: bool,
+    #[command(flatten)]
+    backend: crate::backend::BackendArgs,
 }
 
 impl DoctorArgs {
     pub async fn execute(
         self,
-        backend: Option<&crate::backend::BackendChoice>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let workspace_folder = std::env::current_dir().ok();
         let (backend_client, backend_error) =
-            match crate::commands::resolve_backend_for_command(backend, None).await {
+            match self.backend.resolve_client().await {
                 Ok(client) => (Some(client), None),
                 Err(e) => (None, Some(e.to_string())),
             };
         let backend_kind = backend_client
             .as_ref()
             .map(|c| c.kind())
-            .or_else(|| backend.map(crate::backend::BackendChoice::to_kind));
+            .or_else(|| self.backend.backend.as_ref().map(crate::backend::BackendChoice::to_kind));
         let ctx =
             checks::CheckContext::new(workspace_folder, self.all, backend_kind, backend_client);
         let mut report = checks::run_all_checks(&ctx).await;
 
         // Surface backend connection failure when explicitly requested
-        if let Some(err) = backend_error.filter(|_| backend.is_some()) {
+        if let Some(err) = backend_error.filter(|_| self.backend.backend.is_some()) {
             report.categories.insert(
                 0,
                 CategoryReport::new(

--- a/crates/cella-cli/src/commands/doctor.rs
+++ b/crates/cella-cli/src/commands/doctor.rs
@@ -20,19 +20,18 @@ pub struct DoctorArgs {
 }
 
 impl DoctorArgs {
-    pub async fn execute(
-        self,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
         let workspace_folder = std::env::current_dir().ok();
-        let (backend_client, backend_error) =
-            match self.backend.resolve_client().await {
-                Ok(client) => (Some(client), None),
-                Err(e) => (None, Some(e.to_string())),
-            };
-        let backend_kind = backend_client
-            .as_ref()
-            .map(|c| c.kind())
-            .or_else(|| self.backend.backend.as_ref().map(crate::backend::BackendChoice::to_kind));
+        let (backend_client, backend_error) = match self.backend.resolve_client().await {
+            Ok(client) => (Some(client), None),
+            Err(e) => (None, Some(e.to_string())),
+        };
+        let backend_kind = backend_client.as_ref().map(|c| c.kind()).or_else(|| {
+            self.backend
+                .backend
+                .as_ref()
+                .map(crate::backend::BackendChoice::to_kind)
+        });
         let ctx =
             checks::CheckContext::new(workspace_folder, self.all, backend_kind, backend_client);
         let mut report = checks::run_all_checks(&ctx).await;

--- a/crates/cella-cli/src/commands/down.rs
+++ b/crates/cella-cli/src/commands/down.rs
@@ -97,7 +97,7 @@ impl DownArgs {
         self,
         backend: Option<&crate::backend::BackendChoice>,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let client = super::resolve_backend_for_command(backend, self.docker_host.as_deref())?;
+        let client = super::resolve_backend_for_command(backend, self.docker_host.as_deref()).await?;
 
         let workspace_folder = if let Some(ref branch_name) = self.branch {
             Some(resolve_branch_to_path(branch_name)?)

--- a/crates/cella-cli/src/commands/down.rs
+++ b/crates/cella-cli/src/commands/down.rs
@@ -126,6 +126,7 @@ impl DownArgs {
             }
             Err(e) => return Err(e.into()),
         };
+        super::warn_if_missing_backend_label(&container);
 
         // For non-compose containers, honour shutdownAction from label
         if !discovery::is_compose_container(&container.labels) {

--- a/crates/cella-cli/src/commands/down.rs
+++ b/crates/cella-cli/src/commands/down.rs
@@ -44,9 +44,8 @@ pub struct DownArgs {
     #[arg(long)]
     branch: Option<String>,
 
-    /// Explicit Docker host URL (overrides `DOCKER_HOST`).
-    #[arg(long)]
-    docker_host: Option<String>,
+    #[command(flatten)]
+    backend: crate::backend::BackendArgs,
 
     /// Force stop even when shutdownAction is "none".
     #[arg(long)]
@@ -93,11 +92,8 @@ impl DownArgs {
         matches!(self.output, OutputFormat::Text)
     }
 
-    pub async fn execute(
-        self,
-        backend: Option<&crate::backend::BackendChoice>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let client = super::resolve_backend_for_command(backend, self.docker_host.as_deref()).await?;
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+        let client = self.backend.resolve_client().await?;
 
         let workspace_folder = if let Some(ref branch_name) = self.branch {
             Some(resolve_branch_to_path(branch_name)?)

--- a/crates/cella-cli/src/commands/exec.rs
+++ b/crates/cella-cli/src/commands/exec.rs
@@ -48,9 +48,8 @@ pub struct ExecArgs {
     #[arg(short, long)]
     detach: bool,
 
-    /// Explicit Docker host URL (overrides `DOCKER_HOST`).
-    #[arg(long)]
-    docker_host: Option<String>,
+    #[command(flatten)]
+    backend: crate::backend::BackendArgs,
 
     /// The command to execute.
     #[arg(trailing_var_arg = true, required = true)]
@@ -58,11 +57,8 @@ pub struct ExecArgs {
 }
 
 impl ExecArgs {
-    pub async fn execute(
-        self,
-        backend: Option<&crate::backend::BackendChoice>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let client = super::resolve_backend_for_command(backend, self.docker_host.as_deref()).await?;
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+        let client = self.backend.resolve_client().await?;
 
         let target = ContainerTarget {
             container_id: self.container_id,

--- a/crates/cella-cli/src/commands/exec.rs
+++ b/crates/cella-cli/src/commands/exec.rs
@@ -62,7 +62,7 @@ impl ExecArgs {
         self,
         backend: Option<&crate::backend::BackendChoice>,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let client = super::resolve_backend_for_command(backend, self.docker_host.as_deref())?;
+        let client = super::resolve_backend_for_command(backend, self.docker_host.as_deref()).await?;
 
         let target = ContainerTarget {
             container_id: self.container_id,

--- a/crates/cella-cli/src/commands/list.rs
+++ b/crates/cella-cli/src/commands/list.rs
@@ -27,7 +27,7 @@ impl ListArgs {
         self,
         backend: Option<&crate::backend::BackendChoice>,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let client = super::resolve_backend_for_command(backend, self.docker_host.as_deref())?;
+        let client = super::resolve_backend_for_command(backend, self.docker_host.as_deref()).await?;
 
         let containers = client.list_cella_containers(self.running).await?;
 

--- a/crates/cella-cli/src/commands/list.rs
+++ b/crates/cella-cli/src/commands/list.rs
@@ -17,17 +17,13 @@ pub struct ListArgs {
     #[arg(long)]
     json: bool,
 
-    /// Explicit Docker host URL (overrides `DOCKER_HOST`).
-    #[arg(long)]
-    docker_host: Option<String>,
+    #[command(flatten)]
+    backend: crate::backend::BackendArgs,
 }
 
 impl ListArgs {
-    pub async fn execute(
-        self,
-        backend: Option<&crate::backend::BackendChoice>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let client = super::resolve_backend_for_command(backend, self.docker_host.as_deref()).await?;
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+        let client = self.backend.resolve_client().await?;
 
         let containers = client.list_cella_containers(self.running).await?;
 

--- a/crates/cella-cli/src/commands/logs.rs
+++ b/crates/cella-cli/src/commands/logs.rs
@@ -54,7 +54,7 @@ impl LogsArgs {
         &self,
         backend: Option<&crate::backend::BackendChoice>,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let client = super::resolve_backend_for_command(backend, self.docker_host.as_deref())?;
+        let client = super::resolve_backend_for_command(backend, self.docker_host.as_deref()).await?;
 
         let cwd = super::resolve_workspace_folder(self.workspace_folder.as_deref())?;
 

--- a/crates/cella-cli/src/commands/logs.rs
+++ b/crates/cella-cli/src/commands/logs.rs
@@ -27,9 +27,8 @@ pub struct LogsArgs {
     #[arg(long)]
     workspace_folder: Option<PathBuf>,
 
-    /// Explicit Docker host URL (overrides `DOCKER_HOST`).
-    #[arg(long)]
-    docker_host: Option<String>,
+    #[command(flatten)]
+    backend: crate::backend::BackendArgs,
 
     /// Filter logs to a specific compose service (compose only).
     #[arg(long)]
@@ -37,24 +36,18 @@ pub struct LogsArgs {
 }
 
 impl LogsArgs {
-    pub async fn execute(
-        self,
-        backend: Option<&crate::backend::BackendChoice>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
         if self.daemon {
             return self.show_daemon_logs();
         }
         if self.lifecycle {
             return self.show_lifecycle_logs();
         }
-        self.show_container_logs(backend).await
+        self.show_container_logs().await
     }
 
-    async fn show_container_logs(
-        &self,
-        backend: Option<&crate::backend::BackendChoice>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let client = super::resolve_backend_for_command(backend, self.docker_host.as_deref()).await?;
+    async fn show_container_logs(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let client = self.backend.resolve_client().await?;
 
         let cwd = super::resolve_workspace_folder(self.workspace_folder.as_deref())?;
 

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -415,7 +415,7 @@ async fn re_register_containers(
                 forward_ports: vec![],
                 shutdown_action,
                 backend_kind: container.labels.get(cella_backend::BACKEND_LABEL).cloned(),
-                docker_host: None,
+                docker_host: std::env::var("DOCKER_HOST").ok(),
             },
         ));
 

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -137,53 +137,37 @@ impl Command {
     pub async fn execute(
         self,
         progress: Progress,
-        backend: Option<&crate::backend::BackendChoice>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         match self {
-            Self::Up(args) => args.execute(progress, backend).await,
-            Self::Code(args) => args.execute(progress, backend).await,
-            Self::Down(args) => args.execute(backend).await,
-            Self::Shell(args) => args.execute(backend).await,
-            Self::Exec(args) => args.execute(backend).await,
-            Self::Build(args) => args.execute(progress, backend).await,
-            Self::List(args) => args.execute(backend).await,
-            Self::Logs(args) => args.execute(backend).await,
-            Self::Doctor(args) => args.execute(backend).await,
-            Self::Branch(args) => args.execute(progress, backend).await,
-
-            Self::Switch(args) => args.execute(backend).await,
-            Self::Prune(args) => args.execute(backend).await,
+            Self::Up(args) => args.execute(progress).await,
+            Self::Code(args) => args.execute(progress).await,
+            Self::Down(args) => args.execute().await,
+            Self::Shell(args) => args.execute().await,
+            Self::Exec(args) => args.execute().await,
+            Self::Build(args) => args.execute(progress).await,
+            Self::List(args) => args.execute().await,
+            Self::Logs(args) => args.execute().await,
+            Self::Doctor(args) => args.execute().await,
+            Self::Branch(args) => args.execute(progress).await,
+            Self::Switch(args) => args.execute().await,
+            Self::Prune(args) => args.execute().await,
             Self::ReadConfiguration(args) => args.execute(),
             Self::Config(args) => args.execute(),
             Self::Template(args) => args.execute(),
             Self::Features(args) => args.execute(progress).await,
             Self::Init(args) => args.execute(progress).await,
-            Self::Nvim(args) => args.execute(progress, backend).await,
-            Self::Tmux(args) => args.execute(progress, backend).await,
+            Self::Nvim(args) => args.execute(progress).await,
+            Self::Tmux(args) => args.execute(progress).await,
             Self::Completions(args) => {
                 args.execute();
                 Ok(())
             }
-            Self::Credential(args) => args.execute(backend).await,
+            Self::Credential(args) => args.execute().await,
             Self::Network(args) => args.execute(),
-            Self::Ports(args) => args.execute(backend).await,
+            Self::Ports(args) => args.execute().await,
             Self::Daemon(args) => args.execute().await,
         }
     }
-}
-
-/// Resolve the container backend from user choice, with optional Docker host override.
-///
-/// # Errors
-///
-/// Returns error if no backend is available.
-pub async fn resolve_backend_for_command(
-    backend: Option<&crate::backend::BackendChoice>,
-    docker_host: Option<&str>,
-) -> Result<Box<dyn cella_backend::ContainerBackend>, Box<dyn std::error::Error>> {
-    crate::backend::resolve_backend(backend, docker_host)
-        .await
-        .map_err(|e| e as Box<dyn std::error::Error>)
 }
 
 /// Resolve the workspace folder from an optional argument or the current directory.
@@ -391,9 +375,9 @@ async fn re_register_containers(
 ) -> Result<(), Box<dyn std::error::Error>> {
     use cella_protocol::ManagementRequest;
 
-    let client = crate::backend::resolve_backend(None, None)
-        .await
-        .map_err(|e| e as Box<dyn std::error::Error>)?;
+    let client = crate::backend::BackendArgs::default()
+        .resolve_client()
+        .await?;
     let containers = client.list_cella_containers(true).await?;
 
     for container in &containers {

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -402,6 +402,11 @@ async fn re_register_containers(
             other_ports_attributes: other_ports_attrs,
             forward_ports: vec![],
             shutdown_action,
+            backend_kind: container
+                .labels
+                .get(cella_backend::BACKEND_LABEL)
+                .cloned(),
+            docker_host: None,
         };
 
         match cella_daemon::management::send_management_request(socket_path, &req).await {

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -170,6 +170,20 @@ impl Command {
     }
 }
 
+/// Emit a warning if a container lacks the `dev.cella.backend` label.
+///
+/// Pre-existing containers (created before backend labeling) won't have
+/// this label; we assume Docker and nudge the user to rebuild.
+pub fn warn_if_missing_backend_label(container: &cella_backend::ContainerInfo) {
+    if !container.labels.contains_key(cella_backend::BACKEND_LABEL) {
+        warn!(
+            "Container '{}' has no backend label. Assuming Docker. \
+             Run `cella up --rebuild` to add it.",
+            container.name
+        );
+    }
+}
+
 /// Resolve the workspace folder from an optional argument or the current directory.
 ///
 /// # Errors

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -177,11 +177,12 @@ impl Command {
 /// # Errors
 ///
 /// Returns error if no backend is available.
-pub fn resolve_backend_for_command(
+pub async fn resolve_backend_for_command(
     backend: Option<&crate::backend::BackendChoice>,
     docker_host: Option<&str>,
 ) -> Result<Box<dyn cella_backend::ContainerBackend>, Box<dyn std::error::Error>> {
     crate::backend::resolve_backend(backend, docker_host)
+        .await
         .map_err(|e| e as Box<dyn std::error::Error>)
 }
 
@@ -390,8 +391,9 @@ async fn re_register_containers(
 ) -> Result<(), Box<dyn std::error::Error>> {
     use cella_protocol::ManagementRequest;
 
-    let client =
-        crate::backend::resolve_backend(None, None).map_err(|e| e as Box<dyn std::error::Error>)?;
+    let client = crate::backend::resolve_backend(None, None)
+        .await
+        .map_err(|e| e as Box<dyn std::error::Error>)?;
     let containers = client.list_cella_containers(true).await?;
 
     for container in &containers {

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -408,20 +408,22 @@ async fn re_register_containers(
 
         let shutdown_action = container.labels.get("dev.cella.shutdown_action").cloned();
 
-        let req = ManagementRequest::RegisterContainer {
-            container_id: container.id.clone(),
-            container_name: container.name.clone(),
-            container_ip,
-            ports_attributes: ports_attrs,
-            other_ports_attributes: other_ports_attrs,
-            forward_ports: vec![],
-            shutdown_action,
-            backend_kind: container
-                .labels
-                .get(cella_backend::BACKEND_LABEL)
-                .cloned(),
-            docker_host: None,
-        };
+        let req = ManagementRequest::RegisterContainer(Box::new(
+            cella_protocol::ContainerRegistrationData {
+                container_id: container.id.clone(),
+                container_name: container.name.clone(),
+                container_ip,
+                ports_attributes: ports_attrs,
+                other_ports_attributes: other_ports_attrs,
+                forward_ports: vec![],
+                shutdown_action,
+                backend_kind: container
+                    .labels
+                    .get(cella_backend::BACKEND_LABEL)
+                    .cloned(),
+                docker_host: None,
+            },
+        ));
 
         match cella_daemon::management::send_management_request(socket_path, &req).await {
             Ok(resp) => {

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -134,10 +134,7 @@ impl Command {
         matches!(self, Self::Daemon(_))
     }
 
-    pub async fn execute(
-        self,
-        progress: Progress,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn execute(self, progress: Progress) -> Result<(), Box<dyn std::error::Error>> {
         match self {
             Self::Up(args) => args.execute(progress).await,
             Self::Code(args) => args.execute(progress).await,
@@ -417,10 +414,7 @@ async fn re_register_containers(
                 other_ports_attributes: other_ports_attrs,
                 forward_ports: vec![],
                 shutdown_action,
-                backend_kind: container
-                    .labels
-                    .get(cella_backend::BACKEND_LABEL)
-                    .cloned(),
+                backend_kind: container.labels.get(cella_backend::BACKEND_LABEL).cloned(),
                 docker_host: None,
             },
         ));

--- a/crates/cella-cli/src/commands/nvim.rs
+++ b/crates/cella-cli/src/commands/nvim.rs
@@ -34,7 +34,6 @@ impl NvimArgs {
     pub async fn execute(
         self,
         progress: crate::progress::Progress,
-        backend: Option<&crate::backend::BackendChoice>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         // 1. Ensure container is up
         let build_no_cache = self.up.build.build_no_cache;
@@ -42,7 +41,7 @@ impl NvimArgs {
         let output_format = self.up.output.clone();
         let mut up = self.up;
         picker::resolve_up_workspace(&mut up).await;
-        let ctx = UpContext::new(&up, progress, backend).await?;
+        let ctx = UpContext::new(&up, progress).await?;
         let result = ctx.ensure_up(build_no_cache, &strict).await?;
 
         // 2. Resolve compose service if needed

--- a/crates/cella-cli/src/commands/ports.rs
+++ b/crates/cella-cli/src/commands/ports.rs
@@ -78,7 +78,7 @@ async fn print_backend_ports(
     all: bool,
     backend: Option<&crate::backend::BackendChoice>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let client = super::resolve_backend_for_command(backend, None)?;
+    let client = super::resolve_backend_for_command(backend, None).await?;
     let containers = client.list_cella_containers(true).await?;
 
     // Check if any container is compose-managed and try compose ps

--- a/crates/cella-cli/src/commands/ports.rs
+++ b/crates/cella-cli/src/commands/ports.rs
@@ -9,16 +9,19 @@ pub struct PortsArgs {
     /// Show ports across all worktrees/containers.
     #[arg(long)]
     all: bool,
+    #[command(flatten)]
+    backend: crate::backend::BackendArgs,
 }
 
 impl PortsArgs {
-    pub async fn execute(
-        self,
-        backend: Option<&crate::backend::BackendChoice>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
         // Try querying the daemon first for dynamic port info — only when
         // the selected backend uses daemon-managed port forwarding.
-        let use_daemon = backend.is_none_or(|b| matches!(b, crate::backend::BackendChoice::Docker));
+        let use_daemon = self
+            .backend
+            .backend
+            .as_ref()
+            .is_none_or(|b| matches!(b, crate::backend::BackendChoice::Docker));
         if use_daemon
             && let Some(mgmt_sock) = cella_env::paths::daemon_socket_path()
             && mgmt_sock.exists()
@@ -46,7 +49,7 @@ impl PortsArgs {
         }
 
         // Fall back to the selected backend for static port bindings
-        print_backend_ports(self.all, backend).await
+        print_backend_ports(self.all, &self.backend).await
     }
 }
 
@@ -76,9 +79,9 @@ fn print_daemon_ports(ports: &[cella_protocol::ForwardedPortDetail]) {
 
 async fn print_backend_ports(
     all: bool,
-    backend: Option<&crate::backend::BackendChoice>,
+    backend_args: &crate::backend::BackendArgs,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let client = super::resolve_backend_for_command(backend, None).await?;
+    let client = backend_args.resolve_client().await?;
     let containers = client.list_cella_containers(true).await?;
 
     // Check if any container is compose-managed and try compose ps

--- a/crates/cella-cli/src/commands/ports.rs
+++ b/crates/cella-cli/src/commands/ports.rs
@@ -23,10 +23,14 @@ impl PortsArgs {
             .backend
             .as_ref()
             .is_none_or(|b| matches!(b, crate::backend::BackendChoice::Docker));
-        let has_custom_host =
-            self.backend.docker_host.is_some() || std::env::var_os("DOCKER_HOST").is_some();
+        let effective_host = self
+            .backend
+            .docker_host
+            .clone()
+            .or_else(|| std::env::var("DOCKER_HOST").ok());
+        let has_remote_host = effective_host.as_deref().is_some_and(is_remote_docker_host);
         if is_docker_backend
-            && !has_custom_host
+            && !has_remote_host
             && let Some(mgmt_sock) = cella_env::paths::daemon_socket_path()
             && mgmt_sock.exists()
         {
@@ -55,6 +59,24 @@ impl PortsArgs {
         // Fall back to the selected backend for static port bindings
         print_backend_ports(self.all, &self.backend).await
     }
+}
+
+/// Returns `true` when the Docker host points to a non-local engine.
+///
+/// Local aliases (`unix://` sockets, `tcp://localhost`, `tcp://127.0.0.1`)
+/// still target the same daemon the cella daemon manages, so the daemon
+/// fast-path should remain active for those.
+fn is_remote_docker_host(host: &str) -> bool {
+    if host.starts_with("unix://") || host.starts_with("npipe://") {
+        return false;
+    }
+    if let Some(rest) = host.strip_prefix("tcp://") {
+        let authority = rest.split('/').next().unwrap_or(rest);
+        let hostname = authority.split(':').next().unwrap_or(authority);
+        return !matches!(hostname, "localhost" | "127.0.0.1" | "::1" | "[::1]");
+    }
+    // Unknown scheme — assume remote to be safe
+    true
 }
 
 fn print_daemon_ports(ports: &[cella_protocol::ForwardedPortDetail]) {

--- a/crates/cella-cli/src/commands/ports.rs
+++ b/crates/cella-cli/src/commands/ports.rs
@@ -23,7 +23,8 @@ impl PortsArgs {
             .backend
             .as_ref()
             .is_none_or(|b| matches!(b, crate::backend::BackendChoice::Docker));
-        let has_custom_host = self.backend.docker_host.is_some();
+        let has_custom_host =
+            self.backend.docker_host.is_some() || std::env::var_os("DOCKER_HOST").is_some();
         if is_docker_backend
             && !has_custom_host
             && let Some(mgmt_sock) = cella_env::paths::daemon_socket_path()

--- a/crates/cella-cli/src/commands/ports.rs
+++ b/crates/cella-cli/src/commands/ports.rs
@@ -16,13 +16,16 @@ pub struct PortsArgs {
 impl PortsArgs {
     pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
         // Try querying the daemon first for dynamic port info — only when
-        // the selected backend uses daemon-managed port forwarding.
-        let use_daemon = self
+        // the selected backend uses daemon-managed port forwarding and no
+        // custom Docker host is specified (daemon tracks local containers only).
+        let is_docker_backend = self
             .backend
             .backend
             .as_ref()
             .is_none_or(|b| matches!(b, crate::backend::BackendChoice::Docker));
-        if use_daemon
+        let has_custom_host = self.backend.docker_host.is_some();
+        if is_docker_backend
+            && !has_custom_host
             && let Some(mgmt_sock) = cella_env::paths::daemon_socket_path()
             && mgmt_sock.exists()
         {

--- a/crates/cella-cli/src/commands/prune.rs
+++ b/crates/cella-cli/src/commands/prune.rs
@@ -53,7 +53,7 @@ impl PruneArgs {
         let repo_root = &repo_info.root;
 
         // 2. Build candidates via orchestrator
-        let client = super::resolve_backend_for_command(backend, self.docker_host.as_deref())?;
+        let client = super::resolve_backend_for_command(backend, self.docker_host.as_deref()).await?;
         if !self.is_json() {
             eprintln!("Fetching remote refs...");
         }

--- a/crates/cella-cli/src/commands/prune.rs
+++ b/crates/cella-cli/src/commands/prune.rs
@@ -29,9 +29,8 @@ pub struct PruneArgs {
     #[arg(long)]
     all: bool,
 
-    /// Explicit Docker host URL (overrides `DOCKER_HOST`).
-    #[arg(long)]
-    docker_host: Option<String>,
+    #[command(flatten)]
+    backend: crate::backend::BackendArgs,
 
     /// Output format (text or json).
     #[arg(long, default_value = "text")]
@@ -43,17 +42,14 @@ impl PruneArgs {
         matches!(self.output, OutputFormat::Json)
     }
 
-    pub async fn execute(
-        self,
-        backend: Option<&crate::backend::BackendChoice>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
         // 1. Discover git repo
         let cwd = std::env::current_dir()?;
         let repo_info = cella_git::discover(&cwd)?;
         let repo_root = &repo_info.root;
 
         // 2. Build candidates via orchestrator
-        let client = super::resolve_backend_for_command(backend, self.docker_host.as_deref()).await?;
+        let client = self.backend.resolve_client().await?;
         if !self.is_json() {
             eprintln!("Fetching remote refs...");
         }

--- a/crates/cella-cli/src/commands/shell.rs
+++ b/crates/cella-cli/src/commands/shell.rs
@@ -26,9 +26,8 @@ pub struct ShellArgs {
     #[arg(long)]
     container_name: Option<String>,
 
-    /// Explicit Docker host URL (overrides `DOCKER_HOST`).
-    #[arg(long)]
-    docker_host: Option<String>,
+    #[command(flatten)]
+    backend: crate::backend::BackendArgs,
 
     /// Target a specific compose service (defaults to primary service).
     #[arg(long)]
@@ -36,11 +35,8 @@ pub struct ShellArgs {
 }
 
 impl ShellArgs {
-    pub async fn execute(
-        self,
-        backend: Option<&crate::backend::BackendChoice>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let client = super::resolve_backend_for_command(backend, self.docker_host.as_deref()).await?;
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+        let client = self.backend.resolve_client().await?;
 
         let target = ContainerTarget {
             container_id: self.container_id,

--- a/crates/cella-cli/src/commands/shell.rs
+++ b/crates/cella-cli/src/commands/shell.rs
@@ -40,7 +40,7 @@ impl ShellArgs {
         self,
         backend: Option<&crate::backend::BackendChoice>,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let client = super::resolve_backend_for_command(backend, self.docker_host.as_deref())?;
+        let client = super::resolve_backend_for_command(backend, self.docker_host.as_deref()).await?;
 
         let target = ContainerTarget {
             container_id: self.container_id,

--- a/crates/cella-cli/src/commands/switch.rs
+++ b/crates/cella-cli/src/commands/switch.rs
@@ -25,7 +25,7 @@ impl SwitchArgs {
         self,
         backend: Option<&crate::backend::BackendChoice>,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let client = super::resolve_backend_for_command(backend, self.docker_host.as_deref())?;
+        let client = super::resolve_backend_for_command(backend, self.docker_host.as_deref()).await?;
 
         // Discover repo and list worktrees
         let cwd = std::env::current_dir()?;

--- a/crates/cella-cli/src/commands/switch.rs
+++ b/crates/cella-cli/src/commands/switch.rs
@@ -15,17 +15,13 @@ pub struct SwitchArgs {
     #[arg(short, long)]
     shell: Option<String>,
 
-    /// Explicit Docker host URL (overrides `DOCKER_HOST`).
-    #[arg(long)]
-    docker_host: Option<String>,
+    #[command(flatten)]
+    backend: crate::backend::BackendArgs,
 }
 
 impl SwitchArgs {
-    pub async fn execute(
-        self,
-        backend: Option<&crate::backend::BackendChoice>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let client = super::resolve_backend_for_command(backend, self.docker_host.as_deref()).await?;
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+        let client = self.backend.resolve_client().await?;
 
         // Discover repo and list worktrees
         let cwd = std::env::current_dir()?;

--- a/crates/cella-cli/src/commands/tmux.rs
+++ b/crates/cella-cli/src/commands/tmux.rs
@@ -41,13 +41,12 @@ impl TmuxArgs {
     pub async fn execute(
         self,
         progress: crate::progress::Progress,
-        backend: Option<&crate::backend::BackendChoice>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let (build_no_cache, force) = (self.up.build.build_no_cache, self.force);
         let (strict, output_format) = (self.up.strict.clone(), self.up.output.clone());
         let mut up = self.up;
         picker::resolve_up_workspace(&mut up).await;
-        let ctx = UpContext::new(&up, progress, backend).await?;
+        let ctx = UpContext::new(&up, progress).await?;
         let result = ctx.ensure_up(build_no_cache, &strict).await?;
         let container_id = if self.service.is_some() {
             let container = ctx.client.inspect_container(&result.container_id).await?;

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -271,17 +271,19 @@ impl UpContext {
             .get("shutdownAction")
             .and_then(|v| v.as_str())
             .map(String::from);
-        let req = cella_protocol::ManagementRequest::RegisterContainer {
-            container_id: container_id.to_string(),
-            container_name: self.container_nm.clone(),
-            container_ip,
-            ports_attributes: ports_attrs,
-            other_ports_attributes: other_ports_attrs,
-            forward_ports,
-            shutdown_action,
-            backend_kind: Some(self.client.kind().to_string()),
-            docker_host: None,
-        };
+        let req = cella_protocol::ManagementRequest::RegisterContainer(Box::new(
+            cella_protocol::ContainerRegistrationData {
+                container_id: container_id.to_string(),
+                container_name: self.container_nm.clone(),
+                container_ip,
+                ports_attributes: ports_attrs,
+                other_ports_attributes: other_ports_attrs,
+                forward_ports,
+                shutdown_action,
+                backend_kind: Some(self.client.kind().to_string()),
+                docker_host: None,
+            },
+        ));
         match cella_daemon::management::send_management_request(&mgmt_sock, &req).await {
             Ok(resp) => {
                 debug!("Container registered with daemon: {resp:?}");
@@ -534,17 +536,19 @@ impl cella_orchestrator::up::UpHooks for CliUpHooks<'_> {
                 .and_then(|v| v.as_str())
                 .map(String::from);
 
-            let req = cella_protocol::ManagementRequest::RegisterContainer {
-                container_id,
-                container_name,
-                container_ip,
-                ports_attributes: ports_attrs,
-                other_ports_attributes: other_ports_attrs,
-                forward_ports,
-                shutdown_action,
-                backend_kind: Some(backend_kind),
-                docker_host: None,
-            };
+            let req = cella_protocol::ManagementRequest::RegisterContainer(Box::new(
+                cella_protocol::ContainerRegistrationData {
+                    container_id,
+                    container_name,
+                    container_ip,
+                    ports_attributes: ports_attrs,
+                    other_ports_attributes: other_ports_attrs,
+                    forward_ports,
+                    shutdown_action,
+                    backend_kind: Some(backend_kind),
+                    docker_host: None,
+                },
+            ));
             let _ = cella_daemon::management::send_management_request(&mgmt_sock, &req).await;
         })
     }

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -161,7 +161,7 @@ impl UpContext {
             } else {
                 NetworkRulePolicy::Enforce
             },
-            docker_host: args.backend.docker_host.clone(),
+            docker_host: effective_docker_host(&args.backend),
         })
     }
 
@@ -223,7 +223,7 @@ impl UpContext {
             skip_checksum: false,
             extra_labels,
             network_rules: NetworkRulePolicy::Enforce,
-            docker_host: backend_args.docker_host.clone(),
+            docker_host: effective_docker_host(backend_args),
         })
     }
 
@@ -726,6 +726,17 @@ impl UpArgs {
 
 pub fn map_env_object(value: Option<&serde_json::Value>) -> Vec<String> {
     cella_orchestrator::container_setup::map_env_object(value)
+}
+
+/// Return the effective Docker host for daemon registration.
+///
+/// Prefers the explicit CLI `--docker-host` flag; falls back to the
+/// `DOCKER_HOST` environment variable so daemon-spawned follow-up
+/// operations target the same engine.
+fn effective_docker_host(args: &crate::backend::BackendArgs) -> Option<String> {
+    args.docker_host
+        .clone()
+        .or_else(|| std::env::var("DOCKER_HOST").ok())
 }
 
 pub fn output_result(

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -132,7 +132,7 @@ impl UpContext {
         // If Docker's socket exists but the daemon is stopped, auto-detect
         // won't fall through to Apple Container. Users can work around this
         // with `--backend apple-container`.
-        let client = super::resolve_backend_for_command(backend, args.docker_host.as_deref())?;
+        let client = super::resolve_backend_for_command(backend, args.docker_host.as_deref()).await?;
         client.ping().await?;
 
         let container_nm = container_name(&resolved.workspace_root, config_name);
@@ -198,7 +198,7 @@ impl UpContext {
         let config = &resolved.config;
         let config_name = config.get("name").and_then(|v| v.as_str());
 
-        let client = super::resolve_backend_for_command(backend, docker_host)?;
+        let client = super::resolve_backend_for_command(backend, docker_host).await?;
         client.ping().await?;
 
         let container_nm = container_name(&resolved.workspace_root, config_name);

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -40,9 +40,8 @@ pub struct UpArgs {
     #[arg(long)]
     pub(crate) workspace_folder: Option<PathBuf>,
 
-    /// Explicit Docker host URL (overrides `DOCKER_HOST`).
-    #[arg(long)]
-    pub(crate) docker_host: Option<String>,
+    #[command(flatten)]
+    pub(crate) backend: crate::backend::BackendArgs,
 
     /// Path to devcontainer.json (overrides auto-discovery).
     #[arg(long)]
@@ -107,7 +106,6 @@ impl UpContext {
     pub(crate) async fn new(
         args: &UpArgs,
         progress: crate::progress::Progress,
-        backend: Option<&crate::backend::BackendChoice>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let cwd = crate::commands::resolve_workspace_folder(args.workspace_folder.as_deref())?;
 
@@ -128,11 +126,7 @@ impl UpContext {
         let config_name = config.get("name").and_then(|v| v.as_str());
 
         // 2. Connect to backend
-        // NOTE: auto-detect picks the first backend whose socket exists.
-        // If Docker's socket exists but the daemon is stopped, auto-detect
-        // won't fall through to Apple Container. Users can work around this
-        // with `--backend apple-container`.
-        let client = super::resolve_backend_for_command(backend, args.docker_host.as_deref()).await?;
+        let client = args.backend.resolve_client().await?;
         client.ping().await?;
 
         let container_nm = container_name(&resolved.workspace_root, config_name);
@@ -175,11 +169,10 @@ impl UpContext {
     /// `build_no_cache` to false.
     pub async fn for_workspace(
         workspace_path: &std::path::Path,
-        docker_host: Option<&str>,
+        backend_args: &crate::backend::BackendArgs,
         extra_labels: std::collections::HashMap<String, String>,
         progress: crate::progress::Progress,
         output: OutputFormat,
-        backend: Option<&crate::backend::BackendChoice>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let cwd = workspace_path
             .canonicalize()
@@ -198,7 +191,7 @@ impl UpContext {
         let config = &resolved.config;
         let config_name = config.get("name").and_then(|v| v.as_str());
 
-        let client = super::resolve_backend_for_command(backend, docker_host).await?;
+        let client = backend_args.resolve_client().await?;
         client.ping().await?;
 
         let container_nm = container_name(&resolved.workspace_root, config_name);
@@ -639,7 +632,6 @@ impl UpArgs {
         &self,
         branch_name: &str,
         progress: crate::progress::Progress,
-        backend: Option<&crate::backend::BackendChoice>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let cwd = std::env::current_dir()?;
         let repo_info = cella_git::discover(&cwd)?;
@@ -657,11 +649,10 @@ impl UpArgs {
         let extra_labels = cella_backend::worktree_labels(branch_name, &repo_info.root);
         let mut ctx = UpContext::for_workspace(
             &wt.path,
-            self.docker_host.as_deref(),
+            &self.backend,
             extra_labels,
             progress,
             self.output.clone(),
-            backend,
         )
         .await?;
         ctx.remove_container = self.build.rebuild || self.build.remove_existing_container;
@@ -689,13 +680,12 @@ impl UpArgs {
     pub async fn execute(
         self,
         progress: crate::progress::Progress,
-        backend: Option<&crate::backend::BackendChoice>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         if let Some(ref branch_name) = self.branch {
-            return self.execute_branch(branch_name, progress, backend).await;
+            return self.execute_branch(branch_name, progress).await;
         }
 
-        let ctx = UpContext::new(&self, progress, backend).await?;
+        let ctx = UpContext::new(&self, progress).await?;
 
         // Docker Compose branch: if dockerComposeFile is present, delegate to compose flow
         if ctx.config().get("dockerComposeFile").is_some() {

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -279,6 +279,8 @@ impl UpContext {
             other_ports_attributes: other_ports_attrs,
             forward_ports,
             shutdown_action,
+            backend_kind: Some(self.client.kind().to_string()),
+            docker_host: None,
         };
         match cella_daemon::management::send_management_request(&mgmt_sock, &req).await {
             Ok(resp) => {
@@ -463,6 +465,7 @@ pub struct UpResult {
 struct CliUpHooks<'a> {
     config: &'a serde_json::Value,
     managed_agent: bool,
+    backend_kind: String,
 }
 
 impl cella_orchestrator::up::UpHooks for CliUpHooks<'_> {
@@ -498,6 +501,7 @@ impl cella_orchestrator::up::UpHooks for CliUpHooks<'_> {
         let container_name = container_name.to_string();
         let container_ip = container_ip.map(str::to_string);
         let managed_agent = self.managed_agent;
+        let backend_kind = self.backend_kind.clone();
         Box::pin(async move {
             if !managed_agent {
                 return;
@@ -538,6 +542,8 @@ impl cella_orchestrator::up::UpHooks for CliUpHooks<'_> {
                 other_ports_attributes: other_ports_attrs,
                 forward_ports,
                 shutdown_action,
+                backend_kind: Some(backend_kind),
+                docker_host: None,
             };
             let _ = cella_daemon::management::send_management_request(&mgmt_sock, &req).await;
         })
@@ -576,6 +582,7 @@ impl UpContext {
         let hooks = CliUpHooks {
             config: self.config(),
             managed_agent: self.client.capabilities().managed_agent,
+            backend_kind: self.client.kind().to_string(),
         };
         let config = cella_orchestrator::UpConfig {
             resolved: &self.resolved,

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -100,6 +100,8 @@ pub struct UpContext {
     extra_labels: std::collections::HashMap<String, String>,
     /// Network rule enforcement policy.
     network_rules: NetworkRulePolicy,
+    /// Docker host override (forwarded to daemon registration).
+    docker_host: Option<String>,
 }
 
 impl UpContext {
@@ -159,6 +161,7 @@ impl UpContext {
             } else {
                 NetworkRulePolicy::Enforce
             },
+            docker_host: args.backend.docker_host.clone(),
         })
     }
 
@@ -220,6 +223,7 @@ impl UpContext {
             skip_checksum: false,
             extra_labels,
             network_rules: NetworkRulePolicy::Enforce,
+            docker_host: backend_args.docker_host.clone(),
         })
     }
 
@@ -281,7 +285,7 @@ impl UpContext {
                 forward_ports,
                 shutdown_action,
                 backend_kind: Some(self.client.kind().to_string()),
-                docker_host: None,
+                docker_host: self.docker_host.clone(),
             },
         ));
         match cella_daemon::management::send_management_request(&mgmt_sock, &req).await {
@@ -468,6 +472,7 @@ struct CliUpHooks<'a> {
     config: &'a serde_json::Value,
     managed_agent: bool,
     backend_kind: String,
+    docker_host: Option<String>,
 }
 
 impl cella_orchestrator::up::UpHooks for CliUpHooks<'_> {
@@ -504,6 +509,7 @@ impl cella_orchestrator::up::UpHooks for CliUpHooks<'_> {
         let container_ip = container_ip.map(str::to_string);
         let managed_agent = self.managed_agent;
         let backend_kind = self.backend_kind.clone();
+        let docker_host = self.docker_host.clone();
         Box::pin(async move {
             if !managed_agent {
                 return;
@@ -546,7 +552,7 @@ impl cella_orchestrator::up::UpHooks for CliUpHooks<'_> {
                     forward_ports,
                     shutdown_action,
                     backend_kind: Some(backend_kind),
-                    docker_host: None,
+                    docker_host,
                 },
             ));
             let _ = cella_daemon::management::send_management_request(&mgmt_sock, &req).await;
@@ -587,6 +593,7 @@ impl UpContext {
             config: self.config(),
             managed_agent: self.client.capabilities().managed_agent,
             backend_kind: self.client.kind().to_string(),
+            docker_host: self.docker_host.clone(),
         };
         let config = cella_orchestrator::UpConfig {
             resolved: &self.resolved,

--- a/crates/cella-cli/src/main.rs
+++ b/crates/cella-cli/src/main.rs
@@ -497,9 +497,15 @@ mod tests {
 
     #[test]
     fn parse_list_with_backend_and_docker_host() {
-        let cli =
-            parse(&["cella", "list", "--backend", "docker", "--docker-host", "tcp://host:2375"])
-                .unwrap();
+        let cli = parse(&[
+            "cella",
+            "list",
+            "--backend",
+            "docker",
+            "--docker-host",
+            "tcp://host:2375",
+        ])
+        .unwrap();
         assert!(matches!(cli.command, super::commands::Command::List(_)));
     }
 

--- a/crates/cella-cli/src/main.rs
+++ b/crates/cella-cli/src/main.rs
@@ -20,10 +20,6 @@ struct Cli {
     #[arg(short = 'v', long = "version", action = clap::ArgAction::Version)]
     _version: (),
 
-    /// Container backend to use (auto-detected if not specified).
-    #[arg(long, global = true, value_enum)]
-    backend: Option<backend::BackendChoice>,
-
     #[command(subcommand)]
     command: commands::Command,
 }
@@ -59,7 +55,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .init();
     }
 
-    cli.command.execute(progress, cli.backend.as_ref()).await
+    cli.command.execute(progress).await
 }
 
 #[cfg(test)]
@@ -487,24 +483,51 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // ── global backend flag ─────────────────────────────────────────
+    // ── per-command backend flag ──────────────────────────────────────
 
     #[test]
-    fn parse_global_backend_docker() {
-        let cli = parse(&["cella", "--backend", "docker", "list"]).unwrap();
-        assert!(cli.backend.is_some());
+    fn parse_up_with_backend_docker() {
+        let cli = parse(&["cella", "up", "--backend", "docker"]).unwrap();
+        if let super::commands::Command::Up(args) = &cli.command {
+            assert!(args.backend.backend.is_some());
+        } else {
+            panic!("expected Up command");
+        }
     }
 
     #[test]
-    fn parse_global_backend_invalid() {
-        let result = parse(&["cella", "--backend", "invalid", "list"]);
+    fn parse_list_with_backend_and_docker_host() {
+        let cli =
+            parse(&["cella", "list", "--backend", "docker", "--docker-host", "tcp://host:2375"])
+                .unwrap();
+        assert!(matches!(cli.command, super::commands::Command::List(_)));
+    }
+
+    #[test]
+    fn parse_backend_invalid_value() {
+        let result = parse(&["cella", "list", "--backend", "invalid"]);
         assert!(result.is_err());
     }
 
     #[test]
     fn parse_no_backend_is_none() {
+        // Without --backend, parsing should still succeed
         let cli = parse(&["cella", "list"]).unwrap();
-        assert!(cli.backend.is_none());
+        assert!(matches!(cli.command, super::commands::Command::List(_)));
+    }
+
+    #[test]
+    fn parse_config_rejects_backend() {
+        // Commands that don't use BackendArgs should reject --backend
+        let result = parse(&["cella", "config", "show", "--backend", "docker"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_global_backend_no_longer_accepted() {
+        // --backend before the subcommand should fail (it's no longer global)
+        let result = parse(&["cella", "--backend", "docker", "list"]);
+        assert!(result.is_err());
     }
 
     // ── Command::is_text_output / verbosity / is_daemon_start ──────

--- a/crates/cella-cli/src/picker.rs
+++ b/crates/cella-cli/src/picker.rs
@@ -327,7 +327,7 @@ pub async fn resolve_up_workspace(up_args: &mut crate::commands::up::UpArgs) {
     }
 
     // Try to connect to Docker for container status
-    let container_states = if let Ok(client) = crate::backend::resolve_backend(None, None) {
+    let container_states = if let Ok(client) = crate::backend::resolve_backend(None, None).await {
         let containers = client
             .list_cella_containers(false)
             .await

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -2013,10 +2013,9 @@ async fn forward_backend_flags(cmd: &mut tokio::process::Command, wt: &WorktreeH
 /// Resolve the backend CLI binary name and Docker host from the calling container's handle.
 async fn resolve_backend_cli_and_host(wt: &WorktreeHandlerCtx<'_>) -> (String, Option<String>) {
     let handles = wt.container_handles.lock().await;
-    let (kind, host) = handles.get(wt.container_name).map_or(
-        (None, None),
-        |h| (h.backend_kind.clone(), h.docker_host.clone()),
-    );
+    let (kind, host) = handles.get(wt.container_name).map_or((None, None), |h| {
+        (h.backend_kind.clone(), h.docker_host.clone())
+    });
     drop(handles);
     let cmd_name = match kind.as_deref() {
         Some("apple-container") => "container".to_string(),

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -706,7 +706,7 @@ async fn handle_worktree_message<W: AsyncWriteExt + Unpin>(
             handle_task_stop(&request_id, &branch, wt.task_mgr, writer).await?;
         }
         AgentMessage::SwitchRequest { request_id, branch } => {
-            handle_switch_request(&request_id, &branch, writer).await?;
+            handle_switch_request(&request_id, &branch, &wt, writer).await?;
         }
         _ => {}
     }
@@ -1092,8 +1092,8 @@ async fn handle_exec_request<W: AsyncWriteExt + Unpin>(
 ) -> Result<(), CellaDaemonError> {
     use cella_protocol::OutputStream;
 
-    // Find the container for this branch via docker ps with label filter.
-    let container_name = find_container_for_branch(branch).await;
+    // Find the container for this branch via the appropriate backend CLI.
+    let container_name = find_container_for_branch(branch, wt).await;
     let Some(container_name) = container_name else {
         send_message(
             writer,
@@ -1119,18 +1119,8 @@ async fn handle_exec_request<W: AsyncWriteExt + Unpin>(
 
     let mut cmd = tokio::process::Command::new(wt.cella_bin);
     cmd.arg("exec");
-    // Forward --backend / --docker-host from the registered container handle.
-    {
-        let handles = wt.container_handles.lock().await;
-        if let Some(handle) = handles.get(&container_name) {
-            if let Some(ref kind) = handle.backend_kind {
-                cmd.arg("--backend").arg(kind);
-            }
-            if let Some(ref dh) = handle.docker_host {
-                cmd.arg("--docker-host").arg(dh);
-            }
-        }
-    }
+    // Forward --backend / --docker-host from the calling container's handle.
+    forward_backend_flags(&mut cmd, wt).await;
     cmd.arg("--container-name").arg(&container_name);
     cmd.arg("--");
     for arg in command {
@@ -1401,17 +1391,7 @@ async fn handle_up_request<W: AsyncWriteExt + Unpin>(
     let mut cmd = tokio::process::Command::new(wt.cella_bin);
     cmd.arg("up");
     // Forward --backend / --docker-host from the calling container's handle.
-    {
-        let handles = wt.container_handles.lock().await;
-        if let Some(handle) = handles.get(wt.container_name) {
-            if let Some(ref kind) = handle.backend_kind {
-                cmd.arg("--backend").arg(kind);
-            }
-            if let Some(ref dh) = handle.docker_host {
-                cmd.arg("--docker-host").arg(dh);
-            }
-        }
-    }
+    forward_backend_flags(&mut cmd, wt).await;
     cmd.arg("--branch").arg(branch).arg("--output").arg("json");
     if rebuild {
         cmd.arg("--rebuild");
@@ -1508,7 +1488,7 @@ async fn ensure_branch_container<W: AsyncWriteExt + Unpin>(
     wt: &WorktreeHandlerCtx<'_>,
     writer: &mut W,
 ) -> Result<Option<String>, CellaDaemonError> {
-    if let Some(name) = find_container_for_branch(branch).await {
+    if let Some(name) = find_container_for_branch(branch, wt).await {
         return Ok(Some(name));
     }
 
@@ -1523,7 +1503,10 @@ async fn ensure_branch_container<W: AsyncWriteExt + Unpin>(
     .await?;
 
     let mut cmd = tokio::process::Command::new(wt.cella_bin);
-    cmd.arg("branch").arg(branch).arg("--output").arg("json");
+    cmd.arg("branch");
+    // Forward --backend / --docker-host from the calling container's handle.
+    forward_backend_flags(&mut cmd, wt).await;
+    cmd.arg(branch).arg("--output").arg("json");
     if let Some(b) = base {
         cmd.arg("--base").arg(b);
     }
@@ -1548,7 +1531,7 @@ async fn ensure_branch_container<W: AsyncWriteExt + Unpin>(
         return Ok(None);
     }
 
-    Ok(find_container_for_branch(branch).await)
+    Ok(find_container_for_branch(branch, wt).await)
 }
 
 async fn handle_task_run<W: AsyncWriteExt + Unpin>(
@@ -1830,9 +1813,10 @@ async fn handle_task_stop<W: AsyncWriteExt + Unpin>(
 async fn handle_switch_request<W: AsyncWriteExt + Unpin>(
     request_id: &str,
     branch: &str,
+    wt: &WorktreeHandlerCtx<'_>,
     writer: &mut W,
 ) -> Result<(), CellaDaemonError> {
-    let container_name = find_container_for_branch(branch).await;
+    let container_name = find_container_for_branch(branch, wt).await;
     let Some(container_name) = container_name else {
         send_message(
             writer,
@@ -1992,9 +1976,14 @@ fn snapshot_binary(source: &std::path::Path) -> Option<std::path::PathBuf> {
     Some(dest)
 }
 
-/// Find a running container for a given branch name via Docker labels.
-async fn find_container_for_branch(branch: &str) -> Option<String> {
-    let output = tokio::process::Command::new("docker")
+/// Find a running container for a given branch name via the appropriate backend CLI.
+///
+/// Uses the calling container's backend metadata to determine which CLI binary
+/// to invoke (`docker` or `container`), avoiding hardcoded Docker assumptions.
+async fn find_container_for_branch(branch: &str, wt: &WorktreeHandlerCtx<'_>) -> Option<String> {
+    let cmd_name = resolve_backend_cli(wt).await;
+
+    let output = tokio::process::Command::new(&cmd_name)
         .args([
             "ps",
             "--filter",
@@ -2016,6 +2005,34 @@ async fn find_container_for_branch(branch: &str) -> Option<String> {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     stdout.lines().next().map(ToString::to_string)
+}
+
+/// Append `--backend` and `--docker-host` flags from the calling container's handle.
+async fn forward_backend_flags(cmd: &mut tokio::process::Command, wt: &WorktreeHandlerCtx<'_>) {
+    let handles = wt.container_handles.lock().await;
+    if let Some(handle) = handles.get(wt.container_name) {
+        if let Some(ref kind) = handle.backend_kind {
+            cmd.arg("--backend").arg(kind);
+        }
+        if let Some(ref dh) = handle.docker_host {
+            cmd.arg("--docker-host").arg(dh);
+        }
+    }
+}
+
+/// Resolve the backend CLI binary name from the calling container's handle.
+async fn resolve_backend_cli(wt: &WorktreeHandlerCtx<'_>) -> String {
+    let handles = wt.container_handles.lock().await;
+    handles
+        .get(wt.container_name)
+        .and_then(|h| h.backend_kind.as_deref())
+        .map_or_else(
+            || "docker".to_string(),
+            |kind| match kind {
+                "apple-container" => "container".to_string(),
+                other => other.to_string(),
+            },
+        )
 }
 
 /// Extract the port number from a URL like `http://localhost:3000/path`.

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -1409,10 +1409,7 @@ async fn handle_up_request<W: AsyncWriteExt + Unpin>(
             }
         }
     }
-    cmd.arg("--branch")
-        .arg(branch)
-        .arg("--output")
-        .arg("json");
+    cmd.arg("--branch").arg(branch).arg("--output").arg("json");
     if rebuild {
         cmd.arg("--rebuild");
     }

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -60,6 +60,10 @@ impl Default for AgentConnectionState {
 pub struct ContainerHandle {
     pub container_id: String,
     pub agent_state: Arc<AgentConnectionState>,
+    /// Which backend created this container (e.g. `"docker"`, `"apple-container"`).
+    pub backend_kind: Option<String>,
+    /// Docker host override used when the container was created.
+    pub docker_host: Option<String>,
 }
 
 /// Spawn a handler task for a new agent TCP connection.
@@ -2164,6 +2168,8 @@ mod tests {
         let handle = ContainerHandle {
             container_id: "abc123".into(),
             agent_state: Arc::new(AgentConnectionState::new()),
+            backend_kind: Some("docker".into()),
+            docker_host: None,
         };
         assert_eq!(handle.container_id, "abc123");
         assert!(!handle.agent_state.connected.load(Ordering::Relaxed));

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -316,6 +316,7 @@ async fn handle_agent_connection(
                     cella_bin: &ctx.cella_bin,
                     task_mgr: &ctx.task_manager,
                     container_handles: &ctx.container_handles,
+                    container_name: &hs.container_name,
                 },
                 &mut writer,
             )
@@ -615,6 +616,8 @@ struct WorktreeHandlerCtx<'a> {
     cella_bin: &'a std::path::Path,
     task_mgr: &'a crate::task_manager::SharedTaskManager,
     container_handles: &'a Arc<Mutex<HashMap<String, ContainerHandle>>>,
+    /// Name of the container that initiated this request (from agent handshake).
+    container_name: &'a str,
 }
 
 /// Handle worktree/exec/task messages that need writer access for multi-message responses.
@@ -1397,10 +1400,10 @@ async fn handle_up_request<W: AsyncWriteExt + Unpin>(
 
     let mut cmd = tokio::process::Command::new(wt.cella_bin);
     cmd.arg("up");
-    // Forward --backend / --docker-host from the registered container handle.
+    // Forward --backend / --docker-host from the calling container's handle.
     {
         let handles = wt.container_handles.lock().await;
-        if let Some(handle) = handles.values().next() {
+        if let Some(handle) = handles.get(wt.container_name) {
             if let Some(ref kind) = handle.backend_kind {
                 cmd.arg("--backend").arg(kind);
             }

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -569,13 +569,14 @@ async fn lookup_container_labels(
     container_id: &str,
     container_handles: &Arc<Mutex<HashMap<String, ContainerHandle>>>,
 ) -> HashMap<String, String> {
-    // Determine which CLI binary to use from the registered backend kind.
-    let backend_kind = {
+    // Determine which CLI binary and Docker host to use from the registered handle.
+    let (backend_kind, docker_host) = {
         let handles = container_handles.lock().await;
         handles
             .values()
             .find(|h| h.container_id == container_id)
-            .and_then(|h| h.backend_kind.clone())
+            .map(|h| (h.backend_kind.clone(), h.docker_host.clone()))
+            .unwrap_or_default()
     };
 
     let cmd_name = match backend_kind.as_deref() {
@@ -583,17 +584,20 @@ async fn lookup_container_labels(
         _ => "docker",
     };
 
-    let output = tokio::process::Command::new(cmd_name)
-        .args([
-            "inspect",
-            "--format",
-            "{{json .Config.Labels}}",
-            container_id,
-        ])
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
-        .output()
-        .await;
+    let mut cmd = tokio::process::Command::new(cmd_name);
+    if let Some(ref host) = docker_host {
+        cmd.arg("-H").arg(host);
+    }
+    cmd.args([
+        "inspect",
+        "--format",
+        "{{json .Config.Labels}}",
+        container_id,
+    ]);
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::null());
+
+    let output = cmd.output().await;
 
     let Ok(output) = output else {
         return HashMap::new();
@@ -632,15 +636,7 @@ async fn handle_worktree_message<W: AsyncWriteExt + Unpin>(
             branch,
             base,
         } => {
-            handle_branch_request(
-                &request_id,
-                &branch,
-                base.as_deref(),
-                wt.workspace_path,
-                wt.cella_bin,
-                writer,
-            )
-            .await?;
+            handle_branch_request(&request_id, &branch, base.as_deref(), &wt, writer).await?;
         }
         AgentMessage::ListRequest { request_id } => {
             handle_list_request(&request_id, wt.workspace_path, writer).await?;
@@ -655,15 +651,7 @@ async fn handle_worktree_message<W: AsyncWriteExt + Unpin>(
             dry_run,
             all,
         } => {
-            handle_prune_request(
-                &request_id,
-                dry_run,
-                all,
-                wt.workspace_path,
-                wt.cella_bin,
-                writer,
-            )
-            .await?;
+            handle_prune_request(&request_id, dry_run, all, &wt, writer).await?;
         }
         AgentMessage::DownRequest {
             request_id,
@@ -720,8 +708,7 @@ async fn handle_branch_request<W: AsyncWriteExt + Unpin>(
     request_id: &str,
     branch: &str,
     base: Option<&str>,
-    workspace_path: Option<&str>,
-    cella_bin: &std::path::Path,
+    wt: &WorktreeHandlerCtx<'_>,
     writer: &mut W,
 ) -> Result<(), CellaDaemonError> {
     use cella_protocol::WorktreeOperationResult;
@@ -729,7 +716,7 @@ async fn handle_branch_request<W: AsyncWriteExt + Unpin>(
 
     info!(
         "Handling BranchRequest: branch={branch} base={base:?} via {}",
-        cella_bin.display()
+        wt.cella_bin.display()
     );
 
     // Send initial progress
@@ -744,12 +731,14 @@ async fn handle_branch_request<W: AsyncWriteExt + Unpin>(
     .await?;
 
     // Build command
-    let mut cmd = Command::new(cella_bin);
-    cmd.arg("branch").arg(branch).arg("--output").arg("json");
+    let mut cmd = Command::new(wt.cella_bin);
+    cmd.arg("branch");
+    forward_backend_flags(&mut cmd, wt).await;
+    cmd.arg(branch).arg("--output").arg("json");
     if let Some(b) = base {
         cmd.arg("--base").arg(b);
     }
-    if let Some(ws) = workspace_path {
+    if let Some(ws) = wt.workspace_path {
         cmd.current_dir(ws);
     }
     cmd.stdout(std::process::Stdio::piped());
@@ -1172,19 +1161,20 @@ async fn handle_prune_request<W: AsyncWriteExt + Unpin>(
     request_id: &str,
     dry_run: bool,
     all: bool,
-    workspace_path: Option<&str>,
-    cella_bin: &std::path::Path,
+    wt: &WorktreeHandlerCtx<'_>,
     writer: &mut W,
 ) -> Result<(), CellaDaemonError> {
-    let mut cmd = tokio::process::Command::new(cella_bin);
-    cmd.arg("prune").arg("--force").arg("--output").arg("json");
+    let mut cmd = tokio::process::Command::new(wt.cella_bin);
+    cmd.arg("prune");
+    forward_backend_flags(&mut cmd, wt).await;
+    cmd.arg("--force").arg("--output").arg("json");
     if dry_run {
         cmd.arg("--dry-run");
     }
     if all {
         cmd.arg("--all");
     }
-    if let Some(ws) = workspace_path {
+    if let Some(ws) = wt.workspace_path {
         cmd.current_dir(ws);
     }
     cmd.stdout(std::process::Stdio::piped());
@@ -1254,11 +1244,9 @@ async fn handle_down_request<W: AsyncWriteExt + Unpin>(
     .await?;
 
     let mut cmd = tokio::process::Command::new(wt.cella_bin);
-    cmd.arg("down")
-        .arg("--branch")
-        .arg(branch)
-        .arg("--output")
-        .arg("json");
+    cmd.arg("down");
+    forward_backend_flags(&mut cmd, wt).await;
+    cmd.arg("--branch").arg(branch).arg("--output").arg("json");
     if rm {
         cmd.arg("--rm");
     }
@@ -1981,23 +1969,25 @@ fn snapshot_binary(source: &std::path::Path) -> Option<std::path::PathBuf> {
 /// Uses the calling container's backend metadata to determine which CLI binary
 /// to invoke (`docker` or `container`), avoiding hardcoded Docker assumptions.
 async fn find_container_for_branch(branch: &str, wt: &WorktreeHandlerCtx<'_>) -> Option<String> {
-    let cmd_name = resolve_backend_cli(wt).await;
+    let (cmd_name, docker_host) = resolve_backend_cli_and_host(wt).await;
 
-    let output = tokio::process::Command::new(&cmd_name)
-        .args([
-            "ps",
-            "--filter",
-            &format!("label=dev.cella.branch={branch}"),
-            "--filter",
-            "label=dev.cella.worktree=true",
-            "--format",
-            "{{.Names}}",
-        ])
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
-        .output()
-        .await
-        .ok()?;
+    let mut cmd = tokio::process::Command::new(&cmd_name);
+    if let Some(ref host) = docker_host {
+        cmd.arg("-H").arg(host);
+    }
+    cmd.args([
+        "ps",
+        "--filter",
+        &format!("label=dev.cella.branch={branch}"),
+        "--filter",
+        "label=dev.cella.worktree=true",
+        "--format",
+        "{{.Names}}",
+    ]);
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::null());
+
+    let output = cmd.output().await.ok()?;
 
     if !output.status.success() {
         return None;
@@ -2020,19 +2010,20 @@ async fn forward_backend_flags(cmd: &mut tokio::process::Command, wt: &WorktreeH
     }
 }
 
-/// Resolve the backend CLI binary name from the calling container's handle.
-async fn resolve_backend_cli(wt: &WorktreeHandlerCtx<'_>) -> String {
+/// Resolve the backend CLI binary name and Docker host from the calling container's handle.
+async fn resolve_backend_cli_and_host(wt: &WorktreeHandlerCtx<'_>) -> (String, Option<String>) {
     let handles = wt.container_handles.lock().await;
-    handles
-        .get(wt.container_name)
-        .and_then(|h| h.backend_kind.as_deref())
-        .map_or_else(
-            || "docker".to_string(),
-            |kind| match kind {
-                "apple-container" => "container".to_string(),
-                other => other.to_string(),
-            },
-        )
+    let (kind, host) = handles.get(wt.container_name).map_or(
+        (None, None),
+        |h| (h.backend_kind.clone(), h.docker_host.clone()),
+    );
+    drop(handles);
+    let cmd_name = match kind.as_deref() {
+        Some("apple-container") => "container".to_string(),
+        Some(other) => other.to_string(),
+        None => "docker".to_string(),
+    };
+    (cmd_name, host)
 }
 
 /// Extract the port number from a URL like `http://localhost:3000/path`.

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -217,7 +217,7 @@ where
     }
 
     // Send DaemonHello success with workspace metadata from container labels.
-    let labels = lookup_container_labels(&container_id).await;
+    let labels = lookup_container_labels(&container_id, &ctx.container_handles).await;
     let hello = DaemonHello {
         protocol_version: PROTOCOL_VERSION,
         daemon_version: env!("CARGO_PKG_VERSION").to_string(),
@@ -315,6 +315,7 @@ async fn handle_agent_connection(
                     workspace_path: hs.workspace_path.as_deref(),
                     cella_bin: &ctx.cella_bin,
                     task_mgr: &ctx.task_manager,
+                    container_handles: &ctx.container_handles,
                 },
                 &mut writer,
             )
@@ -555,15 +556,33 @@ async fn send_message<W: AsyncWriteExt + Unpin>(
 }
 
 // ---------------------------------------------------------------------------
-// Docker label lookup
+// Container label lookup
 // ---------------------------------------------------------------------------
 
-/// Look up container labels via `docker inspect`.
+/// Look up container labels via the appropriate backend CLI.
 ///
-/// Returns an empty map on any failure (Docker not running, container not found, etc.)
-/// so callers can proceed with defaults.
-async fn lookup_container_labels(container_id: &str) -> HashMap<String, String> {
-    let output = tokio::process::Command::new("docker")
+/// Uses the registered `backend_kind` to decide between `docker inspect`
+/// and `container inspect`. Returns an empty map on any failure so callers
+/// can proceed with defaults.
+async fn lookup_container_labels(
+    container_id: &str,
+    container_handles: &Arc<Mutex<HashMap<String, ContainerHandle>>>,
+) -> HashMap<String, String> {
+    // Determine which CLI binary to use from the registered backend kind.
+    let backend_kind = {
+        let handles = container_handles.lock().await;
+        handles
+            .values()
+            .find(|h| h.container_id == container_id)
+            .and_then(|h| h.backend_kind.clone())
+    };
+
+    let cmd_name = match backend_kind.as_deref() {
+        Some("apple-container") => "container",
+        _ => "docker",
+    };
+
+    let output = tokio::process::Command::new(cmd_name)
         .args([
             "inspect",
             "--format",
@@ -595,6 +614,7 @@ struct WorktreeHandlerCtx<'a> {
     workspace_path: Option<&'a str>,
     cella_bin: &'a std::path::Path,
     task_mgr: &'a crate::task_manager::SharedTaskManager,
+    container_handles: &'a Arc<Mutex<HashMap<String, ContainerHandle>>>,
 }
 
 /// Handle worktree/exec/task messages that need writer access for multi-message responses.
@@ -626,9 +646,7 @@ async fn handle_worktree_message<W: AsyncWriteExt + Unpin>(
             request_id,
             branch,
             command,
-        } => {
-            handle_exec_request(&request_id, &branch, &command, writer).await?;
-        }
+        } => handle_exec_request(&request_id, &branch, &command, &wt, writer).await?,
         AgentMessage::PruneRequest {
             request_id,
             dry_run,
@@ -658,15 +676,7 @@ async fn handle_worktree_message<W: AsyncWriteExt + Unpin>(
             branch,
             rebuild,
         } => {
-            handle_up_request(
-                &request_id,
-                &branch,
-                rebuild,
-                wt.workspace_path,
-                wt.cella_bin,
-                writer,
-            )
-            .await?;
+            handle_up_request(&request_id, &branch, rebuild, &wt, writer).await?;
         }
         AgentMessage::TaskRunRequest {
             request_id,
@@ -1069,11 +1079,12 @@ async fn list_cella_containers() -> Vec<CellaContainer> {
         .collect()
 }
 
-/// Handle an `ExecRequest` by finding the branch's container and running docker exec.
+/// Handle an `ExecRequest` by finding the branch's container and running `cella exec`.
 async fn handle_exec_request<W: AsyncWriteExt + Unpin>(
     request_id: &str,
     branch: &str,
     command: &[String],
+    wt: &WorktreeHandlerCtx<'_>,
     writer: &mut W,
 ) -> Result<(), CellaDaemonError> {
     use cella_protocol::OutputStream;
@@ -1103,11 +1114,22 @@ async fn handle_exec_request<W: AsyncWriteExt + Unpin>(
 
     info!("Handling ExecRequest: branch={branch} container={container_name}");
 
-    // TODO: use the backend abstraction instead of shelling out to Docker
-    // directly.  Currently only Docker containers have a managed agent, so
-    // this path is only reachable for Docker backends.
-    let mut cmd = tokio::process::Command::new("docker");
-    cmd.arg("exec").arg(&container_name);
+    let mut cmd = tokio::process::Command::new(wt.cella_bin);
+    cmd.arg("exec");
+    // Forward --backend / --docker-host from the registered container handle.
+    {
+        let handles = wt.container_handles.lock().await;
+        if let Some(handle) = handles.get(&container_name) {
+            if let Some(ref kind) = handle.backend_kind {
+                cmd.arg("--backend").arg(kind);
+            }
+            if let Some(ref dh) = handle.docker_host {
+                cmd.arg("--docker-host").arg(dh);
+            }
+        }
+    }
+    cmd.arg("--container-name").arg(&container_name);
+    cmd.arg("--");
     for arg in command {
         cmd.arg(arg);
     }
@@ -1122,7 +1144,7 @@ async fn handle_exec_request<W: AsyncWriteExt + Unpin>(
                 &DaemonMessage::OperationOutput {
                     request_id: request_id.to_string(),
                     stream: OutputStream::Stderr,
-                    data: format!("failed to spawn docker exec: {e}\n"),
+                    data: format!("failed to spawn cella exec: {e}\n"),
                 },
             )
             .await?;
@@ -1356,8 +1378,7 @@ async fn handle_up_request<W: AsyncWriteExt + Unpin>(
     request_id: &str,
     branch: &str,
     rebuild: bool,
-    workspace_path: Option<&str>,
-    cella_bin: &std::path::Path,
+    wt: &WorktreeHandlerCtx<'_>,
     writer: &mut W,
 ) -> Result<(), CellaDaemonError> {
     use cella_protocol::WorktreeOperationResult;
@@ -1374,19 +1395,28 @@ async fn handle_up_request<W: AsyncWriteExt + Unpin>(
     )
     .await?;
 
-    // TODO: forward --backend / --docker-host when backend selection is
-    // stored per-container.  Currently only Docker containers have a managed
-    // agent, so these daemon-spawned subprocesses always target Docker.
-    let mut cmd = tokio::process::Command::new(cella_bin);
-    cmd.arg("up")
-        .arg("--branch")
+    let mut cmd = tokio::process::Command::new(wt.cella_bin);
+    cmd.arg("up");
+    // Forward --backend / --docker-host from the registered container handle.
+    {
+        let handles = wt.container_handles.lock().await;
+        if let Some(handle) = handles.values().next() {
+            if let Some(ref kind) = handle.backend_kind {
+                cmd.arg("--backend").arg(kind);
+            }
+            if let Some(ref dh) = handle.docker_host {
+                cmd.arg("--docker-host").arg(dh);
+            }
+        }
+    }
+    cmd.arg("--branch")
         .arg(branch)
         .arg("--output")
         .arg("json");
     if rebuild {
         cmd.arg("--rebuild");
     }
-    if let Some(ws) = workspace_path {
+    if let Some(ws) = wt.workspace_path {
         cmd.current_dir(ws);
     }
     cmd.stdout(std::process::Stdio::piped());

--- a/crates/cella-daemon/src/management.rs
+++ b/crates/cella-daemon/src/management.rs
@@ -205,6 +205,8 @@ async fn handle_management_request(
             other_ports_attributes,
             forward_ports,
             shutdown_action: _,
+            backend_kind,
+            docker_host,
         } => {
             let reg = ContainerRegistration {
                 container_id,
@@ -213,6 +215,8 @@ async fn handle_management_request(
                 ports_attributes,
                 other_ports_attributes,
                 forward_ports,
+                backend_kind,
+                docker_host,
             };
             handle_register(reg, &ctx.port_manager, container_handles).await
         }
@@ -250,6 +254,8 @@ struct ContainerRegistration {
     ports_attributes: Vec<PortAttributes>,
     other_ports_attributes: Option<PortAttributes>,
     forward_ports: Vec<u16>,
+    backend_kind: Option<String>,
+    docker_host: Option<String>,
 }
 
 /// Handle container registration.
@@ -288,6 +294,8 @@ async fn handle_register(
             ContainerHandle {
                 container_id: reg.container_id,
                 agent_state: Arc::new(AgentConnectionState::new()),
+                backend_kind: reg.backend_kind,
+                docker_host: reg.docker_host,
             },
         );
     }
@@ -539,6 +547,8 @@ mod tests {
                 other_ports_attributes: None,
                 forward_ports: vec![],
                 shutdown_action: None,
+                backend_kind: Some("docker".to_string()),
+                docker_host: None,
             },
         )
         .await

--- a/crates/cella-daemon/src/management.rs
+++ b/crates/cella-daemon/src/management.rs
@@ -197,26 +197,16 @@ async fn handle_management_request(
     container_handles: &Arc<Mutex<HashMap<String, ContainerHandle>>>,
 ) -> ManagementResponse {
     match req {
-        ManagementRequest::RegisterContainer {
-            container_id,
-            container_name,
-            container_ip,
-            ports_attributes,
-            other_ports_attributes,
-            forward_ports,
-            shutdown_action: _,
-            backend_kind,
-            docker_host,
-        } => {
+        ManagementRequest::RegisterContainer(data) => {
             let reg = ContainerRegistration {
-                container_id,
-                container_name,
-                container_ip,
-                ports_attributes,
-                other_ports_attributes,
-                forward_ports,
-                backend_kind,
-                docker_host,
+                container_id: data.container_id,
+                container_name: data.container_name,
+                container_ip: data.container_ip,
+                ports_attributes: data.ports_attributes,
+                other_ports_attributes: data.other_ports_attributes,
+                forward_ports: data.forward_ports,
+                backend_kind: data.backend_kind,
+                docker_host: data.docker_host,
             };
             handle_register(reg, &ctx.port_manager, container_handles).await
         }
@@ -539,17 +529,19 @@ mod tests {
         // Register container
         let resp = send_management_request(
             &socket_path,
-            &ManagementRequest::RegisterContainer {
-                container_id: "abc123".to_string(),
-                container_name: "test-container".to_string(),
-                container_ip: Some("172.20.0.5".to_string()),
-                ports_attributes: vec![],
-                other_ports_attributes: None,
-                forward_ports: vec![],
-                shutdown_action: None,
-                backend_kind: Some("docker".to_string()),
-                docker_host: None,
-            },
+            &ManagementRequest::RegisterContainer(Box::new(
+                cella_protocol::ContainerRegistrationData {
+                    container_id: "abc123".to_string(),
+                    container_name: "test-container".to_string(),
+                    container_ip: Some("172.20.0.5".to_string()),
+                    ports_attributes: vec![],
+                    other_ports_attributes: None,
+                    forward_ports: vec![],
+                    shutdown_action: None,
+                    backend_kind: Some("docker".to_string()),
+                    docker_host: None,
+                },
+            )),
         )
         .await
         .unwrap();

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -547,6 +547,10 @@ impl EnsureUpContext<'_> {
             runtime.as_label(),
         );
 
+        labels.insert(
+            cella_backend::BACKEND_LABEL.to_string(),
+            self.client.kind().to_string(),
+        );
         labels.insert("dev.cella.remote_user".to_string(), remote_user.to_string());
         labels.insert(
             "dev.cella.version".to_string(),

--- a/crates/cella-protocol/src/lib.rs
+++ b/crates/cella-protocol/src/lib.rs
@@ -172,6 +172,12 @@ pub enum ManagementRequest {
         /// The `shutdownAction` from devcontainer.json (`"none"` or `"stopContainer"`).
         #[serde(default)]
         shutdown_action: Option<String>,
+        /// Which backend created this container (e.g. `"docker"`, `"apple-container"`).
+        #[serde(default)]
+        backend_kind: Option<String>,
+        /// Docker host override used when the container was created.
+        #[serde(default)]
+        docker_host: Option<String>,
     },
     /// Deregister a container (stop proxies, release ports).
     DeregisterContainer { container_name: String },
@@ -677,6 +683,8 @@ mod tests {
             other_ports_attributes: None,
             forward_ports: vec![],
             shutdown_action: None,
+            backend_kind: Some("docker".to_string()),
+            docker_host: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(json.contains("\"type\":\"register_container\""));

--- a/crates/cella-protocol/src/lib.rs
+++ b/crates/cella-protocol/src/lib.rs
@@ -155,30 +155,34 @@ pub enum AgentMessage {
 // Management protocol (CLI ↔ daemon via ~/.cella/daemon.sock)
 // ---------------------------------------------------------------------------
 
+/// Data for a container registration request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContainerRegistrationData {
+    pub container_id: String,
+    pub container_name: String,
+    pub container_ip: Option<String>,
+    pub ports_attributes: Vec<PortAttributes>,
+    pub other_ports_attributes: Option<PortAttributes>,
+    /// Ports from `forwardPorts` in devcontainer.json (pre-allocate on registration).
+    #[serde(default)]
+    pub forward_ports: Vec<u16>,
+    /// The `shutdownAction` from devcontainer.json (`"none"` or `"stopContainer"`).
+    #[serde(default)]
+    pub shutdown_action: Option<String>,
+    /// Which backend created this container (e.g. `"docker"`, `"apple-container"`).
+    #[serde(default)]
+    pub backend_kind: Option<String>,
+    /// Docker host override used when the container was created.
+    #[serde(default)]
+    pub docker_host: Option<String>,
+}
+
 /// Requests from CLI tools to the daemon management socket.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ManagementRequest {
     /// Register a new container for port management.
-    RegisterContainer {
-        container_id: String,
-        container_name: String,
-        container_ip: Option<String>,
-        ports_attributes: Vec<PortAttributes>,
-        other_ports_attributes: Option<PortAttributes>,
-        /// Ports from `forwardPorts` in devcontainer.json (pre-allocate on registration).
-        #[serde(default)]
-        forward_ports: Vec<u16>,
-        /// The `shutdownAction` from devcontainer.json (`"none"` or `"stopContainer"`).
-        #[serde(default)]
-        shutdown_action: Option<String>,
-        /// Which backend created this container (e.g. `"docker"`, `"apple-container"`).
-        #[serde(default)]
-        backend_kind: Option<String>,
-        /// Docker host override used when the container was created.
-        #[serde(default)]
-        docker_host: Option<String>,
-    },
+    RegisterContainer(Box<ContainerRegistrationData>),
     /// Deregister a container (stop proxies, release ports).
     DeregisterContainer { container_name: String },
     /// Query all forwarded ports across containers.
@@ -675,7 +679,7 @@ mod tests {
 
     #[test]
     fn serialize_management_register() {
-        let req = ManagementRequest::RegisterContainer {
+        let req = ManagementRequest::RegisterContainer(Box::new(ContainerRegistrationData {
             container_id: "abc123".to_string(),
             container_name: "cella-myapp-main".to_string(),
             container_ip: Some("172.20.0.5".to_string()),
@@ -685,7 +689,7 @@ mod tests {
             shutdown_action: None,
             backend_kind: Some("docker".to_string()),
             docker_host: None,
-        };
+        }));
         let json = serde_json::to_string(&req).unwrap();
         assert!(json.contains("\"type\":\"register_container\""));
         assert!(json.contains("\"container_ip\":\"172.20.0.5\""));

--- a/crates/cella-protocol/src/lib.rs
+++ b/crates/cella-protocol/src/lib.rs
@@ -696,6 +696,19 @@ mod tests {
     }
 
     #[test]
+    fn deserialize_register_without_backend_fields() {
+        // Backward compatibility: old CLI versions may omit backend_kind/docker_host.
+        let json = r#"{"type":"register_container","container_id":"abc","container_name":"test","container_ip":null,"ports_attributes":[],"other_ports_attributes":null,"forward_ports":[],"shutdown_action":null}"#;
+        let req: ManagementRequest = serde_json::from_str(json).unwrap();
+        if let ManagementRequest::RegisterContainer(data) = req {
+            assert!(data.backend_kind.is_none());
+            assert!(data.docker_host.is_none());
+        } else {
+            panic!("expected RegisterContainer");
+        }
+    }
+
+    #[test]
     fn serialize_management_deregister() {
         let req = ManagementRequest::DeregisterContainer {
             container_name: "cella-myapp-main".to_string(),


### PR DESCRIPTION
## Summary

- **Remove global `--backend`**, flatten `BackendArgs` per-command so commands that don't need a backend (`config`, `init`, `features`, etc.) reject it at parse time
- **Async auto-detect with ping**: `resolve_backend` now pings the Docker daemon during auto-detection — if a Docker socket exists but the daemon isn't responding, falls through to Apple Container instead of failing with a confusing error later
- **Error on `--backend apple-container` + `--docker-host`** conflict instead of silently ignoring `--docker-host`
- **Consolidate `--docker-host`** into `BackendArgs` so all 16 backend-using commands get both flags from a single source
- **Set `dev.cella.backend` label** on containers at creation time; warn + assume Docker for pre-existing containers without the label
- **Daemon forwards `--backend`**: replace hardcoded `docker exec` with `cella exec --backend <kind>`, forward `--backend`/`--docker-host` when spawning `cella up` subprocesses, parameterize `lookup_container_labels` per backend
- **Add `backend_kind`/`docker_host` to `RegisterContainer`** protocol message so the daemon knows which backend manages each container

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings -D clippy::all`
- [x] `cargo test --workspace` — all tests pass
- [x] Manual: `cella up --backend docker` works, `cella --backend docker up` errors (no longer global)
- [x] Manual: `cella config show --backend docker` produces clap error
- [x] Manual: `cella up --backend apple-container --docker-host tcp://...` errors with conflict message

🤖 Generated with [Claude Code](https://claude.com/claude-code)