### PR TITLE
feat: run lifecycle hooks from prebuilt devcontainer images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,7 @@ dependencies = [
  "cella-network",
  "cella-port",
  "cella-protocol",
+ "miette",
  "nix 0.31.2",
  "notify",
  "rcgen",
@@ -325,6 +326,7 @@ dependencies = [
  "chrono",
  "futures-util",
  "hex",
+ "miette",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -373,6 +375,7 @@ dependencies = [
  "heck",
  "indexmap",
  "insta",
+ "miette",
  "prettyplease",
  "proc-macro2",
  "quote",
@@ -387,6 +390,7 @@ version = "0.0.15"
 dependencies = [
  "hex",
  "insta",
+ "miette",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -431,6 +435,7 @@ version = "0.0.15"
 dependencies = [
  "cella-port",
  "cella-protocol",
+ "miette",
  "nix 0.31.2",
  "portable-pty",
  "serde_json",
@@ -452,6 +457,7 @@ dependencies = [
  "futures-util",
  "glob",
  "hex",
+ "miette",
  "reqwest 0.13.2",
  "sha2 0.11.0",
  "tar",
@@ -481,6 +487,7 @@ name = "cella-env"
 version = "0.0.15"
 dependencies = [
  "cella-network",
+ "miette",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
@@ -515,6 +522,7 @@ name = "cella-git"
 version = "0.0.15"
 dependencies = [
  "insta",
+ "miette",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
@@ -525,6 +533,7 @@ name = "cella-network"
 version = "0.0.15"
 dependencies = [
  "base64 0.22.1",
+ "miette",
  "rcgen",
  "rustls-native-certs",
  "serde",
@@ -547,6 +556,8 @@ dependencies = [
  "cella-network",
  "cella-protocol",
  "hex",
+ "miette",
+ "serde",
  "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.18",
@@ -559,6 +570,7 @@ name = "cella-port"
 version = "0.0.15"
 dependencies = [
  "cella-protocol",
+ "miette",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",

--- a/crates/cella-git/src/content_hash.rs
+++ b/crates/cella-git/src/content_hash.rs
@@ -9,8 +9,8 @@ use tracing::debug;
 
 /// Compute a content hash for the workspace.
 ///
-/// For git repos: SHA-256 of `HEAD` commit hash + porcelain status.
-/// For non-git workspaces: SHA-256 of sorted top-level file mtimes.
+/// For git repos: hash of `HEAD` commit hash + porcelain status.
+/// For non-git workspaces: hash of sorted top-level file mtimes.
 ///
 /// Returns a hex-encoded 16-character hash string.
 pub fn compute(workspace_root: &Path) -> String {
@@ -44,7 +44,7 @@ fn git_content_hash(workspace_root: &Path) -> Option<String> {
         .unwrap_or_default();
 
     let input = format!("{head_hash}\n{status}");
-    Some(sha256_short(&input))
+    Some(fast_hash_short(&input))
 }
 
 /// Mtime-based content hash: sorted top-level file modification times.
@@ -76,15 +76,17 @@ fn mtime_content_hash(workspace_root: &Path) -> String {
         .collect::<Vec<_>>()
         .join("\n");
 
-    sha256_short(&input)
+    fast_hash_short(&input)
 }
 
-/// SHA-256 of input, returning first 16 hex characters.
-fn sha256_short(input: &str) -> String {
+/// Fast non-cryptographic hash of input, returning first 16 hex characters.
+///
+/// Uses `DefaultHasher` (`SipHash`) — collision avoidance is sufficient here;
+/// this is NOT a SHA-256 hash despite the original name.
+fn fast_hash_short(input: &str) -> String {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
 
-    // Use a fast non-cryptographic hash — collision avoidance is sufficient here
     let mut hasher = DefaultHasher::new();
     input.hash(&mut hasher);
     let h1 = hasher.finish();

--- a/crates/cella-orchestrator/Cargo.toml
+++ b/crates/cella-orchestrator/Cargo.toml
@@ -15,6 +15,7 @@ cella-git.workspace = true
 cella-network.workspace = true
 hex.workspace = true
 miette.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true

--- a/crates/cella-orchestrator/src/image.rs
+++ b/crates/cella-orchestrator/src/image.rs
@@ -191,8 +191,7 @@ async fn resolve_base_image(
         );
 
         if !will_build_features {
-            let metadata_label =
-                cella_features::generate_metadata_label(&[], input.config, None);
+            let metadata_label = cella_features::generate_metadata_label(&[], input.config, None);
             build_opts
                 .options
                 .push(format!("--label=devcontainer.metadata={metadata_label}"));
@@ -206,9 +205,9 @@ async fn resolve_base_image(
         let elapsed_str = format_elapsed(start.elapsed());
         match &result {
             Ok(_) => {
-                input.progress.println(&format!(
-                    "  \x1b[32m✓\x1b[0m Built Dockerfile{elapsed_str}"
-                ));
+                input
+                    .progress
+                    .println(&format!("  \x1b[32m✓\x1b[0m Built Dockerfile{elapsed_str}"));
             }
             Err(e) => {
                 input

--- a/crates/cella-orchestrator/src/image.rs
+++ b/crates/cella-orchestrator/src/image.rs
@@ -128,16 +128,7 @@ pub async fn ensure_image(
         .and_then(|v| v.as_object())
         .is_some_and(|obj| !obj.is_empty());
 
-    let base_image_tag = resolve_base_image(
-        input.client,
-        input.config,
-        input.workspace_root,
-        input.config_name,
-        input.no_cache,
-        input.pull_policy,
-        input.progress,
-    )
-    .await?;
+    let base_image_tag = resolve_base_image(input, has_features).await?;
 
     let base_image_details = input.client.inspect_image_details(&base_image_tag).await?;
 
@@ -162,19 +153,20 @@ pub async fn ensure_image(
 }
 
 /// Pull or build the base image and return its tag.
+///
+/// When `will_build_features` is false and the config has a Dockerfile build,
+/// the devcontainer lifecycle metadata is embedded as a Docker label so that
+/// prebuilt images carry their lifecycle commands. This is skipped when
+/// features will be layered on top, because the features build produces its
+/// own metadata label and including it here would cause duplication.
 async fn resolve_base_image(
-    client: &dyn ContainerBackend,
-    config: &serde_json::Value,
-    workspace_root: &Path,
-    config_name: Option<&str>,
-    no_cache: bool,
-    pull_policy: Option<&str>,
-    progress: &ProgressSender,
+    input: &EnsureImageInput<'_>,
+    will_build_features: bool,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    let force_pull = pull_policy == Some("always");
-    let never_pull = pull_policy == Some("never");
-    if let Some(image) = config.get("image").and_then(|v| v.as_str()) {
-        let exists = client.image_exists(image).await?;
+    let force_pull = input.pull_policy == Some("always");
+    let never_pull = input.pull_policy == Some("never");
+    if let Some(image) = input.config.get("image").and_then(|v| v.as_str()) {
+        let exists = input.client.image_exists(image).await?;
         if never_pull {
             if !exists {
                 return Err(format!(
@@ -182,26 +174,46 @@ async fn resolve_base_image(
                 )
                 .into());
             }
-        } else if no_cache || force_pull || !exists {
-            let step = progress.step("Pulling base image...");
-            client.pull_image(image).await?;
+        } else if input.no_cache || force_pull || !exists {
+            let step = input.progress.step("Pulling base image...");
+            input.client.pull_image(image).await?;
             step.finish();
         }
         Ok(image.to_string())
-    } else if let Some(build) = config.get("build").and_then(|v| v.as_object()) {
-        let img_name = image_name(workspace_root, config_name);
-        let build_opts =
-            parse_build_options(build, &img_name, workspace_root, no_cache, pull_policy);
+    } else if let Some(build) = input.config.get("build").and_then(|v| v.as_object()) {
+        let img_name = image_name(input.workspace_root, input.config_name);
+        let mut build_opts = parse_build_options(
+            build,
+            &img_name,
+            input.workspace_root,
+            input.no_cache,
+            input.pull_policy,
+        );
+
+        if !will_build_features {
+            let metadata_label =
+                cella_features::generate_metadata_label(&[], input.config, None);
+            build_opts
+                .options
+                .push(format!("--label=devcontainer.metadata={metadata_label}"));
+        }
+
         let start = std::time::Instant::now();
-        progress.println("  \x1b[36m▸\x1b[0m Building Dockerfile...");
-        let result = client.build_image(&build_opts).await;
+        input
+            .progress
+            .println("  \x1b[36m▸\x1b[0m Building Dockerfile...");
+        let result = input.client.build_image(&build_opts).await;
         let elapsed_str = format_elapsed(start.elapsed());
         match &result {
             Ok(_) => {
-                progress.println(&format!("  \x1b[32m✓\x1b[0m Built Dockerfile{elapsed_str}"));
+                input.progress.println(&format!(
+                    "  \x1b[32m✓\x1b[0m Built Dockerfile{elapsed_str}"
+                ));
             }
             Err(e) => {
-                progress.println(&format!("  \x1b[31m✗\x1b[0m Building Dockerfile: {e}"));
+                input
+                    .progress
+                    .println(&format!("  \x1b[31m✗\x1b[0m Building Dockerfile: {e}"));
             }
         }
         result?;

--- a/crates/cella-orchestrator/src/lifecycle.rs
+++ b/crates/cella-orchestrator/src/lifecycle.rs
@@ -3,6 +3,7 @@
 //! Moved from `cella-cli/src/commands/up/lifecycle.rs`. Uses
 //! [`ProgressSender`] instead of the indicatif-coupled `Progress` type.
 
+use sha2::{Digest, Sha256};
 use tracing::debug;
 
 use cella_backend::{
@@ -10,6 +11,114 @@ use cella_backend::{
 };
 
 use crate::progress::{ProgressSender, format_elapsed};
+
+/// Shell-quote an argv array into a single command string safe for `sh -c`.
+///
+/// Arguments containing only safe characters (alphanumeric plus a small set of
+/// punctuation) are passed through unquoted. Everything else is single-quoted
+/// with embedded single-quotes escaped via the `'\''` idiom.
+fn shell_quote_argv(argv: &[&str]) -> String {
+    argv.iter()
+        .map(|a| {
+            if a.chars()
+                .all(|c| c.is_alphanumeric() || "-_/.:=@".contains(c))
+            {
+                (*a).to_string()
+            } else {
+                format!("'{}'", a.replace('\'', "'\\''"))
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle state tracking (persisted inside the container)
+// ---------------------------------------------------------------------------
+
+/// Tracks which lifecycle phases have already run inside a container.
+///
+/// Stored at `/tmp/.cella/lifecycle_state.json` so that restarts of prebuilt
+/// containers can skip phases that already completed.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct LifecycleState {
+    /// Whether `onCreateCommand` has already been executed.
+    #[serde(default)]
+    pub oncreate_done: bool,
+}
+
+/// Read the persisted lifecycle state from a running container.
+///
+/// Returns [`LifecycleState::default()`] when the file does not exist or
+/// cannot be parsed (e.g. first run on a fresh container).
+pub async fn read_lifecycle_state(
+    client: &dyn ContainerBackend,
+    container_id: &str,
+    user: &str,
+) -> LifecycleState {
+    let result = client
+        .exec_command(
+            container_id,
+            &ExecOptions {
+                cmd: vec![
+                    "cat".to_string(),
+                    "/tmp/.cella/lifecycle_state.json".to_string(),
+                ],
+                user: Some(user.to_string()),
+                env: None,
+                working_dir: None,
+            },
+        )
+        .await;
+
+    result
+        .ok()
+        .filter(|r| r.exit_code == 0)
+        .and_then(|r| serde_json::from_str(r.stdout.trim()).ok())
+        .unwrap_or_default()
+}
+
+/// Persist the lifecycle state inside a running container.
+pub async fn write_lifecycle_state(
+    client: &dyn ContainerBackend,
+    container_id: &str,
+    user: &str,
+    state: &LifecycleState,
+) {
+    let json = serde_json::to_string(state).unwrap_or_default();
+    let _ = client
+        .exec_command(
+            container_id,
+            &ExecOptions {
+                cmd: vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    format!(
+                        "mkdir -p /tmp/.cella && printf '%s' '{json}' > /tmp/.cella/lifecycle_state.json"
+                    ),
+                ],
+                user: Some(user.to_string()),
+                env: None,
+                working_dir: None,
+            },
+        )
+        .await;
+}
+
+/// Compute a deterministic hash of lifecycle command entries for a given phase.
+///
+/// Used to detect whether the commands associated with `updateContentCommand`
+/// have changed between container restarts.
+pub fn hash_lifecycle_entries(entries: &[cella_features::LifecycleEntry]) -> String {
+    let mut hasher = Sha256::new();
+    for entry in entries {
+        hasher.update(entry.origin.as_bytes());
+        hasher.update(b":");
+        hasher.update(entry.command.to_string().as_bytes());
+        hasher.update(b"\n");
+    }
+    hex::encode(hasher.finalize())
+}
 
 /// Resolve lifecycle entries for a phase from feature-resolved config.
 pub fn resolve_phase_entries<'a>(
@@ -105,6 +214,44 @@ pub async fn run_lifecycle_entries(
     Ok(())
 }
 
+/// Resolve lifecycle entries using three-tier priority:
+///
+/// 1. `resolved_features` entries (from local feature build) -- if non-empty
+/// 2. Image metadata entries (from prebuilt image) -- fallback
+/// 3. `config.get(phase)` entries (from `devcontainer.json`) -- final fallback
+fn resolve_entries_with_metadata(
+    resolved_features: Option<&cella_features::ResolvedFeatures>,
+    image_metadata: Option<&str>,
+    config: &serde_json::Value,
+    phase: &str,
+) -> Vec<cella_features::LifecycleEntry> {
+    // Tier 1: feature-resolved entries
+    let feature_entries = resolve_phase_entries(resolved_features, phase);
+    if !feature_entries.is_empty() {
+        return feature_entries.to_vec();
+    }
+
+    // Tier 2: image metadata entries (prebuilt image)
+    if let Some(meta) = image_metadata {
+        let meta_entries = cella_features::lifecycle_from_metadata_label(meta, phase);
+        if !meta_entries.is_empty() {
+            return meta_entries;
+        }
+    }
+
+    // Tier 3: direct devcontainer.json config
+    config
+        .get(phase)
+        .filter(|v| !v.is_null())
+        .map(|cmd| {
+            vec![cella_features::LifecycleEntry {
+                origin: "devcontainer.json".into(),
+                command: cmd.clone(),
+            }]
+        })
+        .unwrap_or_default()
+}
+
 /// Run all lifecycle phases for a first-create scenario.
 ///
 /// # Errors
@@ -114,6 +261,7 @@ pub async fn run_all_lifecycle_phases(
     lc_ctx: &LifecycleContext<'_>,
     config: &serde_json::Value,
     resolved_features: Option<&cella_features::ResolvedFeatures>,
+    image_metadata: Option<&str>,
     progress: &ProgressSender,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let phases = [
@@ -125,16 +273,9 @@ pub async fn run_all_lifecycle_phases(
     ];
 
     for phase in phases {
-        let entries = resolve_phase_entries(resolved_features, phase);
-
-        run_lifecycle_entries(lc_ctx, phase, entries, progress).await?;
-
-        if entries.is_empty()
-            && let Some(cmd) = config.get(phase)
-            && !cmd.is_null()
-        {
-            run_config_phase_with_output(lc_ctx, phase, cmd, progress).await?;
-        }
+        let entries =
+            resolve_entries_with_metadata(resolved_features, image_metadata, config, phase);
+        run_lifecycle_entries(lc_ctx, phase, &entries, progress).await?;
     }
 
     Ok(())
@@ -190,7 +331,7 @@ impl WaitForPhase {
     }
 
     /// Index into the in-container lifecycle phases array.
-    const fn ordinal(self) -> usize {
+    pub(crate) const fn ordinal(self) -> usize {
         match self {
             Self::Initialize => 0,
             Self::OnCreate => 1,
@@ -213,6 +354,7 @@ pub async fn run_lifecycle_phases_with_wait_for(
     lc_ctx: &LifecycleContext<'_>,
     config: &serde_json::Value,
     resolved_features: Option<&cella_features::ResolvedFeatures>,
+    image_metadata: Option<&str>,
     progress: &ProgressSender,
     wait_for: WaitForPhase,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -234,33 +376,39 @@ pub async fn run_lifecycle_phases_with_wait_for(
 
     for (i, &phase) in phases.iter().enumerate() {
         let is_foreground = i < wait_index;
-        let entries = resolve_phase_entries(resolved_features, phase);
+        let entries =
+            resolve_entries_with_metadata(resolved_features, image_metadata, config, phase);
 
         if is_foreground {
-            run_lifecycle_entries(lc_ctx, phase, entries, progress).await?;
-
-            if entries.is_empty()
-                && let Some(cmd) = config.get(phase)
-                && !cmd.is_null()
-            {
-                run_config_phase_with_output(lc_ctx, phase, cmd, progress).await?;
-            }
+            run_lifecycle_entries(lc_ctx, phase, &entries, progress).await?;
         } else {
-            for entry in entries {
+            for entry in &entries {
                 if let Some(s) = entry.command.as_str() {
                     background_cmds.push(s.to_string());
                 } else if let Some(arr) = entry.command.as_array() {
                     let cmd: Vec<&str> = arr.iter().filter_map(|v| v.as_str()).collect();
                     if !cmd.is_empty() {
-                        background_cmds.push(cmd.join(" "));
+                        background_cmds.push(shell_quote_argv(&cmd));
+                    }
+                } else if let Some(obj) = entry.command.as_object() {
+                    // Object commands run their values concurrently (& + wait),
+                    // matching the foreground parallel execution semantics.
+                    let mut parallel = Vec::new();
+                    for val in obj.values() {
+                        if let Some(s) = val.as_str() {
+                            parallel.push(s.to_string());
+                        } else if let Some(arr) = val.as_array() {
+                            let cmd: Vec<&str> = arr.iter().filter_map(|v| v.as_str()).collect();
+                            if !cmd.is_empty() {
+                                parallel.push(shell_quote_argv(&cmd));
+                            }
+                        }
+                    }
+                    if !parallel.is_empty() {
+                        let bg: Vec<String> = parallel.iter().map(|c| format!("( {c} )")).collect();
+                        background_cmds.push(format!("{} & wait", bg.join(" & ")));
                     }
                 }
-            }
-            if entries.is_empty()
-                && let Some(cmd) = config.get(phase)
-                && let Some(s) = cmd.as_str()
-            {
-                background_cmds.push(s.to_string());
             }
         }
     }
@@ -269,8 +417,13 @@ pub async fn run_lifecycle_phases_with_wait_for(
         let script = background_cmds.join("\n");
         let full_script = format!(
             "mkdir -p /tmp/.cella\n\
-             {script}\n\
-             printf '{{\"status\":\"completed\"}}' > /tmp/.cella/lifecycle_status.json\n"
+             (\n  set -e\n  {script}\n)\n\
+             if [ $? -eq 0 ]; then\n\
+               printf '{{\"status\":\"completed\"}}' > /tmp/.cella/lifecycle_status.json\n\
+               printf '{{\"oncreate_done\":true}}' > /tmp/.cella/lifecycle_state.json\n\
+             else\n\
+               printf '{{\"status\":\"failed\"}}' > /tmp/.cella/lifecycle_status.json\n\
+             fi\n"
         );
 
         debug!(
@@ -647,5 +800,142 @@ mod tests {
             WaitForPhase::from_config(&json!({"waitFor": null})),
             WaitForPhase::UpdateContent
         );
+    }
+
+    // ── LifecycleState serde ────────────────────────────────────────────
+
+    #[test]
+    fn lifecycle_state_default_values() {
+        let state = LifecycleState::default();
+        assert!(!state.oncreate_done);
+    }
+
+    #[test]
+    fn lifecycle_state_roundtrip_serde() {
+        let state = LifecycleState {
+            oncreate_done: true,
+        };
+        let json = serde_json::to_string(&state).unwrap();
+        let deserialized: LifecycleState = serde_json::from_str(&json).unwrap();
+        assert!(deserialized.oncreate_done);
+    }
+
+    #[test]
+    fn lifecycle_state_deserialize_empty_object() {
+        let state: LifecycleState = serde_json::from_str("{}").unwrap();
+        assert!(!state.oncreate_done);
+    }
+
+    #[test]
+    fn lifecycle_state_deserialize_partial() {
+        let state: LifecycleState = serde_json::from_str(r#"{"oncreate_done": true}"#).unwrap();
+        assert!(state.oncreate_done);
+    }
+
+    // ── hash_lifecycle_entries ───────────────────────────────────────────
+
+    #[test]
+    fn hash_lifecycle_entries_deterministic() {
+        let entries = vec![cella_features::LifecycleEntry {
+            origin: "feature-a".into(),
+            command: json!("npm install"),
+        }];
+        let h1 = hash_lifecycle_entries(&entries);
+        let h2 = hash_lifecycle_entries(&entries);
+        assert_eq!(h1, h2);
+        assert_eq!(h1.len(), 64); // SHA-256 hex
+    }
+
+    #[test]
+    fn hash_lifecycle_entries_different_for_different_entries() {
+        let entries_a = vec![cella_features::LifecycleEntry {
+            origin: "a".into(),
+            command: json!("echo a"),
+        }];
+        let entries_b = vec![cella_features::LifecycleEntry {
+            origin: "b".into(),
+            command: json!("echo b"),
+        }];
+        assert_ne!(
+            hash_lifecycle_entries(&entries_a),
+            hash_lifecycle_entries(&entries_b)
+        );
+    }
+
+    #[test]
+    fn hash_lifecycle_entries_empty() {
+        let h = hash_lifecycle_entries(&[]);
+        assert_eq!(h.len(), 64);
+    }
+
+    // ── resolve_entries_with_metadata ────────────────────────────────────
+
+    #[test]
+    fn resolve_entries_tier1_features_take_priority() {
+        let mut lifecycle = cella_features::FeatureLifecycle::default();
+        lifecycle.on_create.push(cella_features::LifecycleEntry {
+            origin: "feature-x".into(),
+            command: json!("from features"),
+        });
+        let rf = make_resolved_features(lifecycle);
+        let metadata = r#"[{"id":"img","onCreateCommand":"from metadata"}]"#;
+        let config = json!({"onCreateCommand": "from config"});
+
+        let entries =
+            resolve_entries_with_metadata(Some(&rf), Some(metadata), &config, "onCreateCommand");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].origin, "feature-x");
+    }
+
+    #[test]
+    fn resolve_entries_tier2_metadata_when_no_features() {
+        let metadata = r#"[{"id":"prebuilt","onCreateCommand":"from metadata"}]"#;
+        let config = json!({"onCreateCommand": "from config"});
+
+        let entries =
+            resolve_entries_with_metadata(None, Some(metadata), &config, "onCreateCommand");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].origin, "prebuilt");
+        assert_eq!(entries[0].command, json!("from metadata"));
+    }
+
+    #[test]
+    fn resolve_entries_tier3_config_when_no_features_or_metadata() {
+        let config = json!({"onCreateCommand": "from config"});
+
+        let entries = resolve_entries_with_metadata(None, None, &config, "onCreateCommand");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].origin, "devcontainer.json");
+        assert_eq!(entries[0].command, json!("from config"));
+    }
+
+    #[test]
+    fn resolve_entries_tier3_config_when_metadata_lacks_phase() {
+        let metadata = r#"[{"id":"prebuilt","postStartCommand":"echo hi"}]"#;
+        let config = json!({"onCreateCommand": "from config"});
+
+        let entries =
+            resolve_entries_with_metadata(None, Some(metadata), &config, "onCreateCommand");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].origin, "devcontainer.json");
+    }
+
+    #[test]
+    fn resolve_entries_empty_when_nothing_defined() {
+        let config = json!({});
+        let entries = resolve_entries_with_metadata(None, None, &config, "onCreateCommand");
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn resolve_entries_empty_features_falls_through_to_metadata() {
+        let rf = make_resolved_features(cella_features::FeatureLifecycle::default());
+        let metadata = r#"[{"id":"prebuilt","postCreateCommand":"setup"}]"#;
+        let config = json!({});
+
+        let entries =
+            resolve_entries_with_metadata(Some(&rf), Some(metadata), &config, "postCreateCommand");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].origin, "prebuilt");
     }
 }

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -13,8 +13,9 @@ use cella_backend::{
 use crate::config::{HostRequirementPolicy, ImageStrategy, NetworkRulePolicy, UpConfig};
 use crate::error::OrchestratorError;
 use crate::lifecycle::{
-    WaitForPhase, check_and_run_content_update, lifecycle_entries_for_phase, run_lifecycle_entries,
-    run_lifecycle_phases_with_wait_for, write_content_hash,
+    LifecycleState, WaitForPhase, check_and_run_content_update, lifecycle_entries_for_phase,
+    read_lifecycle_state, run_lifecycle_entries, run_lifecycle_phases_with_wait_for,
+    write_content_hash, write_lifecycle_state,
 };
 use crate::progress::ProgressSender;
 use crate::result::{UpOutcome, UpResult};
@@ -302,6 +303,30 @@ impl EnsureUpContext<'_> {
         (final_probed, lifecycle_env)
     }
 
+    /// For prebuilt images: check lifecycle state and run `onCreateCommand` if
+    /// it hasn't been completed yet. Updates the persisted state on success.
+    async fn run_prebuilt_oncreate_if_needed(
+        &self,
+        container_id: &str,
+        remote_user: &str,
+        metadata: &str,
+        lifecycle_env: &[String],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let lc_state = read_lifecycle_state(self.client, container_id, remote_user).await;
+        if lc_state.oncreate_done {
+            return Ok(());
+        }
+        let lc_ctx = self.build_lifecycle_ctx(container_id, remote_user, lifecycle_env);
+        let entries =
+            lifecycle_entries_for_phase(Some(metadata), self.config_json(), "onCreateCommand");
+        run_lifecycle_entries(&lc_ctx, "onCreateCommand", &entries, &self.progress).await?;
+        let new_state = LifecycleState {
+            oncreate_done: true,
+        };
+        write_lifecycle_state(self.client, container_id, remote_user, &new_state).await;
+        Ok(())
+    }
+
     async fn handle_running(
         &self,
         container: &ContainerInfo,
@@ -374,6 +399,12 @@ impl EnsureUpContext<'_> {
             self.prepare_container_env(&container.id, remote_user).await;
 
         let metadata = container.labels.get("devcontainer.metadata");
+
+        if let Some(meta) = metadata {
+            self.run_prebuilt_oncreate_if_needed(&container.id, remote_user, meta, &lifecycle_env)
+                .await?;
+        }
+
         let lc_ctx_content = self.build_lifecycle_ctx(&container.id, remote_user, &lifecycle_env);
         check_and_run_content_update(
             &lc_ctx_content,
@@ -399,6 +430,43 @@ impl EnsureUpContext<'_> {
             workspace_folder: self.workspace_folder_str().to_string(),
             outcome: UpOutcome::Running,
         })
+    }
+
+    /// Run the restart lifecycle after a stopped container has been started:
+    /// check prebuilt oncreate, content update, then run postStart + postAttach phases.
+    async fn run_restart_lifecycle(
+        &self,
+        container: &ContainerInfo,
+        remote_user: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (_probed_env, lifecycle_env) =
+            self.prepare_container_env(&container.id, remote_user).await;
+        let metadata = container.labels.get("devcontainer.metadata");
+
+        if let Some(meta) = metadata {
+            self.run_prebuilt_oncreate_if_needed(&container.id, remote_user, meta, &lifecycle_env)
+                .await?;
+        }
+
+        let lc_ctx = self.build_lifecycle_ctx(&container.id, remote_user, &lifecycle_env);
+        check_and_run_content_update(
+            &lc_ctx,
+            self.config_json(),
+            metadata.map(String::as_str),
+            &self.config.resolved.workspace_root,
+            &self.progress,
+        )
+        .await?;
+
+        for phase in ["postStartCommand", "postAttachCommand"] {
+            let entries = lifecycle_entries_for_phase(
+                metadata.map(String::as_str),
+                self.config_json(),
+                phase,
+            );
+            run_lifecycle_entries(&lc_ctx, phase, &entries, &self.progress).await?;
+        }
+        Ok(())
     }
 
     async fn handle_stopped(
@@ -475,19 +543,7 @@ impl EnsureUpContext<'_> {
                     restart_agent_in_container(self.client, &container.id).await;
                 }
 
-                let (_probed_env, lifecycle_env) =
-                    self.prepare_container_env(&container.id, remote_user).await;
-
-                let metadata = container.labels.get("devcontainer.metadata");
-                let lc_ctx = self.build_lifecycle_ctx(&container.id, remote_user, &lifecycle_env);
-                for phase in ["postStartCommand", "postAttachCommand"] {
-                    let entries = lifecycle_entries_for_phase(
-                        metadata.map(String::as_str),
-                        self.config_json(),
-                        phase,
-                    );
-                    run_lifecycle_entries(&lc_ctx, phase, &entries, &self.progress).await?;
-                }
+                self.run_restart_lifecycle(container, remote_user).await?;
 
                 if capabilities.managed_agent {
                     let prune_version = env!("CARGO_PKG_VERSION");
@@ -577,10 +633,17 @@ impl EnsureUpContext<'_> {
                 "devcontainer.metadata".to_string(),
                 rf.metadata_label.clone(),
             );
-        } else if base_metadata.is_some() {
+        } else if let Some(existing) = base_metadata {
+            // The base image already carries a devcontainer.metadata label
+            // (either from a prebuilt image or from the Dockerfile build that
+            // embedded it via --label). Re-use it directly instead of
+            // regenerating, which would duplicate entries.
+            labels.insert("devcontainer.metadata".to_string(), existing.to_string());
+        } else {
+            // No features and no base image metadata -- generate from config.
             labels.insert(
                 "devcontainer.metadata".to_string(),
-                cella_features::generate_metadata_label(&[], config, base_metadata),
+                cella_features::generate_metadata_label(&[], config, None),
             );
         }
 
@@ -1014,6 +1077,51 @@ impl EnsureUpContext<'_> {
         }
     }
 
+    /// Run lifecycle phases and write tracking state after container creation.
+    async fn run_create_lifecycle(
+        &self,
+        container_id: &str,
+        remote_user: &str,
+        lifecycle_env: &[String],
+        resolved_features: Option<&cella_features::ResolvedFeatures>,
+        image_metadata: Option<&str>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let config = self.config_json();
+        let wait_for = WaitForPhase::from_config(config);
+        let lc_ctx = self.build_lifecycle_ctx(container_id, remote_user, lifecycle_env);
+        run_lifecycle_phases_with_wait_for(
+            &lc_ctx,
+            config,
+            resolved_features,
+            image_metadata,
+            &self.progress,
+            wait_for,
+        )
+        .await?;
+
+        write_content_hash(
+            self.client,
+            container_id,
+            remote_user,
+            &self.config.resolved.workspace_root,
+        )
+        .await;
+
+        // Mark onCreateCommand as done only when it actually ran in the
+        // foreground. The phases array is [onCreate, updateContent, postCreate,
+        // postStart, postAttach]. When waitFor is Initialize (ordinal 0), ALL
+        // phases are backgrounded and the background script writes the state
+        // file on completion. For any other waitFor value, onCreateCommand
+        // (index 0) ran synchronously before we got here.
+        let oncreate_foreground = !matches!(wait_for, WaitForPhase::Initialize);
+        let state = LifecycleState {
+            oncreate_done: oncreate_foreground,
+        };
+        write_lifecycle_state(self.client, container_id, remote_user, &state).await;
+
+        Ok(())
+    }
+
     async fn create_and_start(
         &self,
         build_no_cache: bool,
@@ -1036,6 +1144,16 @@ impl EnsureUpContext<'_> {
                 progress: &self.progress,
             })
             .await?;
+
+        // Capture image metadata before base_image_details is consumed.
+        // When resolved_features is None (no local feature build), this
+        // metadata from a prebuilt image supplies lifecycle commands.
+        let image_metadata = if resolved_features.is_none() {
+            base_image_details.metadata.clone()
+        } else {
+            None
+        };
+
         let agent_arch = self.detect_arch().await;
         let ImageConfig {
             image_env,
@@ -1092,33 +1210,23 @@ impl EnsureUpContext<'_> {
             )
             .await;
 
-        let lifecycle_err = {
-            let lc_ctx = self.build_lifecycle_ctx(&container_id, &remote_user, &lifecycle_env);
-            run_lifecycle_phases_with_wait_for(
-                &lc_ctx,
-                config,
+        let lifecycle_err = self
+            .run_create_lifecycle(
+                &container_id,
+                &remote_user,
+                &lifecycle_env,
                 resolved_features.as_ref(),
-                &self.progress,
-                WaitForPhase::from_config(config),
+                image_metadata.as_deref(),
             )
             .await
             .err()
-            .map(|e| e.to_string())
-        };
+            .map(|e| e.to_string());
         if let Some(msg) = lifecycle_err {
-            tracing::warn!("Lifecycle failed, cleaning up container {container_id}");
+            warn!("Lifecycle failed, cleaning up container {container_id}");
             let _ = self.client.stop_container(&container_id).await;
             let _ = self.client.remove_container(&container_id, false).await;
             return Err(msg.into());
         }
-
-        write_content_hash(
-            self.client,
-            &container_id,
-            &remote_user,
-            &self.config.resolved.workspace_root,
-        )
-        .await;
 
         Ok(CreateResult {
             container_id,


### PR DESCRIPTION
## Summary

- Run `onCreateCommand` and `updateContentCommand` from prebuilt images that carry `devcontainer.metadata` labels
- Three-tier lifecycle resolution: resolved features > image metadata > devcontainer.json config
- In-container state tracking via `/tmp/.cella/lifecycle_state.json` to avoid re-running completed phases
- Correct background lifecycle handling: failure detection, object-command concurrency, safe shell quoting

Addresses: devcontainers/cli#150 (open 3+ years)

## Changes

**5 atomic commits:**
1. Rename `sha256_short` to `fast_hash_short` (was misleading — uses SipHash, not SHA-256)
2. Add serde dep to cella-orchestrator
3. Add `LifecycleState`, `resolve_entries_with_metadata`, background script fixes, 13 new tests
4. Embed `--label=devcontainer.metadata` in no-features Dockerfile builds only
5. Wire into up pipeline: `run_prebuilt_oncreate_if_needed`, `run_create_lifecycle`, `run_restart_lifecycle`, metadata-aware `build_labels`

**Key correctness guarantees:**
- `oncreate_done` only set true when onCreateCommand ran in foreground (`!matches!(wait_for, WaitForPhase::Initialize)`)
- Background script writes `lifecycle_state.json` on success
- Background failure writes `{"status":"failed"}` to `lifecycle_status.json`
- Metadata label only on no-features builds (avoids duplication when features layer on top)
- Container labels reuse existing base metadata directly

## Test plan

- [ ] `cargo test --workspace` passes (13 new unit tests)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings -D clippy::all` clean
- [ ] Build an image with `cella build`, push to registry, pull on another machine, verify lifecycle hooks run
- [ ] Restart a prebuilt container, verify `onCreateCommand` doesn't re-run
- [ ] Test with `waitFor: initializeCommand` to verify background lifecycle behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)