### PR TITLE
feat: forward AI provider API keys into containers

### DIFF
--- a/crates/cella-cli/src/commands/exec.rs
+++ b/crates/cella-cli/src/commands/exec.rs
@@ -130,6 +130,9 @@ impl ExecArgs {
         // SSH_AUTH_SOCK fallback for containers created before forwarding env was stored
         ensure_ssh_auth_sock(client.as_ref(), &container.id, &user, &mut env).await;
 
+        // Forward AI provider API keys from host environment
+        super::append_ai_keys(&mut env, &container.labels);
+
         // Forward terminal environment variables
         for var in super::TERMINAL_ENV_VARS {
             if let Ok(val) = std::env::var(var) {

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -290,12 +290,16 @@ pub async fn resolve_service_container(
 /// then detects keys that are present on the host, enabled in config,
 /// and not already set by the user (via `remoteEnv` / `containerEnv`).
 pub fn append_ai_keys(env: &mut Vec<String>, labels: &std::collections::HashMap<String, String>) {
-    let settings = labels
+    let Some(workspace_path) = labels
         .get("dev.cella.workspace_path")
-        .map(std::path::Path::new)
-        .map_or_else(cella_config::settings::Settings::default, |p| {
-            cella_config::settings::Settings::load(p)
-        });
+        .filter(|p| !p.trim().is_empty())
+    else {
+        // Only forward host AI credentials to containers that carry the
+        // trusted workspace label identifying them as cella-managed.
+        return;
+    };
+
+    let settings = cella_config::settings::Settings::load(std::path::Path::new(workspace_path));
     let ai = &settings.credentials.ai;
     if !ai.enabled {
         return;

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -290,6 +290,11 @@ pub async fn resolve_service_container(
 /// then detects keys that are present on the host, enabled in config,
 /// and not already set by the user (via `remoteEnv` / `containerEnv`).
 pub fn append_ai_keys(env: &mut Vec<String>, labels: &std::collections::HashMap<String, String>) {
+    // Fast path: skip settings I/O when no AI key env vars exist on the host.
+    if !cella_env::ai_keys::any_ai_key_present() {
+        return;
+    }
+
     // Only forward host AI credentials to cella-managed containers.
     // Without the workspace label, this could be a non-cella container
     // targeted by --container-id, and leaking keys would be unexpected.
@@ -669,5 +674,88 @@ mod tests {
     fn resolve_workspace_folder_returns_absolute_path() {
         let result = resolve_workspace_folder(None).unwrap();
         assert!(result.is_absolute());
+    }
+
+    // ── append_ai_keys ─────────────────────────────────────────────
+
+    /// Serialize tests that mutate the process environment.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn append_ai_keys_skips_without_workspace_label() {
+        let labels = std::collections::HashMap::new();
+        let mut env = Vec::new();
+        append_ai_keys(&mut env, &labels);
+        assert!(
+            env.is_empty(),
+            "no keys should be forwarded without workspace label"
+        );
+    }
+
+    #[test]
+    fn append_ai_keys_skips_empty_workspace_label() {
+        let mut labels = std::collections::HashMap::new();
+        labels.insert("dev.cella.workspace_path".to_string(), "  ".to_string());
+        let mut env = Vec::new();
+        append_ai_keys(&mut env, &labels);
+        assert!(
+            env.is_empty(),
+            "no keys should be forwarded with empty workspace label"
+        );
+    }
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn append_ai_keys_forwards_host_key() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        unsafe { std::env::set_var("COHERE_API_KEY", "test-cohere") };
+
+        // Use a temp dir that has no config files → default settings (all enabled)
+        let tmp = std::env::temp_dir();
+        let mut labels = std::collections::HashMap::new();
+        labels.insert(
+            "dev.cella.workspace_path".to_string(),
+            tmp.to_string_lossy().to_string(),
+        );
+
+        let mut env = Vec::new();
+        append_ai_keys(&mut env, &labels);
+        assert!(
+            env.iter().any(|e| e == "COHERE_API_KEY=test-cohere"),
+            "host COHERE_API_KEY should be forwarded"
+        );
+        unsafe { std::env::remove_var("COHERE_API_KEY") };
+    }
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn append_ai_keys_skips_existing_override() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        unsafe { std::env::set_var("OPENAI_API_KEY", "host-key") };
+
+        let tmp = std::env::temp_dir();
+        let mut labels = std::collections::HashMap::new();
+        labels.insert(
+            "dev.cella.workspace_path".to_string(),
+            tmp.to_string_lossy().to_string(),
+        );
+
+        // Simulate a user override via remoteEnv/containerEnv
+        let mut env = vec!["OPENAI_API_KEY=user-override".to_string()];
+        append_ai_keys(&mut env, &labels);
+
+        // Should still have exactly the original entry, not a duplicate
+        let count = env
+            .iter()
+            .filter(|e| e.starts_with("OPENAI_API_KEY="))
+            .count();
+        assert_eq!(count, 1, "existing override should block auto-forwarding");
+        assert_eq!(env[0], "OPENAI_API_KEY=user-override");
+
+        unsafe { std::env::remove_var("OPENAI_API_KEY") };
     }
 }

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -290,12 +290,13 @@ pub async fn resolve_service_container(
 /// then detects keys that are present on the host, enabled in config,
 /// and not already set by the user (via `remoteEnv` / `containerEnv`).
 pub fn append_ai_keys(env: &mut Vec<String>, labels: &std::collections::HashMap<String, String>) {
+    // Only forward host AI credentials to cella-managed containers.
+    // Without the workspace label, this could be a non-cella container
+    // targeted by --container-id, and leaking keys would be unexpected.
     let Some(workspace_path) = labels
         .get("dev.cella.workspace_path")
         .filter(|p| !p.trim().is_empty())
     else {
-        // Only forward host AI credentials to containers that carry the
-        // trusted workspace label identifying them as cella-managed.
         return;
     };
 

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -758,4 +758,60 @@ mod tests {
 
         unsafe { std::env::remove_var("OPENAI_API_KEY") };
     }
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn append_ai_keys_respects_config_disables() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        unsafe { std::env::set_var("OPENAI_API_KEY", "host-key") };
+
+        let workspace = std::env::temp_dir().join(format!(
+            "cella-append-ai-keys-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        let devcontainer_dir = workspace.join(".devcontainer");
+        std::fs::create_dir_all(&devcontainer_dir).expect("create .devcontainer directory");
+
+        let mut labels = std::collections::HashMap::new();
+        labels.insert(
+            "dev.cella.workspace_path".to_string(),
+            workspace.to_string_lossy().to_string(),
+        );
+
+        // Global disable: [credentials.ai] enabled = false
+        std::fs::write(
+            devcontainer_dir.join("cella.toml"),
+            "[credentials.ai]\nenabled = false\n",
+        )
+        .expect("write disabled AI config");
+
+        let mut env = Vec::new();
+        append_ai_keys(&mut env, &labels);
+        assert!(
+            !env.iter().any(|e| e.starts_with("OPENAI_API_KEY=")),
+            "OPENAI_API_KEY should not be forwarded when [credentials.ai] enabled = false"
+        );
+
+        // Per-provider disable: openai = false
+        std::fs::write(
+            devcontainer_dir.join("cella.toml"),
+            "[credentials.ai]\nopenai = false\n",
+        )
+        .expect("write provider-disabled AI config");
+
+        let mut env = Vec::new();
+        append_ai_keys(&mut env, &labels);
+        assert!(
+            !env.iter().any(|e| e.starts_with("OPENAI_API_KEY=")),
+            "OPENAI_API_KEY should not be forwarded when [credentials.ai] openai = false"
+        );
+
+        unsafe { std::env::remove_var("OPENAI_API_KEY") };
+        let _ = std::fs::remove_dir_all(&workspace);
+    }
 }

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -284,6 +284,33 @@ pub async fn resolve_service_container(
         .ok_or_else(|| format!("Service '{svc}' not found in compose project '{project}'").into())
 }
 
+/// Append AI provider API keys from the host environment into `env`.
+///
+/// Loads settings from the workspace path label on the container,
+/// then detects keys that are present on the host, enabled in config,
+/// and not already set by the user (via `remoteEnv` / `containerEnv`).
+pub fn append_ai_keys(env: &mut Vec<String>, labels: &std::collections::HashMap<String, String>) {
+    let settings = labels
+        .get("dev.cella.workspace_path")
+        .map(std::path::Path::new)
+        .map_or_else(cella_config::settings::Settings::default, |p| {
+            cella_config::settings::Settings::load(p)
+        });
+    let ai = &settings.credentials.ai;
+    if !ai.enabled {
+        return;
+    }
+    let existing_keys: Vec<&str> = env
+        .iter()
+        .filter_map(|e| e.split_once('=').map(|(k, _)| k))
+        .collect();
+    let ai_keys =
+        cella_env::ai_keys::detect_ai_keys(&|id| ai.is_provider_enabled(id), &existing_keys);
+    for (key, value) in ai_keys {
+        env.push(format!("{key}={value}"));
+    }
+}
+
 /// Terminal environment variables to forward into the container.
 pub const TERMINAL_ENV_VARS: &[&str] = &[
     "TERM",

--- a/crates/cella-cli/src/commands/shell.rs
+++ b/crates/cella-cli/src/commands/shell.rs
@@ -120,6 +120,9 @@ impl ShellArgs {
         )
         .await;
 
+        // Forward AI provider API keys from host environment
+        super::append_ai_keys(&mut env, &container.labels);
+
         for var in super::TERMINAL_ENV_VARS {
             if let Ok(val) = std::env::var(var) {
                 env.push(format!("{var}={val}"));

--- a/crates/cella-config/src/settings/ai_credentials.rs
+++ b/crates/cella-config/src/settings/ai_credentials.rs
@@ -1,0 +1,92 @@
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+
+const fn default_true() -> bool {
+    true
+}
+
+/// AI provider API key forwarding settings.
+///
+/// Controls which AI provider API keys are automatically forwarded
+/// from the host environment into dev containers during `exec`/`shell`.
+///
+/// Per-provider toggles are stored as a flattened map so that adding
+/// new providers does not require struct changes. Unknown keys default
+/// to enabled.
+///
+/// Config section: `[credentials.ai]`
+#[derive(Debug, Clone, Deserialize)]
+pub struct AiCredentials {
+    /// Global toggle for AI key forwarding (default: true).
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+
+    /// Per-provider overrides. Key is the provider id (e.g. `"openai"`),
+    /// value is whether forwarding is enabled. Missing providers default
+    /// to `true`.
+    #[serde(flatten)]
+    pub providers: BTreeMap<String, bool>,
+}
+
+impl AiCredentials {
+    /// Check whether a specific provider is enabled.
+    ///
+    /// Returns `false` if the global toggle is off.
+    /// Returns the per-provider override if set, otherwise `true`.
+    pub fn is_provider_enabled(&self, id: &str) -> bool {
+        if !self.enabled {
+            return false;
+        }
+        self.providers.get(id).copied().unwrap_or(true)
+    }
+}
+
+impl Default for AiCredentials {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            providers: BTreeMap::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_enables_all() {
+        let creds = AiCredentials::default();
+        assert!(creds.enabled);
+        assert!(creds.is_provider_enabled("anthropic"));
+        assert!(creds.is_provider_enabled("openai"));
+        assert!(creds.is_provider_enabled("gemini"));
+    }
+
+    #[test]
+    fn deserialize_empty_uses_defaults() {
+        let creds: AiCredentials = toml::from_str("").unwrap();
+        assert!(creds.enabled);
+        assert!(creds.is_provider_enabled("anthropic"));
+        assert!(creds.is_provider_enabled("openai"));
+    }
+
+    #[test]
+    fn deserialize_global_disable() {
+        let creds: AiCredentials = toml::from_str("enabled = false").unwrap();
+        assert!(!creds.enabled);
+        // Global toggle overrides even unlisted providers
+        assert!(!creds.is_provider_enabled("anthropic"));
+    }
+
+    #[test]
+    fn deserialize_individual_disable() {
+        let creds: AiCredentials = toml::from_str("openai = false\ngroq = false").unwrap();
+        assert!(creds.enabled);
+        assert!(!creds.is_provider_enabled("openai"));
+        assert!(!creds.is_provider_enabled("groq"));
+        assert!(creds.is_provider_enabled("anthropic"));
+        assert!(creds.is_provider_enabled("gemini"));
+    }
+}

--- a/crates/cella-config/src/settings/credentials.rs
+++ b/crates/cella-config/src/settings/credentials.rs
@@ -1,5 +1,7 @@
 use serde::Deserialize;
 
+use super::AiCredentials;
+
 const fn default_true() -> bool {
     true
 }
@@ -10,12 +12,18 @@ pub struct Credentials {
     /// Forward gh CLI credentials into containers (default: true).
     #[serde(default = "default_true")]
     pub gh: bool,
-    // Future: claude, codex, gemini
+
+    /// AI provider API key forwarding settings.
+    #[serde(default)]
+    pub ai: AiCredentials,
 }
 
 impl Default for Credentials {
     fn default() -> Self {
-        Self { gh: true }
+        Self {
+            gh: true,
+            ai: AiCredentials::default(),
+        }
     }
 }
 
@@ -27,12 +35,14 @@ mod tests {
     fn default_enables_gh() {
         let settings = Credentials::default();
         assert!(settings.gh);
+        assert!(settings.ai.enabled);
     }
 
     #[test]
     fn deserialize_empty_uses_defaults() {
         let settings: Credentials = toml::from_str("").unwrap();
         assert!(settings.gh);
+        assert!(settings.ai.enabled);
     }
 
     #[test]
@@ -45,5 +55,14 @@ mod tests {
     fn deserialize_explicit_true() {
         let settings: Credentials = toml::from_str("gh = true").unwrap();
         assert!(settings.gh);
+    }
+
+    #[test]
+    fn deserialize_nested_ai_section() {
+        let settings: Credentials = toml::from_str("[ai]\nopenai = false\nenabled = true").unwrap();
+        assert!(settings.gh);
+        assert!(settings.ai.enabled);
+        assert!(!settings.ai.is_provider_enabled("openai"));
+        assert!(settings.ai.is_provider_enabled("anthropic"));
     }
 }

--- a/crates/cella-config/src/settings/mod.rs
+++ b/crates/cella-config/src/settings/mod.rs
@@ -1,3 +1,4 @@
+mod ai_credentials;
 mod claude_code;
 mod codex;
 mod credentials;
@@ -11,6 +12,7 @@ use std::path::Path;
 use serde::Deserialize;
 use tracing::debug;
 
+pub use ai_credentials::AiCredentials;
 pub use claude_code::ClaudeCode;
 pub use codex::Codex;
 pub use credentials::Credentials;
@@ -149,6 +151,7 @@ mod tests {
     fn default_settings() {
         let settings = Settings::default();
         assert!(settings.credentials.gh);
+        assert!(settings.credentials.ai.enabled);
         assert!(settings.tools.claude_code.enabled);
         assert!(settings.tools.claude_code.forward_config);
         assert_eq!(settings.tools.claude_code.version, "latest");
@@ -200,6 +203,10 @@ mod tests {
 [credentials]
 gh = false
 
+[credentials.ai]
+enabled = true
+openai = false
+
 [tools.claude-code]
 enabled = false
 version = "stable"
@@ -223,6 +230,9 @@ config_path = "~/dotfiles/.tmux.conf"
 "#;
         let settings: Settings = toml::from_str(toml_str).unwrap();
         assert!(!settings.credentials.gh);
+        assert!(settings.credentials.ai.enabled);
+        assert!(!settings.credentials.ai.is_provider_enabled("openai"));
+        assert!(settings.credentials.ai.is_provider_enabled("anthropic"));
         assert!(!settings.tools.claude_code.enabled);
         assert_eq!(settings.tools.claude_code.version, "stable");
         assert!(!settings.tools.codex.enabled);
@@ -297,11 +307,17 @@ version = "0.5.0"
     #[test]
     fn merge_project_overrides_global() {
         let global = Settings {
-            credentials: Credentials { gh: true },
+            credentials: Credentials {
+                gh: true,
+                ..Default::default()
+            },
             ..Default::default()
         };
         let project = Settings {
-            credentials: Credentials { gh: false },
+            credentials: Credentials {
+                gh: false,
+                ..Default::default()
+            },
             ..Default::default()
         };
         let merged = Settings::merge(Some(global), Some(project));
@@ -311,7 +327,10 @@ version = "0.5.0"
     #[test]
     fn merge_global_only() {
         let global = Settings {
-            credentials: Credentials { gh: false },
+            credentials: Credentials {
+                gh: false,
+                ..Default::default()
+            },
             ..Default::default()
         };
         let merged = Settings::merge(Some(global), None);

--- a/crates/cella-env/src/ai_keys.rs
+++ b/crates/cella-env/src/ai_keys.rs
@@ -87,6 +87,14 @@ pub fn detect_ai_keys(
         .collect()
 }
 
+/// Returns `true` if at least one known AI API key env var is set and
+/// non-empty on the host. Cheap check — no disk I/O.
+pub fn any_ai_key_present() -> bool {
+    AI_PROVIDERS
+        .iter()
+        .any(|p| std::env::var(p.env_var).ok().is_some_and(|v| !v.is_empty()))
+}
+
 /// Return the names of AI API keys detected on the host (for logging).
 ///
 /// Never returns values, only key names.
@@ -196,5 +204,16 @@ mod tests {
             assert!(!name.contains("secret"));
         }
         unsafe { std::env::remove_var("XAI_API_KEY") };
+    }
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn any_ai_key_present_returns_true_when_set() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        unsafe { std::env::set_var("DEEPSEEK_API_KEY", "dk-test") };
+        assert!(any_ai_key_present());
+        unsafe { std::env::remove_var("DEEPSEEK_API_KEY") };
     }
 }

--- a/crates/cella-env/src/ai_keys.rs
+++ b/crates/cella-env/src/ai_keys.rs
@@ -103,6 +103,14 @@ pub fn detect_ai_key_names(provider_enabled: &dyn Fn(&str) -> bool) -> Vec<&'sta
 mod tests {
     use super::*;
 
+    /// Serialize tests that mutate the process environment.
+    ///
+    /// `std::env::set_var` / `remove_var` are `unsafe` in Rust 2024 because
+    /// concurrent access from multiple threads is UB.  Cargo runs tests in
+    /// parallel by default, so every test that touches env vars must hold
+    /// this lock first.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn providers_count() {
         assert_eq!(AI_PROVIDERS.len(), 11);
@@ -127,6 +135,9 @@ mod tests {
     #[test]
     #[allow(unsafe_code)]
     fn detect_skips_disabled_provider() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         // Even if the env var is set, disabled providers are skipped
         unsafe { std::env::set_var("ANTHROPIC_API_KEY", "test-key") };
         let keys = detect_ai_keys(&|id| id != "anthropic", &[]);
@@ -137,6 +148,9 @@ mod tests {
     #[test]
     #[allow(unsafe_code)]
     fn detect_skips_user_override() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         unsafe { std::env::set_var("OPENAI_API_KEY", "test-key") };
         let keys = detect_ai_keys(&|_| true, &["OPENAI_API_KEY"]);
         assert!(!keys.iter().any(|(k, _)| k == "OPENAI_API_KEY"));
@@ -146,6 +160,9 @@ mod tests {
     #[test]
     #[allow(unsafe_code)]
     fn detect_skips_empty_value() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         unsafe { std::env::set_var("GEMINI_API_KEY", "") };
         let keys = detect_ai_keys(&|_| true, &[]);
         assert!(!keys.iter().any(|(k, _)| k == "GEMINI_API_KEY"));
@@ -155,6 +172,9 @@ mod tests {
     #[test]
     #[allow(unsafe_code)]
     fn detect_returns_present_key() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         unsafe { std::env::set_var("COHERE_API_KEY", "ck-test") };
         let keys = detect_ai_keys(&|_| true, &[]);
         let found = keys.iter().find(|(k, _)| k == "COHERE_API_KEY");
@@ -165,6 +185,9 @@ mod tests {
     #[test]
     #[allow(unsafe_code)]
     fn detect_key_names_never_returns_values() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         unsafe { std::env::set_var("XAI_API_KEY", "secret-value") };
         let names = detect_ai_key_names(&|_| true);
         assert!(names.contains(&"XAI_API_KEY"));

--- a/crates/cella-env/src/ai_keys.rs
+++ b/crates/cella-env/src/ai_keys.rs
@@ -1,0 +1,177 @@
+//! AI provider API key detection and forwarding.
+//!
+//! Reads known AI provider API keys from the host environment and
+//! produces env var entries for container injection. Keys are read
+//! live from the host process on every `exec`/`shell` invocation —
+//! never stored in labels or baked at creation time.
+
+/// A known AI provider and its primary API key environment variable.
+pub struct AiProvider {
+    /// Short provider identifier (e.g., `"anthropic"`, `"openai"`).
+    ///
+    /// Matches the field name in `[credentials.ai]` config.
+    pub id: &'static str,
+
+    /// Environment variable name (e.g., `"ANTHROPIC_API_KEY"`).
+    pub env_var: &'static str,
+}
+
+/// All known AI provider API key mappings.
+pub const AI_PROVIDERS: &[AiProvider] = &[
+    AiProvider {
+        id: "anthropic",
+        env_var: "ANTHROPIC_API_KEY",
+    },
+    AiProvider {
+        id: "openai",
+        env_var: "OPENAI_API_KEY",
+    },
+    AiProvider {
+        id: "gemini",
+        env_var: "GEMINI_API_KEY",
+    },
+    AiProvider {
+        id: "groq",
+        env_var: "GROQ_API_KEY",
+    },
+    AiProvider {
+        id: "mistral",
+        env_var: "MISTRAL_API_KEY",
+    },
+    AiProvider {
+        id: "deepseek",
+        env_var: "DEEPSEEK_API_KEY",
+    },
+    AiProvider {
+        id: "xai",
+        env_var: "XAI_API_KEY",
+    },
+    AiProvider {
+        id: "fireworks",
+        env_var: "FIREWORKS_API_KEY",
+    },
+    AiProvider {
+        id: "together",
+        env_var: "TOGETHER_API_KEY",
+    },
+    AiProvider {
+        id: "perplexity",
+        env_var: "PERPLEXITY_API_KEY",
+    },
+    AiProvider {
+        id: "cohere",
+        env_var: "COHERE_API_KEY",
+    },
+];
+
+/// Detect AI API keys present in the host environment.
+///
+/// Returns `(env_var_name, value)` pairs for keys that:
+/// 1. Are present and non-empty in the host environment
+/// 2. Are enabled via the `provider_enabled` predicate
+/// 3. Are NOT already set by the user (checked via `user_env_keys`)
+pub fn detect_ai_keys(
+    provider_enabled: &dyn Fn(&str) -> bool,
+    user_env_keys: &[&str],
+) -> Vec<(String, String)> {
+    AI_PROVIDERS
+        .iter()
+        .filter(|p| provider_enabled(p.id))
+        .filter(|p| !user_env_keys.contains(&p.env_var))
+        .filter_map(|p| {
+            std::env::var(p.env_var)
+                .ok()
+                .filter(|v| !v.is_empty())
+                .map(|v| (p.env_var.to_string(), v))
+        })
+        .collect()
+}
+
+/// Return the names of AI API keys detected on the host (for logging).
+///
+/// Never returns values, only key names.
+pub fn detect_ai_key_names(provider_enabled: &dyn Fn(&str) -> bool) -> Vec<&'static str> {
+    AI_PROVIDERS
+        .iter()
+        .filter(|p| provider_enabled(p.id))
+        .filter(|p| std::env::var(p.env_var).ok().is_some_and(|v| !v.is_empty()))
+        .map(|p| p.env_var)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn providers_count() {
+        assert_eq!(AI_PROVIDERS.len(), 11);
+    }
+
+    #[test]
+    fn providers_unique_env_vars() {
+        let mut seen = std::collections::HashSet::new();
+        for p in AI_PROVIDERS {
+            assert!(seen.insert(p.env_var), "duplicate env var: {}", p.env_var);
+        }
+    }
+
+    #[test]
+    fn providers_unique_ids() {
+        let mut seen = std::collections::HashSet::new();
+        for p in AI_PROVIDERS {
+            assert!(seen.insert(p.id), "duplicate id: {}", p.id);
+        }
+    }
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn detect_skips_disabled_provider() {
+        // Even if the env var is set, disabled providers are skipped
+        unsafe { std::env::set_var("ANTHROPIC_API_KEY", "test-key") };
+        let keys = detect_ai_keys(&|id| id != "anthropic", &[]);
+        assert!(!keys.iter().any(|(k, _)| k == "ANTHROPIC_API_KEY"));
+        unsafe { std::env::remove_var("ANTHROPIC_API_KEY") };
+    }
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn detect_skips_user_override() {
+        unsafe { std::env::set_var("OPENAI_API_KEY", "test-key") };
+        let keys = detect_ai_keys(&|_| true, &["OPENAI_API_KEY"]);
+        assert!(!keys.iter().any(|(k, _)| k == "OPENAI_API_KEY"));
+        unsafe { std::env::remove_var("OPENAI_API_KEY") };
+    }
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn detect_skips_empty_value() {
+        unsafe { std::env::set_var("GEMINI_API_KEY", "") };
+        let keys = detect_ai_keys(&|_| true, &[]);
+        assert!(!keys.iter().any(|(k, _)| k == "GEMINI_API_KEY"));
+        unsafe { std::env::remove_var("GEMINI_API_KEY") };
+    }
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn detect_returns_present_key() {
+        unsafe { std::env::set_var("COHERE_API_KEY", "ck-test") };
+        let keys = detect_ai_keys(&|_| true, &[]);
+        let found = keys.iter().find(|(k, _)| k == "COHERE_API_KEY");
+        assert_eq!(found.map(|(_, v)| v.as_str()), Some("ck-test"));
+        unsafe { std::env::remove_var("COHERE_API_KEY") };
+    }
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn detect_key_names_never_returns_values() {
+        unsafe { std::env::set_var("XAI_API_KEY", "secret-value") };
+        let names = detect_ai_key_names(&|_| true);
+        assert!(names.contains(&"XAI_API_KEY"));
+        // Ensure we only get the name, not the value
+        for name in &names {
+            assert!(!name.contains("secret"));
+        }
+        unsafe { std::env::remove_var("XAI_API_KEY") };
+    }
+}

--- a/crates/cella-env/src/lib.rs
+++ b/crates/cella-env/src/lib.rs
@@ -4,6 +4,7 @@
 //! then produces mounts, env vars, and post-start injection commands
 //! for the container.
 
+pub mod ai_keys;
 pub mod ca_bundle;
 pub mod claude_code;
 pub mod codex;

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -861,7 +861,10 @@ impl EnsureUpContext<'_> {
             let detected =
                 cella_env::ai_keys::detect_ai_key_names(&|id| ai.is_provider_enabled(id));
             if !detected.is_empty() {
-                tracing::info!("Forwarding AI API keys: {}", detected.join(", "));
+                tracing::info!(
+                    "Detected AI API keys eligible for forwarding: {}",
+                    detected.join(", ")
+                );
             }
         }
 

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -855,6 +855,16 @@ impl EnsureUpContext<'_> {
             .await;
         }
 
+        // Log detected AI API keys (names only, never values)
+        if settings.credentials.ai.enabled {
+            let ai = &settings.credentials.ai;
+            let detected =
+                cella_env::ai_keys::detect_ai_key_names(&|id| ai.is_provider_enabled(id));
+            if !detected.is_empty() {
+                tracing::info!("Forwarding AI API keys: {}", detected.join(", "));
+            }
+        }
+
         let shell = crate::shell_detect::detect_shell(self.client, container_id, remote_user).await;
         let probed_env = run_step_result(&self.progress, "Running userEnvProbe...", async {
             Ok::<_, std::convert::Infallible>(

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -862,7 +862,7 @@ impl EnsureUpContext<'_> {
                 cella_env::ai_keys::detect_ai_key_names(&|id| ai.is_provider_enabled(id));
             if !detected.is_empty() {
                 tracing::info!(
-                    "Detected AI API keys eligible for forwarding: {}",
+                    "AI API keys detected for exec/shell forwarding: {}",
                     detected.join(", ")
                 );
             }

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -861,7 +861,7 @@ impl EnsureUpContext<'_> {
             let detected =
                 cella_env::ai_keys::detect_ai_key_names(&|id| ai.is_provider_enabled(id));
             if !detected.is_empty() {
-                tracing::info!(
+                tracing::debug!(
                     "AI API keys detected for exec/shell forwarding: {}",
                     detected.join(", ")
                 );


### PR DESCRIPTION
## Summary

- Auto-detect 11 known AI provider API keys on the host and inject them live into `cella exec` / `cella shell` sessions
- Keys are read fresh from the host environment on every invocation — no stale snapshots or label storage
- New `[credentials.ai]` config section with global toggle and per-provider overrides
- Respects user overrides in `containerEnv`/`remoteEnv` (skips auto-forwarding if already set)
- Logs detected key names (never values) during `cella up`

### Supported providers

`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, `GROQ_API_KEY`, `MISTRAL_API_KEY`, `DEEPSEEK_API_KEY`, `XAI_API_KEY`, `FIREWORKS_API_KEY`, `TOGETHER_API_KEY`, `PERPLEXITY_API_KEY`, `COHERE_API_KEY`

### Config

```toml
# ~/.cella/config.toml or .devcontainer/cella.toml
[credentials.ai]
enabled = true    # global toggle (default: true)
openai = false    # disable specific provider
```

## Test plan

- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings -D clippy::all` passes
- [ ] `cargo test --workspace` passes (including new unit tests)
- [ ] Set `OPENAI_API_KEY=test` on host, run `cella exec -- env | grep OPENAI` — key appears
- [ ] Set `remoteEnv: {"OPENAI_API_KEY": "override"}` in devcontainer.json — auto-forwarding skipped
- [ ] Set `[credentials.ai] openai = false` in config.toml — `OPENAI_API_KEY` not forwarded
- [ ] Set `[credentials.ai] enabled = false` — no AI keys forwarded

🤖 Generated with [Claude Code](https://claude.com/claude-code)