### PR TITLE
feat: add BuildKit --secret support for image builds

### DIFF
--- a/crates/cella-backend/src/lib.rs
+++ b/crates/cella-backend/src/lib.rs
@@ -18,7 +18,8 @@ pub use names::{
 pub use resolve::ContainerTarget;
 pub use traits::{BackendCapabilities, BoxFuture, ContainerBackend, Platform};
 pub use types::{
-    BackendKind, BuildOptions, ContainerInfo, ContainerState, CreateContainerOptions, DeviceSpec,
-    ExecOptions, ExecResult, FileToUpload, GpuRequest, ImageDetails, InteractiveExecOptions,
-    MountConfig, MountInfo, PortBinding, PortForward, RunArgsOverrides, UlimitSpec,
+    BackendKind, BuildOptions, BuildSecret, ContainerInfo, ContainerState, CreateContainerOptions,
+    DeviceSpec, ExecOptions, ExecResult, FileToUpload, GpuRequest, ImageDetails,
+    InteractiveExecOptions, MountConfig, MountInfo, PortBinding, PortForward, RunArgsOverrides,
+    UlimitSpec,
 };

--- a/crates/cella-backend/src/types.rs
+++ b/crates/cella-backend/src/types.rs
@@ -151,6 +151,14 @@ pub struct ImageDetails {
     pub metadata: Option<String>,
 }
 
+/// A `BuildKit` build secret (`--secret id=X,src=Y` or `--secret id=X,env=Y`).
+#[derive(Debug, Clone)]
+pub struct BuildSecret {
+    pub id: String,
+    pub src: Option<PathBuf>,
+    pub env: Option<String>,
+}
+
 /// Options for building a container image from a Dockerfile.
 pub struct BuildOptions {
     pub image_name: String,
@@ -160,6 +168,7 @@ pub struct BuildOptions {
     pub target: Option<String>,
     pub cache_from: Vec<String>,
     pub options: Vec<String>,
+    pub secrets: Vec<BuildSecret>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -4,6 +4,7 @@ use clap::{Args, ValueEnum};
 use serde_json::json;
 use tracing::{info, warn};
 
+use cella_backend::BuildSecret;
 use cella_config::devcontainer::resolve;
 use cella_orchestrator::image::EnsureImageInput;
 
@@ -31,6 +32,11 @@ pub struct BuildArgs {
 
     #[command(flatten)]
     backend: crate::backend::BackendArgs,
+
+    /// `BuildKit` secret to pass to the build (format: `id=X[,src=Y][,env=Z]`).
+    /// Can be specified multiple times.
+    #[arg(long = "secret")]
+    secrets: Vec<String>,
 
     /// Output format.
     #[arg(long, value_enum, default_value = "text")]
@@ -76,6 +82,12 @@ impl BuildArgs {
 
         let config = &resolved.config;
         let config_name = config.get("name").and_then(|v| v.as_str());
+        let secrets: Vec<BuildSecret> = self
+            .secrets
+            .iter()
+            .map(|s| parse_build_secret(s))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
 
         let client = self.backend.resolve_client().await?;
         client.ping().await?;
@@ -90,6 +102,7 @@ impl BuildArgs {
                 profiles: self.profile.clone(),
                 env_files: self.env_file.clone(),
                 pull_policy: self.pull_policy.clone(),
+                secrets: secrets.clone(),
             };
             let result = cella_orchestrator::compose_build::compose_build(
                 client.as_ref(),
@@ -102,25 +115,7 @@ impl BuildArgs {
             let _ = renderer.await;
             let result = result.map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
 
-            match self.output {
-                OutputFormat::Text => {
-                    eprintln!(
-                        "Compose services built. Primary image: {}",
-                        result.image_name
-                    );
-                }
-                OutputFormat::Json => {
-                    let output = json!({
-                        "outcome": "built",
-                        "imageName": result.image_name,
-                        "compose": true,
-                    });
-                    println!(
-                        "{}",
-                        serde_json::to_string_pretty(&output).unwrap_or_default()
-                    );
-                }
-            }
+            print_result(&self.output, &result.image_name, true);
             return Ok(());
         }
 
@@ -134,6 +129,7 @@ impl BuildArgs {
             config_path: &resolved.config_path,
             no_cache: self.no_cache,
             pull_policy: self.pull.as_deref(),
+            secrets: &secrets,
             progress: &sender,
         };
         let result = cella_orchestrator::image::ensure_image(&input).await;
@@ -151,22 +147,109 @@ impl BuildArgs {
             eprintln!("  Run `cella up --rebuild` to recreate with the updated config.");
         }
 
-        match self.output {
-            OutputFormat::Text => {
-                eprintln!("Image built: {img_name}");
-            }
-            OutputFormat::Json => {
-                let output = json!({
-                    "outcome": "built",
-                    "imageName": img_name,
-                });
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&output).unwrap_or_default()
-                );
+        print_result(&self.output, &img_name, false);
+        Ok(())
+    }
+}
+
+/// Print the build result in the requested output format.
+fn print_result(output: &OutputFormat, image_name: &str, compose: bool) {
+    match output {
+        OutputFormat::Text => {
+            if compose {
+                eprintln!("Compose services built. Primary image: {image_name}");
+            } else {
+                eprintln!("Image built: {image_name}");
             }
         }
+        OutputFormat::Json => {
+            let mut map = json!({
+                "outcome": "built",
+                "imageName": image_name,
+            });
+            if compose {
+                map["compose"] = json!(true);
+            }
+            println!("{}", serde_json::to_string_pretty(&map).unwrap_or_default());
+        }
+    }
+}
 
-        Ok(())
+/// Parse a `--secret` CLI value into a [`BuildSecret`].
+///
+/// Expected format: `id=NAME[,src=PATH][,env=VAR]`.
+pub fn parse_build_secret(s: &str) -> Result<BuildSecret, String> {
+    let mut id = None;
+    let mut src = None;
+    let mut env = None;
+    for part in s.split(',') {
+        if let Some(val) = part.strip_prefix("id=") {
+            id = Some(val.to_string());
+        } else if let Some(val) = part.strip_prefix("src=") {
+            src = Some(PathBuf::from(val));
+        } else if let Some(val) = part.strip_prefix("env=") {
+            env = Some(val.to_string());
+        }
+    }
+    Ok(BuildSecret {
+        id: id.ok_or("missing id= in --secret value")?,
+        src,
+        env,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_secret_id_only() {
+        let secret = parse_build_secret("id=mysecret").unwrap();
+        assert_eq!(secret.id, "mysecret");
+        assert!(secret.src.is_none());
+        assert!(secret.env.is_none());
+    }
+
+    #[test]
+    fn parse_secret_id_and_src() {
+        let secret = parse_build_secret("id=mysecret,src=/run/secrets/token").unwrap();
+        assert_eq!(secret.id, "mysecret");
+        assert_eq!(secret.src.unwrap(), PathBuf::from("/run/secrets/token"));
+        assert!(secret.env.is_none());
+    }
+
+    #[test]
+    fn parse_secret_id_and_env() {
+        let secret = parse_build_secret("id=mysecret,env=MY_TOKEN").unwrap();
+        assert_eq!(secret.id, "mysecret");
+        assert!(secret.src.is_none());
+        assert_eq!(secret.env.unwrap(), "MY_TOKEN");
+    }
+
+    #[test]
+    fn parse_secret_all_fields() {
+        let secret = parse_build_secret("id=mysecret,src=/tmp/secret.txt,env=SECRET_VAR").unwrap();
+        assert_eq!(secret.id, "mysecret");
+        assert_eq!(secret.src.unwrap(), PathBuf::from("/tmp/secret.txt"));
+        assert_eq!(secret.env.unwrap(), "SECRET_VAR");
+    }
+
+    #[test]
+    fn parse_secret_missing_id_fails() {
+        let result = parse_build_secret("src=/tmp/secret.txt");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("missing id="));
+    }
+
+    #[test]
+    fn parse_secret_empty_string_fails() {
+        let result = parse_build_secret("");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_secret_unknown_keys_ignored() {
+        let secret = parse_build_secret("id=mysecret,foo=bar").unwrap();
+        assert_eq!(secret.id, "mysecret");
     }
 }

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -6,7 +6,7 @@ use clap::{Args, ValueEnum};
 use serde_json::json;
 use tracing::{debug, warn};
 
-use cella_backend::{ContainerBackend, ExecOptions, container_name};
+use cella_backend::{BuildSecret, ContainerBackend, ExecOptions, container_name};
 use cella_config::devcontainer::resolve::{self, ResolvedConfig};
 use cella_orchestrator::env_cache::probe_and_cache_user_env;
 use cella_orchestrator::shell_detect::detect_shell;
@@ -29,6 +29,11 @@ pub struct UpBuildArgs {
     /// Image pull policy (e.g. "always", "missing", "never").
     #[arg(long)]
     pub(crate) pull: Option<String>,
+
+    /// `BuildKit` secret to pass to the build (format: `id=X[,src=Y][,env=Z]`).
+    /// Can be specified multiple times.
+    #[arg(long = "secret")]
+    pub(crate) secrets: Vec<String>,
 }
 
 /// Start a dev container for the current workspace.
@@ -126,6 +131,8 @@ pub struct UpContext {
     pub(crate) compose_env_files: Vec<PathBuf>,
     /// Pull policy for Docker Compose services.
     pub(crate) compose_pull_policy: Option<String>,
+    /// `BuildKit` secrets for image builds.
+    build_secrets: Vec<BuildSecret>,
 }
 
 impl UpContext {
@@ -167,6 +174,14 @@ impl UpContext {
         );
         let default_workspace_folder = format!("/workspaces/{workspace_basename}");
 
+        let build_secrets = args
+            .build
+            .secrets
+            .iter()
+            .map(|s| super::build::parse_build_secret(s))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+
         Ok(Self {
             resolved,
             client,
@@ -190,6 +205,7 @@ impl UpContext {
             compose_profiles: args.profile.clone(),
             compose_env_files: args.env_file.clone(),
             compose_pull_policy: args.pull_policy.clone(),
+            build_secrets,
         })
     }
 
@@ -256,6 +272,7 @@ impl UpContext {
             compose_profiles: Vec::new(),
             compose_env_files: Vec::new(),
             compose_pull_policy: None,
+            build_secrets: vec![],
         })
     }
 
@@ -653,6 +670,7 @@ impl UpContext {
             },
             network_rule_policy: self.network_rules,
             pull_policy: self.pull_policy.as_deref(),
+            build_secrets: self.build_secrets.clone(),
         };
 
         let result =

--- a/crates/cella-compose/src/integration_tests/phase_tests.rs
+++ b/crates/cella-compose/src/integration_tests/phase_tests.rs
@@ -32,6 +32,7 @@ fn override_file_exists_before_compose_uses_it() {
         build_target: None,
         build_context: None,
         additional_contexts: BTreeMap::new(),
+        build_secrets: Vec::new(),
     };
 
     let yaml = generate_override_yaml(&override_cfg);
@@ -183,6 +184,7 @@ fn additional_contexts_in_override_for_features() {
         build_target: Some(FEATURES_TARGET_STAGE.to_string()),
         build_context: Some(ctx.fixture_dir.join(".build-context")),
         additional_contexts,
+        build_secrets: Vec::new(),
     };
 
     let yaml = generate_override_yaml(&override_cfg);

--- a/crates/cella-compose/src/integration_tests/smoke_tests.rs
+++ b/crates/cella-compose/src/integration_tests/smoke_tests.rs
@@ -24,6 +24,7 @@ fn plain_override(service: &str) -> OverrideConfig {
         build_target: None,
         build_context: None,
         additional_contexts: BTreeMap::new(),
+        build_secrets: Vec::new(),
     }
 }
 

--- a/crates/cella-compose/src/lib.rs
+++ b/crates/cella-compose/src/lib.rs
@@ -24,7 +24,7 @@ pub use dockerfile::{
     synthetic_dockerfile,
 };
 pub use error::CellaComposeError;
-pub use override_file::OverrideConfig;
+pub use override_file::{ComposeSecret, OverrideConfig};
 pub use project::{ComposeProject, ShutdownAction};
 
 #[cfg(all(test, feature = "integration-tests"))]

--- a/crates/cella-compose/src/override_file.rs
+++ b/crates/cella-compose/src/override_file.rs
@@ -10,6 +10,17 @@ use std::path::{Path, PathBuf};
 
 use crate::error::CellaComposeError;
 
+/// A `BuildKit` secret to forward to compose builds.
+#[derive(Debug, Clone)]
+pub struct ComposeSecret {
+    /// Secret identifier (matches `--mount=type=secret,id=<id>` in Dockerfile).
+    pub id: String,
+    /// Host file path containing the secret value.
+    pub file: Option<PathBuf>,
+    /// Environment variable containing the secret value.
+    pub environment: Option<String>,
+}
+
 /// Configuration for generating the override compose file.
 pub struct OverrideConfig {
     /// The primary service name (must match a service in the user's compose file).
@@ -37,6 +48,8 @@ pub struct OverrideConfig {
     /// Emitted as `build.additional_contexts` in the compose override YAML.
     /// Requires Docker Compose >= 2.17.0.
     pub additional_contexts: BTreeMap<String, PathBuf>,
+    /// `BuildKit` secrets forwarded to compose builds via the override YAML.
+    pub build_secrets: Vec<ComposeSecret>,
 }
 
 /// Generate the override compose YAML as a string.
@@ -57,19 +70,28 @@ pub fn generate_override_yaml(config: &OverrideConfig) -> String {
     }
 
     // Build override (combined Dockerfile for compose + features)
-    if let Some(ref dockerfile) = config.build_dockerfile {
+    let has_build_section = config.build_dockerfile.is_some() || !config.build_secrets.is_empty();
+    if has_build_section {
         yaml.push_str("    build:\n");
-        let _ = writeln!(yaml, "      dockerfile: \"{}\"", dockerfile.display());
-        if let Some(ref target) = config.build_target {
-            let _ = writeln!(yaml, "      target: \"{target}\"");
+        if let Some(ref dockerfile) = config.build_dockerfile {
+            let _ = writeln!(yaml, "      dockerfile: \"{}\"", dockerfile.display());
+            if let Some(ref target) = config.build_target {
+                let _ = writeln!(yaml, "      target: \"{target}\"");
+            }
+            if let Some(ref context) = config.build_context {
+                let _ = writeln!(yaml, "      context: \"{}\"", context.display());
+            }
+            if !config.additional_contexts.is_empty() {
+                yaml.push_str("      additional_contexts:\n");
+                for (name, path) in &config.additional_contexts {
+                    let _ = writeln!(yaml, "        - {name}={}", path.display());
+                }
+            }
         }
-        if let Some(ref context) = config.build_context {
-            let _ = writeln!(yaml, "      context: \"{}\"", context.display());
-        }
-        if !config.additional_contexts.is_empty() {
-            yaml.push_str("      additional_contexts:\n");
-            for (name, path) in &config.additional_contexts {
-                let _ = writeln!(yaml, "        - {name}={}", path.display());
+        if !config.build_secrets.is_empty() {
+            yaml.push_str("      secrets:\n");
+            for secret in &config.build_secrets {
+                let _ = writeln!(yaml, "        - {}", secret.id);
             }
         }
     }
@@ -103,6 +125,20 @@ pub fn generate_override_yaml(config: &OverrideConfig) -> String {
         "      - {}:{}:ro",
         config.agent_volume_name, config.agent_volume_target
     );
+
+    // Top-level secrets declarations (file/environment sources)
+    if !config.build_secrets.is_empty() {
+        yaml.push_str("secrets:\n");
+        for secret in &config.build_secrets {
+            let _ = writeln!(yaml, "  {}:", secret.id);
+            if let Some(ref file) = secret.file {
+                let _ = writeln!(yaml, "    file: \"{}\"", file.display());
+            }
+            if let Some(ref env) = secret.environment {
+                let _ = writeln!(yaml, "    environment: \"{env}\"");
+            }
+        }
+    }
 
     // Top-level volumes declaration (external volume)
     yaml.push_str("volumes:\n");
@@ -151,6 +187,7 @@ mod tests {
             build_target: None,
             build_context: None,
             additional_contexts: BTreeMap::new(),
+            build_secrets: Vec::new(),
         }
     }
 

--- a/crates/cella-docker/src/image.rs
+++ b/crates/cella-docker/src/image.rs
@@ -1,5 +1,6 @@
 //! Image pull and Dockerfile build operations.
 
+use std::fmt::Write as _;
 use std::process::Stdio;
 use std::sync::OnceLock;
 
@@ -98,6 +99,17 @@ fn build_command_args(opts: &BuildOptions, use_buildx: bool) -> Vec<String> {
 
     for opt in &opts.options {
         args.push(opt.clone());
+    }
+
+    for secret in &opts.secrets {
+        let mut spec = format!("id={}", secret.id);
+        if let Some(ref src) = secret.src {
+            let _ = write!(spec, ",src={}", src.display());
+        }
+        if let Some(ref env) = secret.env {
+            let _ = write!(spec, ",env={env}");
+        }
+        args.extend(["--secret".to_string(), spec]);
     }
 
     args.push(opts.context_path.to_string_lossy().to_string());
@@ -324,6 +336,7 @@ mod tests {
             target: None,
             cache_from: Vec::new(),
             options: Vec::new(),
+            secrets: Vec::new(),
         }
     }
 
@@ -518,5 +531,80 @@ mod tests {
         let args = build_command_args(&opts, false);
         // Should be minimal: ["build", "--progress=plain", "-t", name, "-f", path, context]
         assert_eq!(args.len(), 7);
+    }
+
+    #[test]
+    fn build_args_with_secret_id_only() {
+        let mut opts = basic_opts();
+        opts.secrets = vec![cella_backend::BuildSecret {
+            id: "mysecret".to_string(),
+            src: None,
+            env: None,
+        }];
+        let args = build_command_args(&opts, false);
+        assert!(args.contains(&"--secret".to_string()));
+        assert!(args.contains(&"id=mysecret".to_string()));
+        // Context path is still last
+        assert_eq!(args.last().unwrap(), "/src/project");
+    }
+
+    #[test]
+    fn build_args_with_secret_src() {
+        let mut opts = basic_opts();
+        opts.secrets = vec![cella_backend::BuildSecret {
+            id: "token".to_string(),
+            src: Some(PathBuf::from("/run/secrets/token")),
+            env: None,
+        }];
+        let args = build_command_args(&opts, false);
+        let secret_idx = args.iter().position(|a| a == "--secret").unwrap();
+        assert_eq!(args[secret_idx + 1], "id=token,src=/run/secrets/token");
+    }
+
+    #[test]
+    fn build_args_with_secret_env() {
+        let mut opts = basic_opts();
+        opts.secrets = vec![cella_backend::BuildSecret {
+            id: "token".to_string(),
+            src: None,
+            env: Some("MY_TOKEN".to_string()),
+        }];
+        let args = build_command_args(&opts, false);
+        let secret_idx = args.iter().position(|a| a == "--secret").unwrap();
+        assert_eq!(args[secret_idx + 1], "id=token,env=MY_TOKEN");
+    }
+
+    #[test]
+    fn build_args_with_secret_src_and_env() {
+        let mut opts = basic_opts();
+        opts.secrets = vec![cella_backend::BuildSecret {
+            id: "s".to_string(),
+            src: Some(PathBuf::from("/tmp/s")),
+            env: Some("S_VAR".to_string()),
+        }];
+        let args = build_command_args(&opts, false);
+        let secret_idx = args.iter().position(|a| a == "--secret").unwrap();
+        assert_eq!(args[secret_idx + 1], "id=s,src=/tmp/s,env=S_VAR");
+    }
+
+    #[test]
+    fn build_args_with_multiple_secrets() {
+        let mut opts = basic_opts();
+        opts.secrets = vec![
+            cella_backend::BuildSecret {
+                id: "a".to_string(),
+                src: None,
+                env: None,
+            },
+            cella_backend::BuildSecret {
+                id: "b".to_string(),
+                src: Some(PathBuf::from("/tmp/b")),
+                env: None,
+            },
+        ];
+        let args = build_command_args(&opts, false);
+        let secret_count = args.iter().filter(|a| *a == "--secret").count();
+        assert_eq!(secret_count, 2);
+        assert_eq!(args.last().unwrap(), "/src/project");
     }
 }

--- a/crates/cella-orchestrator/src/compose_build.rs
+++ b/crates/cella-orchestrator/src/compose_build.rs
@@ -6,7 +6,7 @@
 
 use std::path::{Path, PathBuf};
 
-use cella_backend::ContainerBackend;
+use cella_backend::{BuildSecret, ContainerBackend};
 use cella_compose::ComposeProject;
 
 use crate::progress::ProgressSender;
@@ -33,6 +33,8 @@ pub struct ComposeBuildConfig<'a> {
     pub env_files: Vec<PathBuf>,
     /// Pull policy for docker compose build (`--pull` flag).
     pub pull_policy: Option<String>,
+    /// `BuildKit` secrets forwarded to compose builds.
+    pub secrets: Vec<BuildSecret>,
 }
 
 /// Run the compose build pipeline: resolve features, write override, build.
@@ -81,6 +83,15 @@ pub async fn compose_build(
         } else {
             (String::new(), String::new(), true)
         };
+        let compose_secrets: Vec<cella_compose::ComposeSecret> = cfg
+            .secrets
+            .iter()
+            .map(|s| cella_compose::ComposeSecret {
+                id: s.id.clone(),
+                file: s.src.clone(),
+                environment: s.env.clone(),
+            })
+            .collect();
         let override_config = cella_compose::OverrideConfig {
             primary_service: project.primary_service.clone(),
             image_override: fb.image_name_override.clone(),
@@ -93,6 +104,7 @@ pub async fn compose_build(
             build_target: Some(fb.build_target.clone()),
             build_context: fb.build_context.clone(),
             additional_contexts: fb.additional_contexts.clone(),
+            build_secrets: compose_secrets,
         };
         let yaml = cella_compose::override_file::generate_override_yaml(&override_config);
         cella_compose::override_file::write_override_file(&project.override_file, &yaml)?;

--- a/crates/cella-orchestrator/src/compose_up.rs
+++ b/crates/cella-orchestrator/src/compose_up.rs
@@ -324,6 +324,7 @@ async fn prepare_and_start(
             .as_ref()
             .map(|b| b.additional_contexts.clone())
             .unwrap_or_default(),
+        build_secrets: Vec::new(),
     };
     let override_yaml = cella_compose::override_file::generate_override_yaml(&override_config);
     cella_compose::override_file::write_override_file(&project.override_file, &override_yaml)?;

--- a/crates/cella-orchestrator/src/config.rs
+++ b/crates/cella-orchestrator/src/config.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+use cella_backend::BuildSecret;
 use cella_config::devcontainer::resolve::ResolvedConfig;
 
 /// Configuration for the full container-up pipeline.
@@ -31,6 +32,8 @@ pub struct UpConfig<'a> {
     pub network_rule_policy: NetworkRulePolicy,
     /// Image pull policy (e.g. "always", "missing", "never").
     pub pull_policy: Option<&'a str>,
+    /// `BuildKit` secrets to inject during image builds.
+    pub build_secrets: Vec<BuildSecret>,
 }
 
 /// How the up pipeline should handle the container image.

--- a/crates/cella-orchestrator/src/image.rs
+++ b/crates/cella-orchestrator/src/image.rs
@@ -10,7 +10,7 @@ use sha2::{Digest, Sha256};
 use tracing::info;
 
 use cella_backend::{
-    BuildOptions, ContainerBackend, ImageDetails, image_name, image_name_with_features,
+    BuildOptions, BuildSecret, ContainerBackend, ImageDetails, image_name, image_name_with_features,
 };
 use cella_features::ResolvedFeatures;
 
@@ -71,6 +71,7 @@ pub async fn build_features_layer(
         target: None,
         cache_from: vec![],
         options,
+        secrets: vec![],
     };
 
     info!(
@@ -103,6 +104,8 @@ pub struct EnsureImageInput<'a> {
     pub config_path: &'a Path,
     pub no_cache: bool,
     pub pull_policy: Option<&'a str>,
+    /// `BuildKit` secrets forwarded to every `docker build` as `--secret` flags.
+    pub secrets: &'a [BuildSecret],
     pub progress: &'a ProgressSender,
 }
 
@@ -189,6 +192,7 @@ async fn resolve_base_image(
             input.no_cache,
             input.pull_policy,
         );
+        build_opts.secrets = input.secrets.to_vec();
 
         if !will_build_features {
             let metadata_label = cella_features::generate_metadata_label(&[], input.config, None);
@@ -376,6 +380,7 @@ pub fn parse_build_options(
         target,
         cache_from,
         options,
+        secrets: vec![],
     }
 }
 
@@ -563,6 +568,7 @@ mod tests {
             target: None,
             cache_from: vec![],
             options: vec![],
+            secrets: vec![],
         };
         inject_proxy_build_args(&mut opts, &proxy);
         // With no proxy env vars set and default config, args should remain empty
@@ -580,6 +586,7 @@ mod tests {
             target: None,
             cache_from: vec![],
             options: vec![],
+            secrets: vec![],
         };
         inject_proxy_build_args(&mut opts, &proxy);
         // Existing value must not be overwritten

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -1141,6 +1141,7 @@ impl EnsureUpContext<'_> {
                 config_path: &self.config.resolved.config_path,
                 no_cache: build_no_cache,
                 pull_policy: self.config.pull_policy,
+                secrets: &self.config.build_secrets,
                 progress: &self.progress,
             })
             .await?;


### PR DESCRIPTION
## Summary

- Add `--secret` flag to `cella build` and `cella up` for BuildKit build secrets
- Secrets are passed as `--secret id=X,src=Y` or `--secret id=X,env=Z` to `docker build`
- Compose builds forward secrets via override YAML `build.secrets` and top-level `secrets` declarations
- Secrets are never baked into image layers (BuildKit guarantee)

Addresses: devcontainers/cli#1077

## Changes

- `cella-backend`: `BuildSecret` type, `secrets` field on `BuildOptions`
- `cella-docker`: `--secret` flag emission in `build_command_args()` (5 new tests)
- `cella-cli`: `--secret` CLI flag with `parse_build_secret()` parser (7 new tests)
- `cella-orchestrator`: Threading through `UpConfig`, `EnsureImageInput`, compose paths
- `cella-compose`: `ComposeSecret` type, override YAML generation for build secrets

## Test plan

- [ ] `cargo test --workspace` passes (12 new tests)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings -D clippy::all` clean
- [ ] `cella build --secret id=mysecret,src=./secret.txt` passes secret to docker build
- [ ] `cella build --secret id=token,env=GITHUB_TOKEN` passes env-based secret
- [ ] Compose builds with secrets generate correct override YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)