### PR TITLE
feat(init): sort templates, image pinning, name customization

### DIFF
--- a/crates/cella-cli/src/commands/init/mod.rs
+++ b/crates/cella-cli/src/commands/init/mod.rs
@@ -68,6 +68,10 @@ pub struct InitArgs {
     #[arg(long)]
     pub refresh: bool,
 
+    /// Name for the dev container (overrides template default).
+    #[arg(long)]
+    pub name: Option<String>,
+
     /// Start dev container after generating config.
     #[arg(long)]
     pub up: bool,

--- a/crates/cella-cli/src/commands/init/mod.rs
+++ b/crates/cella-cli/src/commands/init/mod.rs
@@ -72,6 +72,10 @@ pub struct InitArgs {
     #[arg(long)]
     pub name: Option<String>,
 
+    /// Pin the base image to a specific tag (e.g. `4.0.6-22-trixie`).
+    #[arg(long)]
+    pub pin_image: Option<String>,
+
     /// Start dev container after generating config.
     #[arg(long)]
     pub up: bool,

--- a/crates/cella-cli/src/commands/init/noninteractive.rs
+++ b/crates/cella-cli/src/commands/init/noninteractive.rs
@@ -46,9 +46,29 @@ pub async fn run(args: InitArgs) -> Result<(), Box<dyn std::error::Error + Send 
     // Parse feature options from --option flags
     let features = parse_features(&args.feature, &args.option)?;
 
+    // Construct pinned image if --pin-image was provided
+    let pinned_image = args.pin_image.map(|tag| {
+        // Read template config to get base image
+        let config_content =
+            std::fs::read_to_string(template_dir.join(".devcontainer").join("devcontainer.json"))
+                .ok()
+                .or_else(|| std::fs::read_to_string(template_dir.join("devcontainer.json")).ok());
+
+        if let Some(info) = config_content
+            .as_deref()
+            .and_then(cella_templates::tags::detect_image_variant_option)
+        {
+            format!("{}:{tag}", info.base_image)
+        } else {
+            // No variant detected; use tag as-is (user knows what they're doing)
+            tag
+        }
+    });
+
     // Apply template (include all optional paths in non-interactive mode)
     let overrides = cella_templates::apply::ConfigOverrides {
         name: args.name,
+        pinned_image,
         ..Default::default()
     };
     let written_path = cella_templates::apply::apply_template(

--- a/crates/cella-cli/src/commands/init/noninteractive.rs
+++ b/crates/cella-cli/src/commands/init/noninteractive.rs
@@ -54,7 +54,7 @@ pub async fn run(args: InitArgs) -> Result<(), Box<dyn std::error::Error + Send 
         &resolved_opts,
         &features,
         args.output_format.to_template_format(),
-        &[],
+        &cella_templates::apply::ConfigOverrides::default(),
     )?;
 
     super::verify_generated_config(&written_path);

--- a/crates/cella-cli/src/commands/init/noninteractive.rs
+++ b/crates/cella-cli/src/commands/init/noninteractive.rs
@@ -47,6 +47,10 @@ pub async fn run(args: InitArgs) -> Result<(), Box<dyn std::error::Error + Send 
     let features = parse_features(&args.feature, &args.option)?;
 
     // Apply template (include all optional paths in non-interactive mode)
+    let overrides = cella_templates::apply::ConfigOverrides {
+        name: args.name,
+        ..Default::default()
+    };
     let written_path = cella_templates::apply::apply_template(
         &metadata.id,
         &template_dir,
@@ -54,7 +58,7 @@ pub async fn run(args: InitArgs) -> Result<(), Box<dyn std::error::Error + Send 
         &resolved_opts,
         &features,
         args.output_format.to_template_format(),
-        &cella_templates::apply::ConfigOverrides::default(),
+        &overrides,
     )?;
 
     super::verify_generated_config(&written_path);

--- a/crates/cella-cli/src/commands/init/summary.rs
+++ b/crates/cella-cli/src/commands/init/summary.rs
@@ -7,6 +7,7 @@ use crate::style;
 /// Display a summary of the init configuration before writing.
 pub fn display_summary(
     template_name: &str,
+    container_name: &str,
     template_options: &[(String, String)],
     features: &[SelectedFeature],
     output_format: OutputFormat,
@@ -18,6 +19,11 @@ pub fn display_summary(
         "  {}  {}",
         style::label("Template:"),
         style::value(template_name)
+    );
+    eprintln!(
+        "  {}      {}",
+        style::label("Name:"),
+        style::value(container_name)
     );
 
     if !template_options.is_empty() {

--- a/crates/cella-cli/src/commands/init/summary.rs
+++ b/crates/cella-cli/src/commands/init/summary.rs
@@ -8,6 +8,7 @@ use crate::style;
 pub fn display_summary(
     template_name: &str,
     container_name: &str,
+    pinned_image: Option<&str>,
     template_options: &[(String, String)],
     features: &[SelectedFeature],
     output_format: OutputFormat,
@@ -25,6 +26,9 @@ pub fn display_summary(
         style::label("Name:"),
         style::value(container_name)
     );
+    if let Some(image) = pinned_image {
+        eprintln!("  {}     {}", style::label("Image:"), style::value(image));
+    }
 
     if !template_options.is_empty() {
         for (key, value) in template_options {

--- a/crates/cella-cli/src/commands/init/wizard.rs
+++ b/crates/cella-cli/src/commands/init/wizard.rs
@@ -14,8 +14,8 @@ use cella_templates::collection::{self, DEFAULT_FEATURE_COLLECTION, DEFAULT_TEMP
 use cella_templates::fetcher;
 use cella_templates::index::{self, is_official_collection};
 use cella_templates::types::{
-    DevcontainerIndex, FeatureSummary, IndexCollection, OutputFormat, SelectedFeature,
-    TemplateMetadata, TemplateSummary,
+    DevcontainerIndex, FeatureSummary, IndexCollection, IndexFeatureSummary, IndexTemplateSummary,
+    OutputFormat, SelectedFeature, TemplateMetadata, TemplateSummary,
 };
 
 use crate::commands::features::prompts::{prompt_feature_options, prompt_single_option};
@@ -246,7 +246,10 @@ enum TemplateChoice {
 fn prompt_official_templates(
     templates: &[TemplateSummary],
 ) -> Result<TemplateChoice, Box<dyn std::error::Error + Send + Sync>> {
-    let entries = templates
+    let mut sorted: Vec<&TemplateSummary> = templates.iter().collect();
+    sort_by_display_name(&mut sorted, |t| t.name.as_deref(), |t| &t.id);
+
+    let entries = sorted
         .iter()
         .map(|t| format_entry(t.name.as_deref().unwrap_or(&t.id), t.description.as_deref()));
     let (entry_choices, index_map) = build_choices_with_index(entries);
@@ -268,7 +271,7 @@ fn prompt_official_templates(
     }
 
     let idx = resolve_selection(&index_map, &selection)?;
-    Ok(TemplateChoice::Selected(templates[idx].clone()))
+    Ok(TemplateChoice::Selected((*sorted[idx]).clone()))
 }
 
 /// Browse all template sources via the aggregated index.
@@ -317,8 +320,10 @@ async fn browse_custom_registry(
         return Ok(None);
     }
 
-    let entries = custom_collection
-        .templates
+    let mut sorted: Vec<&TemplateSummary> = custom_collection.templates.iter().collect();
+    sort_by_display_name(&mut sorted, |t| t.name.as_deref(), |t| &t.id);
+
+    let entries = sorted
         .iter()
         .map(|t| format_entry(t.name.as_deref().unwrap_or(&t.id), t.description.as_deref()));
     let (entry_choices, index_map) = build_choices_with_index(entries);
@@ -337,7 +342,7 @@ async fn browse_custom_registry(
 
     let idx = resolve_selection(&index_map, &selection)?;
 
-    let t = &custom_collection.templates[idx];
+    let t = sorted[idx];
     let name = t.name.as_deref().unwrap_or(&t.id);
     let oci_ref = format!("{registry}/{}:{}", t.id, t.version);
     let template_dir = progress
@@ -372,7 +377,7 @@ fn prompt_collection_picker(
         CollectionKind::Features => BACK_TO_OFFICIAL_FEATURES,
     };
 
-    let relevant: Vec<&IndexCollection> = index
+    let mut relevant: Vec<&IndexCollection> = index
         .collections
         .iter()
         .filter(|c| match kind {
@@ -380,6 +385,11 @@ fn prompt_collection_picker(
             CollectionKind::Features => !c.features.is_empty(),
         })
         .collect();
+    sort_by_display_name(
+        &mut relevant,
+        |c| c.source_information.name.as_deref(),
+        |c| c.source_information.oci_reference.as_deref().unwrap_or(""),
+    );
 
     let kind_label = match kind {
         CollectionKind::Templates => "templates",
@@ -447,8 +457,11 @@ async fn prompt_index_templates(
         .name
         .as_deref()
         .unwrap_or("unknown");
-    let entries = collection
-        .templates
+
+    let mut sorted: Vec<&IndexTemplateSummary> = collection.templates.iter().collect();
+    sort_by_display_name(&mut sorted, |t| t.name.as_deref(), |t| &t.id);
+
+    let entries = sorted
         .iter()
         .map(|t| format_entry(t.name.as_deref().unwrap_or(&t.id), t.description.as_deref()));
     let (entry_choices, index_map) = build_choices_with_index(entries);
@@ -467,7 +480,7 @@ async fn prompt_index_templates(
 
     let idx = resolve_selection(&index_map, &selection)?;
 
-    let t = &collection.templates[idx];
+    let t = sorted[idx];
     let name = t.name.as_deref().unwrap_or(&t.id);
     let oci_ref = format!("{}:{}", t.id, t.version);
     let template_dir = progress
@@ -534,9 +547,18 @@ enum FeatureChoice {
 fn prompt_feature_list(
     available: &[FeatureSummary],
 ) -> Result<FeatureChoice, Box<dyn std::error::Error + Send + Sync>> {
-    let entries = available
-        .iter()
-        .map(|f| format_entry(f.name.as_deref().unwrap_or(&f.id), f.description.as_deref()));
+    // Build sorted indices so we can map back to original positions.
+    let mut sorted_indices: Vec<usize> = (0..available.len()).collect();
+    sorted_indices.sort_by(|&a, &b| {
+        let a_name = available[a].name.as_deref().unwrap_or(&available[a].id);
+        let b_name = available[b].name.as_deref().unwrap_or(&available[b].id);
+        a_name.to_lowercase().cmp(&b_name.to_lowercase())
+    });
+
+    let entries = sorted_indices.iter().map(|&i| {
+        let f = &available[i];
+        format_entry(f.name.as_deref().unwrap_or(&f.id), f.description.as_deref())
+    });
     let (entry_choices, index_map) = build_choices_with_index(entries);
 
     let mut choices: Vec<String> = Vec::with_capacity(entry_choices.len() + 2);
@@ -555,8 +577,8 @@ fn prompt_feature_list(
         return Ok(FeatureChoice::ShowAllSources);
     }
 
-    let idx = resolve_selection(&index_map, &selection)?;
-    Ok(FeatureChoice::Selected(idx))
+    let sorted_idx = resolve_selection(&index_map, &selection)?;
+    Ok(FeatureChoice::Selected(sorted_indices[sorted_idx]))
 }
 
 /// Configure an official feature (fetch metadata + prompt options).
@@ -628,8 +650,11 @@ async fn prompt_index_features(
         .name
         .as_deref()
         .unwrap_or("unknown");
-    let entries = collection
-        .features
+
+    let mut sorted: Vec<&IndexFeatureSummary> = collection.features.iter().collect();
+    sort_by_display_name(&mut sorted, |f| f.name.as_deref(), |f| &f.id);
+
+    let entries = sorted
         .iter()
         .map(|f| format_entry(f.name.as_deref().unwrap_or(&f.id), f.description.as_deref()));
     let (entry_choices, index_map) = build_choices_with_index(entries);
@@ -648,7 +673,7 @@ async fn prompt_index_features(
 
     let idx = resolve_selection(&index_map, &selection)?;
 
-    let f = &collection.features[idx];
+    let f = sorted[idx];
     let feature_ref = format!("{}:{}", f.id, f.version);
     let short_id = f.id.rsplit('/').next().unwrap_or(&f.id);
     let feature_options =
@@ -803,4 +828,17 @@ fn resolve_selection(
         .get(selection)
         .copied()
         .ok_or_else(|| "item not found in selection".into())
+}
+
+/// Sort a slice of items by display name (case-insensitive), falling back to id.
+fn sort_by_display_name<T>(
+    items: &mut [T],
+    get_name: fn(&T) -> Option<&str>,
+    get_id: fn(&T) -> &str,
+) {
+    items.sort_by(|a, b| {
+        let a_name = get_name(a).unwrap_or_else(|| get_id(a));
+        let b_name = get_name(b).unwrap_or_else(|| get_id(b));
+        a_name.to_lowercase().cmp(&b_name.to_lowercase())
+    });
 }

--- a/crates/cella-cli/src/commands/init/wizard.rs
+++ b/crates/cella-cli/src/commands/init/wizard.rs
@@ -89,38 +89,31 @@ pub async fn run(
     // Step 4b: Optional paths
     let excluded_paths = prompt_optional_paths(&metadata)?;
 
-    // Step 5: Feature selection loop (with multi-source support)
+    // Step 5: Dev container name
+    let container_name = prompt_container_name(&metadata)?;
+
+    // Step 6: Feature selection loop (with multi-source support)
     let features = select_features(&cache, args.refresh, &progress).await?;
 
-    // Step 6: Output format
+    // Step 7: Output format
     let format = prompt_output_format()?;
 
-    // Step 7: Summary + confirm
-    let opt_display: Vec<(String, String)> = template_opts
-        .iter()
-        .map(|(k, v)| {
-            let display = match v {
-                serde_json::Value::String(s) => s.clone(),
-                other => other.to_string(),
-            };
-            (k.clone(), display)
-        })
-        .collect();
-
-    let template_name = metadata.name.as_deref().unwrap_or(&metadata.id);
-
-    summary::display_summary(template_name, &opt_display, &features, format, &config_path);
-
-    let confirmed = Confirm::new("Write configuration files?")
-        .with_default(true)
-        .prompt()?;
-    if !confirmed {
+    // Step 8: Summary + confirm
+    if !confirm_summary(
+        &metadata,
+        &container_name,
+        &template_opts,
+        &features,
+        format,
+        &config_path,
+    )? {
         eprintln!("Aborted.");
         return Ok(());
     }
 
-    // Step 8: Apply
+    // Step 9: Apply
     let overrides = cella_templates::apply::ConfigOverrides {
+        name: Some(container_name),
         excluded_paths,
         ..Default::default()
     };
@@ -771,6 +764,17 @@ fn prompt_optional_paths(
     Ok(excluded)
 }
 
+/// Prompt for the dev container name.
+fn prompt_container_name(
+    metadata: &TemplateMetadata,
+) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+    let default_name = metadata.name.as_deref().unwrap_or(&metadata.id);
+    let name = Text::new("Dev container name:")
+        .with_default(default_name)
+        .prompt()?;
+    Ok(name)
+}
+
 /// Prompt for output format.
 fn prompt_output_format() -> Result<OutputFormat, Box<dyn std::error::Error + Send + Sync>> {
     let choices = vec![
@@ -783,6 +787,42 @@ fn prompt_output_format() -> Result<OutputFormat, Box<dyn std::error::Error + Se
     } else {
         Ok(OutputFormat::Jsonc)
     }
+}
+
+/// Display the configuration summary and prompt for confirmation.
+fn confirm_summary(
+    metadata: &TemplateMetadata,
+    container_name: &str,
+    template_opts: &HashMap<String, serde_json::Value>,
+    features: &[SelectedFeature],
+    format: OutputFormat,
+    config_path: &std::path::Path,
+) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
+    let opt_display: Vec<(String, String)> = template_opts
+        .iter()
+        .map(|(k, v)| {
+            let display = match v {
+                serde_json::Value::String(s) => s.clone(),
+                other => other.to_string(),
+            };
+            (k.clone(), display)
+        })
+        .collect();
+
+    let template_name = metadata.name.as_deref().unwrap_or(&metadata.id);
+
+    summary::display_summary(
+        template_name,
+        container_name,
+        &opt_display,
+        features,
+        format,
+        config_path,
+    );
+
+    Ok(Confirm::new("Write configuration files?")
+        .with_default(true)
+        .prompt()?)
 }
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/crates/cella-cli/src/commands/init/wizard.rs
+++ b/crates/cella-cli/src/commands/init/wizard.rs
@@ -83,8 +83,20 @@ pub async fn run(
     )
     .await?;
 
-    // Step 4: Template options
-    let template_opts = prompt_all_options(&metadata)?;
+    // Detect image variant option for pinning support
+    let image_variant_info = read_template_config(&template_dir)
+        .as_deref()
+        .and_then(cella_templates::tags::detect_image_variant_option);
+
+    // Step 4: Template options (with optional pin flow for variant option)
+    let (template_opts, pinned_image) = prompt_options_with_pin(
+        &metadata,
+        image_variant_info.as_ref(),
+        &cache,
+        args.refresh,
+        &progress,
+    )
+    .await?;
 
     // Step 4b: Optional paths
     let excluded_paths = prompt_optional_paths(&metadata)?;
@@ -102,6 +114,7 @@ pub async fn run(
     if !confirm_summary(
         &metadata,
         &container_name,
+        pinned_image.as_deref(),
         &template_opts,
         &features,
         format,
@@ -114,8 +127,8 @@ pub async fn run(
     // Step 9: Apply
     let overrides = cella_templates::apply::ConfigOverrides {
         name: Some(container_name),
+        pinned_image,
         excluded_paths,
-        ..Default::default()
     };
     let written_path = cella_templates::apply::apply_template(
         &metadata.id,
@@ -130,7 +143,17 @@ pub async fn run(
     // Step 9: Verify the generated config is parseable
     super::verify_generated_config(&written_path);
 
-    // Step 10: Success + next steps
+    // Step 10: Success + optional cella up
+    print_success_and_prompt_up(&written_path, args.up)?;
+
+    Ok(())
+}
+
+/// Print success message and optionally prompt to run `cella up`.
+fn print_success_and_prompt_up(
+    written_path: &std::path::Path,
+    auto_up: bool,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     eprintln!();
     eprintln!(
         "{} Created {}",
@@ -149,9 +172,8 @@ pub async fn run(
         style::dim("Edit .devcontainer/devcontainer.json to customize")
     );
 
-    // Step 10: Prompt to run cella up
     eprintln!();
-    if args.up {
+    if auto_up {
         eprintln!("Starting dev container...");
         exec_cella_up()?;
     } else {
@@ -716,29 +738,150 @@ async fn fetch_and_prompt_feature_options(
 // Template options, optional paths, output format
 // ═══════════════════════════════════════════════════════════════════════
 
-/// Prompt the user for all template options, showing defaults.
-fn prompt_all_options(
+/// Read the template's `devcontainer.json` content (pre-substitution).
+fn read_template_config(template_dir: &std::path::Path) -> Option<String> {
+    std::fs::read_to_string(template_dir.join(".devcontainer").join("devcontainer.json"))
+        .ok()
+        .or_else(|| std::fs::read_to_string(template_dir.join("devcontainer.json")).ok())
+}
+
+const PIN_IMAGE_SENTINEL: &str = "Pin to specific image version...";
+
+/// Prompt for template options with optional image pinning support.
+///
+/// Returns `(options, pinned_image)` where `pinned_image` is `Some` if the
+/// user chose to pin to a specific image tag.
+async fn prompt_options_with_pin(
     metadata: &TemplateMetadata,
-) -> Result<HashMap<String, serde_json::Value>, Box<dyn std::error::Error + Send + Sync>> {
+    variant_info: Option<&cella_templates::tags::ImageVariantInfo>,
+    cache: &TemplateCache,
+    refresh: bool,
+    progress: &Progress,
+) -> Result<
+    (HashMap<String, serde_json::Value>, Option<String>),
+    Box<dyn std::error::Error + Send + Sync>,
+> {
     if metadata.options.is_empty() {
-        return Ok(HashMap::new());
+        return Ok((HashMap::new(), None));
     }
 
     eprintln!();
     eprintln!("{}", style::label("Configure template options:"));
 
     let mut resolved = HashMap::new();
+    let mut pinned_image: Option<String> = None;
+
     for (key, opt) in &metadata.options {
         eprintln!();
         eprintln!("  {}", style::label(key));
         if let Some(desc) = &opt.description {
             eprintln!("  {}", style::dim(desc));
         }
-        let value = prompt_single_option(key, opt)?;
-        resolved.insert(key.clone(), value);
+
+        // Check if this is the variant option that supports pinning.
+        let is_variant_option =
+            variant_info.is_some_and(|info| info.option_key == *key) && opt.proposals.is_some();
+
+        if is_variant_option {
+            let (value, pin) =
+                prompt_variant_with_pin(key, opt, variant_info.unwrap(), cache, refresh, progress)
+                    .await?;
+            resolved.insert(key.clone(), value);
+            pinned_image = pin;
+        } else {
+            let value = prompt_single_option(key, opt)?;
+            resolved.insert(key.clone(), value);
+        }
     }
 
-    Ok(resolved)
+    Ok((resolved, pinned_image))
+}
+
+/// Prompt for an image variant option with a pin sentinel at the end.
+///
+/// Returns `(chosen_value, optional_pinned_image)`.
+async fn prompt_variant_with_pin(
+    key: &str,
+    opt: &cella_templates::types::TemplateOption,
+    variant_info: &cella_templates::tags::ImageVariantInfo,
+    cache: &TemplateCache,
+    refresh: bool,
+    progress: &Progress,
+) -> Result<(serde_json::Value, Option<String>), Box<dyn std::error::Error + Send + Sync>> {
+    let description = opt.description.as_deref().unwrap_or(key);
+    let proposals = opt.proposals.as_deref().unwrap_or_default();
+
+    // Build choices: proposals + (custom) + pin sentinel
+    let mut choices: Vec<String> = proposals.to_vec();
+    choices.push("(custom)".to_owned());
+    choices.push(PIN_IMAGE_SENTINEL.to_owned());
+
+    let default_str = opt.default.as_str().unwrap_or("");
+    let default_idx = choices.iter().position(|v| v == default_str).unwrap_or(0);
+
+    let selection = Select::new(description, choices)
+        .with_starting_cursor(default_idx)
+        .prompt()?;
+
+    if selection == "(custom)" {
+        let custom = Text::new(&format!("{description} (custom value):"))
+            .with_default(default_str)
+            .prompt()?;
+        return Ok((serde_json::json!(custom), None));
+    }
+
+    if selection == PIN_IMAGE_SENTINEL {
+        // Step 1: Ask which codename to filter by
+        let codename =
+            Select::new("Select variant to filter tags:", proposals.to_vec()).prompt()?;
+
+        // Step 2: Fetch tags
+        let tags_result = progress
+            .run_step_result(
+                "Fetching image tags",
+                cella_templates::tags::fetch_image_tags(&variant_info.base_image, cache, refresh),
+            )
+            .await;
+
+        match tags_result {
+            Ok(all_tags) => {
+                let tag_refs: Vec<&str> = all_tags.iter().map(String::as_str).collect();
+                let mut filtered =
+                    cella_templates::tags::filter_tags_by_suffix(&tag_refs, &codename);
+                cella_templates::tags::sort_tags_descending(&mut filtered);
+                filtered.truncate(cella_templates::tags::MAX_PINNED_TAGS);
+
+                if filtered.is_empty() {
+                    eprintln!(
+                        "  {} No pinnable tags found for variant \"{codename}\"; using as-is",
+                        style::dim("(note)")
+                    );
+                    return Ok((serde_json::json!(codename), None));
+                }
+
+                let pinned_tag = Select::new(
+                    "Select image version:",
+                    filtered.iter().map(|s| (*s).to_owned()).collect(),
+                )
+                .with_page_size(15)
+                .prompt()?;
+
+                let full_image = format!("{}:{pinned_tag}", variant_info.base_image);
+                // Still set the codename as the option value for substitution of
+                // other template files that reference this option.
+                Ok((serde_json::json!(codename), Some(full_image)))
+            }
+            Err(e) => {
+                eprintln!(
+                    "  {} could not fetch image tags: {e}; using variant as-is",
+                    style::dim("(note)")
+                );
+                Ok((serde_json::json!(codename), None))
+            }
+        }
+    } else {
+        Ok((serde_json::json!(selection), None))
+    }
 }
 
 /// Prompt for which optional paths to include via multi-select.
@@ -793,6 +936,7 @@ fn prompt_output_format() -> Result<OutputFormat, Box<dyn std::error::Error + Se
 fn confirm_summary(
     metadata: &TemplateMetadata,
     container_name: &str,
+    pinned_image: Option<&str>,
     template_opts: &HashMap<String, serde_json::Value>,
     features: &[SelectedFeature],
     format: OutputFormat,
@@ -814,6 +958,7 @@ fn confirm_summary(
     summary::display_summary(
         template_name,
         container_name,
+        pinned_image,
         &opt_display,
         features,
         format,

--- a/crates/cella-cli/src/commands/init/wizard.rs
+++ b/crates/cella-cli/src/commands/init/wizard.rs
@@ -120,6 +120,10 @@ pub async fn run(
     }
 
     // Step 8: Apply
+    let overrides = cella_templates::apply::ConfigOverrides {
+        excluded_paths,
+        ..Default::default()
+    };
     let written_path = cella_templates::apply::apply_template(
         &metadata.id,
         &template_dir,
@@ -127,7 +131,7 @@ pub async fn run(
         &template_opts,
         &features,
         format,
-        &excluded_paths,
+        &overrides,
     )?;
 
     // Step 9: Verify the generated config is parseable

--- a/crates/cella-templates/src/apply.rs
+++ b/crates/cella-templates/src/apply.rs
@@ -82,6 +82,34 @@ pub fn merge_features(config: &mut serde_json::Value, features: &[SelectedFeatur
 }
 
 // ---------------------------------------------------------------------------
+// Config overrides
+// ---------------------------------------------------------------------------
+
+/// User customizations applied on top of the template during generation.
+#[derive(Debug, Default)]
+pub struct ConfigOverrides {
+    /// Custom name for the dev container (overrides template's name).
+    pub name: Option<String>,
+    /// Full pinned image reference (replaces entire `"image"` field value).
+    pub pinned_image: Option<String>,
+    /// Template paths to exclude from the output.
+    pub excluded_paths: Vec<String>,
+}
+
+/// Apply user-specified overrides to the parsed config.
+pub fn apply_overrides(config: &mut serde_json::Value, overrides: &ConfigOverrides) {
+    let Some(obj) = config.as_object_mut() else {
+        return;
+    };
+    if let Some(name) = &overrides.name {
+        obj.insert("name".to_owned(), serde_json::Value::String(name.clone()));
+    }
+    if let Some(image) = &overrides.pinned_image {
+        obj.insert("image".to_owned(), serde_json::Value::String(image.clone()));
+    }
+}
+
+// ---------------------------------------------------------------------------
 // JSONC generation
 // ---------------------------------------------------------------------------
 
@@ -197,7 +225,7 @@ pub fn apply_template<S: std::hash::BuildHasher>(
     options: &HashMap<String, serde_json::Value, S>,
     features: &[SelectedFeature],
     format: OutputFormat,
-    excluded_paths: &[String],
+    overrides: &ConfigOverrides,
 ) -> Result<std::path::PathBuf, TemplateError> {
     let devcontainer_dir = output_dir.join(".devcontainer");
     std::fs::create_dir_all(&devcontainer_dir)?;
@@ -212,7 +240,8 @@ pub fn apply_template<S: std::hash::BuildHasher>(
     };
 
     // Compile exclude patterns
-    let compiled_excludes: Vec<glob::Pattern> = excluded_paths
+    let compiled_excludes: Vec<glob::Pattern> = overrides
+        .excluded_paths
         .iter()
         .filter_map(|p| glob::Pattern::new(p).ok())
         .collect();
@@ -242,6 +271,7 @@ pub fn apply_template<S: std::hash::BuildHasher>(
             }
         })?;
 
+        apply_overrides(&mut config, overrides);
         merge_features(&mut config, features);
 
         let formatted = format_config(&config, format);
@@ -494,7 +524,7 @@ mod tests {
             &options,
             &[],
             OutputFormat::Json,
-            &[],
+            &ConfigOverrides::default(),
         )
         .unwrap();
 
@@ -529,7 +559,7 @@ mod tests {
             &HashMap::new(),
             &features,
             OutputFormat::Json,
-            &[],
+            &ConfigOverrides::default(),
         )
         .unwrap();
 
@@ -567,7 +597,7 @@ mod tests {
             &options,
             &[],
             OutputFormat::Json,
-            &[],
+            &ConfigOverrides::default(),
         )
         .unwrap();
 
@@ -601,7 +631,10 @@ mod tests {
             &HashMap::new(),
             &[],
             OutputFormat::Json,
-            &[".github/*".to_owned()],
+            &ConfigOverrides {
+                excluded_paths: vec![".github/*".to_owned()],
+                ..Default::default()
+            },
         )
         .unwrap();
 
@@ -648,7 +681,7 @@ mod tests {
             &HashMap::new(),
             &[],
             OutputFormat::Json,
-            &[],
+            &ConfigOverrides::default(),
         )
         .unwrap();
 
@@ -677,7 +710,7 @@ mod tests {
             &HashMap::new(),
             &[],
             OutputFormat::Json,
-            &[],
+            &ConfigOverrides::default(),
         )
         .unwrap();
 
@@ -706,7 +739,7 @@ mod tests {
             &HashMap::new(),
             &[],
             OutputFormat::Json,
-            &[],
+            &ConfigOverrides::default(),
         )
         .unwrap();
 
@@ -740,7 +773,7 @@ mod tests {
             &options,
             &[],
             OutputFormat::Json,
-            &[],
+            &ConfigOverrides::default(),
         )
         .unwrap();
 
@@ -773,7 +806,7 @@ mod tests {
             &options,
             &[],
             OutputFormat::Json,
-            &[],
+            &ConfigOverrides::default(),
         )
         .unwrap();
 
@@ -804,7 +837,7 @@ mod tests {
             &HashMap::new(),
             &[],
             OutputFormat::Json,
-            &[],
+            &ConfigOverrides::default(),
         )
         .unwrap();
 
@@ -845,5 +878,69 @@ mod tests {
 
         // devcontainer.json should NOT be copied by copy_and_substitute
         assert!(!dest_dc.join("devcontainer.json").exists());
+    }
+
+    // -----------------------------------------------------------------------
+    // apply_overrides
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn apply_overrides_sets_name() {
+        let mut config = serde_json::json!({"name": "Template Name", "image": "ubuntu"});
+        let overrides = ConfigOverrides {
+            name: Some("My Project".to_owned()),
+            pinned_image: None,
+            ..Default::default()
+        };
+        apply_overrides(&mut config, &overrides);
+        assert_eq!(config["name"], "My Project");
+    }
+
+    #[test]
+    fn apply_overrides_sets_pinned_image() {
+        let mut config = serde_json::json!({"name": "Test", "image": "mcr.microsoft.com/devcontainers/rust:1-trixie"});
+        let overrides = ConfigOverrides {
+            name: None,
+            pinned_image: Some("mcr.microsoft.com/devcontainers/rust:1.87-trixie".to_owned()),
+            ..Default::default()
+        };
+        apply_overrides(&mut config, &overrides);
+        assert_eq!(
+            config["image"],
+            "mcr.microsoft.com/devcontainers/rust:1.87-trixie"
+        );
+    }
+
+    #[test]
+    fn apply_overrides_both() {
+        let mut config = serde_json::json!({"name": "Old", "image": "old:tag"});
+        let overrides = ConfigOverrides {
+            name: Some("New".to_owned()),
+            pinned_image: Some("new:pinned".to_owned()),
+            ..Default::default()
+        };
+        apply_overrides(&mut config, &overrides);
+        assert_eq!(config["name"], "New");
+        assert_eq!(config["image"], "new:pinned");
+    }
+
+    #[test]
+    fn apply_overrides_noop_when_empty() {
+        let mut config = serde_json::json!({"name": "Test", "image": "ubuntu"});
+        let original = config.clone();
+        apply_overrides(&mut config, &ConfigOverrides::default());
+        assert_eq!(config, original);
+    }
+
+    #[test]
+    fn apply_overrides_inserts_name_when_missing() {
+        let mut config = serde_json::json!({"image": "ubuntu"});
+        let overrides = ConfigOverrides {
+            name: Some("Added Name".to_owned()),
+            pinned_image: None,
+            ..Default::default()
+        };
+        apply_overrides(&mut config, &overrides);
+        assert_eq!(config["name"], "Added Name");
     }
 }

--- a/crates/cella-templates/src/cache.rs
+++ b/crates/cella-templates/src/cache.rs
@@ -18,6 +18,9 @@ use crate::{FeatureCollectionIndex, TemplateCollectionIndex};
 /// How long a cached collection index is considered fresh.
 const COLLECTION_TTL: Duration = Duration::from_secs(24 * 60 * 60);
 
+/// How long cached image tags are considered fresh.
+const IMAGE_TAG_TTL: Duration = Duration::from_secs(60 * 60);
+
 /// On-disk cache for template collections and artifacts.
 #[derive(Debug, Clone)]
 pub struct TemplateCache {
@@ -203,6 +206,63 @@ impl TemplateCache {
             path.display()
         );
         Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Template artifact cache
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // Image tag cache (1-hour TTL)
+    // -----------------------------------------------------------------------
+
+    /// Get cached image tags if they exist and are fresh (< 1h old).
+    pub fn get_image_tags(&self, image_ref: &str) -> Option<Vec<String>> {
+        let path = self.image_tags_path(image_ref);
+        let metadata = std::fs::metadata(&path).ok()?;
+        let modified = metadata.modified().ok()?;
+
+        let age = SystemTime::now()
+            .duration_since(modified)
+            .unwrap_or_default();
+        if age > IMAGE_TAG_TTL {
+            debug!("image tag cache expired for {image_ref} (age: {age:?})");
+            return None;
+        }
+
+        let content = std::fs::read_to_string(&path).ok()?;
+        let tags: Vec<String> = serde_json::from_str(&content).ok()?;
+        debug!("image tag cache hit for {image_ref}");
+        Some(tags)
+    }
+
+    /// Write image tags to the cache.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TemplateError::CacheError`] if the write fails.
+    pub fn put_image_tags(&self, image_ref: &str, tags: &[String]) -> Result<(), TemplateError> {
+        let path = self.image_tags_path(image_ref);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| TemplateError::CacheError {
+                message: format!("failed to create cache directory: {e}"),
+            })?;
+        }
+        let json = serde_json::to_string(tags).map_err(|e| TemplateError::CacheError {
+            message: format!("failed to serialize image tags: {e}"),
+        })?;
+        std::fs::write(&path, json).map_err(|e| TemplateError::CacheError {
+            message: format!("failed to write image tag cache: {e}"),
+        })?;
+        debug!("cached image tags for {image_ref} at {}", path.display());
+        Ok(())
+    }
+
+    /// Compute the cache file path for image tags.
+    fn image_tags_path(&self, image_ref: &str) -> PathBuf {
+        let prefixed = format!("tags::{image_ref}");
+        let hash = hex::encode(&Sha256::digest(prefixed.as_bytes())[..8]);
+        self.root.join("tags").join(format!("{hash}.json"))
     }
 
     // -----------------------------------------------------------------------

--- a/crates/cella-templates/src/error.rs
+++ b/crates/cella-templates/src/error.rs
@@ -57,6 +57,11 @@ pub enum TemplateError {
     #[diagnostic(code(cella::templates::index_fetch_failed))]
     IndexFetchFailed { message: String },
 
+    /// Failed to fetch image tags from a registry.
+    #[error("failed to fetch tags for {image}: {message}")]
+    #[diagnostic(code(cella::templates::tag_fetch_failed))]
+    TagFetchFailed { image: String, message: String },
+
     /// Cache I/O error.
     #[error("cache error: {message}")]
     #[diagnostic(code(cella::templates::cache_error))]

--- a/crates/cella-templates/src/lib.rs
+++ b/crates/cella-templates/src/lib.rs
@@ -15,6 +15,7 @@ pub mod error;
 pub mod fetcher;
 pub mod index;
 pub mod options;
+pub mod tags;
 pub mod types;
 
 pub use cache::TemplateCache;

--- a/crates/cella-templates/src/tags.rs
+++ b/crates/cella-templates/src/tags.rs
@@ -1,0 +1,356 @@
+//! Image tag fetching, filtering, and sorting for version pinning.
+//!
+//! Enables users to pin a devcontainer to a specific image version
+//! (e.g. `4.0.6-22-trixie`) rather than using the template's default
+//! tag pattern.
+
+use oci_distribution::Reference;
+use oci_distribution::client::{ClientConfig, ClientProtocol};
+use oci_distribution::secrets::RegistryAuth;
+use tracing::debug;
+
+use crate::cache::TemplateCache;
+use crate::error::TemplateError;
+
+/// Maximum number of pinned tags to present to the user.
+pub const MAX_PINNED_TAGS: usize = 15;
+
+/// Information about the image variant option detected in a template.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImageVariantInfo {
+    /// Base image without tag (e.g. `mcr.microsoft.com/devcontainers/rust`).
+    pub base_image: String,
+    /// Template option key that controls the variant (e.g. `imageVariant`).
+    pub option_key: String,
+}
+
+/// Detect which template option controls the image variant by parsing the
+/// template's `devcontainer.json` content (as raw JSONC-stripped JSON).
+///
+/// Looks for `${templateOption:KEY}` in the `"image"` field value. Returns
+/// the last option reference found in the tag portion (after `:`).
+pub fn detect_image_variant_option(config_content: &str) -> Option<ImageVariantInfo> {
+    let parsed: serde_json::Value = serde_json::from_str(config_content).ok()?;
+    let image = parsed.get("image")?.as_str()?;
+
+    // Split image into base and tag. The tag separator is the first ':'
+    // that appears after the last '/' (to avoid matching colons inside
+    // `${templateOption:...}` or port numbers).
+    let last_slash = image.rfind('/').unwrap_or(0);
+    let (base, tag_portion) = image[last_slash..]
+        .find(':')
+        .map_or((image, ""), |colon_offset| {
+            let colon_pos = last_slash + colon_offset;
+            (&image[..colon_pos], &image[colon_pos + 1..])
+        });
+
+    // Find the last ${templateOption:KEY} in the tag portion.
+    let pattern = "${templateOption:";
+    let mut last_key = None;
+    let mut search_from = 0;
+    while let Some(start) = tag_portion[search_from..].find(pattern) {
+        let key_start = search_from + start + pattern.len();
+        if let Some(end) = tag_portion[key_start..].find('}') {
+            last_key = Some(tag_portion[key_start..key_start + end].to_owned());
+            search_from = key_start + end + 1;
+        } else {
+            break;
+        }
+    }
+
+    Some(ImageVariantInfo {
+        base_image: base.to_owned(),
+        option_key: last_key?,
+    })
+}
+
+/// Parse an image reference into `(registry, repository)`.
+///
+/// # Errors
+///
+/// Returns [`TemplateError::TagFetchFailed`] if the reference has no `/`.
+pub fn parse_image_ref(image: &str) -> Result<(String, String), TemplateError> {
+    image
+        .split_once('/')
+        .map(|(reg, repo)| (reg.to_owned(), repo.to_owned()))
+        .ok_or_else(|| TemplateError::TagFetchFailed {
+            image: image.to_owned(),
+            message: "invalid image reference: expected registry/repository".to_owned(),
+        })
+}
+
+/// Filter tags to those ending with `-{suffix}` that have a version prefix.
+///
+/// Bare codenames (e.g. just `"trixie"`) are excluded — only tags with a
+/// leading numeric component before the suffix are returned.
+pub fn filter_tags_by_suffix<'a>(tags: &[&'a str], suffix: &str) -> Vec<&'a str> {
+    let needle = format!("-{suffix}");
+    tags.iter()
+        .copied()
+        .filter(|tag| tag.ends_with(&needle) && tag.len() > needle.len())
+        .collect()
+}
+
+/// Parse leading dot-and-dash-separated numbers from a tag for sorting.
+///
+/// Stops at the first segment that cannot be parsed as `u64`.
+///
+/// # Examples
+///
+/// - `"4.0.6-trixie"` → `[4, 0, 6]`
+/// - `"4.0.6-22-trixie"` → `[4, 0, 6, 22]`
+/// - `"22-trixie"` → `[22]`
+/// - `"latest"` → `[]`
+pub fn parse_version_key(tag: &str) -> Vec<u64> {
+    let mut nums = Vec::new();
+    for segment in tag.split(['.', '-']) {
+        if let Ok(n) = segment.parse::<u64>() {
+            nums.push(n);
+        } else {
+            break;
+        }
+    }
+    nums
+}
+
+/// Sort tags in descending version order.
+pub fn sort_tags_descending(tags: &mut [&str]) {
+    tags.sort_by(|a, b| {
+        let a_key = parse_version_key(a);
+        let b_key = parse_version_key(b);
+        b_key.cmp(&a_key)
+    });
+}
+
+/// Fetch available tags for an image from its OCI registry.
+///
+/// # Errors
+///
+/// Returns [`TemplateError::TagFetchFailed`] on network or API errors.
+pub async fn fetch_image_tags(
+    image_ref: &str,
+    cache: &TemplateCache,
+    force_refresh: bool,
+) -> Result<Vec<String>, TemplateError> {
+    if !force_refresh && let Some(tags) = cache.get_image_tags(image_ref) {
+        return Ok(tags);
+    }
+
+    let (registry, repository) = parse_image_ref(image_ref)?;
+
+    let config = ClientConfig {
+        protocol: ClientProtocol::Https,
+        ..ClientConfig::default()
+    };
+    let client = oci_distribution::Client::new(config);
+
+    let oci_ref = Reference::with_tag(registry.clone(), repository.clone(), "latest".to_owned());
+    let auth = build_registry_auth(&registry);
+
+    debug!("fetching image tags for {image_ref}");
+
+    let response = client
+        .list_tags(&oci_ref, &auth, None, None)
+        .await
+        .map_err(|e| TemplateError::TagFetchFailed {
+            image: image_ref.to_owned(),
+            message: format!("failed to list tags: {e}"),
+        })?;
+
+    let _ = cache.put_image_tags(image_ref, &response.tags);
+
+    Ok(response.tags)
+}
+
+/// Build [`RegistryAuth`] from Docker credential store.
+fn build_registry_auth(registry: &str) -> RegistryAuth {
+    let creds = cella_features::auth::resolve_credentials(registry);
+    if let (Some(u), Some(p)) = (creds.username, creds.password) {
+        debug!("using basic auth for {registry}");
+        RegistryAuth::Basic(u, p)
+    } else {
+        debug!("no credentials for {registry}; using anonymous auth");
+        RegistryAuth::Anonymous
+    }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+#[expect(clippy::literal_string_with_formatting_args)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------------
+    // detect_image_variant_option
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn detect_variant_simple_image() {
+        let config =
+            r#"{"image": "mcr.microsoft.com/devcontainers/rust:1-${templateOption:imageVariant}"}"#;
+        let info = detect_image_variant_option(config).unwrap();
+        assert_eq!(info.base_image, "mcr.microsoft.com/devcontainers/rust");
+        assert_eq!(info.option_key, "imageVariant");
+    }
+
+    #[test]
+    fn detect_variant_multiple_options_returns_last() {
+        let config = r#"{"image": "mcr.microsoft.com/devcontainers/typescript-node:${templateOption:nodeVersion}-${templateOption:imageVariant}"}"#;
+        let info = detect_image_variant_option(config).unwrap();
+        assert_eq!(
+            info.base_image,
+            "mcr.microsoft.com/devcontainers/typescript-node"
+        );
+        assert_eq!(info.option_key, "imageVariant");
+    }
+
+    #[test]
+    fn detect_variant_no_image_field() {
+        let config = r#"{"build": {"dockerfile": "Dockerfile"}}"#;
+        assert!(detect_image_variant_option(config).is_none());
+    }
+
+    #[test]
+    fn detect_variant_no_template_option_in_tag() {
+        let config = r#"{"image": "ubuntu:latest"}"#;
+        assert!(detect_image_variant_option(config).is_none());
+    }
+
+    #[test]
+    fn detect_variant_no_tag_at_all() {
+        let config = r#"{"image": "ubuntu"}"#;
+        assert!(detect_image_variant_option(config).is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // parse_image_ref
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_image_ref_mcr() {
+        let (reg, repo) = parse_image_ref("mcr.microsoft.com/devcontainers/rust").unwrap();
+        assert_eq!(reg, "mcr.microsoft.com");
+        assert_eq!(repo, "devcontainers/rust");
+    }
+
+    #[test]
+    fn parse_image_ref_ghcr() {
+        let (reg, repo) = parse_image_ref("ghcr.io/myorg/myimage").unwrap();
+        assert_eq!(reg, "ghcr.io");
+        assert_eq!(repo, "myorg/myimage");
+    }
+
+    #[test]
+    fn parse_image_ref_invalid() {
+        assert!(parse_image_ref("no-slash").is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // filter_tags_by_suffix
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn filter_tags_matching_codename() {
+        let tags = vec![
+            "4.0.6-trixie",
+            "4.0.5-trixie",
+            "4.0.6-bookworm",
+            "1-trixie",
+            "latest",
+            "trixie",
+        ];
+        let filtered = filter_tags_by_suffix(&tags, "trixie");
+        assert!(filtered.contains(&"4.0.6-trixie"));
+        assert!(filtered.contains(&"4.0.5-trixie"));
+        assert!(filtered.contains(&"1-trixie"));
+        assert!(!filtered.contains(&"4.0.6-bookworm"));
+        assert!(!filtered.contains(&"latest"));
+        assert!(!filtered.contains(&"trixie")); // bare codename excluded
+    }
+
+    #[test]
+    fn filter_tags_no_matches() {
+        let tags = vec!["latest", "bookworm"];
+        let filtered = filter_tags_by_suffix(&tags, "trixie");
+        assert!(filtered.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // parse_version_key
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn version_key_full_semver() {
+        assert_eq!(parse_version_key("4.0.6-trixie"), vec![4, 0, 6]);
+    }
+
+    #[test]
+    fn version_key_with_extra_number() {
+        assert_eq!(parse_version_key("4.0.6-22-trixie"), vec![4, 0, 6, 22]);
+    }
+
+    #[test]
+    fn version_key_major_only() {
+        assert_eq!(parse_version_key("22-trixie"), vec![22]);
+    }
+
+    #[test]
+    fn version_key_no_numbers() {
+        assert_eq!(parse_version_key("latest"), Vec::<u64>::new());
+    }
+
+    // -----------------------------------------------------------------------
+    // sort_tags_descending
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn sort_descending_mixed_versions() {
+        let mut tags = vec![
+            "4.0.5-trixie",
+            "4.0.6-trixie",
+            "3.9.0-trixie",
+            "4.0.6-22-trixie",
+        ];
+        sort_tags_descending(&mut tags);
+        assert_eq!(tags[0], "4.0.6-22-trixie");
+        assert_eq!(tags[1], "4.0.6-trixie");
+        assert_eq!(tags[2], "4.0.5-trixie");
+        assert_eq!(tags[3], "3.9.0-trixie");
+    }
+
+    #[test]
+    fn sort_descending_same_prefix() {
+        let mut tags = vec!["1-trixie", "22-trixie", "20-trixie"];
+        sort_tags_descending(&mut tags);
+        assert_eq!(tags, vec!["22-trixie", "20-trixie", "1-trixie"]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Image tag cache
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn image_tag_cache_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = TemplateCache::with_root(dir.path());
+        let tags = vec!["4.0.6-trixie".to_owned(), "4.0.5-trixie".to_owned()];
+
+        cache
+            .put_image_tags("mcr.microsoft.com/devcontainers/rust", &tags)
+            .unwrap();
+        let cached = cache
+            .get_image_tags("mcr.microsoft.com/devcontainers/rust")
+            .unwrap();
+        assert_eq!(cached, tags);
+    }
+
+    #[test]
+    fn image_tag_cache_miss() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = TemplateCache::with_root(dir.path());
+        assert!(cache.get_image_tags("nonexistent").is_none());
+    }
+}


### PR DESCRIPTION
## Summary

- **Sort templates and features by name** across all selection contexts (official, aggregated index, custom registry) — case-insensitive alphabetical ordering
- **Dev container name prompt** — interactive `Text` prompt after template options with template name as default; `--name` flag for non-interactive mode
- **Image version pinning** — detect image variant options from template `devcontainer.json`, fetch tags from OCI registries (1h cache), filter by codename, sort by version descending, present top 15; `--pin-image <TAG>` for non-interactive mode
- **ConfigOverrides** — clean abstraction for name, pinned image, and excluded paths applied after template substitution

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings -D clippy::all` passes
- [x] `cargo test --workspace` passes (18 new tests in tags.rs, 5 new tests in apply.rs)
- [x] `cargo insta test --workspace --check --unreferenced=reject` passes
- [x] Manual: `cella init` shows templates sorted alphabetically
- [x] Manual: `cella init` prompts for dev container name after template options
- [x] Manual: variant option shows "Pin to specific image version..." sentinel
- [x] Manual: `cella init --template ghcr.io/devcontainers/templates/rust:5.0.0 --name "My App" --force` sets name in generated config
- [x] Manual: `cella init --template ... --pin-image "1.87-trixie" --force` pins image in generated config

🤖 Generated with [Claude Code](https://claude.com/claude-code)