### PR TITLE
feat: add compose --profile, --env-file, and --pull-policy support

### DIFF
--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -32,6 +32,18 @@ pub struct BuildArgs {
     /// Output format.
     #[arg(long, value_enum, default_value = "text")]
     output: OutputFormat,
+
+    /// Docker Compose profile(s) to activate (repeatable).
+    #[arg(long = "profile")]
+    profile: Vec<String>,
+
+    /// Extra env-file(s) to pass to Docker Compose (repeatable).
+    #[arg(long = "env-file")]
+    env_file: Vec<PathBuf>,
+
+    /// Pull policy for Docker Compose services (always, missing, never).
+    #[arg(long = "pull-policy")]
+    pull_policy: Option<String>,
 }
 
 /// Output format for build command.
@@ -68,11 +80,17 @@ impl BuildArgs {
         // Docker Compose path: delegate to orchestrator
         if config.get("dockerComposeFile").is_some() {
             let (sender, renderer) = crate::progress::bridge(&progress);
+            let build_cfg = cella_orchestrator::compose_build::ComposeBuildConfig {
+                config,
+                config_path: &resolved.config_path,
+                workspace_root: &resolved.workspace_root,
+                profiles: self.profile.clone(),
+                env_files: self.env_file.clone(),
+                pull_policy: self.pull_policy.clone(),
+            };
             let result = cella_orchestrator::compose_build::compose_build(
                 client.as_ref(),
-                config,
-                &resolved.config_path,
-                &resolved.workspace_root,
+                &build_cfg,
                 &sender,
             )
             .await

--- a/crates/cella-cli/src/commands/compose_up.rs
+++ b/crates/cella-cli/src/commands/compose_up.rs
@@ -28,6 +28,9 @@ pub async fn compose_up(ctx: UpContext) -> Result<(), Box<dyn std::error::Error>
         remove_container: ctx.remove_container,
         build_no_cache: ctx.build_no_cache,
         skip_checksum: ctx.skip_checksum,
+        profiles: ctx.compose_profiles.clone(),
+        env_files: ctx.compose_env_files.clone(),
+        pull_policy: ctx.compose_pull_policy.clone(),
     };
 
     let (sender, renderer) = crate::progress::bridge(&ctx.progress);

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -66,6 +66,18 @@ pub struct UpArgs {
     /// Start container without network blocking rules (proxy forwarding still active).
     #[arg(long)]
     pub(crate) no_network_rules: bool,
+
+    /// Docker Compose profile(s) to activate (repeatable).
+    #[arg(long = "profile")]
+    pub(crate) profile: Vec<String>,
+
+    /// Extra env-file(s) to pass to Docker Compose (repeatable).
+    #[arg(long = "env-file")]
+    pub(crate) env_file: Vec<PathBuf>,
+
+    /// Pull policy for Docker Compose services (always, missing, never).
+    #[arg(long = "pull-policy")]
+    pub(crate) pull_policy: Option<String>,
 }
 
 /// Output format for container commands.
@@ -102,6 +114,12 @@ pub struct UpContext {
     network_rules: NetworkRulePolicy,
     /// Docker host override (forwarded to daemon registration).
     docker_host: Option<String>,
+    /// Docker Compose profiles to activate.
+    pub(crate) compose_profiles: Vec<String>,
+    /// Extra env-file paths for Docker Compose.
+    pub(crate) compose_env_files: Vec<PathBuf>,
+    /// Pull policy for Docker Compose services.
+    pub(crate) compose_pull_policy: Option<String>,
 }
 
 impl UpContext {
@@ -162,6 +180,9 @@ impl UpContext {
                 NetworkRulePolicy::Enforce
             },
             docker_host: effective_docker_host(&args.backend),
+            compose_profiles: args.profile.clone(),
+            compose_env_files: args.env_file.clone(),
+            compose_pull_policy: args.pull_policy.clone(),
         })
     }
 
@@ -224,6 +245,9 @@ impl UpContext {
             extra_labels,
             network_rules: NetworkRulePolicy::Enforce,
             docker_host: effective_docker_host(backend_args),
+            compose_profiles: Vec::new(),
+            compose_env_files: Vec::new(),
+            compose_pull_policy: None,
         })
     }
 

--- a/crates/cella-compose/src/cli.rs
+++ b/crates/cella-compose/src/cli.rs
@@ -52,6 +52,9 @@ pub struct ComposeCommand {
     compose_files: Vec<PathBuf>,
     override_file: Option<PathBuf>,
     working_dir: PathBuf,
+    profiles: Vec<String>,
+    env_files: Vec<PathBuf>,
+    pull_policy: Option<String>,
 }
 
 impl ComposeCommand {
@@ -62,6 +65,9 @@ impl ComposeCommand {
             compose_files: project.compose_files.clone(),
             override_file: Some(project.override_file.clone()),
             working_dir: project.config_dir.clone(),
+            profiles: project.profiles.clone(),
+            env_files: project.env_files.clone(),
+            pull_policy: project.pull_policy.clone(),
         }
     }
 
@@ -75,6 +81,9 @@ impl ComposeCommand {
             compose_files: project.compose_files.clone(),
             override_file: None,
             working_dir: project.config_dir.clone(),
+            profiles: project.profiles.clone(),
+            env_files: project.env_files.clone(),
+            pull_policy: project.pull_policy.clone(),
         }
     }
 
@@ -85,6 +94,9 @@ impl ComposeCommand {
             compose_files: Vec::new(),
             override_file: None,
             working_dir: PathBuf::from("."),
+            profiles: Vec::new(),
+            env_files: Vec::new(),
+            pull_policy: None,
         }
     }
 
@@ -93,6 +105,12 @@ impl ComposeCommand {
         let mut cmd = Command::new("docker");
         cmd.arg("compose");
         cmd.arg("--project-name").arg(&self.project_name);
+        for p in &self.profiles {
+            cmd.arg("--profile").arg(p);
+        }
+        for ef in &self.env_files {
+            cmd.arg("--env-file").arg(ef);
+        }
         for f in &self.compose_files {
             cmd.arg("-f").arg(f);
         }
@@ -116,6 +134,9 @@ impl ComposeCommand {
     ) -> Result<(), CellaComposeError> {
         let mut cmd = self.base_command();
         cmd.arg("up").arg("-d");
+        if let Some(ref policy) = self.pull_policy {
+            cmd.arg("--pull").arg(policy);
+        }
         if build {
             cmd.arg("--build");
         }
@@ -148,6 +169,11 @@ impl ComposeCommand {
     pub async fn build(&self, services: Option<&[String]>) -> Result<(), CellaComposeError> {
         let mut cmd = self.base_command();
         cmd.arg("build");
+        if let Some(ref policy) = self.pull_policy
+            && policy == "always"
+        {
+            cmd.arg("--pull");
+        }
         if let Some(svcs) = services {
             for s in svcs {
                 cmd.arg(s);
@@ -471,6 +497,9 @@ mod tests {
             config_dir: PathBuf::from("/workspace/.devcontainer"),
             workspace_root: PathBuf::from("/workspace"),
             config_hash: "abc123".to_string(),
+            profiles: Vec::new(),
+            env_files: Vec::new(),
+            pull_policy: None,
         };
 
         let cmd = ComposeCommand::new(&project);
@@ -502,6 +531,9 @@ mod tests {
             config_dir: PathBuf::from("/workspace/.devcontainer"),
             workspace_root: PathBuf::from("/workspace"),
             config_hash: "abc123".to_string(),
+            profiles: Vec::new(),
+            env_files: Vec::new(),
+            pull_policy: None,
         };
 
         let cmd = ComposeCommand::without_override(&project);
@@ -596,6 +628,9 @@ mod tests {
             config_dir: PathBuf::from("/workspace/.devcontainer"),
             workspace_root: PathBuf::from("/workspace"),
             config_hash: "abc123".to_string(),
+            profiles: Vec::new(),
+            env_files: Vec::new(),
+            pull_policy: None,
         };
 
         let cmd = ComposeCommand::without_override(&project);
@@ -632,6 +667,9 @@ mod tests {
             config_dir: PathBuf::from("/workspace/.devcontainer"),
             workspace_root: PathBuf::from("/workspace"),
             config_hash: "abc123".to_string(),
+            profiles: Vec::new(),
+            env_files: Vec::new(),
+            pull_policy: None,
         };
 
         let cmd = ComposeCommand::new(&project);
@@ -664,5 +702,109 @@ mod tests {
             parse_compose_version("Docker Compose version v99.99.99"),
             Some((99, 99, 99))
         );
+    }
+
+    #[test]
+    fn base_command_includes_profiles() {
+        let project = ComposeProject {
+            project_name: "cella-test-abc12345".to_string(),
+            compose_files: vec![PathBuf::from("/workspace/docker-compose.yml")],
+            override_file: PathBuf::from("/tmp/override.yml"),
+            primary_service: "app".to_string(),
+            run_services: None,
+            shutdown_action: crate::project::ShutdownAction::StopCompose,
+            override_command: false,
+            workspace_folder: "/workspaces/myapp".to_string(),
+            config_dir: PathBuf::from("/workspace"),
+            workspace_root: PathBuf::from("/workspace"),
+            config_hash: "abc123".to_string(),
+            profiles: vec!["debug".to_string(), "monitoring".to_string()],
+            env_files: Vec::new(),
+            pull_policy: None,
+        };
+
+        let cmd = ComposeCommand::new(&project);
+        let base = cmd.base_command();
+        let args: Vec<_> = base.as_std().get_args().collect();
+
+        // --profile debug --profile monitoring should appear after --project-name
+        let profile_indices: Vec<_> = args
+            .iter()
+            .enumerate()
+            .filter(|(_, a)| **a == "--profile")
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(profile_indices.len(), 2);
+        assert_eq!(args[profile_indices[0] + 1], "debug");
+        assert_eq!(args[profile_indices[1] + 1], "monitoring");
+    }
+
+    #[test]
+    fn base_command_includes_env_files() {
+        let project = ComposeProject {
+            project_name: "cella-test-abc12345".to_string(),
+            compose_files: vec![PathBuf::from("/workspace/docker-compose.yml")],
+            override_file: PathBuf::from("/tmp/override.yml"),
+            primary_service: "app".to_string(),
+            run_services: None,
+            shutdown_action: crate::project::ShutdownAction::StopCompose,
+            override_command: false,
+            workspace_folder: "/workspaces/myapp".to_string(),
+            config_dir: PathBuf::from("/workspace"),
+            workspace_root: PathBuf::from("/workspace"),
+            config_hash: "abc123".to_string(),
+            profiles: Vec::new(),
+            env_files: vec![
+                PathBuf::from("/workspace/.env"),
+                PathBuf::from("/workspace/.env.local"),
+            ],
+            pull_policy: None,
+        };
+
+        let cmd = ComposeCommand::new(&project);
+        let base = cmd.base_command();
+        let args: Vec<_> = base.as_std().get_args().collect();
+
+        let env_file_indices: Vec<_> = args
+            .iter()
+            .enumerate()
+            .filter(|(_, a)| **a == "--env-file")
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(env_file_indices.len(), 2);
+        assert_eq!(args[env_file_indices[0] + 1], "/workspace/.env");
+        assert_eq!(args[env_file_indices[1] + 1], "/workspace/.env.local");
+    }
+
+    #[test]
+    fn profiles_and_env_files_appear_before_compose_files() {
+        let project = ComposeProject {
+            project_name: "cella-order-abc12345".to_string(),
+            compose_files: vec![PathBuf::from("/workspace/docker-compose.yml")],
+            override_file: PathBuf::from("/tmp/override.yml"),
+            primary_service: "app".to_string(),
+            run_services: None,
+            shutdown_action: crate::project::ShutdownAction::StopCompose,
+            override_command: false,
+            workspace_folder: "/workspaces/myapp".to_string(),
+            config_dir: PathBuf::from("/workspace"),
+            workspace_root: PathBuf::from("/workspace"),
+            config_hash: "abc123".to_string(),
+            profiles: vec!["dev".to_string()],
+            env_files: vec![PathBuf::from("/workspace/.env")],
+            pull_policy: None,
+        };
+
+        let cmd = ComposeCommand::new(&project);
+        let base = cmd.base_command();
+        let args: Vec<_> = base.as_std().get_args().collect();
+
+        let profile_idx = args.iter().position(|a| *a == "--profile").unwrap();
+        let env_file_idx = args.iter().position(|a| *a == "--env-file").unwrap();
+        let first_f_idx = args.iter().position(|a| *a == "-f").unwrap();
+
+        // --profile and --env-file must appear before -f flags
+        assert!(profile_idx < first_f_idx);
+        assert!(env_file_idx < first_f_idx);
     }
 }

--- a/crates/cella-compose/src/project.rs
+++ b/crates/cella-compose/src/project.rs
@@ -3,6 +3,7 @@
 use std::path::{Path, PathBuf};
 
 use sha2::{Digest, Sha256};
+use tracing::debug;
 
 use crate::error::CellaComposeError;
 use crate::hash::compute_compose_hash;
@@ -50,6 +51,12 @@ pub struct ComposeProject {
     pub workspace_root: PathBuf,
     /// SHA256 hash of devcontainer.json + all compose files.
     pub config_hash: String,
+    /// Docker Compose profiles to activate (`--profile` flags).
+    pub profiles: Vec<String>,
+    /// Extra env-file paths to pass to docker compose (`--env-file` flags).
+    pub env_files: Vec<PathBuf>,
+    /// Pull policy for `docker compose up`/`build` (`--pull` flag).
+    pub pull_policy: Option<String>,
 }
 
 impl ComposeProject {
@@ -133,6 +140,9 @@ impl ComposeProject {
             config_dir,
             workspace_root: workspace_root.to_path_buf(),
             config_hash,
+            profiles: Vec::new(),
+            env_files: Vec::new(),
+            pull_policy: None,
         })
     }
 
@@ -142,6 +152,47 @@ impl ComposeProject {
         self.override_file = compose_override_path(&name);
         self.project_name = name;
         self
+    }
+
+    /// Set compose profiles, env-file paths, and pull policy from CLI arguments.
+    ///
+    /// Recomputes `config_hash` to include the new options so that changing
+    /// e.g. `--profile` triggers container re-creation.
+    pub fn set_compose_options(
+        &mut self,
+        profiles: Vec<String>,
+        env_files: Vec<PathBuf>,
+        pull_policy: Option<String>,
+    ) {
+        if !profiles.is_empty() {
+            debug!("Compose profiles: {profiles:?}");
+        }
+        if !env_files.is_empty() {
+            debug!("Compose env files: {env_files:?}");
+        }
+        if let Some(ref policy) = pull_policy {
+            debug!("Compose pull policy: {policy}");
+        }
+        self.profiles = profiles;
+        self.env_files = env_files;
+        self.pull_policy = pull_policy;
+
+        // Recompute hash to include CLI options that affect the compose project.
+        let mut hasher = Sha256::new();
+        hasher.update(self.config_hash.as_bytes());
+        for p in &self.profiles {
+            hasher.update(b"profile:");
+            hasher.update(p.as_bytes());
+        }
+        for ef in &self.env_files {
+            hasher.update(b"env_file:");
+            hasher.update(ef.to_string_lossy().as_bytes());
+        }
+        if let Some(ref pp) = self.pull_policy {
+            hasher.update(b"pull_policy:");
+            hasher.update(pp.as_bytes());
+        }
+        self.config_hash = hex::encode(hasher.finalize());
     }
 }
 

--- a/crates/cella-orchestrator/src/compose_build.rs
+++ b/crates/cella-orchestrator/src/compose_build.rs
@@ -4,7 +4,7 @@
 //! `docker compose build`. Shared by both `cella build` and `cella up`
 //! (compose path).
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use cella_backend::ContainerBackend;
 use cella_compose::ComposeProject;
@@ -19,6 +19,22 @@ pub struct ComposeBuildResult {
     pub had_features: bool,
 }
 
+/// Configuration for a compose build invocation.
+pub struct ComposeBuildConfig<'a> {
+    /// Parsed devcontainer JSON.
+    pub config: &'a serde_json::Value,
+    /// Path to devcontainer.json.
+    pub config_path: &'a Path,
+    /// Workspace root on the host.
+    pub workspace_root: &'a Path,
+    /// Docker Compose profiles to activate (`--profile` flags).
+    pub profiles: Vec<String>,
+    /// Extra env-file paths for docker compose (`--env-file` flags).
+    pub env_files: Vec<PathBuf>,
+    /// Pull policy for docker compose build (`--pull` flag).
+    pub pull_policy: Option<String>,
+}
+
 /// Run the compose build pipeline: resolve features, write override, build.
 ///
 /// # Errors
@@ -27,9 +43,7 @@ pub struct ComposeBuildResult {
 /// compose build command fails.
 pub async fn compose_build(
     client: &dyn ContainerBackend,
-    config: &serde_json::Value,
-    config_path: &Path,
-    workspace_root: &Path,
+    cfg: &ComposeBuildConfig<'_>,
     progress: &ProgressSender,
 ) -> Result<ComposeBuildResult, Box<dyn std::error::Error>> {
     if !client.capabilities().compose {
@@ -40,7 +54,15 @@ pub async fn compose_build(
         .into());
     }
 
-    let project = ComposeProject::from_resolved(config, config_path, workspace_root)?;
+    let config = cfg.config;
+    let config_path = cfg.config_path;
+    let workspace_root = cfg.workspace_root;
+    let mut project = ComposeProject::from_resolved(config, config_path, workspace_root)?;
+    project.set_compose_options(
+        cfg.profiles.clone(),
+        cfg.env_files.clone(),
+        cfg.pull_policy.clone(),
+    );
 
     // Resolve features via combined-Dockerfile approach
     let features_build = crate::compose_features::resolve_compose_features(

--- a/crates/cella-orchestrator/src/compose_up.rs
+++ b/crates/cella-orchestrator/src/compose_up.rs
@@ -6,7 +6,7 @@
 
 use std::collections::BTreeMap;
 use std::future::Future;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
 
 use tracing::{debug, info, warn};
@@ -42,6 +42,12 @@ pub struct ComposeUpConfig<'a> {
     pub build_no_cache: bool,
     /// Skip agent checksum verification.
     pub skip_checksum: bool,
+    /// Docker Compose profiles to activate (`--profile` flags).
+    pub profiles: Vec<String>,
+    /// Extra env-file paths for docker compose (`--env-file` flags).
+    pub env_files: Vec<PathBuf>,
+    /// Pull policy for docker compose up/build (`--pull` flag).
+    pub pull_policy: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -148,7 +154,12 @@ pub async fn compose_up(
     let config = cfg.config;
 
     // 1. Build ComposeProject from resolved config
-    let project = ComposeProject::from_resolved(config, cfg.config_path, cfg.workspace_root)?;
+    let mut project = ComposeProject::from_resolved(config, cfg.config_path, cfg.workspace_root)?;
+    project.set_compose_options(
+        cfg.profiles.clone(),
+        cfg.env_files.clone(),
+        cfg.pull_policy.clone(),
+    );
 
     info!(
         "Compose project: {} (primary service: {})",


### PR DESCRIPTION
## Summary

- Add `--profile`, `--env-file`, and `--pull-policy` flags to `cella up` and `cella build` for Docker Compose workflows
- Flags are passed through to `docker compose` commands (`--profile` and `--env-file` as global flags, `--pull` in `up`/`build` subcommands)
- Changing profiles/env-files/pull-policy triggers container re-creation via config hash recomputation

Addresses: devcontainers/cli#669, devcontainers/cli#483, devcontainers/cli#1100

## Changes

- `cella-compose`: Added `profiles`, `env_files`, `pull_policy` to `ComposeProject` and `ComposeCommand` with `set_compose_options()` method
- `cella-orchestrator`: Updated `ComposeUpConfig` and introduced `ComposeBuildConfig` struct
- `cella-cli`: Added CLI args and threaded through `UpContext`

## Test plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings -D clippy::all` clean
- [x] Test `cella up --profile dev` with a compose project that has profiles
- [x] Test `cella up --env-file .env.local` forwards the env file
- [x] Test `cella up --pull-policy always` forces image re-pull in compose

🤖 Generated with [Claude Code](https://claude.com/claude-code)