### PR TITLE
refactor: use ValueEnum for strict CLI flag parsing

### DIFF
--- a/crates/cella-cli/src/commands/branch.rs
+++ b/crates/cella-cli/src/commands/branch.rs
@@ -1,6 +1,7 @@
 use clap::Args;
 
-use super::up::{OutputFormat, UpContext};
+use super::OutputFormat;
+use super::up::UpContext;
 use cella_backend::{ExecOptions, worktree_labels};
 
 /// Create a new worktree-backed branch with its own dev container.

--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -1,8 +1,10 @@
 use std::path::PathBuf;
 
-use clap::{Args, ValueEnum};
+use clap::Args;
 use serde_json::json;
 use tracing::{info, warn};
+
+use super::OutputFormat;
 
 use cella_backend::BuildSecret;
 use cella_config::devcontainer::resolve;
@@ -53,13 +55,6 @@ pub struct BuildArgs {
     /// Pull policy for Docker Compose services (always, missing, never).
     #[arg(long = "pull-policy")]
     pull_policy: Option<String>,
-}
-
-/// Output format for build command.
-#[derive(Clone, ValueEnum)]
-enum OutputFormat {
-    Text,
-    Json,
 }
 
 impl BuildArgs {

--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -4,7 +4,7 @@ use clap::Args;
 use serde_json::json;
 use tracing::{info, warn};
 
-use super::OutputFormat;
+use super::{ImagePullPolicy, OutputFormat};
 
 use cella_backend::BuildSecret;
 use cella_config::devcontainer::resolve;
@@ -20,9 +20,9 @@ pub struct BuildArgs {
     #[arg(long)]
     no_cache: bool,
 
-    /// Image pull policy (e.g. "always", "missing", "never").
-    #[arg(long)]
-    pull: Option<String>,
+    /// Image pull policy.
+    #[arg(long, value_enum)]
+    pull: Option<ImagePullPolicy>,
 
     /// Explicit workspace folder path (defaults to current directory).
     #[arg(long)]
@@ -123,7 +123,7 @@ impl BuildArgs {
             config_name,
             config_path: &resolved.config_path,
             no_cache: self.no_cache,
-            pull_policy: self.pull.as_deref(),
+            pull_policy: self.pull.as_ref().map(ImagePullPolicy::as_str),
             secrets: &secrets,
             progress: &sender,
         };

--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -4,7 +4,7 @@ use clap::Args;
 use serde_json::json;
 use tracing::{info, warn};
 
-use super::{ImagePullPolicy, OutputFormat};
+use super::{ComposePullPolicy, ImagePullPolicy, OutputFormat};
 
 use cella_backend::BuildSecret;
 use cella_config::devcontainer::resolve;
@@ -52,9 +52,9 @@ pub struct BuildArgs {
     #[arg(long = "env-file")]
     env_file: Vec<PathBuf>,
 
-    /// Pull policy for Docker Compose services (always, missing, never).
-    #[arg(long = "pull-policy")]
-    pull_policy: Option<String>,
+    /// Pull policy for Docker Compose services.
+    #[arg(long = "pull-policy", value_enum)]
+    pull_policy: Option<ComposePullPolicy>,
 }
 
 impl BuildArgs {
@@ -96,7 +96,7 @@ impl BuildArgs {
                 workspace_root: &resolved.workspace_root,
                 profiles: self.profile.clone(),
                 env_files: self.env_file.clone(),
-                pull_policy: self.pull_policy.clone(),
+                pull_policy: self.pull_policy.as_ref().map(|p| p.as_str().to_string()),
                 secrets: secrets.clone(),
             };
             let result = cella_orchestrator::compose_build::compose_build(

--- a/crates/cella-cli/src/commands/code.rs
+++ b/crates/cella-cli/src/commands/code.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
-use clap::Args;
+use clap::{Args, ValueEnum};
 use serde_json::json;
 use tracing::debug;
 
@@ -10,6 +10,17 @@ use cella_backend::ExecOptions;
 use super::OutputFormat;
 use super::up::{UpArgs, UpContext, output_result};
 
+/// Editor to open for the dev container.
+#[derive(Clone, ValueEnum)]
+pub enum EditorChoice {
+    /// VS Code (stable).
+    Code,
+    /// VS Code Insiders.
+    Insiders,
+    /// Cursor.
+    Cursor,
+}
+
 use crate::picker;
 
 /// Open VS Code connected to the dev container.
@@ -17,21 +28,16 @@ use crate::picker;
 /// Ensures the container is running (auto-up if needed), runs `postAttachCommand`,
 /// then opens VS Code using the `attached-container` remote URI scheme.
 #[derive(Args)]
-#[allow(clippy::struct_excessive_bools)]
 pub struct CodeArgs {
     #[command(flatten)]
     pub up: UpArgs,
 
-    /// Open VS Code Insiders instead of stable.
-    #[arg(long, conflicts_with_all = ["cursor", "binary"])]
-    pub insider: bool,
-
-    /// Open Cursor instead of VS Code.
-    #[arg(long, conflicts_with_all = ["insider", "binary"])]
-    pub cursor: bool,
+    /// Editor to open (defaults to code).
+    #[arg(long, value_enum, default_value = "code", conflicts_with = "binary")]
+    pub editor: EditorChoice,
 
     /// Custom editor binary name or path.
-    #[arg(long, conflicts_with_all = ["insider", "cursor"])]
+    #[arg(long)]
     pub binary: Option<String>,
 
     /// Target a specific compose service (defaults to primary service).
@@ -52,7 +58,7 @@ impl CodeArgs {
         check_local_docker()?;
 
         // 2. Resolve editor binary (fail fast before container work)
-        let editor = resolve_editor_binary(self.insider, self.cursor, self.binary.as_deref())?;
+        let editor = resolve_editor_binary(&self.editor, self.binary.as_deref())?;
         debug!("Resolved editor binary: {}", editor.display());
 
         // 3. Ensure container is up
@@ -179,8 +185,7 @@ fn build_vscode_uri(container_id: &str, workspace_folder: &str) -> String {
 /// Returns the path to the editor binary. If the binary is not found, returns
 /// an error with platform-specific installation instructions.
 fn resolve_editor_binary(
-    insider: bool,
-    cursor: bool,
+    editor: &EditorChoice,
     binary: Option<&str>,
 ) -> Result<PathBuf, Box<dyn std::error::Error>> {
     let name = if let Some(b) = binary {
@@ -193,12 +198,12 @@ fn resolve_editor_binary(
             return Err(format!("Editor binary not found: {b}").into());
         }
         b.to_string()
-    } else if insider {
-        "code-insiders".to_string()
-    } else if cursor {
-        "cursor".to_string()
     } else {
-        "code".to_string()
+        match editor {
+            EditorChoice::Code => "code".to_string(),
+            EditorChoice::Insiders => "code-insiders".to_string(),
+            EditorChoice::Cursor => "cursor".to_string(),
+        }
     };
 
     which_binary(&name)
@@ -470,13 +475,13 @@ mod tests {
     #[test]
     fn resolve_editor_binary_missing_custom() {
         // A binary that doesn't exist should error
-        let result = resolve_editor_binary(false, false, Some("/nonexistent/editor"));
+        let result = resolve_editor_binary(&EditorChoice::Code, Some("/nonexistent/editor"));
         assert!(result.is_err());
     }
 
     #[test]
     fn resolve_editor_binary_name_not_in_path() {
-        let result = resolve_editor_binary(false, false, Some("totally-nonexistent-editor-xyz"));
+        let result = resolve_editor_binary(&EditorChoice::Code, Some("totally-nonexistent-editor-xyz"));
         assert!(result.is_err());
     }
 

--- a/crates/cella-cli/src/commands/code.rs
+++ b/crates/cella-cli/src/commands/code.rs
@@ -481,7 +481,8 @@ mod tests {
 
     #[test]
     fn resolve_editor_binary_name_not_in_path() {
-        let result = resolve_editor_binary(&EditorChoice::Code, Some("totally-nonexistent-editor-xyz"));
+        let result =
+            resolve_editor_binary(&EditorChoice::Code, Some("totally-nonexistent-editor-xyz"));
         assert!(result.is_err());
     }
 

--- a/crates/cella-cli/src/commands/code.rs
+++ b/crates/cella-cli/src/commands/code.rs
@@ -7,7 +7,8 @@ use tracing::debug;
 
 use cella_backend::ExecOptions;
 
-use super::up::{OutputFormat, UpArgs, UpContext, output_result};
+use super::OutputFormat;
+use super::up::{UpArgs, UpContext, output_result};
 
 use crate::picker;
 

--- a/crates/cella-cli/src/commands/doctor.rs
+++ b/crates/cella-cli/src/commands/doctor.rs
@@ -3,15 +3,17 @@ use clap::Args;
 use cella_doctor::checks::{self, CategoryReport, CheckResult, Report, Severity};
 use cella_doctor::redact::Redactor;
 
+use super::OutputFormat;
+
 /// Check system dependencies and configuration.
 #[derive(Args)]
 pub struct DoctorArgs {
     /// Check all running cella containers (not just current workspace).
     #[arg(long)]
     all: bool,
-    /// Output as JSON (machine-readable).
-    #[arg(long)]
-    json: bool,
+    /// Output format.
+    #[arg(long, value_enum, default_value = "text")]
+    output: OutputFormat,
     /// Disable redaction of sensitive information (home paths, tokens).
     #[arg(long)]
     no_redact: bool,
@@ -58,7 +60,7 @@ impl DoctorArgs {
             report.redact(&redactor);
         }
 
-        if self.json {
+        if matches!(self.output, OutputFormat::Json) {
             let json = report.to_json();
             println!(
                 "{}",

--- a/crates/cella-cli/src/commands/down.rs
+++ b/crates/cella-cli/src/commands/down.rs
@@ -4,7 +4,7 @@ use clap::Args;
 use serde_json::json;
 use tracing::{debug, info};
 
-use super::up::OutputFormat;
+use super::OutputFormat;
 use cella_backend::ContainerTarget;
 use cella_backend::{ContainerInfo, ContainerState};
 use cella_compose::discovery;

--- a/crates/cella-cli/src/commands/features/list.rs
+++ b/crates/cella-cli/src/commands/features/list.rs
@@ -6,6 +6,7 @@ use cella_templates::cache::TemplateCache;
 use cella_templates::collection::{self, DEFAULT_FEATURE_COLLECTION};
 
 use super::resolve::{self, CommonFeatureFlags};
+use crate::commands::OutputFormat;
 
 /// List configured or available devcontainer features.
 #[derive(Args)]
@@ -13,9 +14,9 @@ pub struct ListArgs {
     #[command(flatten)]
     pub common: CommonFeatureFlags,
 
-    /// Output as JSON for machine consumption.
-    #[arg(long)]
-    pub json: bool,
+    /// Output format.
+    #[arg(long, value_enum, default_value = "text")]
+    pub output: OutputFormat,
 
     /// Show available features from the registry instead of configured ones.
     #[arg(long)]
@@ -50,7 +51,7 @@ impl ListArgs {
         let features = resolve::extract_features(&config);
 
         if features.is_empty() {
-            if self.json {
+            if matches!(self.output, OutputFormat::Json) {
                 println!("[]");
             } else {
                 eprintln!("No features configured.");
@@ -58,7 +59,7 @@ impl ListArgs {
             return Ok(());
         }
 
-        if self.json {
+        if matches!(self.output, OutputFormat::Json) {
             let json_features: Vec<serde_json::Value> = features
                 .iter()
                 .map(|(reference, options)| {
@@ -104,7 +105,7 @@ impl ListArgs {
             collection::fetch_feature_collection(registry, &cache, self.refresh).await?;
 
         if collection.features.is_empty() {
-            if self.json {
+            if matches!(self.output, OutputFormat::Json) {
                 println!("[]");
             } else {
                 eprintln!("No features found in {registry}.");
@@ -112,7 +113,7 @@ impl ListArgs {
             return Ok(());
         }
 
-        if self.json {
+        if matches!(self.output, OutputFormat::Json) {
             let json_features: Vec<serde_json::Value> = collection
                 .features
                 .iter()

--- a/crates/cella-cli/src/commands/features/update.rs
+++ b/crates/cella-cli/src/commands/features/update.rs
@@ -7,6 +7,7 @@ use cella_templates::cache::TemplateCache;
 
 use super::jsonc_edit::{self, FeatureEdit};
 use super::resolve::{self, CommonFeatureFlags};
+use crate::commands::OutputFormat;
 
 /// Check for and apply feature version updates.
 #[derive(Args)]
@@ -22,9 +23,9 @@ pub struct UpdateArgs {
     #[arg(long)]
     pub check: bool,
 
-    /// Output as JSON (implies --check).
-    #[arg(long)]
-    pub json: bool,
+    /// Output format (json implies --check).
+    #[arg(long, value_enum, default_value = "text")]
+    pub output: OutputFormat,
 }
 
 /// A feature with an available update.
@@ -56,7 +57,7 @@ impl UpdateArgs {
         let features = resolve::extract_features(&config);
 
         if features.is_empty() {
-            print_empty_message(self.json, "No features configured.");
+            print_empty_message(matches!(self.output, OutputFormat::Json), "No features configured.");
             return Ok(());
         }
 
@@ -72,11 +73,11 @@ impl UpdateArgs {
         let candidates = find_update_candidates(&features, &collection, &cache).await;
 
         if candidates.is_empty() {
-            print_empty_message(self.json, "All features are up to date.");
+            print_empty_message(matches!(self.output, OutputFormat::Json), "All features are up to date.");
             return Ok(());
         }
 
-        if self.json {
+        if matches!(self.output, OutputFormat::Json) {
             print_candidates_json(&candidates)?;
             return Ok(());
         }

--- a/crates/cella-cli/src/commands/features/update.rs
+++ b/crates/cella-cli/src/commands/features/update.rs
@@ -57,7 +57,10 @@ impl UpdateArgs {
         let features = resolve::extract_features(&config);
 
         if features.is_empty() {
-            print_empty_message(matches!(self.output, OutputFormat::Json), "No features configured.");
+            print_empty_message(
+                matches!(self.output, OutputFormat::Json),
+                "No features configured.",
+            );
             return Ok(());
         }
 
@@ -73,7 +76,10 @@ impl UpdateArgs {
         let candidates = find_update_candidates(&features, &collection, &cache).await;
 
         if candidates.is_empty() {
-            print_empty_message(matches!(self.output, OutputFormat::Json), "All features are up to date.");
+            print_empty_message(
+                matches!(self.output, OutputFormat::Json),
+                "All features are up to date.",
+            );
             return Ok(());
         }
 

--- a/crates/cella-cli/src/commands/list.rs
+++ b/crates/cella-cli/src/commands/list.rs
@@ -6,6 +6,8 @@ use serde_json::json;
 use cella_backend::{ContainerInfo, ContainerState};
 use cella_compose::discovery;
 
+use super::OutputFormat;
+
 /// List all dev containers managed by cella.
 #[derive(Args)]
 pub struct ListArgs {
@@ -13,9 +15,9 @@ pub struct ListArgs {
     #[arg(long)]
     running: bool,
 
-    /// Output as JSON.
-    #[arg(long)]
-    json: bool,
+    /// Output format.
+    #[arg(long, value_enum, default_value = "text")]
+    output: OutputFormat,
 
     #[command(flatten)]
     backend: crate::backend::BackendArgs,
@@ -27,7 +29,7 @@ impl ListArgs {
 
         let containers = client.list_cella_containers(self.running).await?;
 
-        if self.json {
+        if matches!(self.output, OutputFormat::Json) {
             print_json(&containers);
         } else {
             print_table(&containers);

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -63,6 +63,26 @@ impl ImagePullPolicy {
     }
 }
 
+/// Pull policy for Docker Compose services.
+#[derive(Clone, ValueEnum)]
+pub enum ComposePullPolicy {
+    Always,
+    Missing,
+    Never,
+    Build,
+}
+
+impl ComposePullPolicy {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Always => "always",
+            Self::Missing => "missing",
+            Self::Never => "never",
+            Self::Build => "build",
+        }
+    }
+}
+
 /// Top-level CLI commands.
 #[derive(Subcommand)]
 pub enum Command {

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -63,6 +63,16 @@ impl ImagePullPolicy {
     }
 }
 
+/// Strictness level for validation.
+#[derive(Clone, ValueEnum)]
+pub enum StrictnessLevel {
+    /// Fail on unmet host requirements.
+    #[value(name = "host-requirements")]
+    HostRequirements,
+    /// Enable all strictness checks.
+    All,
+}
+
 /// Pull policy for Docker Compose services.
 #[derive(Clone, ValueEnum)]
 pub enum ComposePullPolicy {

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -45,6 +45,24 @@ pub enum OutputFormat {
     Json,
 }
 
+/// Image pull policy for container builds.
+#[derive(Clone, ValueEnum)]
+pub enum ImagePullPolicy {
+    Always,
+    Missing,
+    Never,
+}
+
+impl ImagePullPolicy {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Always => "always",
+            Self::Missing => "missing",
+            Self::Never => "never",
+        }
+    }
+}
+
 /// Top-level CLI commands.
 #[derive(Subcommand)]
 pub enum Command {

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -25,7 +25,7 @@ mod switch;
 mod template;
 pub mod up;
 
-use clap::{Args, Subcommand};
+use clap::{Args, Subcommand, ValueEnum};
 use tracing::warn;
 
 use crate::progress::{Progress, Verbosity};
@@ -36,6 +36,13 @@ pub struct VerboseArgs {
     /// Show expanded step details (container names, feature resolution, etc.).
     #[arg(short, long)]
     pub verbose: bool,
+}
+
+/// Output format for container commands.
+#[derive(Clone, ValueEnum)]
+pub enum OutputFormat {
+    Text,
+    Json,
 }
 
 /// Top-level CLI commands.

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -54,7 +54,7 @@ pub enum ImagePullPolicy {
 }
 
 impl ImagePullPolicy {
-    pub fn as_str(&self) -> &str {
+    pub const fn as_str(&self) -> &str {
         match self {
             Self::Always => "always",
             Self::Missing => "missing",
@@ -83,7 +83,7 @@ pub enum ComposePullPolicy {
 }
 
 impl ComposePullPolicy {
-    pub fn as_str(&self) -> &str {
+    pub const fn as_str(&self) -> &str {
         match self {
             Self::Always => "always",
             Self::Missing => "missing",

--- a/crates/cella-cli/src/commands/nvim.rs
+++ b/crates/cella-cli/src/commands/nvim.rs
@@ -4,7 +4,8 @@ use tracing::debug;
 
 use cella_backend::{ExecOptions, InteractiveExecOptions};
 
-use super::up::{OutputFormat, UpArgs, UpContext};
+use super::OutputFormat;
+use super::up::{UpArgs, UpContext};
 
 use crate::picker;
 

--- a/crates/cella-cli/src/commands/prune.rs
+++ b/crates/cella-cli/src/commands/prune.rs
@@ -7,7 +7,7 @@ use std::pin::Pin;
 
 use cella_orchestrator::prune::{PruneCandidate, PruneHooks};
 
-use super::up::OutputFormat;
+use super::OutputFormat;
 
 /// Remove stale worktrees and their associated containers.
 ///
@@ -33,7 +33,7 @@ pub struct PruneArgs {
     backend: crate::backend::BackendArgs,
 
     /// Output format (text or json).
-    #[arg(long, default_value = "text")]
+    #[arg(long, value_enum, default_value = "text")]
     output: OutputFormat,
 }
 

--- a/crates/cella-cli/src/commands/tmux.rs
+++ b/crates/cella-cli/src/commands/tmux.rs
@@ -6,7 +6,8 @@ use tracing::debug;
 
 use cella_backend::{ExecOptions, InteractiveExecOptions};
 
-use super::up::{OutputFormat, UpArgs, UpContext};
+use super::OutputFormat;
+use super::up::{UpArgs, UpContext};
 
 use crate::picker;
 

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -189,7 +189,12 @@ impl UpContext {
             remove_container,
             build_no_cache: args.build.build_no_cache,
             skip_checksum: args.skip_checksum,
-            pull_policy: args.build.pull.as_ref().map(ImagePullPolicy::as_str).map(String::from),
+            pull_policy: args
+                .build
+                .pull
+                .as_ref()
+                .map(ImagePullPolicy::as_str)
+                .map(String::from),
             extra_labels: std::collections::HashMap::new(),
             network_rules: if args.no_network_rules {
                 NetworkRulePolicy::Skip
@@ -637,9 +642,10 @@ impl UpContext {
             },
             remove_existing_container: self.remove_container,
             skip_checksum: self.skip_checksum,
-            host_requirement_policy: if strict.iter().any(|s| {
-                matches!(s, StrictnessLevel::HostRequirements | StrictnessLevel::All)
-            }) {
+            host_requirement_policy: if strict
+                .iter()
+                .any(|s| matches!(s, StrictnessLevel::HostRequirements | StrictnessLevel::All))
+            {
                 cella_orchestrator::HostRequirementPolicy::Error
             } else {
                 cella_orchestrator::HostRequirementPolicy::Warn
@@ -703,7 +709,12 @@ impl UpArgs {
         ctx.remove_container = self.build.rebuild || self.build.remove_existing_container;
         ctx.build_no_cache = self.build.build_no_cache;
         ctx.skip_checksum = self.skip_checksum;
-        ctx.pull_policy = self.build.pull.as_ref().map(ImagePullPolicy::as_str).map(String::from);
+        ctx.pull_policy = self
+            .build
+            .pull
+            .as_ref()
+            .map(ImagePullPolicy::as_str)
+            .map(String::from);
         ctx.network_rules = if self.no_network_rules {
             NetworkRulePolicy::Skip
         } else {

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -6,7 +6,7 @@ use clap::Args;
 use serde_json::json;
 use tracing::{debug, warn};
 
-use super::{ImagePullPolicy, OutputFormat};
+use super::{ComposePullPolicy, ImagePullPolicy, OutputFormat};
 
 use cella_backend::{BuildSecret, ContainerBackend, ExecOptions, container_name};
 use cella_config::devcontainer::resolve::{self, ResolvedConfig};
@@ -86,9 +86,9 @@ pub struct UpArgs {
     #[arg(long = "env-file")]
     pub(crate) env_file: Vec<PathBuf>,
 
-    /// Pull policy for Docker Compose services (always, missing, never).
-    #[arg(long = "pull-policy")]
-    pub(crate) pull_policy: Option<String>,
+    /// Pull policy for Docker Compose services.
+    #[arg(long = "pull-policy", value_enum)]
+    pub(crate) pull_policy: Option<ComposePullPolicy>,
 }
 
 impl UpArgs {
@@ -199,7 +199,7 @@ impl UpContext {
             docker_host: effective_docker_host(&args.backend),
             compose_profiles: args.profile.clone(),
             compose_env_files: args.env_file.clone(),
-            compose_pull_policy: args.pull_policy.clone(),
+            compose_pull_policy: args.pull_policy.as_ref().map(|p| p.as_str().to_string()),
             build_secrets,
         })
     }

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -2,9 +2,11 @@ use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
 
-use clap::{Args, ValueEnum};
+use clap::Args;
 use serde_json::json;
 use tracing::{debug, warn};
+
+use super::OutputFormat;
 
 use cella_backend::{BuildSecret, ContainerBackend, ExecOptions, container_name};
 use cella_config::devcontainer::resolve::{self, ResolvedConfig};
@@ -87,13 +89,6 @@ pub struct UpArgs {
     /// Pull policy for Docker Compose services (always, missing, never).
     #[arg(long = "pull-policy")]
     pub(crate) pull_policy: Option<String>,
-}
-
-/// Output format for container commands.
-#[derive(Clone, ValueEnum)]
-pub enum OutputFormat {
-    Text,
-    Json,
 }
 
 impl UpArgs {

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -6,7 +6,7 @@ use clap::Args;
 use serde_json::json;
 use tracing::{debug, warn};
 
-use super::{ComposePullPolicy, ImagePullPolicy, OutputFormat};
+use super::{ComposePullPolicy, ImagePullPolicy, OutputFormat, StrictnessLevel};
 
 use cella_backend::{BuildSecret, ContainerBackend, ExecOptions, container_name};
 use cella_config::devcontainer::resolve::{self, ResolvedConfig};
@@ -62,9 +62,9 @@ pub struct UpArgs {
     #[arg(long, value_enum, default_value = "text")]
     pub(crate) output: OutputFormat,
 
-    /// Strictness level for validation ("host-requirements" to fail on unmet requirements).
-    #[arg(long)]
-    pub(crate) strict: Vec<String>,
+    /// Strictness level for validation.
+    #[arg(long, value_enum)]
+    pub(crate) strict: Vec<StrictnessLevel>,
 
     /// Skip SHA256 checksum verification for agent binary download.
     #[arg(long)]
@@ -612,7 +612,7 @@ impl UpContext {
     pub async fn ensure_up(
         &self,
         build_no_cache: bool,
-        strict: &[String],
+        strict: &[StrictnessLevel],
     ) -> Result<UpResult, Box<dyn std::error::Error>> {
         let (sender, renderer) = crate::progress::bridge(&self.progress);
         let hooks = CliUpHooks {
@@ -637,10 +637,9 @@ impl UpContext {
             },
             remove_existing_container: self.remove_container,
             skip_checksum: self.skip_checksum,
-            host_requirement_policy: if strict
-                .iter()
-                .any(|s| s == "host-requirements" || s == "all")
-            {
+            host_requirement_policy: if strict.iter().any(|s| {
+                matches!(s, StrictnessLevel::HostRequirements | StrictnessLevel::All)
+            }) {
                 cella_orchestrator::HostRequirementPolicy::Error
             } else {
                 cella_orchestrator::HostRequirementPolicy::Warn

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -6,7 +6,7 @@ use clap::Args;
 use serde_json::json;
 use tracing::{debug, warn};
 
-use super::OutputFormat;
+use super::{ImagePullPolicy, OutputFormat};
 
 use cella_backend::{BuildSecret, ContainerBackend, ExecOptions, container_name};
 use cella_config::devcontainer::resolve::{self, ResolvedConfig};
@@ -28,9 +28,9 @@ pub struct UpBuildArgs {
     #[arg(long)]
     pub(crate) remove_existing_container: bool,
 
-    /// Image pull policy (e.g. "always", "missing", "never").
-    #[arg(long)]
-    pub(crate) pull: Option<String>,
+    /// Image pull policy.
+    #[arg(long, value_enum)]
+    pub(crate) pull: Option<ImagePullPolicy>,
 
     /// `BuildKit` secret to pass to the build (format: `id=X[,src=Y][,env=Z]`).
     /// Can be specified multiple times.
@@ -189,7 +189,7 @@ impl UpContext {
             remove_container,
             build_no_cache: args.build.build_no_cache,
             skip_checksum: args.skip_checksum,
-            pull_policy: args.build.pull.clone(),
+            pull_policy: args.build.pull.as_ref().map(ImagePullPolicy::as_str).map(String::from),
             extra_labels: std::collections::HashMap::new(),
             network_rules: if args.no_network_rules {
                 NetworkRulePolicy::Skip
@@ -704,7 +704,7 @@ impl UpArgs {
         ctx.remove_container = self.build.rebuild || self.build.remove_existing_container;
         ctx.build_no_cache = self.build.build_no_cache;
         ctx.skip_checksum = self.skip_checksum;
-        ctx.pull_policy = self.build.pull.clone();
+        ctx.pull_policy = self.build.pull.as_ref().map(ImagePullPolicy::as_str).map(String::from);
         ctx.network_rules = if self.no_network_rules {
             NetworkRulePolicy::Skip
         } else {

--- a/crates/cella-cli/src/main.rs
+++ b/crates/cella-cli/src/main.rs
@@ -260,8 +260,8 @@ mod tests {
     }
 
     #[test]
-    fn parse_list_json() {
-        let cli = parse(&["cella", "list", "--json"]).unwrap();
+    fn parse_list_output_json() {
+        let cli = parse(&["cella", "list", "--output", "json"]).unwrap();
         assert!(matches!(cli.command, super::commands::Command::List(_)));
     }
 
@@ -280,8 +280,8 @@ mod tests {
     }
 
     #[test]
-    fn parse_doctor_json() {
-        let cli = parse(&["cella", "doctor", "--json"]).unwrap();
+    fn parse_doctor_output_json() {
+        let cli = parse(&["cella", "doctor", "--output", "json"]).unwrap();
         assert!(matches!(cli.command, super::commands::Command::Doctor(_)));
     }
 
@@ -293,7 +293,15 @@ mod tests {
 
     #[test]
     fn parse_doctor_all_flags() {
-        let cli = parse(&["cella", "doctor", "--all", "--json", "--no-redact"]).unwrap();
+        let cli = parse(&[
+            "cella",
+            "doctor",
+            "--all",
+            "--output",
+            "json",
+            "--no-redact",
+        ])
+        .unwrap();
         assert!(matches!(cli.command, super::commands::Command::Doctor(_)));
     }
 
@@ -389,6 +397,38 @@ mod tests {
         assert!(matches!(cli.command, super::commands::Command::Build(_)));
     }
 
+    // ── pull policy enums ────────────────────────────────────────────
+
+    #[test]
+    fn parse_up_pull_always() {
+        let cli = parse(&["cella", "up", "--pull", "always"]).unwrap();
+        assert!(matches!(cli.command, super::commands::Command::Up(_)));
+    }
+
+    #[test]
+    fn parse_up_pull_invalid() {
+        let result = parse(&["cella", "up", "--pull", "invalid"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_up_pull_policy_build() {
+        let cli = parse(&["cella", "up", "--pull-policy", "build"]).unwrap();
+        assert!(matches!(cli.command, super::commands::Command::Up(_)));
+    }
+
+    #[test]
+    fn parse_up_strict_host_requirements() {
+        let cli = parse(&["cella", "up", "--strict", "host-requirements"]).unwrap();
+        assert!(matches!(cli.command, super::commands::Command::Up(_)));
+    }
+
+    #[test]
+    fn parse_up_strict_invalid() {
+        let result = parse(&["cella", "up", "--strict", "invalid"]);
+        assert!(result.is_err());
+    }
+
     // ── code command ────────────────────────────────────────────────
 
     #[test]
@@ -398,28 +438,20 @@ mod tests {
     }
 
     #[test]
-    fn parse_code_insider() {
-        let cli = parse(&["cella", "code", "--insider"]).unwrap();
-        if let super::commands::Command::Code(args) = cli.command {
-            assert!(args.insider);
-        } else {
-            panic!("expected Code command");
-        }
+    fn parse_code_editor_insiders() {
+        let cli = parse(&["cella", "code", "--editor", "insiders"]).unwrap();
+        assert!(matches!(cli.command, super::commands::Command::Code(_)));
     }
 
     #[test]
-    fn parse_code_cursor() {
-        let cli = parse(&["cella", "code", "--cursor"]).unwrap();
-        if let super::commands::Command::Code(args) = cli.command {
-            assert!(args.cursor);
-        } else {
-            panic!("expected Code command");
-        }
+    fn parse_code_editor_cursor() {
+        let cli = parse(&["cella", "code", "--editor", "cursor"]).unwrap();
+        assert!(matches!(cli.command, super::commands::Command::Code(_)));
     }
 
     #[test]
-    fn parse_code_insider_and_cursor_conflict() {
-        let result = parse(&["cella", "code", "--insider", "--cursor"]);
+    fn parse_code_editor_invalid() {
+        let result = parse(&["cella", "code", "--editor", "vim"]);
         assert!(result.is_err());
     }
 
@@ -434,8 +466,8 @@ mod tests {
     }
 
     #[test]
-    fn parse_code_binary_and_insider_conflict() {
-        let result = parse(&["cella", "code", "--binary", "x", "--insider"]);
+    fn parse_code_binary_conflicts_with_editor() {
+        let result = parse(&["cella", "code", "--binary", "x", "--editor", "cursor"]);
         assert!(result.is_err());
     }
 


### PR DESCRIPTION
## Summary

- **Consolidate `OutputFormat`** — merge duplicate enums from `up/mod.rs` and `build.rs` into a single definition in `commands/mod.rs`
- **Add `ImagePullPolicy` enum** — replace `Option<String>` with strict `always`/`missing`/`never` ValueEnum for `--pull` flag
- **Add `ComposePullPolicy` enum** — replace `Option<String>` with strict `always`/`missing`/`never`/`build` ValueEnum for `--pull-policy` flag
- **Add `StrictnessLevel` enum** — replace `Vec<String>` with strict `host-requirements`/`all` ValueEnum for `--strict` flag
- **Replace `--insider`/`--cursor` with `--editor` enum** — single `--editor code|insiders|cursor` flag instead of three mutually exclusive booleans
- **Unify `--json` to `--output`** — replace `--json` bool flags with `--output text|json` ValueEnum in `list`, `doctor`, `features list`, `features update`

All enums stay within `cella-cli` — converted to strings at the boundary when passing to orchestrator/compose crates.

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings -D clippy::all` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test -p cella-cli` — all 403 tests pass
- [x] Invalid enum values (e.g. `--pull invalid`, `--strict invalid`, `--editor vim`) rejected at parse time with helpful error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)