### PR TITLE
fix: feature collection cache drops features after first run

### DIFF
--- a/crates/cella-agent/src/cli.rs
+++ b/crates/cella-agent/src/cli.rs
@@ -22,12 +22,12 @@ const TIMEOUT_SLOW: Duration = Duration::from_secs(600);
 async fn recv_timeout(
     client: &mut ControlClient,
     dur: Duration,
-) -> Result<DaemonMessage, Box<dyn std::error::Error>> {
-    Ok(timeout(dur, client.recv())
-        .await
-        .map_err(|_| -> Box<dyn std::error::Error> {
+) -> Result<DaemonMessage, Box<dyn std::error::Error + Send + Sync>> {
+    Ok(timeout(dur, client.recv()).await.map_err(
+        |_| -> Box<dyn std::error::Error + Send + Sync> {
             "timed out waiting for response from daemon".into()
-        })??)
+        },
+    )??)
 }
 
 /// In-container CLI commands.
@@ -240,7 +240,7 @@ fn parse_task_subcommand(args: &[String]) -> CliCommand {
 }
 
 /// Run the in-container CLI.
-pub async fn run(command: CliCommand) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn run(command: CliCommand) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     match command {
         CliCommand::Help => {
             print_help();
@@ -326,7 +326,7 @@ Run `cella --help` on the host for all commands."
 ///
 /// Reads connection info from env vars, falling back to the `.daemon_addr`
 /// file on the shared agent volume.
-async fn connect_daemon() -> Result<ControlClient, Box<dyn std::error::Error>> {
+async fn connect_daemon() -> Result<ControlClient, Box<dyn std::error::Error + Send + Sync>> {
     let (addr, token) = if let Some(info) = crate::control::read_daemon_addr_file() {
         (info.addr, info.token)
     } else if let Ok(addr) = std::env::var("CELLA_DAEMON_ADDR") {
@@ -352,7 +352,7 @@ fn request_id() -> String {
     format!("cli-{n}")
 }
 
-async fn run_doctor() -> Result<(), Box<dyn std::error::Error>> {
+async fn run_doctor() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let agent_version = env!("CARGO_PKG_VERSION");
     eprintln!("cella doctor (in-container, agent v{agent_version})\n");
 
@@ -417,7 +417,10 @@ async fn run_doctor() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-async fn run_branch(name: &str, base: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {
+async fn run_branch(
+    name: &str,
+    base: Option<&str>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut client = connect_daemon().await?;
 
     let id = request_id();
@@ -458,7 +461,7 @@ async fn run_branch(name: &str, base: Option<&str>) -> Result<(), Box<dyn std::e
     }
 }
 
-async fn run_list() -> Result<(), Box<dyn std::error::Error>> {
+async fn run_list() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut client = connect_daemon().await?;
 
     let id = request_id();
@@ -481,7 +484,10 @@ async fn run_list() -> Result<(), Box<dyn std::error::Error>> {
     }
 }
 
-async fn run_exec(branch: &str, command: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+async fn run_exec(
+    branch: &str,
+    command: &[String],
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut client = connect_daemon().await?;
 
     let id = request_id();
@@ -513,7 +519,7 @@ async fn run_exec(branch: &str, command: &[String]) -> Result<(), Box<dyn std::e
 async fn check_self_target(
     client: &mut ControlClient,
     branch: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let own_container = std::env::var("CELLA_CONTAINER_NAME").unwrap_or_default();
     if own_container.is_empty() {
         return Ok(());
@@ -546,7 +552,7 @@ async fn run_down(
     rm: bool,
     volumes: bool,
     force: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut client = connect_daemon().await?;
     check_self_target(&mut client, branch).await?;
 
@@ -594,7 +600,10 @@ async fn run_down(
     }
 }
 
-async fn run_up(branch: &str, rebuild: bool) -> Result<(), Box<dyn std::error::Error>> {
+async fn run_up(
+    branch: &str,
+    rebuild: bool,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut client = connect_daemon().await?;
 
     let id = request_id();
@@ -632,7 +641,10 @@ async fn run_up(branch: &str, rebuild: bool) -> Result<(), Box<dyn std::error::E
     }
 }
 
-async fn run_prune(dry_run: bool, all: bool) -> Result<(), Box<dyn std::error::Error>> {
+async fn run_prune(
+    dry_run: bool,
+    all: bool,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut client = connect_daemon().await?;
 
     let id = request_id();
@@ -671,7 +683,7 @@ async fn run_task_run(
     branch: &str,
     command: &[String],
     base: Option<&str>,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut client = connect_daemon().await?;
 
     let id = request_id();
@@ -710,7 +722,7 @@ async fn run_task_run(
     }
 }
 
-async fn run_task_list() -> Result<(), Box<dyn std::error::Error>> {
+async fn run_task_list() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut client = connect_daemon().await?;
 
     let id = request_id();
@@ -743,7 +755,10 @@ async fn run_task_list() -> Result<(), Box<dyn std::error::Error>> {
     }
 }
 
-async fn run_task_logs(branch: &str, follow: bool) -> Result<(), Box<dyn std::error::Error>> {
+async fn run_task_logs(
+    branch: &str,
+    follow: bool,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut client = connect_daemon().await?;
 
     let id = request_id();
@@ -767,7 +782,7 @@ async fn run_task_logs(branch: &str, follow: bool) -> Result<(), Box<dyn std::er
     }
 }
 
-async fn run_task_wait(branch: &str) -> Result<(), Box<dyn std::error::Error>> {
+async fn run_task_wait(branch: &str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut client = connect_daemon().await?;
 
     let id = request_id();
@@ -790,7 +805,7 @@ async fn run_task_wait(branch: &str) -> Result<(), Box<dyn std::error::Error>> {
     }
 }
 
-async fn run_task_stop(branch: &str) -> Result<(), Box<dyn std::error::Error>> {
+async fn run_task_stop(branch: &str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut client = connect_daemon().await?;
 
     let id = request_id();
@@ -813,7 +828,7 @@ async fn run_task_stop(branch: &str) -> Result<(), Box<dyn std::error::Error>> {
     }
 }
 
-async fn run_switch(branch: &str) -> Result<(), Box<dyn std::error::Error>> {
+async fn run_switch(branch: &str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut client = connect_daemon().await?;
 
     let id = request_id();

--- a/crates/cella-cli/src/backend.rs
+++ b/crates/cella-cli/src/backend.rs
@@ -56,7 +56,7 @@ impl BackendArgs {
         resolve_backend(self.backend.as_ref(), self.docker_host.as_deref()).await
     }
 
-    /// Convenience wrapper that coerces the error to `Box<dyn Error>`.
+    /// Convenience wrapper around [`resolve`](Self::resolve).
     ///
     /// # Errors
     ///
@@ -64,9 +64,7 @@ impl BackendArgs {
     pub async fn resolve_client(
         &self,
     ) -> Result<Box<dyn ContainerBackend>, Box<dyn std::error::Error + Send + Sync>> {
-        self.resolve()
-            .await
-            .map_err(|e| e as Box<dyn std::error::Error + Send + Sync>)
+        self.resolve().await
     }
 }
 

--- a/crates/cella-cli/src/backend.rs
+++ b/crates/cella-cli/src/backend.rs
@@ -63,10 +63,10 @@ impl BackendArgs {
     /// Returns error if backend resolution fails (see [`resolve`](Self::resolve)).
     pub async fn resolve_client(
         &self,
-    ) -> Result<Box<dyn ContainerBackend>, Box<dyn std::error::Error>> {
+    ) -> Result<Box<dyn ContainerBackend>, Box<dyn std::error::Error + Send + Sync>> {
         self.resolve()
             .await
-            .map_err(|e| e as Box<dyn std::error::Error>)
+            .map_err(|e| e as Box<dyn std::error::Error + Send + Sync>)
     }
 }
 

--- a/crates/cella-cli/src/commands/branch.rs
+++ b/crates/cella-cli/src/commands/branch.rs
@@ -33,12 +33,13 @@ impl BranchArgs {
     pub async fn execute(
         self,
         progress: crate::progress::Progress,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         // 1. Discover git repo
         let cwd = std::env::current_dir()?;
-        let repo_info = cella_git::discover(&cwd).map_err(|e| -> Box<dyn std::error::Error> {
-            format!("Not inside a git repository: {e}").into()
-        })?;
+        let repo_info =
+            cella_git::discover(&cwd).map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {
+                format!("Not inside a git repository: {e}").into()
+            })?;
         let repo_root = &repo_info.root;
 
         // 2. Create git worktree via orchestrator
@@ -50,7 +51,7 @@ impl BranchArgs {
             None,
             &sender,
         )
-        .map_err(|e| -> Box<dyn std::error::Error> { Box::new(e) })?;
+        .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::new(e) })?;
         drop(sender);
         let _ = renderer.await;
 
@@ -79,7 +80,7 @@ impl BranchArgs {
         wt_path: &std::path::Path,
         repo_root: &std::path::Path,
         progress: &crate::progress::Progress,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         // Prepare worktree-specific labels
         let extra_labels = worktree_labels(&self.name, repo_root);
 

--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -65,7 +65,7 @@ impl BuildArgs {
     pub async fn execute(
         self,
         progress: crate::progress::Progress,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let cwd = super::resolve_workspace_folder(self.workspace_folder.as_deref())?;
 
         info!("Resolving devcontainer config...");
@@ -82,7 +82,7 @@ impl BuildArgs {
             .iter()
             .map(|s| parse_build_secret(s))
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })?;
 
         let client = self.backend.resolve_client().await?;
         client.ping().await?;
@@ -108,7 +108,8 @@ impl BuildArgs {
             .map_err(|e| e.to_string());
             drop(sender);
             let _ = renderer.await;
-            let result = result.map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+            let result =
+                result.map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })?;
 
             print_result(&self.output, &result.image_name, true);
             return Ok(());

--- a/crates/cella-cli/src/commands/code.rs
+++ b/crates/cella-cli/src/commands/code.rs
@@ -53,7 +53,7 @@ impl CodeArgs {
     pub async fn execute(
         self,
         progress: crate::progress::Progress,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         // 1. Check for remote Docker (unsupported)
         check_local_docker()?;
 
@@ -187,7 +187,7 @@ fn build_vscode_uri(container_id: &str, workspace_folder: &str) -> String {
 fn resolve_editor_binary(
     editor: &EditorChoice,
     binary: Option<&str>,
-) -> Result<PathBuf, Box<dyn std::error::Error>> {
+) -> Result<PathBuf, Box<dyn std::error::Error + Send + Sync>> {
     let name = if let Some(b) = binary {
         // If it contains a path separator, treat as path
         if b.contains('/') {
@@ -210,7 +210,7 @@ fn resolve_editor_binary(
 }
 
 /// Look up a binary name in PATH.
-fn which_binary(name: &str) -> Result<PathBuf, Box<dyn std::error::Error>> {
+fn which_binary(name: &str) -> Result<PathBuf, Box<dyn std::error::Error + Send + Sync>> {
     if let Ok(path_var) = std::env::var("PATH") {
         for dir in std::env::split_paths(&path_var) {
             let candidate = dir.join(name);
@@ -257,7 +257,7 @@ fn editor_install_hint(editor: &Path) -> String {
 }
 
 /// Check that Docker is local (not a remote host via SSH or TCP).
-fn check_local_docker() -> Result<(), Box<dyn std::error::Error>> {
+fn check_local_docker() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let docker_host = std::env::var("DOCKER_HOST").ok();
     if let Some(ref host) = docker_host {
         if host.starts_with("ssh://") {

--- a/crates/cella-cli/src/commands/compose_up.rs
+++ b/crates/cella-cli/src/commands/compose_up.rs
@@ -17,7 +17,7 @@ use super::up::{UpContext, output_result};
 /// Run the Docker Compose orchestration flow.
 ///
 /// Called from `UpArgs::execute()` when the resolved config contains `dockerComposeFile`.
-pub async fn compose_up(ctx: UpContext) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn compose_up(ctx: UpContext) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let hooks = CliComposeUpHooks { ctx: &ctx };
     let cfg = ComposeUpConfig {
         config: ctx.config(),
@@ -39,7 +39,7 @@ pub async fn compose_up(ctx: UpContext) -> Result<(), Box<dyn std::error::Error>
             .await
             .map_err(|e| e.to_string());
     let _ = renderer.await;
-    let result = result.map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+    let result = result.map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })?;
 
     let outcome = match result.outcome {
         ComposeUpOutcome::Created => "created",

--- a/crates/cella-cli/src/commands/config.rs
+++ b/crates/cella-cli/src/commands/config.rs
@@ -31,7 +31,7 @@ pub enum ConfigCommand {
 }
 
 impl ConfigArgs {
-    pub fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         match self.command {
             ConfigCommand::Validate { file, strict } => validate(file, strict),
             ConfigCommand::Show
@@ -45,7 +45,10 @@ impl ConfigArgs {
     }
 }
 
-fn validate(file: Option<PathBuf>, strict: bool) -> Result<(), Box<dyn std::error::Error>> {
+fn validate(
+    file: Option<PathBuf>,
+    strict: bool,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let path = if let Some(p) = file {
         p
     } else {

--- a/crates/cella-cli/src/commands/credential.rs
+++ b/crates/cella-cli/src/commands/credential.rs
@@ -52,7 +52,7 @@ enum CredentialTool {
 }
 
 impl CredentialArgs {
-    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         match self.command {
             CredentialCommand::Sync(args) => run_sync(args, &self.backend).await,
             CredentialCommand::Status(args) => run_status(args, &self.backend).await,
@@ -63,7 +63,7 @@ impl CredentialArgs {
 async fn run_sync(
     args: SyncArgs,
     backend: &crate::backend::BackendArgs,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     match args.tool {
         CredentialTool::Gh => sync_gh(args.container, args.workspace_folder, backend).await,
     }
@@ -73,7 +73,7 @@ async fn sync_gh(
     container_id_override: Option<String>,
     workspace_folder: Option<PathBuf>,
     backend: &crate::backend::BackendArgs,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let client = backend.resolve_client().await?;
 
     let cwd = super::resolve_workspace_folder(workspace_folder.as_deref())?;
@@ -178,7 +178,7 @@ async fn sync_gh(
 async fn run_status(
     args: StatusArgs,
     backend: &crate::backend::BackendArgs,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let redactor = cella_doctor::redact::Redactor::new();
 
     // Host section: check gh auth status

--- a/crates/cella-cli/src/commands/daemon.rs
+++ b/crates/cella-cli/src/commands/daemon.rs
@@ -34,7 +34,7 @@ struct StartArgs {
 }
 
 impl DaemonArgs {
-    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         match self.command {
             DaemonCommand::Start(args) => run_start(args).await,
             DaemonCommand::Stop => run_stop(),
@@ -43,7 +43,7 @@ impl DaemonArgs {
     }
 }
 
-async fn run_start(args: StartArgs) -> Result<(), Box<dyn std::error::Error>> {
+async fn run_start(args: StartArgs) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let data_dir = cella_data_dir().ok_or("cannot determine data dir: HOME not set")?;
     cella_daemon::logging::init_daemon_logging(&data_dir.join("daemon.log"));
 
@@ -56,7 +56,7 @@ async fn run_start(args: StartArgs) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn run_stop() -> Result<(), Box<dyn std::error::Error>> {
+fn run_stop() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let data_dir = cella_data_dir().ok_or("cannot determine data dir: HOME not set")?;
     let pid_path = data_dir.join("daemon.pid");
     let socket_path = data_dir.join("daemon.sock");
@@ -65,7 +65,7 @@ fn run_stop() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-async fn run_status() -> Result<(), Box<dyn std::error::Error>> {
+async fn run_status() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let data_dir = cella_data_dir().ok_or("cannot determine data dir: HOME not set")?;
     let pid_path = data_dir.join("daemon.pid");
     let socket_path = data_dir.join("daemon.sock");

--- a/crates/cella-cli/src/commands/doctor.rs
+++ b/crates/cella-cli/src/commands/doctor.rs
@@ -22,7 +22,7 @@ pub struct DoctorArgs {
 }
 
 impl DoctorArgs {
-    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let workspace_folder = std::env::current_dir().ok();
         let (backend_client, backend_error) = match self.backend.resolve_client().await {
             Ok(client) => (Some(client), None),

--- a/crates/cella-cli/src/commands/down.rs
+++ b/crates/cella-cli/src/commands/down.rs
@@ -57,7 +57,9 @@ pub struct DownArgs {
 }
 
 /// Resolve a branch name to its worktree path.
-fn resolve_branch_to_path(branch_name: &str) -> Result<PathBuf, Box<dyn std::error::Error>> {
+fn resolve_branch_to_path(
+    branch_name: &str,
+) -> Result<PathBuf, Box<dyn std::error::Error + Send + Sync>> {
     let cwd = std::env::current_dir()?;
     let repo_info = cella_git::discover(&cwd)?;
     let worktrees = cella_git::list(&repo_info.root)?;
@@ -69,7 +71,7 @@ fn resolve_branch_to_path(branch_name: &str) -> Result<PathBuf, Box<dyn std::err
 }
 
 /// Remove the worktree directory and clean up stale git records.
-fn remove_worktree(branch_name: &str) -> Result<(), Box<dyn std::error::Error>> {
+fn remove_worktree(branch_name: &str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let cwd = std::env::current_dir()?;
     let repo_info = cella_git::discover(&cwd)?;
     let worktrees = cella_git::list(&repo_info.root)?;
@@ -92,7 +94,7 @@ impl DownArgs {
         matches!(self.output, OutputFormat::Text)
     }
 
-    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let client = self.backend.resolve_client().await?;
 
         let workspace_folder = if let Some(ref branch_name) = self.branch {
@@ -164,7 +166,7 @@ impl DownArgs {
             compose_cmd
                 .down()
                 .await
-                .map_err(|e| -> Box<dyn std::error::Error> {
+                .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {
                     format!("docker compose down failed: {e}").into()
                 })?;
 

--- a/crates/cella-cli/src/commands/exec.rs
+++ b/crates/cella-cli/src/commands/exec.rs
@@ -57,7 +57,7 @@ pub struct ExecArgs {
 }
 
 impl ExecArgs {
-    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let client = self.backend.resolve_client().await?;
 
         let target = ContainerTarget {

--- a/crates/cella-cli/src/commands/features/edit.rs
+++ b/crates/cella-cli/src/commands/features/edit.rs
@@ -49,7 +49,7 @@ impl EditArgs {
     /// # Errors
     ///
     /// Returns error on config discovery failure, parse errors, or I/O errors.
-    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         if self.is_non_interactive() {
             self.run_non_interactive()
         } else {
@@ -57,7 +57,7 @@ impl EditArgs {
         }
     }
 
-    fn run_non_interactive(&self) -> Result<(), Box<dyn std::error::Error>> {
+    fn run_non_interactive(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let config_path = resolve::discover_config(&self.common)?;
         let raw = resolve::read_raw_config(&config_path)?;
         let stripped = cella_jsonc::strip(&raw)?;
@@ -108,7 +108,7 @@ impl EditArgs {
         Ok(())
     }
 
-    async fn run_interactive(&self) -> Result<(), Box<dyn std::error::Error>> {
+    async fn run_interactive(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let config_path = resolve::discover_config(&self.common)?;
         let raw = resolve::read_raw_config(&config_path)?;
         let stripped = cella_jsonc::strip(&raw)?;
@@ -196,7 +196,7 @@ async fn handle_add_feature(
     edits: &mut Vec<FeatureEdit>,
     cache: &TemplateCache,
     registry: Option<&str>,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     if let Some((feature, opts)) = prompt_add_feature(cache, registry).await? {
         current_features.push((feature.reference.clone(), options_to_json(&feature.options)));
         edits.push(FeatureEdit::Add {
@@ -211,7 +211,7 @@ async fn handle_add_feature(
 fn handle_remove_feature(
     current_features: &mut Vec<(String, serde_json::Value)>,
     edits: &mut Vec<FeatureEdit>,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     if current_features.is_empty() {
         eprintln!("No features to remove.");
         return Ok(());
@@ -230,7 +230,7 @@ async fn handle_edit_options(
     current_features: &mut [(String, serde_json::Value)],
     edits: &mut Vec<FeatureEdit>,
     cache: &TemplateCache,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     if current_features.is_empty() {
         eprintln!("No features to edit.");
         return Ok(());
@@ -260,8 +260,10 @@ async fn handle_edit_options(
 async fn prompt_add_feature(
     cache: &TemplateCache,
     registry: Option<&str>,
-) -> Result<Option<(SelectedFeature, HashMap<String, serde_json::Value>)>, Box<dyn std::error::Error>>
-{
+) -> Result<
+    Option<(SelectedFeature, HashMap<String, serde_json::Value>)>,
+    Box<dyn std::error::Error + Send + Sync>,
+> {
     let reg = registry.unwrap_or(DEFAULT_FEATURE_COLLECTION);
     let collection = collection::fetch_feature_collection(reg, cache, false).await?;
 
@@ -339,7 +341,7 @@ async fn prompt_edit_options(
     reference: &str,
     current_options: &serde_json::Value,
     cache: &TemplateCache,
-) -> Result<HashMap<String, serde_json::Value>, Box<dyn std::error::Error>> {
+) -> Result<HashMap<String, serde_json::Value>, Box<dyn std::error::Error + Send + Sync>> {
     // Try to fetch metadata for proper option types
     if let Ok(feature_dir) = fetcher::fetch_template(reference, cache).await
         && let Ok(content) = std::fs::read_to_string(feature_dir.join("devcontainer-feature.json"))
@@ -384,7 +386,7 @@ async fn prompt_edit_options(
 /// Parse a `--set-option` flag value: `REF=KEY=VALUE`.
 fn parse_set_option_flag(
     s: &str,
-) -> Result<(String, String, serde_json::Value), Box<dyn std::error::Error>> {
+) -> Result<(String, String, serde_json::Value), Box<dyn std::error::Error + Send + Sync>> {
     let (ref_id, rest) = s
         .split_once('=')
         .ok_or_else(|| format!("invalid --set-option format: {s:?} (expected REF=KEY=VALUE)"))?;

--- a/crates/cella-cli/src/commands/features/jsonc_edit.rs
+++ b/crates/cella-cli/src/commands/features/jsonc_edit.rs
@@ -37,7 +37,7 @@ pub enum FeatureEdit {
 pub fn apply_edits(
     source: &str,
     edits: &[FeatureEdit],
-) -> Result<String, Box<dyn std::error::Error>> {
+) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
     if edits.is_empty() {
         return Ok(source.to_owned());
     }

--- a/crates/cella-cli/src/commands/features/list.rs
+++ b/crates/cella-cli/src/commands/features/list.rs
@@ -33,7 +33,7 @@ impl ListArgs {
     /// # Errors
     ///
     /// Returns error on config discovery failure or network errors.
-    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         if self.available {
             self.list_available().await
         } else {
@@ -41,7 +41,7 @@ impl ListArgs {
         }
     }
 
-    async fn list_configured(&self) -> Result<(), Box<dyn std::error::Error>> {
+    async fn list_configured(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let config_path = resolve::discover_config(&self.common)?;
         let raw = resolve::read_raw_config(&config_path)?;
 
@@ -94,7 +94,7 @@ impl ListArgs {
         Ok(())
     }
 
-    async fn list_available(&self) -> Result<(), Box<dyn std::error::Error>> {
+    async fn list_available(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let registry = self
             .common
             .registry

--- a/crates/cella-cli/src/commands/features/mod.rs
+++ b/crates/cella-cli/src/commands/features/mod.rs
@@ -31,7 +31,10 @@ pub enum FeaturesCommand {
 }
 
 impl FeaturesArgs {
-    pub async fn execute(self, _progress: Progress) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn execute(
+        self,
+        _progress: Progress,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         match self.command {
             FeaturesCommand::Edit(args) => args.execute().await,
             FeaturesCommand::List(args) => args.execute().await,

--- a/crates/cella-cli/src/commands/features/prompts.rs
+++ b/crates/cella-cli/src/commands/features/prompts.rs
@@ -18,7 +18,7 @@ use cella_templates::types::TemplateOption;
 pub fn prompt_single_option(
     key: &str,
     opt: &TemplateOption,
-) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
     let description = opt.description.as_deref().unwrap_or(key);
 
     match opt.option_type.as_str() {
@@ -77,7 +77,7 @@ pub fn prompt_single_option(
 pub fn prompt_feature_options(
     feature_id: &str,
     meta: &serde_json::Value,
-) -> Result<HashMap<String, serde_json::Value>, Box<dyn std::error::Error>> {
+) -> Result<HashMap<String, serde_json::Value>, Box<dyn std::error::Error + Send + Sync>> {
     let Some(options_obj) = meta.get("options").and_then(|o| o.as_object()) else {
         return Ok(HashMap::new());
     };

--- a/crates/cella-cli/src/commands/features/resolve.rs
+++ b/crates/cella-cli/src/commands/features/resolve.rs
@@ -29,7 +29,9 @@ pub struct CommonFeatureFlags {
 /// # Errors
 ///
 /// Returns error with an init suggestion when no config is found.
-pub fn discover_config(flags: &CommonFeatureFlags) -> Result<PathBuf, Box<dyn std::error::Error>> {
+pub fn discover_config(
+    flags: &CommonFeatureFlags,
+) -> Result<PathBuf, Box<dyn std::error::Error + Send + Sync>> {
     let workspace = crate::commands::resolve_workspace_folder(flags.workspace_folder.as_deref())?;
 
     if let Some(file) = &flags.file {
@@ -47,7 +49,7 @@ pub fn discover_config(flags: &CommonFeatureFlags) -> Result<PathBuf, Box<dyn st
         if matches!(e, cella_config::devcontainer::discover::Error::NotFound) {
             format!("{e}\nhint: run 'cella init' to create a devcontainer configuration").into()
         } else {
-            Box::new(e) as Box<dyn std::error::Error>
+            Box::new(e) as Box<dyn std::error::Error + Send + Sync>
         }
     })
 }
@@ -57,7 +59,7 @@ pub fn discover_config(flags: &CommonFeatureFlags) -> Result<PathBuf, Box<dyn st
 /// # Errors
 ///
 /// Returns I/O error.
-pub fn read_raw_config(path: &Path) -> Result<String, Box<dyn std::error::Error>> {
+pub fn read_raw_config(path: &Path) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
     Ok(std::fs::read_to_string(path)?)
 }
 

--- a/crates/cella-cli/src/commands/features/update.rs
+++ b/crates/cella-cli/src/commands/features/update.rs
@@ -49,7 +49,7 @@ impl UpdateArgs {
     /// # Errors
     ///
     /// Returns error on config discovery failure or network errors.
-    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let config_path = resolve::discover_config(&self.common)?;
         let raw = resolve::read_raw_config(&config_path)?;
         let stripped = cella_jsonc::strip(&raw)?;
@@ -130,7 +130,9 @@ async fn find_update_candidates(
 }
 
 /// Print update candidates as JSON.
-fn print_candidates_json(candidates: &[UpdateCandidate]) -> Result<(), Box<dyn std::error::Error>> {
+fn print_candidates_json(
+    candidates: &[UpdateCandidate],
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let json_candidates: Vec<serde_json::Value> = candidates
         .iter()
         .map(|c| {
@@ -162,7 +164,7 @@ fn display_update_table(candidates: &[UpdateCandidate]) {
 fn select_updates(
     candidates: &[UpdateCandidate],
     auto_accept: bool,
-) -> Result<Vec<UpdateCandidate>, Box<dyn std::error::Error>> {
+) -> Result<Vec<UpdateCandidate>, Box<dyn std::error::Error + Send + Sync>> {
     if auto_accept {
         return Ok(candidates.to_vec());
     }
@@ -190,7 +192,7 @@ fn apply_updates(
     config_path: &std::path::Path,
     features: &[(String, serde_json::Value)],
     to_update: &[UpdateCandidate],
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut edits: Vec<FeatureEdit> = Vec::new();
     for candidate in to_update {
         let current_opts = features

--- a/crates/cella-cli/src/commands/init/mod.rs
+++ b/crates/cella-cli/src/commands/init/mod.rs
@@ -74,7 +74,10 @@ pub struct InitArgs {
 }
 
 impl InitArgs {
-    pub async fn execute(self, progress: Progress) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn execute(
+        self,
+        progress: Progress,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         if self.template.is_some() {
             noninteractive::run(self).await
         } else {

--- a/crates/cella-cli/src/commands/init/noninteractive.rs
+++ b/crates/cella-cli/src/commands/init/noninteractive.rs
@@ -17,7 +17,7 @@ use super::InitArgs;
 /// # Errors
 ///
 /// Returns errors for invalid flags, network failures, or I/O errors.
-pub async fn run(args: InitArgs) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn run(args: InitArgs) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let template_ref = args
         .template
         .as_deref()
@@ -67,7 +67,7 @@ pub async fn run(args: InitArgs) -> Result<(), Box<dyn std::error::Error>> {
 /// Parse `KEY=VALUE` pairs from CLI flag values.
 fn parse_key_value_pairs(
     pairs: &[String],
-) -> Result<HashMap<String, serde_json::Value>, Box<dyn std::error::Error>> {
+) -> Result<HashMap<String, serde_json::Value>, Box<dyn std::error::Error + Send + Sync>> {
     let mut map = HashMap::new();
     for pair in pairs {
         let (key, value) = pair
@@ -84,7 +84,7 @@ fn parse_key_value_pairs(
 fn parse_features(
     feature_refs: &[String],
     option_flags: &[String],
-) -> Result<Vec<SelectedFeature>, Box<dyn std::error::Error>> {
+) -> Result<Vec<SelectedFeature>, Box<dyn std::error::Error + Send + Sync>> {
     // Group options by feature ID
     let mut feature_options: HashMap<String, HashMap<String, serde_json::Value>> = HashMap::new();
     for opt in option_flags {

--- a/crates/cella-cli/src/commands/init/wizard.rs
+++ b/crates/cella-cli/src/commands/init/wizard.rs
@@ -3,8 +3,6 @@
 //! Guides the user through template selection, option configuration,
 //! feature selection, and config generation using inquire prompts.
 //!
-//! The wizard runs on a single thread (user interaction), so futures
-//! do not need to be `Send`.
 
 use std::collections::HashMap;
 
@@ -44,8 +42,10 @@ const BACK_TO_FEATURE_SOURCE_LIST: &str = "\u{2190} Back to feature source list"
 /// # Errors
 ///
 /// Returns errors for network failures, user cancellation, or I/O errors.
-#[allow(clippy::future_not_send)]
-pub async fn run(args: InitArgs, progress: Progress) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn run(
+    args: InitArgs,
+    progress: Progress,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let workspace = crate::commands::resolve_workspace_folder(args.workspace_folder.as_deref())?;
     let config_path = workspace.join(".devcontainer").join("devcontainer.json");
     let cache = TemplateCache::new();
@@ -171,7 +171,7 @@ pub async fn run(args: InitArgs, progress: Progress) -> Result<(), Box<dyn std::
 
 /// Launch `cella up`, replacing the current process on Unix.
 #[expect(clippy::needless_return)]
-fn exec_cella_up() -> Result<(), Box<dyn std::error::Error>> {
+fn exec_cella_up() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut cmd = std::process::Command::new("cella");
     cmd.arg("up");
 
@@ -200,17 +200,14 @@ fn exec_cella_up() -> Result<(), Box<dyn std::error::Error>> {
 type ResolvedTemplate = (String, std::path::PathBuf, Box<TemplateMetadata>);
 
 /// Select a template through the multi-level navigation flow.
-#[allow(clippy::future_not_send)]
 async fn select_template(
     official_templates: &[TemplateSummary],
     collection_ref: &str,
     cache: &TemplateCache,
     refresh: bool,
     progress: &Progress,
-) -> Result<ResolvedTemplate, Box<dyn std::error::Error>> {
+) -> Result<ResolvedTemplate, Box<dyn std::error::Error + Send + Sync>> {
     loop {
-        // Bind the choice before any await to avoid holding non-Send
-        // Box<dyn Error> across await points.
         let choice = prompt_official_templates(official_templates)?;
         match choice {
             TemplateChoice::Selected(summary) => {
@@ -248,7 +245,7 @@ enum TemplateChoice {
 /// Show the official template list with sentinel options.
 fn prompt_official_templates(
     templates: &[TemplateSummary],
-) -> Result<TemplateChoice, Box<dyn std::error::Error>> {
+) -> Result<TemplateChoice, Box<dyn std::error::Error + Send + Sync>> {
     let entries = templates
         .iter()
         .map(|t| format_entry(t.name.as_deref().unwrap_or(&t.id), t.description.as_deref()));
@@ -281,7 +278,7 @@ async fn browse_all_template_sources(
     cache: &TemplateCache,
     refresh: bool,
     progress: &Progress,
-) -> Result<Option<ResolvedTemplate>, Box<dyn std::error::Error>> {
+) -> Result<Option<ResolvedTemplate>, Box<dyn std::error::Error + Send + Sync>> {
     let index = progress
         .run_step_result(
             "Fetching template index",
@@ -307,7 +304,7 @@ async fn browse_custom_registry(
     cache: &TemplateCache,
     refresh: bool,
     progress: &Progress,
-) -> Result<Option<ResolvedTemplate>, Box<dyn std::error::Error>> {
+) -> Result<Option<ResolvedTemplate>, Box<dyn std::error::Error + Send + Sync>> {
     let registry = Text::new("Enter registry (e.g. ghcr.io/myorg/templates):").prompt()?;
     let custom_collection = progress
         .run_step_result(
@@ -369,7 +366,7 @@ enum CollectionPick {
 fn prompt_collection_picker(
     index: &DevcontainerIndex,
     kind: CollectionKind,
-) -> Result<CollectionPick, Box<dyn std::error::Error>> {
+) -> Result<CollectionPick, Box<dyn std::error::Error + Send + Sync>> {
     let back_label = match kind {
         CollectionKind::Templates => BACK_TO_OFFICIAL,
         CollectionKind::Features => BACK_TO_OFFICIAL_FEATURES,
@@ -444,7 +441,7 @@ async fn prompt_index_templates(
     collection: &IndexCollection,
     cache: &TemplateCache,
     progress: &Progress,
-) -> Result<Option<ResolvedTemplate>, Box<dyn std::error::Error>> {
+) -> Result<Option<ResolvedTemplate>, Box<dyn std::error::Error + Send + Sync>> {
     let source_name = collection
         .source_information
         .name
@@ -488,12 +485,11 @@ async fn prompt_index_templates(
 // ═══════════════════════════════════════════════════════════════════════
 
 /// Feature selection loop with multi-source support.
-#[allow(clippy::future_not_send)]
 async fn select_features(
     cache: &TemplateCache,
     refresh: bool,
     progress: &Progress,
-) -> Result<Vec<SelectedFeature>, Box<dyn std::error::Error>> {
+) -> Result<Vec<SelectedFeature>, Box<dyn std::error::Error + Send + Sync>> {
     let feature_collection = progress
         .run_step_result(
             "Fetching features",
@@ -537,7 +533,7 @@ enum FeatureChoice {
 
 fn prompt_feature_list(
     available: &[FeatureSummary],
-) -> Result<FeatureChoice, Box<dyn std::error::Error>> {
+) -> Result<FeatureChoice, Box<dyn std::error::Error + Send + Sync>> {
     let entries = available
         .iter()
         .map(|f| format_entry(f.name.as_deref().unwrap_or(&f.id), f.description.as_deref()));
@@ -568,7 +564,7 @@ async fn configure_official_feature(
     feature_summary: &FeatureSummary,
     cache: &TemplateCache,
     progress: &Progress,
-) -> Result<SelectedFeature, Box<dyn std::error::Error>> {
+) -> Result<SelectedFeature, Box<dyn std::error::Error + Send + Sync>> {
     let feature_ref = format!(
         "{DEFAULT_FEATURE_COLLECTION}/{}:{}",
         feature_summary.id, feature_summary.version
@@ -599,7 +595,7 @@ async fn browse_all_feature_sources(
     cache: &TemplateCache,
     refresh: bool,
     progress: &Progress,
-) -> Result<Option<SelectedFeature>, Box<dyn std::error::Error>> {
+) -> Result<Option<SelectedFeature>, Box<dyn std::error::Error + Send + Sync>> {
     let index = progress
         .run_step_result(
             "Fetching feature index",
@@ -626,7 +622,7 @@ async fn prompt_index_features(
     collection: &IndexCollection,
     cache: &TemplateCache,
     progress: &Progress,
-) -> Result<Option<SelectedFeature>, Box<dyn std::error::Error>> {
+) -> Result<Option<SelectedFeature>, Box<dyn std::error::Error + Send + Sync>> {
     let source_name = collection
         .source_information
         .name
@@ -670,7 +666,7 @@ async fn fetch_and_prompt_feature_options(
     display_id: &str,
     cache: &TemplateCache,
     progress: &Progress,
-) -> Result<HashMap<String, serde_json::Value>, Box<dyn std::error::Error>> {
+) -> Result<HashMap<String, serde_json::Value>, Box<dyn std::error::Error + Send + Sync>> {
     let fetch_result = progress
         .run_step_result(
             &format!("Fetching feature {display_id}"),
@@ -701,7 +697,7 @@ async fn fetch_and_prompt_feature_options(
 /// Prompt the user for all template options, showing defaults.
 fn prompt_all_options(
     metadata: &TemplateMetadata,
-) -> Result<HashMap<String, serde_json::Value>, Box<dyn std::error::Error>> {
+) -> Result<HashMap<String, serde_json::Value>, Box<dyn std::error::Error + Send + Sync>> {
     if metadata.options.is_empty() {
         return Ok(HashMap::new());
     }
@@ -726,7 +722,7 @@ fn prompt_all_options(
 /// Prompt for which optional paths to include via multi-select.
 fn prompt_optional_paths(
     metadata: &TemplateMetadata,
-) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+) -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
     if metadata.optional_paths.is_empty() {
         return Ok(Vec::new());
     }
@@ -747,7 +743,7 @@ fn prompt_optional_paths(
 }
 
 /// Prompt for output format.
-fn prompt_output_format() -> Result<OutputFormat, Box<dyn std::error::Error>> {
+fn prompt_output_format() -> Result<OutputFormat, Box<dyn std::error::Error + Send + Sync>> {
     let choices = vec![
         "JSONC (with comments)".to_owned(),
         "JSON (plain)".to_owned(),
@@ -802,7 +798,7 @@ fn build_choices_with_index<I: Iterator<Item = String>>(
 fn resolve_selection(
     index_map: &HashMap<String, usize>,
     selection: &str,
-) -> Result<usize, Box<dyn std::error::Error>> {
+) -> Result<usize, Box<dyn std::error::Error + Send + Sync>> {
     index_map
         .get(selection)
         .copied()

--- a/crates/cella-cli/src/commands/list.rs
+++ b/crates/cella-cli/src/commands/list.rs
@@ -24,7 +24,7 @@ pub struct ListArgs {
 }
 
 impl ListArgs {
-    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let client = self.backend.resolve_client().await?;
 
         let containers = client.list_cella_containers(self.running).await?;

--- a/crates/cella-cli/src/commands/logs.rs
+++ b/crates/cella-cli/src/commands/logs.rs
@@ -36,7 +36,7 @@ pub struct LogsArgs {
 }
 
 impl LogsArgs {
-    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         if self.daemon {
             return self.show_daemon_logs();
         }
@@ -46,7 +46,7 @@ impl LogsArgs {
         self.show_container_logs().await
     }
 
-    async fn show_container_logs(&self) -> Result<(), Box<dyn std::error::Error>> {
+    async fn show_container_logs(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let client = self.backend.resolve_client().await?;
 
         let cwd = super::resolve_workspace_folder(self.workspace_folder.as_deref())?;
@@ -74,7 +74,7 @@ impl LogsArgs {
             compose_cmd
                 .logs(self.follow, self.tail, services.as_deref())
                 .await
-                .map_err(|e| -> Box<dyn std::error::Error> {
+                .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {
                     format!("docker compose logs failed: {e}").into()
                 })?;
             return Ok(());
@@ -111,7 +111,7 @@ impl LogsArgs {
         Ok(())
     }
 
-    fn show_daemon_logs(&self) -> Result<(), Box<dyn std::error::Error>> {
+    fn show_daemon_logs(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let Some(data_dir) = cella_env::paths::cella_data_dir() else {
             return Err("Cannot determine cella data directory".into());
         };
@@ -130,7 +130,7 @@ impl LogsArgs {
         Ok(())
     }
 
-    fn show_lifecycle_logs(&self) -> Result<(), Box<dyn std::error::Error>> {
+    fn show_lifecycle_logs(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let _ = self; // tail unused for lifecycle logs
         let Some(data_dir) = cella_env::paths::cella_data_dir() else {
             return Err("Cannot determine cella data directory".into());

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -188,7 +188,10 @@ impl Command {
         matches!(self, Self::Daemon(_))
     }
 
-    pub async fn execute(self, progress: Progress) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn execute(
+        self,
+        progress: Progress,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         match self {
             Self::Up(args) => args.execute(progress).await,
             Self::Code(args) => args.execute(progress).await,
@@ -242,7 +245,7 @@ pub fn warn_if_missing_backend_label(container: &cella_backend::ContainerInfo) {
 /// Returns error if the current directory cannot be determined.
 pub fn resolve_workspace_folder(
     opt: Option<&std::path::Path>,
-) -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
+) -> Result<std::path::PathBuf, Box<dyn std::error::Error + Send + Sync>> {
     if let Some(wf) = opt {
         Ok(wf.canonicalize().unwrap_or_else(|_| wf.to_path_buf()))
     } else {
@@ -262,7 +265,7 @@ pub async fn resolve_service_container(
     client: &dyn cella_backend::ContainerBackend,
     container: cella_backend::ContainerInfo,
     service: Option<&str>,
-) -> Result<cella_backend::ContainerInfo, Box<dyn std::error::Error>> {
+) -> Result<cella_backend::ContainerInfo, Box<dyn std::error::Error + Send + Sync>> {
     let Some(svc) = service else {
         return Ok(container);
     };
@@ -437,7 +440,7 @@ async fn wait_for_socket(socket_path: &std::path::Path) {
 /// Re-register all running cella containers with the daemon.
 async fn re_register_containers(
     socket_path: &std::path::Path,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     use cella_protocol::ManagementRequest;
 
     let client = crate::backend::BackendArgs::default()

--- a/crates/cella-cli/src/commands/network.rs
+++ b/crates/cella-cli/src/commands/network.rs
@@ -22,7 +22,7 @@ enum NetworkCommand {
 }
 
 impl NetworkArgs {
-    pub fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         match self.command {
             NetworkCommand::Status => execute_status(),
             NetworkCommand::Test { url } => execute_test(&url),
@@ -34,7 +34,7 @@ impl NetworkArgs {
     }
 }
 
-fn execute_status() -> Result<(), Box<dyn std::error::Error>> {
+fn execute_status() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let workspace_root = std::env::current_dir()?;
     let settings = cella_config::settings::Settings::load(&workspace_root);
     let net_config = settings.network.to_network_config();
@@ -96,7 +96,7 @@ fn execute_status() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn execute_test(url: &str) -> Result<(), Box<dyn std::error::Error>> {
+fn execute_test(url: &str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let workspace_root = std::env::current_dir()?;
     let settings = cella_config::settings::Settings::load(&workspace_root);
     let net_config = settings.network.to_network_config();

--- a/crates/cella-cli/src/commands/nvim.rs
+++ b/crates/cella-cli/src/commands/nvim.rs
@@ -35,7 +35,7 @@ impl NvimArgs {
     pub async fn execute(
         self,
         progress: crate::progress::Progress,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         // 1. Ensure container is up
         let build_no_cache = self.up.build.build_no_cache;
         let strict = self.up.strict.clone();
@@ -149,7 +149,7 @@ async fn ensure_nvim(
     ctx: &UpContext,
     container_id: &str,
     remote_user: &str,
-) -> Result<NvimInfo, Box<dyn std::error::Error>> {
+) -> Result<NvimInfo, Box<dyn std::error::Error + Send + Sync>> {
     // Check if nvim is already installed
     let check = ctx
         .client
@@ -230,7 +230,7 @@ async fn install_nvim(
     ctx: &UpContext,
     container_id: &str,
     remote_user: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Detect architecture
     let arch_result = ctx
         .client

--- a/crates/cella-cli/src/commands/ports.rs
+++ b/crates/cella-cli/src/commands/ports.rs
@@ -14,7 +14,7 @@ pub struct PortsArgs {
 }
 
 impl PortsArgs {
-    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         // Try querying the daemon first for dynamic port info — only when
         // the selected backend uses daemon-managed port forwarding and no
         // custom Docker host is specified (daemon tracks local containers only).
@@ -106,7 +106,7 @@ fn print_daemon_ports(ports: &[cella_protocol::ForwardedPortDetail]) {
 async fn print_backend_ports(
     all: bool,
     backend_args: &crate::backend::BackendArgs,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let client = backend_args.resolve_client().await?;
     let containers = client.list_cella_containers(true).await?;
 

--- a/crates/cella-cli/src/commands/prune.rs
+++ b/crates/cella-cli/src/commands/prune.rs
@@ -42,7 +42,7 @@ impl PruneArgs {
         matches!(self.output, OutputFormat::Json)
     }
 
-    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         // 1. Discover git repo
         let cwd = std::env::current_dir()?;
         let repo_info = cella_git::discover(&cwd)?;
@@ -78,7 +78,7 @@ impl PruneArgs {
         candidates: Vec<PruneCandidate>,
         client: &dyn cella_backend::ContainerBackend,
         repo_root: &std::path::Path,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         if !self.is_json() {
             print_candidates(&candidates);
         }

--- a/crates/cella-cli/src/commands/read_configuration.rs
+++ b/crates/cella-cli/src/commands/read_configuration.rs
@@ -26,7 +26,7 @@ pub struct ReadConfigurationArgs {
 }
 
 impl ReadConfigurationArgs {
-    pub fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let cwd = super::resolve_workspace_folder(self.workspace_folder.as_deref())?;
 
         let resolved = resolve::config(&cwd, self.config.as_deref())?;

--- a/crates/cella-cli/src/commands/shell.rs
+++ b/crates/cella-cli/src/commands/shell.rs
@@ -35,7 +35,7 @@ pub struct ShellArgs {
 }
 
 impl ShellArgs {
-    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let client = self.backend.resolve_client().await?;
 
         let target = ContainerTarget {

--- a/crates/cella-cli/src/commands/switch.rs
+++ b/crates/cella-cli/src/commands/switch.rs
@@ -20,7 +20,7 @@ pub struct SwitchArgs {
 }
 
 impl SwitchArgs {
-    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let client = self.backend.resolve_client().await?;
 
         // Discover repo and list worktrees

--- a/crates/cella-cli/src/commands/template.rs
+++ b/crates/cella-cli/src/commands/template.rs
@@ -24,7 +24,7 @@ pub enum TemplateCommand {
 }
 
 impl TemplateArgs {
-    pub fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         match self.command {
             TemplateCommand::New { .. } | TemplateCommand::List | TemplateCommand::Edit { .. } => {
                 eprintln!("cella template: not yet implemented");

--- a/crates/cella-cli/src/commands/tmux.rs
+++ b/crates/cella-cli/src/commands/tmux.rs
@@ -42,7 +42,7 @@ impl TmuxArgs {
     pub async fn execute(
         self,
         progress: crate::progress::Progress,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let (build_no_cache, force) = (self.up.build.build_no_cache, self.force);
         let (strict, output_format) = (self.up.strict.clone(), self.up.output.clone());
         let mut up = self.up;
@@ -185,7 +185,7 @@ async fn ensure_tmux(
     ctx: &UpContext,
     container_id: &str,
     remote_user: &str,
-) -> Result<TmuxInfo, Box<dyn std::error::Error>> {
+) -> Result<TmuxInfo, Box<dyn std::error::Error + Send + Sync>> {
     let check = ctx
         .client
         .exec_command(
@@ -243,7 +243,7 @@ async fn get_tmux_version(
 async fn install_tmux(
     ctx: &UpContext,
     container_id: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Detect package manager and build install command
     let install_commands: &[(&str, &str)] = &[
         (
@@ -337,7 +337,7 @@ async fn check_tmux_session(
 }
 
 /// Warn the user about nested tmux sessions and prompt to continue.
-fn warn_nested_tmux() -> Result<(), Box<dyn std::error::Error>> {
+fn warn_nested_tmux() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     eprintln!();
     eprintln!("\x1b[33m\u{26a0}\x1b[0m  You're already inside a tmux session.");
     eprintln!("   Running cella tmux will create a nested tmux session (tmux-inside-tmux).");

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -134,7 +134,7 @@ impl UpContext {
     pub(crate) async fn new(
         args: &UpArgs,
         progress: crate::progress::Progress,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let cwd = crate::commands::resolve_workspace_folder(args.workspace_folder.as_deref())?;
 
         let remove_container = args.build.rebuild || args.build.remove_existing_container;
@@ -175,7 +175,7 @@ impl UpContext {
             .iter()
             .map(|s| super::build::parse_build_secret(s))
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })?;
 
         Ok(Self {
             resolved,
@@ -220,7 +220,7 @@ impl UpContext {
         extra_labels: std::collections::HashMap<String, String>,
         progress: crate::progress::Progress,
         output: OutputFormat,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let cwd = workspace_path
             .canonicalize()
             .unwrap_or_else(|_| workspace_path.to_path_buf());
@@ -618,7 +618,7 @@ impl UpContext {
         &self,
         build_no_cache: bool,
         strict: &[StrictnessLevel],
-    ) -> Result<UpResult, Box<dyn std::error::Error>> {
+    ) -> Result<UpResult, Box<dyn std::error::Error + Send + Sync>> {
         let (sender, renderer) = crate::progress::bridge(&self.progress);
         let hooks = CliUpHooks {
             config: self.config(),
@@ -662,7 +662,8 @@ impl UpContext {
         // queued events (final step, warnings) are flushed before exit.
         let _ = renderer.await;
 
-        let result = result.map_err(|e| -> Box<dyn std::error::Error> { Box::new(e) })?;
+        let result =
+            result.map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::new(e) })?;
 
         Ok(UpResult {
             container_id: result.container_id,
@@ -683,7 +684,7 @@ impl UpArgs {
         &self,
         branch_name: &str,
         progress: crate::progress::Progress,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let cwd = std::env::current_dir()?;
         let repo_info = cella_git::discover(&cwd)?;
         let worktrees = cella_git::list(&repo_info.root)?;
@@ -737,7 +738,7 @@ impl UpArgs {
     pub async fn execute(
         self,
         progress: crate::progress::Progress,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         if let Some(ref branch_name) = self.branch {
             return self.execute_branch(branch_name, progress).await;
         }

--- a/crates/cella-cli/src/main.rs
+++ b/crates/cella-cli/src/main.rs
@@ -25,7 +25,7 @@ struct Cli {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Install miette's graphical error handler for pretty diagnostics
     miette::set_hook(Box::new(|_| {
         Box::new(miette::GraphicalReportHandler::new_themed(

--- a/crates/cella-cli/src/picker.rs
+++ b/crates/cella-cli/src/picker.rs
@@ -189,7 +189,7 @@ pub fn resolve_worktree_interactive<S: std::hash::BuildHasher>(
     container_states: &HashMap<String, ContainerState, S>,
     name: Option<&str>,
     exclude_branch: Option<&str>,
-) -> Result<WorktreeInfo, Box<dyn std::error::Error>> {
+) -> Result<WorktreeInfo, Box<dyn std::error::Error + Send + Sync>> {
     // Try exact match first
     if let Some(name) = name
         && let Some(wt) = worktrees
@@ -266,7 +266,7 @@ pub fn resolve_container_interactive(
     exclude_name: Option<&str>,
     prompt: &str,
     initial_filter: Option<&str>,
-) -> Result<ContainerInfo, Box<dyn std::error::Error>> {
+) -> Result<ContainerInfo, Box<dyn std::error::Error + Send + Sync>> {
     let items = container_picker_items(containers, exclude_name);
 
     if items.is_empty() {
@@ -721,7 +721,7 @@ mod tests {
 
     #[test]
     fn picker_error_is_std_error() {
-        let err: Box<dyn std::error::Error> = Box::new(PickerError::NoCandidates);
+        let err: Box<dyn std::error::Error + Send + Sync> = Box::new(PickerError::NoCandidates);
         assert_eq!(err.to_string(), "no candidates available");
     }
 

--- a/crates/cella-orchestrator/src/compose_build.rs
+++ b/crates/cella-orchestrator/src/compose_build.rs
@@ -47,7 +47,7 @@ pub async fn compose_build(
     client: &dyn ContainerBackend,
     cfg: &ComposeBuildConfig<'_>,
     progress: &ProgressSender,
-) -> Result<ComposeBuildResult, Box<dyn std::error::Error>> {
+) -> Result<ComposeBuildResult, Box<dyn std::error::Error + Send + Sync>> {
     if !client.capabilities().compose {
         return Err(format!(
             "selected backend '{}' does not support Docker Compose devcontainers",
@@ -115,7 +115,7 @@ pub async fn compose_build(
     compose_cmd
         .build(None)
         .await
-        .map_err(|e| -> Box<dyn std::error::Error> {
+        .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {
             format!("docker compose build failed: {e}").into()
         })?;
 

--- a/crates/cella-orchestrator/src/compose_features.rs
+++ b/crates/cella-orchestrator/src/compose_features.rs
@@ -61,7 +61,7 @@ pub async fn resolve_compose_features(
     config_path: &Path,
     project: &ComposeProject,
     progress: &ProgressSender,
-) -> Result<Option<ComposeFeaturesBuild>, Box<dyn std::error::Error>> {
+) -> Result<Option<ComposeFeaturesBuild>, Box<dyn std::error::Error + Send + Sync>> {
     // 1. Check if features are present
     if !has_features(config) {
         return Ok(None);
@@ -183,7 +183,7 @@ fn write_combined_dockerfile(
     original_dockerfile: &str,
     features_dockerfile: &str,
     stage_name: &str,
-) -> Result<PathBuf, Box<dyn std::error::Error>> {
+) -> Result<PathBuf, Box<dyn std::error::Error + Send + Sync>> {
     let combined = cella_compose::generate_combined_dockerfile(
         original_dockerfile,
         features_dockerfile,
@@ -209,7 +209,7 @@ fn assemble_features_build(
     combined_dockerfile: PathBuf,
     resolved: ResolvedFeatures,
     image_user: String,
-) -> Result<ComposeFeaturesBuild, Box<dyn std::error::Error>> {
+) -> Result<ComposeFeaturesBuild, Box<dyn std::error::Error + Send + Sync>> {
     let mut additional_contexts = BTreeMap::new();
     additional_contexts.insert(
         cella_features::FEATURE_CONTENT_SOURCE.to_string(),

--- a/crates/cella-orchestrator/src/compose_up.rs
+++ b/crates/cella-orchestrator/src/compose_up.rs
@@ -144,7 +144,7 @@ pub async fn compose_up(
     cfg: &ComposeUpConfig<'_>,
     hooks: &dyn ComposeUpHooks,
     progress: ProgressSender,
-) -> Result<ComposeUpResult, Box<dyn std::error::Error>> {
+) -> Result<ComposeUpResult, Box<dyn std::error::Error + Send + Sync>> {
     let ctx = Ctx {
         client,
         cfg,
@@ -236,8 +236,10 @@ pub async fn compose_up(
 async fn prepare_and_start(
     ctx: &Ctx<'_>,
     project: &ComposeProject,
-) -> Result<(String, Option<cella_features::ResolvedFeatures>, String), Box<dyn std::error::Error>>
-{
+) -> Result<
+    (String, Option<cella_features::ResolvedFeatures>, String),
+    Box<dyn std::error::Error + Send + Sync>,
+> {
     let (client, cfg, hooks, progress) = (ctx.client, ctx.cfg, ctx.hooks, ctx.progress);
     let config = cfg.config;
 
@@ -348,7 +350,7 @@ async fn finalize_compose(
     remote_user: &str,
     resolved_features: Option<&cella_features::ResolvedFeatures>,
     agent_arch: &str,
-) -> Result<ComposeUpResult, Box<dyn std::error::Error>> {
+) -> Result<ComposeUpResult, Box<dyn std::error::Error + Send + Sync>> {
     let (client, cfg, hooks, progress) = (ctx.client, ctx.cfg, ctx.hooks, ctx.progress);
     let config = cfg.config;
 
@@ -424,7 +426,7 @@ async fn handle_compose_running(
     ctx: &Ctx<'_>,
     project: &ComposeProject,
     container: &ContainerInfo,
-) -> Result<ComposeUpResult, Box<dyn std::error::Error>> {
+) -> Result<ComposeUpResult, Box<dyn std::error::Error + Send + Sync>> {
     let (client, cfg, hooks, progress) = (ctx.client, ctx.cfg, ctx.hooks, ctx.progress);
     let config = cfg.config;
     let remote_user = resolve_remote_user(config, None, "root");
@@ -483,7 +485,7 @@ fn write_build_override(
     project: &ComposeProject,
     features_build: Option<&crate::compose_features::ComposeFeaturesBuild>,
     ov: &OverrideContext,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let override_config = OverrideConfig {
         primary_service: project.primary_service.clone(),
         image_override: features_build.and_then(|b| b.image_name_override.clone()),
@@ -520,7 +522,7 @@ async fn build_uid_remap_override(
     features_build: Option<&crate::compose_features::ComposeFeaturesBuild>,
     remote_user: &str,
     ov: &OverrideContext,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let update_uid = ctx
         .cfg
         .config
@@ -638,7 +640,7 @@ async fn find_compose_container(
     client: &dyn ContainerBackend,
     project_name: &str,
     service_name: &str,
-) -> Result<Option<ContainerInfo>, Box<dyn std::error::Error>> {
+) -> Result<Option<ContainerInfo>, Box<dyn std::error::Error + Send + Sync>> {
     Ok(client
         .find_compose_service(project_name, service_name)
         .await?)

--- a/crates/cella-orchestrator/src/container_setup.rs
+++ b/crates/cella-orchestrator/src/container_setup.rs
@@ -21,7 +21,7 @@ use tracing::{debug, info, warn};
 pub fn run_host_command(
     phase: &str,
     value: &serde_json::Value,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     info!("Running {phase} on host");
 
     match value {
@@ -54,7 +54,7 @@ pub fn run_host_command(
 fn run_json_array_command(
     phase: &str,
     arr: &[serde_json::Value],
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let cmd: Vec<String> = arr
         .iter()
         .filter_map(|v| v.as_str().map(String::from))
@@ -66,7 +66,10 @@ fn run_json_array_command(
     Ok(())
 }
 
-fn run_single_host_command(phase: &str, cmd: &[&str]) -> Result<(), Box<dyn std::error::Error>> {
+fn run_single_host_command(
+    phase: &str,
+    cmd: &[&str],
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     if cmd.is_empty() {
         return Ok(());
     }
@@ -143,7 +146,7 @@ pub fn resolve_remote_user(
 pub async fn verify_container_running(
     client: &dyn ContainerBackend,
     container_id: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let info = client.inspect_container(container_id).await?;
     if info.state != ContainerState::Running {
         let logs = client.container_logs(container_id, 20).await?;

--- a/crates/cella-orchestrator/src/image.rs
+++ b/crates/cella-orchestrator/src/image.rs
@@ -43,7 +43,7 @@ pub struct FeaturesLayerContext<'a> {
 /// Returns an error if the Docker build fails or the build context is invalid.
 pub async fn build_features_layer(
     ctx: &FeaturesLayerContext<'_>,
-) -> Result<String, Box<dyn std::error::Error>> {
+) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
     let features_digest = compute_features_digest(ctx.config);
     let features_image =
         image_name_with_features(ctx.workspace_root, ctx.config_name, &features_digest);
@@ -124,7 +124,10 @@ pub struct EnsureImageInput<'a> {
 /// Returns an error if the image pull/build or feature resolution fails.
 pub async fn ensure_image(
     input: &EnsureImageInput<'_>,
-) -> Result<(String, Option<ResolvedFeatures>, ImageDetails), Box<dyn std::error::Error>> {
+) -> Result<
+    (String, Option<ResolvedFeatures>, ImageDetails),
+    Box<dyn std::error::Error + Send + Sync>,
+> {
     let has_features = input
         .config
         .get("features")
@@ -165,7 +168,7 @@ pub async fn ensure_image(
 async fn resolve_base_image(
     input: &EnsureImageInput<'_>,
     will_build_features: bool,
-) -> Result<String, Box<dyn std::error::Error>> {
+) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
     let force_pull = input.pull_policy == Some("always");
     let never_pull = input.pull_policy == Some("never");
     if let Some(image) = input.config.get("image").and_then(|v| v.as_str()) {
@@ -242,7 +245,7 @@ struct FeaturesBuildInput<'a> {
 /// Resolve features and build the features layer image.
 async fn resolve_and_build_features(
     input: &FeaturesBuildInput<'_>,
-) -> Result<(String, ResolvedFeatures), Box<dyn std::error::Error>> {
+) -> Result<(String, ResolvedFeatures), Box<dyn std::error::Error + Send + Sync>> {
     info!("Resolving devcontainer features...");
     let backend_platform = input
         .client

--- a/crates/cella-orchestrator/src/lifecycle.rs
+++ b/crates/cella-orchestrator/src/lifecycle.rs
@@ -263,7 +263,7 @@ pub async fn run_all_lifecycle_phases(
     resolved_features: Option<&cella_features::ResolvedFeatures>,
     image_metadata: Option<&str>,
     progress: &ProgressSender,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let phases = [
         "onCreateCommand",
         "updateContentCommand",
@@ -358,7 +358,7 @@ pub async fn run_lifecycle_phases_with_wait_for(
     image_metadata: Option<&str>,
     progress: &ProgressSender,
     wait_for: WaitForPhase,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let phases: &[&str] = &[
         "onCreateCommand",
         "updateContentCommand",
@@ -485,7 +485,7 @@ pub async fn check_and_run_content_update(
     metadata: Option<&str>,
     workspace_root: &std::path::Path,
     progress: &ProgressSender,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let current_hash = cella_git::content_hash::compute(workspace_root);
 
     let read_result = lc_ctx

--- a/crates/cella-orchestrator/src/uid_image.rs
+++ b/crates/cella-orchestrator/src/uid_image.rs
@@ -63,7 +63,7 @@ pub async fn build_uid_remap_image(
     image_user: &str,
     remote_user: &str,
     progress: &ProgressSender,
-) -> Result<Option<String>, Box<dyn std::error::Error>> {
+) -> Result<Option<String>, Box<dyn std::error::Error + Send + Sync>> {
     if remote_user == "root" {
         debug!("Skipping UID remap: remote user is root");
         return Ok(None);

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -311,7 +311,7 @@ impl EnsureUpContext<'_> {
         remote_user: &str,
         metadata: &str,
         lifecycle_env: &[String],
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let lc_state = read_lifecycle_state(self.client, container_id, remote_user).await;
         if lc_state.oncreate_done {
             return Ok(());
@@ -331,7 +331,7 @@ impl EnsureUpContext<'_> {
         &self,
         container: &ContainerInfo,
         remote_user: &str,
-    ) -> Result<UpResult, Box<dyn std::error::Error>> {
+    ) -> Result<UpResult, Box<dyn std::error::Error + Send + Sync>> {
         // Spec: initializeCommand runs on the host during every start, including reconnects.
         let config = self.config_json();
         if let Some(init_cmd) = config.get("initializeCommand") {
@@ -444,7 +444,7 @@ impl EnsureUpContext<'_> {
         &self,
         container: &ContainerInfo,
         remote_user: &str,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let (_probed_env, lifecycle_env) =
             self.prepare_container_env(&container.id, remote_user).await;
         let metadata = container.labels.get("devcontainer.metadata");
@@ -479,7 +479,7 @@ impl EnsureUpContext<'_> {
         &self,
         container: &ContainerInfo,
         remote_user: &str,
-    ) -> Result<Option<UpResult>, Box<dyn std::error::Error>> {
+    ) -> Result<Option<UpResult>, Box<dyn std::error::Error + Send + Sync>> {
         let capabilities = self.client.capabilities();
 
         if let Some(old_hash) = &container.config_hash
@@ -581,7 +581,7 @@ impl EnsureUpContext<'_> {
         &self,
         container: &ContainerInfo,
         reason: &str,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         self.hooks
             .on_container_stopping(self.config.container_name)
             .await;
@@ -679,7 +679,7 @@ impl EnsureUpContext<'_> {
         remote_user: &str,
         settings: &cella_config::settings::Settings,
         agent_arch: &str,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let capabilities = self.client.capabilities();
 
         for m in &env_fwd.mounts {
@@ -779,7 +779,10 @@ impl EnsureUpContext<'_> {
         Ok(())
     }
 
-    async fn start_and_notify(&self, container_id: &str) -> Result<(), Box<dyn std::error::Error>> {
+    async fn start_and_notify(
+        &self,
+        container_id: &str,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let label = if self.progress.is_verbose() {
             let short_id = &container_id[..12.min(container_id.len())];
             format!("Starting container: {short_id}...")
@@ -1070,7 +1073,7 @@ impl EnsureUpContext<'_> {
         lifecycle_env: &[String],
         resolved_features: Option<&cella_features::ResolvedFeatures>,
         image_metadata: Option<&str>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let config = self.config_json();
         let wait_for = WaitForPhase::from_config(config);
         let lc_ctx = self.build_lifecycle_ctx(container_id, remote_user, lifecycle_env);
@@ -1111,7 +1114,7 @@ impl EnsureUpContext<'_> {
     async fn create_container(
         &self,
         create_opts: &cella_backend::CreateContainerOptions,
-    ) -> Result<String, Box<dyn std::error::Error>> {
+    ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
         if self.progress.is_verbose() {
             let step = self.progress.step(&format!(
                 "Creating container: {}...",
@@ -1141,7 +1144,7 @@ impl EnsureUpContext<'_> {
         image_user: &str,
         remote_user: &str,
         create_opts: &mut cella_backend::CreateContainerOptions,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let update_uid = config
             .get("updateRemoteUserUID")
             .and_then(serde_json::Value::as_bool)
@@ -1165,7 +1168,7 @@ impl EnsureUpContext<'_> {
     async fn create_and_start(
         &self,
         build_no_cache: bool,
-    ) -> Result<CreateResult, Box<dyn std::error::Error>> {
+    ) -> Result<CreateResult, Box<dyn std::error::Error + Send + Sync>> {
         let config = self.config_json();
 
         if let Some(init_cmd) = config.get("initializeCommand") {
@@ -1264,7 +1267,7 @@ impl EnsureUpContext<'_> {
         })
     }
 
-    async fn ensure_up(self) -> Result<UpResult, Box<dyn std::error::Error>> {
+    async fn ensure_up(self) -> Result<UpResult, Box<dyn std::error::Error + Send + Sync>> {
         let build_no_cache = matches!(self.config.image_strategy, ImageStrategy::RebuildNoCache);
         let remove_container = self.config.remove_existing_container
             || matches!(

--- a/crates/cella-templates/src/cache.rs
+++ b/crates/cella-templates/src/cache.rs
@@ -12,8 +12,8 @@ use std::time::{Duration, SystemTime};
 use sha2::{Digest, Sha256};
 use tracing::debug;
 
-use crate::TemplateCollectionIndex;
 use crate::error::TemplateError;
+use crate::{FeatureCollectionIndex, TemplateCollectionIndex};
 
 /// How long a cached collection index is considered fresh.
 const COLLECTION_TTL: Duration = Duration::from_secs(24 * 60 * 60);
@@ -123,6 +123,72 @@ impl TemplateCache {
     fn collection_path(&self, registry: &str) -> PathBuf {
         let hash = hex::encode(&Sha256::digest(registry.as_bytes())[..8]);
         self.root.join("collections").join(format!("{hash}.json"))
+    }
+
+    // -----------------------------------------------------------------------
+    // Feature collection index cache
+    // -----------------------------------------------------------------------
+
+    /// Get a cached feature collection index if it exists and is fresh (< 24h old).
+    pub fn get_feature_collection(
+        &self,
+        registry: &str,
+    ) -> Option<(FeatureCollectionIndex, SystemTime)> {
+        let path = self.collection_path(registry);
+        let metadata = std::fs::metadata(&path).ok()?;
+        let modified = metadata.modified().ok()?;
+
+        let age = SystemTime::now()
+            .duration_since(modified)
+            .unwrap_or_default();
+        if age > COLLECTION_TTL {
+            debug!("feature collection cache expired for {registry} (age: {age:?})");
+            return None;
+        }
+
+        let content = std::fs::read_to_string(&path).ok()?;
+        let index: FeatureCollectionIndex = serde_json::from_str(&content).ok()?;
+        debug!("feature collection cache hit for {registry}");
+        Some((index, modified))
+    }
+
+    /// Get a cached feature collection index even if expired (for offline fallback).
+    pub fn get_feature_collection_stale(
+        &self,
+        registry: &str,
+    ) -> Option<(FeatureCollectionIndex, SystemTime)> {
+        let path = self.collection_path(registry);
+        let metadata = std::fs::metadata(&path).ok()?;
+        let modified = metadata.modified().ok()?;
+        let content = std::fs::read_to_string(&path).ok()?;
+        let index: FeatureCollectionIndex = serde_json::from_str(&content).ok()?;
+        debug!("feature collection stale cache hit for {registry}");
+        Some((index, modified))
+    }
+
+    /// Write a feature collection index to the cache.
+    pub fn put_feature_collection(
+        &self,
+        registry: &str,
+        index: &FeatureCollectionIndex,
+    ) -> Result<(), TemplateError> {
+        let path = self.collection_path(registry);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| TemplateError::CacheError {
+                message: format!("failed to create cache directory: {e}"),
+            })?;
+        }
+        let json = serde_json::to_string(index).map_err(|e| TemplateError::CacheError {
+            message: format!("failed to serialize feature collection index: {e}"),
+        })?;
+        std::fs::write(&path, json).map_err(|e| TemplateError::CacheError {
+            message: format!("failed to write feature collection cache: {e}"),
+        })?;
+        debug!(
+            "cached feature collection index for {registry} at {}",
+            path.display()
+        );
+        Ok(())
     }
 
     // -----------------------------------------------------------------------

--- a/crates/cella-templates/src/cache.rs
+++ b/crates/cella-templates/src/cache.rs
@@ -129,12 +129,22 @@ impl TemplateCache {
     // Feature collection index cache
     // -----------------------------------------------------------------------
 
+    /// Compute the cache file path for a feature collection index.
+    ///
+    /// Uses a `feature::` prefix before hashing to avoid collisions with
+    /// template collection entries that share the same registry string.
+    fn feature_collection_path(&self, registry: &str) -> PathBuf {
+        let prefixed = format!("feature::{registry}");
+        let hash = hex::encode(&Sha256::digest(prefixed.as_bytes())[..8]);
+        self.root.join("collections").join(format!("{hash}.json"))
+    }
+
     /// Get a cached feature collection index if it exists and is fresh (< 24h old).
     pub fn get_feature_collection(
         &self,
         registry: &str,
     ) -> Option<(FeatureCollectionIndex, SystemTime)> {
-        let path = self.collection_path(registry);
+        let path = self.feature_collection_path(registry);
         let metadata = std::fs::metadata(&path).ok()?;
         let modified = metadata.modified().ok()?;
 
@@ -157,7 +167,7 @@ impl TemplateCache {
         &self,
         registry: &str,
     ) -> Option<(FeatureCollectionIndex, SystemTime)> {
-        let path = self.collection_path(registry);
+        let path = self.feature_collection_path(registry);
         let metadata = std::fs::metadata(&path).ok()?;
         let modified = metadata.modified().ok()?;
         let content = std::fs::read_to_string(&path).ok()?;
@@ -176,7 +186,7 @@ impl TemplateCache {
         registry: &str,
         index: &FeatureCollectionIndex,
     ) -> Result<(), TemplateError> {
-        let path = self.collection_path(registry);
+        let path = self.feature_collection_path(registry);
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).map_err(|e| TemplateError::CacheError {
                 message: format!("failed to create cache directory: {e}"),
@@ -438,7 +448,7 @@ mod tests {
             .unwrap();
 
         // Backdate to simulate expiry
-        let path = cache.collection_path("ghcr.io/features");
+        let path = cache.feature_collection_path("ghcr.io/features");
         let old_time = filetime::FileTime::from_unix_time(0, 0);
         filetime::set_file_mtime(&path, old_time).unwrap();
 

--- a/crates/cella-templates/src/cache.rs
+++ b/crates/cella-templates/src/cache.rs
@@ -167,6 +167,10 @@ impl TemplateCache {
     }
 
     /// Write a feature collection index to the cache.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TemplateError::CacheError`] if the write fails.
     pub fn put_feature_collection(
         &self,
         registry: &str,
@@ -383,5 +387,106 @@ mod tests {
             "first"
         );
         assert!(!staging.exists());
+    }
+
+    // -----------------------------------------------------------------------
+    // Feature collection cache: miss, hit, expiry, empty
+    // -----------------------------------------------------------------------
+
+    fn sample_feature_collection() -> FeatureCollectionIndex {
+        serde_json::from_str(
+            r#"{
+            "features": [
+                { "id": "node", "version": "1.5.0", "name": "Node.js" },
+                { "id": "python", "version": "2.0.0", "name": "Python" }
+            ]
+        }"#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn feature_collection_cache_miss() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = TemplateCache::with_root(dir.path());
+        assert!(cache.get_feature_collection("ghcr.io/features").is_none());
+    }
+
+    #[test]
+    fn feature_collection_cache_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = TemplateCache::with_root(dir.path());
+        let index = sample_feature_collection();
+
+        cache
+            .put_feature_collection("ghcr.io/features", &index)
+            .unwrap();
+        let (cached, _) = cache.get_feature_collection("ghcr.io/features").unwrap();
+        assert_eq!(cached.features.len(), 2);
+        assert_eq!(cached.features[0].id, "node");
+        assert_eq!(cached.features[1].id, "python");
+    }
+
+    #[test]
+    fn feature_collection_stale_cache_returns_expired() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = TemplateCache::with_root(dir.path());
+        let index = sample_feature_collection();
+
+        cache
+            .put_feature_collection("ghcr.io/features", &index)
+            .unwrap();
+
+        // Backdate to simulate expiry
+        let path = cache.collection_path("ghcr.io/features");
+        let old_time = filetime::FileTime::from_unix_time(0, 0);
+        filetime::set_file_mtime(&path, old_time).unwrap();
+
+        // Fresh cache should miss
+        assert!(cache.get_feature_collection("ghcr.io/features").is_none());
+
+        // Stale cache should still hit
+        let (stale, _) = cache
+            .get_feature_collection_stale("ghcr.io/features")
+            .unwrap();
+        assert_eq!(stale.features.len(), 2);
+        assert_eq!(stale.features[0].id, "node");
+    }
+
+    #[test]
+    fn feature_collection_empty_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = TemplateCache::with_root(dir.path());
+        let index: FeatureCollectionIndex = serde_json::from_str(r#"{ "features": [] }"#).unwrap();
+
+        cache
+            .put_feature_collection("ghcr.io/empty", &index)
+            .unwrap();
+        let (cached, _) = cache.get_feature_collection("ghcr.io/empty").unwrap();
+        assert!(cached.features.is_empty());
+    }
+
+    #[test]
+    fn template_cache_unaffected_by_feature_methods() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = TemplateCache::with_root(dir.path());
+
+        // Write both types
+        cache
+            .put_collection("ghcr.io/templates", &sample_collection())
+            .unwrap();
+        cache
+            .put_feature_collection("ghcr.io/features", &sample_feature_collection())
+            .unwrap();
+
+        // Template cache still works
+        let (tc, _) = cache.get_collection("ghcr.io/templates").unwrap();
+        assert_eq!(tc.templates.len(), 1);
+        assert_eq!(tc.templates[0].id, "rust");
+
+        // Feature cache still works
+        let (fc, _) = cache.get_feature_collection("ghcr.io/features").unwrap();
+        assert_eq!(fc.features.len(), 2);
+        assert_eq!(fc.features[0].id, "node");
     }
 }

--- a/crates/cella-templates/src/collection.rs
+++ b/crates/cella-templates/src/collection.rs
@@ -219,6 +219,43 @@ mod tests {
         assert!(matches!(err, TemplateError::CollectionFetchFailed { .. }));
     }
 
+    #[test]
+    fn feature_collection_cache_roundtrip_preserves_features() {
+        // Regression test: previously, caching a FeatureCollectionIndex through
+        // TemplateCollectionIndex-typed methods silently dropped the features array.
+        let dir = tempfile::tempdir().unwrap();
+        let cache = TemplateCache::with_root(dir.path());
+
+        let json = r#"{
+            "features": [
+                { "id": "node", "version": "1.5.0", "name": "Node.js", "description": "Installs Node.js" },
+                { "id": "python", "version": "2.0.0", "name": "Python", "description": "Installs Python" },
+                { "id": "rust", "version": "1.0.0", "name": "Rust", "description": "Installs Rust" }
+            ],
+            "sourceInformation": { "name": "Official Features" }
+        }"#;
+        let index: FeatureCollectionIndex = serde_json::from_str(json).unwrap();
+
+        // Write to cache
+        cache
+            .put_feature_collection("ghcr.io/devcontainers/features", &index)
+            .unwrap();
+
+        // Read back — this is the exact code path that was broken
+        let (cached, _) = cache
+            .get_feature_collection("ghcr.io/devcontainers/features")
+            .unwrap();
+
+        assert_eq!(
+            cached.features.len(),
+            3,
+            "all features must survive cache round-trip"
+        );
+        assert_eq!(cached.features[0].id, "node");
+        assert_eq!(cached.features[1].id, "python");
+        assert_eq!(cached.features[2].id, "rust");
+    }
+
     #[tokio::test]
     #[cfg(feature = "integration-tests")]
     async fn fetch_official_template_collection() {

--- a/crates/cella-templates/src/collection.rs
+++ b/crates/cella-templates/src/collection.rs
@@ -82,18 +82,8 @@ pub async fn fetch_feature_collection(
     cache: &TemplateCache,
     force_refresh: bool,
 ) -> Result<FeatureCollectionIndex, TemplateError> {
-    if !force_refresh {
-        // Feature collections share the same cache infra; we store them
-        // under a different key by using the full collection ref.
-        if let Some((index, _)) = cache.get_collection(collection_ref) {
-            let feature_index: FeatureCollectionIndex =
-                serde_json::from_value(serde_json::to_value(index).unwrap_or_default())
-                    .unwrap_or_else(|_| FeatureCollectionIndex {
-                        features: vec![],
-                        source_information: None,
-                    });
-            return Ok(feature_index);
-        }
+    if !force_refresh && let Some((index, _)) = cache.get_feature_collection(collection_ref) {
+        return Ok(index);
     }
 
     match fetch_collection_json(collection_ref).await {
@@ -103,17 +93,12 @@ pub async fn fetch_feature_collection(
                     registry: collection_ref.to_owned(),
                     message: format!("failed to parse feature collection index: {e}"),
                 })?;
-            // Cache the raw JSON by wrapping in a TemplateCollectionIndex shape
-            // (the cache is generic JSON under the hood)
-            let raw: serde_json::Value = serde_json::from_str(&json).unwrap_or_default();
-            if let Ok(template_shaped) = serde_json::from_value::<TemplateCollectionIndex>(raw) {
-                let _ = cache.put_collection(collection_ref, &template_shaped);
-            }
+            let _ = cache.put_feature_collection(collection_ref, &index);
             Ok(index)
         }
         Err(e) => {
-            // Fall back to stale cache (same pattern as template collection)
-            if let Some((stale_index, modified)) = cache.get_collection_stale(collection_ref) {
+            // Fall back to stale cache
+            if let Some((index, modified)) = cache.get_feature_collection_stale(collection_ref) {
                 let age = std::time::SystemTime::now()
                     .duration_since(modified)
                     .unwrap_or_default();
@@ -121,13 +106,7 @@ pub async fn fetch_feature_collection(
                     "could not fetch feature collection from {collection_ref}: {e}; \
                      using cached index ({age:.0?} old)"
                 );
-                let feature_index: FeatureCollectionIndex =
-                    serde_json::from_value(serde_json::to_value(stale_index).unwrap_or_default())
-                        .unwrap_or_else(|_| FeatureCollectionIndex {
-                            features: vec![],
-                            source_information: None,
-                        });
-                Ok(feature_index)
+                Ok(index)
             } else {
                 Err(e)
             }


### PR DESCRIPTION
## Summary

- Fix bug where official features disappear in `cella init` (and `features list/edit/update`) after the first run due to cache type mismatch — `TemplateCache` was typed around `TemplateCollectionIndex`, silently dropping the `features` array when caching `FeatureCollectionIndex` data
- Add dedicated `get_feature_collection`/`put_feature_collection` cache methods and rewrite `fetch_feature_collection` to mirror `fetch_template_collection` exactly
- Add 6 regression tests covering cache round-trip, stale fallback, empty collections, and template/feature isolation
- Migrate all `Box<dyn Error>` to `Box<dyn Error + Send + Sync>` across `cella-cli`, `cella-orchestrator`, and `cella-agent` (115+ occurrences), removing all 3 `#[allow(clippy::future_not_send)]` annotations

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings -D clippy::all`
- [x] `cargo test --workspace` — all pass
- [x] Manual: run `cella init`, select template, verify features shown on first AND second run (warm cache)
- [x] Manual: run `cella features list` twice to confirm cached features persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)