### PR TITLE
fix: full miette diagnostic conversion + lifecycle failure cleanup

### DIFF
--- a/crates/cella-agent/Cargo.toml
+++ b/crates/cella-agent/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 [dependencies]
 cella-network.workspace = true
 cella-port.workspace = true
+miette.workspace = true
 cella-protocol.workspace = true
 nix.workspace = true
 notify.workspace = true

--- a/crates/cella-agent/src/error.rs
+++ b/crates/cella-agent/src/error.rs
@@ -1,14 +1,17 @@
+use miette::Diagnostic;
 use thiserror::Error;
 
 /// Errors that can occur during agent sandbox operations.
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum CellaAgentError {
     /// Failed to create the agent sandbox.
     #[error("failed to create agent sandbox: {0}")]
+    #[diagnostic(code(cella::agent::sandbox_creation))]
     SandboxCreation(String),
 
     /// The agent sandbox is not running.
     #[error("agent sandbox is not running")]
+    #[diagnostic(code(cella::agent::not_running))]
     NotRunning,
 }
 

--- a/crates/cella-backend/Cargo.toml
+++ b/crates/cella-backend/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 chrono.workspace = true
 futures-util.workspace = true
 hex.workspace = true
+miette.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/cella-backend/src/error.rs
+++ b/crates/cella-backend/src/error.rs
@@ -1,63 +1,95 @@
 //! Unified error type for container backend operations.
 
+use miette::Diagnostic;
 use thiserror::Error;
 
 /// Errors that can occur during container backend operations.
 ///
 /// All backends map their internal errors to these variants so callers can
 /// handle failures uniformly regardless of the underlying runtime.
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum BackendError {
     /// No container found for the given identifier.
     #[error("container not found: {identifier}")]
+    #[diagnostic(
+        code(cella::container_not_found),
+        help("Run `cella up` to start a container, or `cella list` to see existing ones.")
+    )]
     ContainerNotFound { identifier: String },
 
     /// Container exists but is not running.
     #[error("{hint}")]
+    #[diagnostic(code(cella::backend::container_not_running))]
     ContainerNotRunning { hint: String },
 
     /// Image not found locally.
     #[error("image not found: {image}")]
+    #[diagnostic(code(cella::backend::image_not_found))]
     ImageNotFound { image: String },
 
     /// Image build failed.
     #[error("build failed: {message}")]
+    #[diagnostic(
+        code(cella::build_failed),
+        help("Check your Dockerfile syntax and build context.")
+    )]
     ImageBuildFailed { message: String },
 
     /// Command execution inside a container failed.
     #[error("exec failed (exit code {exit_code}): {command}")]
+    #[diagnostic(code(cella::backend::exec_failed))]
     ExecFailed { command: String, exit_code: i64 },
 
     /// Lifecycle command phase failed.
     #[error("lifecycle command failed: {phase} — {message}")]
+    #[diagnostic(
+        code(cella::lifecycle_failed),
+        help("A lifecycle command failed. Use `cella exec` to debug the container.")
+    )]
     LifecycleFailed { phase: String, message: String },
 
     /// Cannot connect to container runtime.
     #[error("connection failed: {message}")]
+    #[diagnostic(
+        code(cella::connection_failed),
+        help("Is Docker running? Try `cella doctor` to diagnose.")
+    )]
     ConnectionFailed { message: String },
 
     /// The requested operation is not supported by this backend.
     #[error("not supported by {backend}: {operation}")]
+    #[diagnostic(code(cella::backend::not_supported))]
     NotSupported { backend: String, operation: String },
 
     /// The backend CLI binary was not found.
     #[error("backend CLI not found: {message}")]
+    #[diagnostic(
+        code(cella::cli_not_found),
+        help("Install Docker Desktop or ensure `docker` is in your PATH.")
+    )]
     CliNotFound { message: String },
 
     /// Container exited immediately after start.
     #[error("container exited immediately (exit code {exit_code}):\n{logs_tail}")]
+    #[diagnostic(
+        code(cella::container_exited),
+        help("The container exited before it could be used. Check the logs above.")
+    )]
     ContainerExitedImmediately { exit_code: i64, logs_tail: String },
 
     /// Agent volume population error.
     #[error("agent volume error: {message}")]
+    #[diagnostic(code(cella::backend::agent_volume))]
     AgentVolume { message: String },
 
     /// Agent binary checksum verification failed.
     #[error("agent binary checksum mismatch: expected {expected}, got {actual}")]
+    #[diagnostic(code(cella::backend::agent_checksum_mismatch))]
     AgentChecksumMismatch { expected: String, actual: String },
 
     /// A host-side command failed.
     #[error("host command failed: {command}")]
+    #[diagnostic(code(cella::backend::host_command_failed))]
     HostCommandFailed {
         command: String,
         #[source]
@@ -66,9 +98,11 @@ pub enum BackendError {
 
     /// Generic I/O error.
     #[error("I/O error: {0}")]
+    #[diagnostic(code(cella::backend::io))]
     Io(#[from] std::io::Error),
 
     /// Wrapped runtime-specific error from the underlying SDK.
     #[error(transparent)]
+    #[diagnostic(code(cella::backend::runtime))]
     Runtime(Box<dyn std::error::Error + Send + Sync>),
 }

--- a/crates/cella-cli/src/picker.rs
+++ b/crates/cella-cli/src/picker.rs
@@ -38,9 +38,11 @@ pub enum PickResult<T> {
 }
 
 /// Error returned when the picker cannot be shown or has no candidates.
-#[derive(Debug)]
+#[derive(Debug, miette::Diagnostic)]
 pub enum PickerError {
+    #[diagnostic(code(cella::cli::no_candidates))]
     NoCandidates,
+    #[diagnostic(code(cella::cli::non_interactive))]
     NonInteractive {
         message: String,
         candidates: Vec<String>,

--- a/crates/cella-codegen/Cargo.toml
+++ b/crates/cella-codegen/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+miette.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 syn = { version = "2.0.117", features = ["full"] }

--- a/crates/cella-codegen/src/error.rs
+++ b/crates/cella-codegen/src/error.rs
@@ -1,16 +1,21 @@
+use miette::Diagnostic;
 use thiserror::Error;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum CellaCodegenError {
     #[error("failed to parse schema JSON: {0}")]
+    #[diagnostic(code(cella::codegen::json_parse))]
     JsonParse(#[from] serde_json::Error),
 
     #[error("invalid schema: {0}")]
+    #[diagnostic(code(cella::codegen::schema))]
     Schema(String),
 
     #[error("code emission failed: {0}")]
+    #[diagnostic(code(cella::codegen::emit))]
     Emit(String),
 
     #[error("formatting failed: {0}")]
+    #[diagnostic(code(cella::codegen::format))]
     Format(String),
 }

--- a/crates/cella-compose/Cargo.toml
+++ b/crates/cella-compose/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 hex.workspace = true
+miette.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 yaml_serde.workspace = true

--- a/crates/cella-compose/src/error.rs
+++ b/crates/cella-compose/src/error.rs
@@ -2,11 +2,14 @@
 
 use std::path::PathBuf;
 
+use miette::Diagnostic;
+
 /// Errors that can occur during Docker Compose operations.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, Diagnostic)]
 pub enum CellaComposeError {
     /// Docker Compose CLI not found or not V2.
     #[error("docker compose CLI not found: {message}")]
+    #[diagnostic(code(cella::compose::cli_not_found))]
     CliNotFound {
         /// Details about what went wrong.
         message: String,
@@ -14,6 +17,7 @@ pub enum CellaComposeError {
 
     /// Docker Compose command failed with a non-zero exit code.
     #[error("docker compose failed (exit {exit_code}): {stderr}")]
+    #[diagnostic(code(cella::compose::compose_failed))]
     ComposeFailed {
         /// The exit code from the docker compose process.
         exit_code: i32,
@@ -23,6 +27,7 @@ pub enum CellaComposeError {
 
     /// A referenced compose file does not exist.
     #[error("compose file not found: {}", path.display())]
+    #[diagnostic(code(cella::compose::file_not_found))]
     FileNotFound {
         /// The missing file path.
         path: PathBuf,
@@ -30,6 +35,7 @@ pub enum CellaComposeError {
 
     /// The primary service is not defined in any compose file.
     #[error("service '{service}' not found in compose file(s); available: {available}")]
+    #[diagnostic(code(cella::compose::service_not_found))]
     ServiceNotFound {
         /// The service name that was not found.
         service: String,
@@ -39,10 +45,12 @@ pub enum CellaComposeError {
 
     /// Failed to parse a compose YAML file.
     #[error("compose YAML parse error: {0}")]
+    #[diagnostic(code(cella::compose::yaml_parse))]
     YamlParse(String),
 
     /// Missing required field in devcontainer.json for compose config.
     #[error("missing required compose field: {field}")]
+    #[diagnostic(code(cella::compose::missing_field))]
     MissingField {
         /// The name of the missing field.
         field: String,
@@ -50,6 +58,7 @@ pub enum CellaComposeError {
 
     /// Failed to parse `docker compose config` output.
     #[error("docker compose config parse failed: {message}")]
+    #[diagnostic(code(cella::compose::config_parse_failed))]
     ConfigParseFailed {
         /// Details about what went wrong.
         message: String,
@@ -57,6 +66,7 @@ pub enum CellaComposeError {
 
     /// Service has neither `build` nor `image` defined.
     #[error("service '{service}' has neither 'build' nor 'image' in compose config")]
+    #[diagnostic(code(cella::compose::service_has_no_build_or_image))]
     ServiceHasNoBuildOrImage {
         /// The service name.
         service: String,
@@ -64,6 +74,7 @@ pub enum CellaComposeError {
 
     /// Docker Compose version is too old for the requested operation.
     #[error("Docker Compose >= {required} required for {feature}. Found: {found}")]
+    #[diagnostic(code(cella::compose::unsupported_version))]
     UnsupportedVersion {
         /// The minimum required version (e.g., "2.17.0").
         required: String,
@@ -75,6 +86,7 @@ pub enum CellaComposeError {
 
     /// Dockerfile parsing error.
     #[error("dockerfile error: {message}")]
+    #[diagnostic(code(cella::compose::dockerfile_parse))]
     DockerfileParse {
         /// Details about what went wrong.
         message: String,
@@ -82,5 +94,6 @@ pub enum CellaComposeError {
 
     /// I/O error (reading compose files, writing override files).
     #[error(transparent)]
+    #[diagnostic(code(cella::compose::io))]
     Io(#[from] std::io::Error),
 }

--- a/crates/cella-config/src/devcontainer/discover.rs
+++ b/crates/cella-config/src/devcontainer/discover.rs
@@ -5,14 +5,19 @@
 
 use std::path::{Path, PathBuf};
 
+use miette::Diagnostic;
+
 /// Errors that can occur during config discovery.
-#[derive(Debug)]
+#[derive(Debug, Diagnostic)]
 pub enum Error {
     /// No devcontainer.json found in any standard location.
+    #[diagnostic(code(cella::config::discover::not_found))]
     NotFound,
     /// Multiple subfolder configs found — user must specify `--file`.
+    #[diagnostic(code(cella::config::discover::ambiguous))]
     Ambiguous(Vec<PathBuf>),
     /// Failed to read a directory during discovery.
+    #[diagnostic(code(cella::config::discover::read_dir))]
     ReadDir {
         path: PathBuf,
         source: std::io::Error,

--- a/crates/cella-config/src/devcontainer/error.rs
+++ b/crates/cella-config/src/devcontainer/error.rs
@@ -1,11 +1,13 @@
 use super::discover;
+use miette::Diagnostic;
 use thiserror::Error;
 
 /// Errors that can occur during configuration parsing and management.
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum CellaConfigError {
     /// Failed to read a configuration file.
     #[error("failed to read config file: {path}")]
+    #[diagnostic(code(cella::config::read_file))]
     ReadFile {
         path: String,
         #[source]
@@ -14,17 +16,21 @@ pub enum CellaConfigError {
 
     /// Failed to parse JSON content.
     #[error("failed to parse config")]
+    #[diagnostic(code(cella::config::parse))]
     Parse(#[from] serde_json::Error),
 
     /// JSONC preprocessing failed.
     #[error("JSONC error: {0}")]
+    #[diagnostic(code(cella::config::jsonc))]
     Jsonc(String),
 
     /// Config validation failed with diagnostics.
     #[error("config validation failed with {error_count} error(s)")]
+    #[diagnostic(code(cella::config::validation))]
     Validation { error_count: usize },
 
     /// Config discovery failed.
     #[error("config discovery failed: {0}")]
+    #[diagnostic(code(cella::config::discovery))]
     Discovery(#[from] discover::Error),
 }

--- a/crates/cella-daemon/Cargo.toml
+++ b/crates/cella-daemon/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [dependencies]
 cella-port.workspace = true
 cella-protocol.workspace = true
+miette.workspace = true
 nix.workspace = true
 portable-pty.workspace = true
 serde_json.workspace = true

--- a/crates/cella-daemon/src/error.rs
+++ b/crates/cella-daemon/src/error.rs
@@ -1,38 +1,47 @@
+use miette::Diagnostic;
 use thiserror::Error;
 
 /// Errors that can occur in the cella daemon.
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum CellaDaemonError {
     /// Failed to create or bind a socket.
     #[error("socket error: {message}")]
+    #[diagnostic(code(cella::daemon::socket))]
     Socket { message: String },
 
     /// Failed to write or read the PID file.
     #[error("PID file error: {message}")]
+    #[diagnostic(code(cella::daemon::pid_file))]
     PidFile { message: String },
 
     /// Failed to invoke the host git credential helper.
     #[error("git credential error: {message}")]
+    #[diagnostic(code(cella::daemon::git_credential))]
     GitCredential { message: String },
 
     /// Protocol parse error.
     #[error("protocol error: {message}")]
+    #[diagnostic(code(cella::daemon::protocol))]
     Protocol { message: String },
 
     /// The daemon is already running.
     #[error("cella daemon is already running (PID {pid})")]
+    #[diagnostic(code(cella::daemon::already_running))]
     AlreadyRunning { pid: u32 },
 
     /// The daemon is not running.
     #[error("cella daemon is not running")]
+    #[diagnostic(code(cella::daemon::not_running))]
     NotRunning,
 
     /// Port forwarding error.
     #[error("port forwarding error: {message}")]
+    #[diagnostic(code(cella::daemon::port_forwarding))]
     PortForwarding { message: String },
 
     /// Generic I/O error.
     #[error("I/O error: {0}")]
+    #[diagnostic(code(cella::daemon::io))]
     Io(#[from] std::io::Error),
 }
 

--- a/crates/cella-docker/Cargo.toml
+++ b/crates/cella-docker/Cargo.toml
@@ -10,6 +10,7 @@ reqwest.workspace = true
 cella-backend.workspace = true
 crossterm.workspace = true
 glob.workspace = true
+miette.workspace = true
 tar.workspace = true
 chrono.workspace = true
 futures-util.workspace = true

--- a/crates/cella-docker/src/error.rs
+++ b/crates/cella-docker/src/error.rs
@@ -1,46 +1,60 @@
+use miette::Diagnostic;
 use thiserror::Error;
 
 /// Errors that can occur during container runtime operations.
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum CellaDockerError {
     /// The container runtime is not available.
     #[error("container runtime not found: {message}")]
+    #[diagnostic(
+        code(cella::docker::runtime_not_found),
+        help("Is Docker Desktop running? Try `cella doctor`.")
+    )]
     RuntimeNotFound { message: String },
 
     /// Docker API error.
     #[error("Docker API error: {0}")]
+    #[diagnostic(code(cella::docker::docker_api))]
     DockerApi(#[from] bollard::errors::Error),
 
     /// Image not found.
     #[error("image not found: {image}")]
+    #[diagnostic(code(cella::docker::image_not_found))]
     ImageNotFound { image: String },
 
     /// Docker CLI not found.
     #[error("docker CLI not found: {message}")]
+    #[diagnostic(code(cella::docker::docker_cli_not_found))]
     DockerCliNotFound { message: String },
 
     /// Image build failed.
     #[error("build failed: {message}")]
+    #[diagnostic(code(cella::docker::build_failed))]
     BuildFailed { message: String },
 
     /// No container for the given workspace.
     #[error("container not found for workspace: {workspace}")]
+    #[diagnostic(code(cella::docker::container_not_found))]
     ContainerNotFound { workspace: String },
 
     /// Container exists but is not running.
     #[error("{hint}")]
+    #[diagnostic(code(cella::docker::container_not_running))]
     ContainerNotRunning { hint: String },
 
     /// A command executed inside the container failed.
     #[error("exec failed (exit code {exit_code}): {command}")]
+    #[diagnostic(code(cella::docker::exec_failed))]
     ExecFailed { command: String, exit_code: i64 },
 
     /// A lifecycle command phase failed.
     #[error("lifecycle command failed: {phase} — {message}")]
+    #[diagnostic(code(cella::docker::lifecycle_failed))]
     LifecycleFailed { phase: String, message: String },
 
     /// A host-side command failed.
     #[error("host command failed: {command}")]
+    #[diagnostic(code(cella::docker::host_command_failed))]
     HostCommandFailed {
         command: String,
         #[source]
@@ -49,18 +63,22 @@ pub enum CellaDockerError {
 
     /// The container exited immediately after start.
     #[error("container exited immediately (exit code {exit_code}):\n{logs_tail}")]
+    #[diagnostic(code(cella::docker::container_exited_immediately))]
     ContainerExitedImmediately { exit_code: i64, logs_tail: String },
 
     /// Agent volume population error.
     #[error("agent volume error: {message}")]
+    #[diagnostic(code(cella::docker::agent_volume))]
     AgentVolume { message: String },
 
     /// Agent binary checksum verification failed.
     #[error("agent binary checksum mismatch: expected {expected}, got {actual}")]
+    #[diagnostic(code(cella::docker::agent_checksum_mismatch))]
     AgentChecksumMismatch { expected: String, actual: String },
 
     /// Generic I/O error.
     #[error("I/O error: {0}")]
+    #[diagnostic(code(cella::docker::io))]
     Io(#[from] std::io::Error),
 }
 

--- a/crates/cella-env/Cargo.toml
+++ b/crates/cella-env/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 cella-network.workspace = true
+miette.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/cella-env/src/error.rs
+++ b/crates/cella-env/src/error.rs
@@ -1,21 +1,26 @@
+use miette::Diagnostic;
 use thiserror::Error;
 
 /// Errors that can occur during environment forwarding setup.
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum CellaEnvError {
     /// Failed to read host git configuration.
     #[error("failed to read host git config: {message}")]
+    #[diagnostic(code(cella::env::git_config_read))]
     GitConfigRead { message: String },
 
     /// Failed to read SSH configuration files.
     #[error("failed to read SSH config: {message}")]
+    #[diagnostic(code(cella::env::ssh_config_read))]
     SshConfigRead { message: String },
 
     /// Failed to probe user environment inside container.
     #[error("failed to probe user environment: {message}")]
+    #[diagnostic(code(cella::env::user_env_probe))]
     UserEnvProbe { message: String },
 
     /// Generic I/O error.
     #[error("I/O error: {0}")]
+    #[diagnostic(code(cella::env::io))]
     Io(#[from] std::io::Error),
 }

--- a/crates/cella-features/src/error.rs
+++ b/crates/cella-features/src/error.rs
@@ -8,34 +8,42 @@ use thiserror::Error;
 pub enum FeatureError {
     /// OCI registry communication failed.
     #[error("registry error for {registry}: {message}")]
+    #[diagnostic(code(cella::features::registry_error))]
     RegistryError { registry: String, message: String },
 
     /// Registry authentication failed.
     #[error("authentication failed for registry {registry}")]
+    #[diagnostic(code(cella::features::authentication_failed))]
     AuthenticationFailed { registry: String },
 
     /// The requested feature does not exist.
     #[error("feature not found: {reference}")]
+    #[diagnostic(code(cella::features::feature_not_found))]
     FeatureNotFound { reference: String },
 
     /// The downloaded artifact is malformed.
     #[error("invalid feature artifact for {feature_id}: {reason}")]
+    #[diagnostic(code(cella::features::invalid_artifact))]
     InvalidArtifact { feature_id: String, reason: String },
 
     /// Feature metadata (devcontainer-feature.json) is invalid.
     #[error("invalid feature metadata for {feature_id}: {reason}")]
+    #[diagnostic(code(cella::features::invalid_metadata))]
     InvalidMetadata { feature_id: String, reason: String },
 
     /// Cyclic dependency detected among features.
     #[error("cyclic installsAfter dependency among features: {}", features.join(", "))]
+    #[diagnostic(code(cella::features::cyclic_dependency))]
     CyclicDependency { features: Vec<String> },
 
     /// Feature install script failed during container build.
     #[error("feature build failed for {feature_id}: {message}")]
+    #[diagnostic(code(cella::features::build_failed))]
     BuildFailed { feature_id: String, message: String },
 
     /// Downloaded blob digest does not match the OCI manifest.
     #[error("digest mismatch for {feature_id}: expected {expected}, got {actual}")]
+    #[diagnostic(code(cella::features::digest_mismatch))]
     DigestMismatch {
         feature_id: String,
         expected: String,
@@ -44,18 +52,22 @@ pub enum FeatureError {
 
     /// HTTP fetch failed.
     #[error("failed to fetch {url}: {message}")]
+    #[diagnostic(code(cella::features::fetch_failed))]
     FetchFailed { url: String, message: String },
 
     /// A local feature path does not exist.
     #[error("local feature not found: {}", path.display())]
+    #[diagnostic(code(cella::features::local_feature_not_found))]
     LocalFeatureNotFound { path: PathBuf },
 
     /// The feature reference string cannot be parsed.
     #[error("invalid feature reference: {reference}: {reason}")]
+    #[diagnostic(code(cella::features::invalid_reference))]
     InvalidReference { reference: String, reason: String },
 
     /// Generic I/O error.
     #[error(transparent)]
+    #[diagnostic(code(cella::features::io))]
     Io(#[from] std::io::Error),
 }
 

--- a/crates/cella-git/Cargo.toml
+++ b/crates/cella-git/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+miette.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 

--- a/crates/cella-git/src/error.rs
+++ b/crates/cella-git/src/error.rs
@@ -1,36 +1,44 @@
 use std::path::PathBuf;
 
+use miette::Diagnostic;
 use thiserror::Error;
 
 /// Errors that can occur during git operations.
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum CellaGitError {
     /// Git is not installed or not found in PATH.
     #[error("git not found in PATH")]
+    #[diagnostic(code(cella::git::git_not_found))]
     GitNotFound,
 
     /// The current directory is not a git repository.
     #[error("not a git repository: {path}")]
+    #[diagnostic(code(cella::git::not_a_repository))]
     NotARepository { path: PathBuf },
 
     /// A git command failed.
     #[error("git command failed: `git {args}`\n{stderr}")]
+    #[diagnostic(code(cella::git::command_failed))]
     CommandFailed { args: String, stderr: String },
 
     /// Git lock was held and retries were exhausted.
     #[error("git lock held, retries exhausted: {path}")]
+    #[diagnostic(code(cella::git::lock_contention))]
     LockContention { path: PathBuf },
 
     /// A worktree already exists at the given path.
     #[error("worktree already exists: {}", path.display())]
+    #[diagnostic(code(cella::git::worktree_already_exists))]
     WorktreeAlreadyExists { path: PathBuf },
 
     /// No worktree was found at the given path.
     #[error("worktree not found: {}", path.display())]
+    #[diagnostic(code(cella::git::worktree_not_found))]
     WorktreeNotFound { path: PathBuf },
 
     /// The branch is already checked out in another worktree.
     #[error("branch '{branch}' is already checked out at {}", worktree_path.display())]
+    #[diagnostic(code(cella::git::branch_checked_out))]
     BranchCheckedOut {
         branch: String,
         worktree_path: PathBuf,
@@ -38,14 +46,17 @@ pub enum CellaGitError {
 
     /// The specified branch was not found.
     #[error("branch not found: {branch}")]
+    #[diagnostic(code(cella::git::branch_not_found))]
     BranchNotFound { branch: String },
 
     /// Git output could not be parsed.
     #[error("failed to parse git output: {context}")]
+    #[diagnostic(code(cella::git::parse_error))]
     ParseError { context: String },
 
     /// An I/O error occurred.
     #[error(transparent)]
+    #[diagnostic(code(cella::git::io))]
     Io(#[from] std::io::Error),
 }
 

--- a/crates/cella-network/Cargo.toml
+++ b/crates/cella-network/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 base64.workspace = true
+miette.workspace = true
 rcgen.workspace = true
 rustls-native-certs.workspace = true
 serde.workspace = true

--- a/crates/cella-network/src/ca.rs
+++ b/crates/cella-network/src/ca.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
+use miette::Diagnostic;
 use rcgen::{CertificateParams, DnType, IsCa, KeyPair};
 use thiserror::Error;
 
@@ -15,18 +16,22 @@ const CA_DIR: &str = ".cella/proxy";
 const CA_CERT_FILE: &str = "ca.pem";
 const CA_KEY_FILE: &str = "ca.key";
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum CaError {
     #[error("failed to generate CA key pair: {0}")]
+    #[diagnostic(code(cella::network::key_generation))]
     KeyGeneration(#[source] rcgen::Error),
 
     #[error("failed to generate CA certificate: {0}")]
+    #[diagnostic(code(cella::network::cert_generation))]
     CertGeneration(#[source] rcgen::Error),
 
     #[error("failed to write CA files: {0}")]
+    #[diagnostic(code(cella::network::io))]
     Io(#[from] std::io::Error),
 
     #[error("failed to read CA certificate: {0}")]
+    #[diagnostic(code(cella::network::read_cert))]
     ReadCert(String),
 }
 

--- a/crates/cella-orchestrator/Cargo.toml
+++ b/crates/cella-orchestrator/Cargo.toml
@@ -14,6 +14,7 @@ cella-protocol.workspace = true
 cella-git.workspace = true
 cella-network.workspace = true
 hex.workspace = true
+miette.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true

--- a/crates/cella-orchestrator/src/error.rs
+++ b/crates/cella-orchestrator/src/error.rs
@@ -1,24 +1,35 @@
 //! Orchestrator error types.
 
+use miette::Diagnostic;
+
 /// Errors from orchestrator operations.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, Diagnostic)]
 pub enum OrchestratorError {
     #[error("backend: {message}")]
+    #[diagnostic(code(cella::orchestrator::backend))]
     Backend { message: String },
 
     #[error("git: {message}")]
+    #[diagnostic(code(cella::orchestrator::git))]
     Git { message: String },
 
     #[error("config: {message}")]
+    #[diagnostic(code(cella::orchestrator::config))]
     Config { message: String },
 
     #[error("container exited immediately: {message}")]
+    #[diagnostic(code(cella::orchestrator::container_exited))]
     ContainerExited { message: String },
 
     #[error("host requirements not met: {message}")]
+    #[diagnostic(
+        code(cella::host_requirements),
+        help("Run `cella doctor` to check system dependencies.")
+    )]
     HostRequirements { message: String },
 
     #[error("{message}")]
+    #[diagnostic(code(cella::orchestrator::other))]
     Other { message: String },
 }
 

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -1090,7 +1090,7 @@ impl EnsureUpContext<'_> {
             )
             .await;
 
-        {
+        let lifecycle_err = {
             let lc_ctx = self.build_lifecycle_ctx(&container_id, &remote_user, &lifecycle_env);
             run_lifecycle_phases_with_wait_for(
                 &lc_ctx,
@@ -1099,7 +1099,15 @@ impl EnsureUpContext<'_> {
                 &self.progress,
                 WaitForPhase::from_config(config),
             )
-            .await?;
+            .await
+            .err()
+            .map(|e| e.to_string())
+        };
+        if let Some(msg) = lifecycle_err {
+            tracing::warn!("Lifecycle failed, cleaning up container {container_id}");
+            let _ = self.client.stop_container(&container_id).await;
+            let _ = self.client.remove_container(&container_id, false).await;
+            return Err(msg.into());
         }
 
         write_content_hash(

--- a/crates/cella-port/Cargo.toml
+++ b/crates/cella-port/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 cella-protocol.workspace = true
+miette.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 

--- a/crates/cella-port/src/error.rs
+++ b/crates/cella-port/src/error.rs
@@ -1,25 +1,31 @@
+use miette::Diagnostic;
 use thiserror::Error;
 
 /// Errors that can occur during port management.
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum CellaPortError {
     /// The requested port is already in use.
     #[error("port {0} is already in use")]
+    #[diagnostic(code(cella::port::port_in_use))]
     PortInUse(u16),
 
     /// No available ports in the configured range.
     #[error("no available ports in range")]
+    #[diagnostic(code(cella::port::no_available_ports))]
     NoAvailablePorts,
 
     /// Failed to read /proc/net/tcp.
     #[error("port detection error: {0}")]
+    #[diagnostic(code(cella::port::detection))]
     Detection(#[from] std::io::Error),
 
     /// Control socket communication error.
     #[error("control socket error: {message}")]
+    #[diagnostic(code(cella::port::control_socket))]
     ControlSocket { message: String },
 
     /// Failed to serialize/deserialize protocol messages.
     #[error("protocol error: {0}")]
+    #[diagnostic(code(cella::port::protocol))]
     Protocol(#[from] serde_json::Error),
 }

--- a/crates/cella-templates/src/error.rs
+++ b/crates/cella-templates/src/error.rs
@@ -6,26 +6,32 @@ use thiserror::Error;
 pub enum TemplateError {
     /// OCI registry communication failed.
     #[error("registry error for {registry}: {message}")]
+    #[diagnostic(code(cella::templates::registry_error))]
     RegistryError { registry: String, message: String },
 
     /// The collection index could not be fetched or parsed.
     #[error("failed to fetch collection index from {registry}: {message}")]
+    #[diagnostic(code(cella::templates::collection_fetch_failed))]
     CollectionFetchFailed { registry: String, message: String },
 
     /// The requested template does not exist in the collection.
     #[error("template not found: {id}")]
+    #[diagnostic(code(cella::templates::template_not_found))]
     TemplateNotFound { id: String },
 
     /// The downloaded template artifact is malformed.
     #[error("invalid template artifact for {template_id}: {reason}")]
+    #[diagnostic(code(cella::templates::invalid_artifact))]
     InvalidArtifact { template_id: String, reason: String },
 
     /// Template metadata (devcontainer-template.json) is invalid.
     #[error("invalid template metadata for {template_id}: {reason}")]
+    #[diagnostic(code(cella::templates::invalid_metadata))]
     InvalidMetadata { template_id: String, reason: String },
 
     /// A template option value is invalid.
     #[error("invalid option value for {template_id}.{option}: {reason}")]
+    #[diagnostic(code(cella::templates::invalid_option_value))]
     InvalidOptionValue {
         template_id: String,
         option: String,
@@ -34,6 +40,7 @@ pub enum TemplateError {
 
     /// Downloaded blob digest does not match the OCI manifest.
     #[error("digest mismatch for {template_id}: expected {expected}, got {actual}")]
+    #[diagnostic(code(cella::templates::digest_mismatch))]
     DigestMismatch {
         template_id: String,
         expected: String,
@@ -42,17 +49,21 @@ pub enum TemplateError {
 
     /// The output directory already contains a devcontainer configuration.
     #[error("devcontainer configuration already exists at {}", path.display())]
+    #[diagnostic(code(cella::templates::config_already_exists))]
     ConfigAlreadyExists { path: std::path::PathBuf },
 
     /// Failed to fetch the aggregated devcontainer index.
     #[error("failed to fetch devcontainer index: {message}")]
+    #[diagnostic(code(cella::templates::index_fetch_failed))]
     IndexFetchFailed { message: String },
 
     /// Cache I/O error.
     #[error("cache error: {message}")]
+    #[diagnostic(code(cella::templates::cache_error))]
     CacheError { message: String },
 
     /// Generic I/O error.
     #[error(transparent)]
+    #[diagnostic(code(cella::templates::io))]
     Io(#[from] std::io::Error),
 }


### PR DESCRIPTION
## Summary

- Add `miette::Diagnostic` derive to all 17 error types across 13 crates
- Add `#[diagnostic(code(...), help(...))]` attributes with actionable help text for user-facing errors
- Stop and remove container on lifecycle hook failure (prevents zombie containers)

Addresses: devcontainers/cli#1187 (no error when Docker not running), community reports of silent postCreateCommand failures

## Key diagnostics

| Error | Help text |
|---|---|
| `ConnectionFailed` | "Is Docker running? Try `cella doctor` to diagnose." |
| `LifecycleFailed` | "A lifecycle command failed. Use `cella exec` to debug the container." |
| `ImageBuildFailed` | "Check your Dockerfile syntax and build context." |
| `ContainerNotFound` | "Run `cella up` to start a container, or `cella list` to see existing ones." |
| `CliNotFound` | "Install Docker Desktop or ensure `docker` is in your PATH." |

## Changes

- 3 atomic commits: deps → diagnostics → lifecycle cleanup
- 16 error files updated with Diagnostic derive + codes
- `create_and_start` in up.rs: on lifecycle failure, stops+removes container (keeps image)

## Test plan

- [x] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings -D clippy::all` clean
- [x] Trigger a lifecycle failure and verify container is cleaned up
- [x] Verify error output shows diagnostic codes and help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)