### PR TITLE
fix: agent lifecycle and port forwarding after restart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ cargo test -p cella-features -p cella-daemon -p cella-compose --features integra
 
 Update snapshots with `cargo insta review`.
 
+**Note:** `cargo-insta` may not be installed in dev containers. Use `cargo test` to check snapshot correctness; update snapshots from the host with `cargo insta review`.
+
 ## Testing
 
 - Unit tests colocated in source files (`#[cfg(test)] mod tests`) — not separate test directories
@@ -42,6 +44,7 @@ Always research before suggesting changes or asking the user questions. Use `/sp
 - No `#[allow(clippy::...)]` annotations — fix the warning or restructure the code
 - No `_`-prefixed unused variables — delete dead code entirely
 - Workspace lints: clippy::pedantic + clippy::nursery (warn), unsafe_code (deny), unused_qualifications (deny)
+- `clippy::significant_drop_tightening` is active — inline mutex `.lock().await.method()` calls instead of binding the guard to a variable when only one method call is needed
 - Error types: thiserror for custom errors, miette for user-facing diagnostics
 - Async: tokio runtime, bollard for Docker API, gix for git operations
 - No backward compatibility constraints — refactor freely when improving code
@@ -57,6 +60,12 @@ Rust workspace (edition 2024, MSRV 1.94.0) with 19 crates in `crates/`. Three-ti
 - **Tier 3 (Foundation):** cella-backend, cella-port, cella-codegen, cella-network, cella-protocol, cella-jsonc
 
 Backend-agnostic design: cella-backend defines traits, cella-docker and cella-container implement them. Hooks pattern (PruneHooks, ComposeUpHooks, UpHooks) bridges CLI-owned operations into the orchestrator without circular dependencies.
+
+Key runtime constraints:
+- The `cella-agent` Docker volume is shared across ALL containers — changes affect every running container
+- Daemon state (port allocations, registrations) is in-memory only, lost on daemon restart
+- Docker container labels and env vars are immutable after creation — don't design around updating them
+- The agent entrypoint runs in a restart loop; `restart_agent_in_container()` just sends pkill and the loop handles restart
 
 ## Commits & PRs
 

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -594,27 +594,31 @@ impl cella_orchestrator::up::UpHooks for CliUpHooks<'_> {
         &self,
         container_id: &str,
         container_ip: Option<&str>,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+    ) -> Pin<Box<dyn Future<Output = bool> + Send + '_>> {
         let container_id = container_id.to_string();
         let container_ip = container_ip.map(str::to_string);
         let managed_agent = self.managed_agent;
         Box::pin(async move {
             if !managed_agent {
-                return;
+                return true;
             }
 
             let Some(mgmt_sock) = cella_env::paths::daemon_socket_path() else {
-                return;
+                return false;
             };
             if !mgmt_sock.exists() {
-                return;
+                return false;
             }
 
             let req = cella_protocol::ManagementRequest::UpdateContainerIp {
-                container_id,
+                container_id: container_id.clone(),
                 container_ip,
             };
-            let _ = cella_daemon::management::send_management_request(&mgmt_sock, &req).await;
+            // Check if the daemon recognized the container.
+            matches!(
+                cella_daemon::management::send_management_request(&mgmt_sock, &req).await,
+                Ok(cella_protocol::ManagementResponse::ContainerIpUpdated { .. })
+            )
         })
     }
 

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -590,6 +590,34 @@ impl cella_orchestrator::up::UpHooks for CliUpHooks<'_> {
         })
     }
 
+    fn update_container_ip(
+        &self,
+        container_id: &str,
+        container_ip: Option<&str>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        let container_id = container_id.to_string();
+        let container_ip = container_ip.map(str::to_string);
+        let managed_agent = self.managed_agent;
+        Box::pin(async move {
+            if !managed_agent {
+                return;
+            }
+
+            let Some(mgmt_sock) = cella_env::paths::daemon_socket_path() else {
+                return;
+            };
+            if !mgmt_sock.exists() {
+                return;
+            }
+
+            let req = cella_protocol::ManagementRequest::UpdateContainerIp {
+                container_id,
+                container_ip,
+            };
+            let _ = cella_daemon::management::send_management_request(&mgmt_sock, &req).await;
+        })
+    }
+
     fn on_container_stopping(
         &self,
         container_name: &str,

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -39,6 +39,8 @@ pub(crate) struct ControlContext {
 pub struct AgentConnectionState {
     pub connected: AtomicBool,
     pub last_seen_secs: AtomicU64,
+    /// Agent version from the most recent `AgentHello` handshake.
+    pub agent_version: std::sync::Mutex<Option<String>>,
 }
 
 impl AgentConnectionState {
@@ -46,6 +48,7 @@ impl AgentConnectionState {
         Self {
             connected: AtomicBool::new(false),
             last_seen_secs: AtomicU64::new(0),
+            agent_version: std::sync::Mutex::new(None),
         }
     }
 }
@@ -207,6 +210,11 @@ where
         let pm = ctx.port_manager.lock().await;
         pm.container_ip(&container_id).map(String::from)
     };
+
+    // Store the live agent version for status queries.
+    if let Ok(mut v) = agent_state.agent_version.lock() {
+        *v = Some(agent_hello.agent_version.clone());
+    }
 
     if agent_hello.agent_version != env!("CARGO_PKG_VERSION") {
         warn!(

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -346,6 +346,14 @@ async fn handle_agent_connection(
         }
     }
 
+    // Connection closed — clear live state so status queries don't report
+    // stale version/connectivity info for this container.
+    hs.agent_state.connected.store(false, Ordering::Relaxed);
+    if let Ok(mut v) = hs.agent_state.agent_version.lock() {
+        *v = None;
+    }
+    info!("Agent disconnected for container {}", hs.container_name);
+
     Ok(())
 }
 

--- a/crates/cella-daemon/src/management.rs
+++ b/crates/cella-daemon/src/management.rs
@@ -226,6 +226,22 @@ async fn handle_management_request(
             )
             .await
         }
+        ManagementRequest::UpdateContainerIp {
+            container_id,
+            container_ip,
+        } => {
+            let found = ctx
+                .port_manager
+                .lock()
+                .await
+                .update_container_ip(&container_id, container_ip);
+            if found {
+                info!("Updated container IP for {container_id}");
+            } else {
+                warn!("UpdateContainerIp: unknown container {container_id}");
+            }
+            ManagementResponse::ContainerIpUpdated { container_id }
+        }
         ManagementRequest::Ping => ManagementResponse::Pong,
         ManagementRequest::Shutdown => {
             let pid = std::process::id();

--- a/crates/cella-daemon/src/management.rs
+++ b/crates/cella-daemon/src/management.rs
@@ -208,7 +208,7 @@ async fn handle_management_request(
                 backend_kind: data.backend_kind,
                 docker_host: data.docker_host,
             };
-            handle_register(reg, &ctx.port_manager, container_handles).await
+            handle_register(reg, &ctx.port_manager, container_handles, &ctx.proxy_cmd_tx).await
         }
         ManagementRequest::DeregisterContainer { container_name } => {
             handle_deregister(&container_name, &ctx.port_manager, container_handles).await
@@ -269,17 +269,25 @@ async fn handle_register(
     reg: ContainerRegistration,
     port_manager: &Arc<Mutex<PortManager>>,
     container_handles: &Arc<Mutex<HashMap<String, ContainerHandle>>>,
+    proxy_cmd_tx: &mpsc::Sender<ProxyCommand>,
 ) -> ManagementResponse {
     // Register with port manager
     {
         let mut pm = port_manager.lock().await;
-        pm.register_container(
+        let released = pm.register_container(
             &reg.container_id,
             &reg.container_name,
             reg.container_ip,
             reg.ports_attributes,
             reg.other_ports_attributes,
         );
+
+        // Stop coordinator-owned proxies for ports released by re-registration.
+        for hp in released {
+            let _ = proxy_cmd_tx
+                .send(ProxyCommand::Stop { host_port: hp })
+                .await;
+        }
 
         // Pre-allocate host ports for forwardPorts
         for &fwd_port in &reg.forward_ports {

--- a/crates/cella-daemon/src/management.rs
+++ b/crates/cella-daemon/src/management.rs
@@ -400,6 +400,12 @@ async fn handle_query_status(
                 forwarded_port_count: port_count,
                 agent_connected: handle.agent_state.connected.load(Ordering::Relaxed),
                 last_seen_secs: handle.agent_state.last_seen_secs.load(Ordering::Relaxed),
+                agent_version: handle
+                    .agent_state
+                    .agent_version
+                    .lock()
+                    .ok()
+                    .and_then(|v| v.clone()),
             }
         })
         .collect();

--- a/crates/cella-daemon/src/management.rs
+++ b/crates/cella-daemon/src/management.rs
@@ -237,10 +237,13 @@ async fn handle_management_request(
                 .update_container_ip(&container_id, container_ip);
             if found {
                 info!("Updated container IP for {container_id}");
+                ManagementResponse::ContainerIpUpdated { container_id }
             } else {
                 warn!("UpdateContainerIp: unknown container {container_id}");
+                ManagementResponse::Error {
+                    message: format!("unknown container: {container_id}"),
+                }
             }
-            ManagementResponse::ContainerIpUpdated { container_id }
         }
         ManagementRequest::Ping => ManagementResponse::Pong,
         ManagementRequest::Shutdown => {

--- a/crates/cella-daemon/src/port_manager.rs
+++ b/crates/cella-daemon/src/port_manager.rs
@@ -113,6 +113,19 @@ impl PortManager {
         );
     }
 
+    /// Update a container's IP address without touching ports or allocations.
+    ///
+    /// Used after pre-registration (with `None` IP) once the container is
+    /// running and its IP is known.  Returns `true` if the container was found.
+    pub fn update_container_ip(&mut self, container_id: &str, ip: Option<String>) -> bool {
+        if let Some(container) = self.containers.get_mut(container_id) {
+            container.container_ip = ip;
+            true
+        } else {
+            false
+        }
+    }
+
     /// Get the container's IP address.
     pub fn container_ip(&self, container_id: &str) -> Option<&str> {
         self.containers
@@ -488,5 +501,26 @@ mod tests {
             Some(3000),
             "port should get native allocation after re-register"
         );
+    }
+
+    #[test]
+    fn update_container_ip_preserves_ports() {
+        let mut pm = PortManager::new(false);
+        pm.register_container("c1", "test", None, vec![], None);
+        pm.handle_port_open("c1", 3000, PortProtocol::Tcp, None);
+
+        assert!(pm.update_container_ip("c1", Some("172.20.0.5".to_string())));
+        assert_eq!(pm.container_ip("c1"), Some("172.20.0.5"));
+
+        // Ports must still be forwarded after IP update.
+        let ports = pm.all_forwarded_ports();
+        assert_eq!(ports.len(), 1);
+        assert_eq!(ports[0].host_port, 3000);
+    }
+
+    #[test]
+    fn update_container_ip_unknown_container() {
+        let mut pm = PortManager::new(false);
+        assert!(!pm.update_container_ip("unknown", Some("1.2.3.4".to_string())));
     }
 }

--- a/crates/cella-daemon/src/port_manager.rs
+++ b/crates/cella-daemon/src/port_manager.rs
@@ -6,8 +6,6 @@ use cella_port::allocation::PortAllocationTable;
 use cella_protocol::{OnAutoForward, PortAttributes, PortProtocol};
 use tracing::{info, warn};
 
-use crate::proxy::ProxyHandle;
-
 /// Check if a host port is free at the OS level.
 ///
 /// Uses a synchronous TCP bind probe. Fast (~1μs).
@@ -23,8 +21,6 @@ pub struct PortManager {
     allocation: PortAllocationTable,
     /// Whether we're running on `OrbStack` (skips TCP proxies).
     is_orbstack: bool,
-    /// Active TCP proxy handles.
-    proxy_handles: HashMap<u16, ProxyHandle>,
     /// Optional OS-level port availability check.
     port_checker: Option<Box<dyn Fn(u16) -> bool + Send + Sync>>,
 }
@@ -54,7 +50,6 @@ impl PortManager {
             containers: HashMap::new(),
             allocation: PortAllocationTable::new(),
             is_orbstack,
-            proxy_handles: HashMap::new(),
             port_checker: None,
         }
     }
@@ -75,8 +70,12 @@ impl PortManager {
     /// Register a container for port management.
     ///
     /// If the container was previously registered (e.g. after a restart),
-    /// all existing port allocations and proxy handles are released first
-    /// so the agent can re-report ports without silent remapping.
+    /// all existing port allocations are released first so the agent can
+    /// re-report ports without silent remapping.
+    ///
+    /// Returns the list of host ports that were released. The caller must
+    /// send `ProxyCommand::Stop` for each to stop the coordinator-owned
+    /// TCP proxies.
     pub fn register_container(
         &mut self,
         container_id: &str,
@@ -84,20 +83,17 @@ impl PortManager {
         container_ip: Option<String>,
         ports_attributes: Vec<PortAttributes>,
         other_ports_attributes: Option<PortAttributes>,
-    ) {
-        // Release stale allocations and proxies from a previous registration.
+    ) -> Vec<u16> {
+        let mut released_ports = Vec::new();
+
+        // Release stale allocations from a previous registration.
         if self.containers.contains_key(container_id) {
-            let released: Vec<u16> = self
+            released_ports = self
                 .allocation
                 .container_ports(container_id)
                 .iter()
                 .map(|p| p.host_port)
                 .collect();
-            for hp in released {
-                if let Some(handle) = self.proxy_handles.remove(&hp) {
-                    handle.abort();
-                }
-            }
             self.allocation.release_container(container_id);
         }
 
@@ -111,6 +107,8 @@ impl PortManager {
                 other_ports_attributes,
             },
         );
+
+        released_ports
     }
 
     /// Update a container's IP address without touching ports or allocations.
@@ -255,9 +253,6 @@ impl PortManager {
 
         if let Some(hp) = host_port {
             self.allocation.release_port(hp);
-            if let Some(handle) = self.proxy_handles.remove(&hp) {
-                handle.abort();
-            }
         }
 
         host_port

--- a/crates/cella-daemon/src/port_manager.rs
+++ b/crates/cella-daemon/src/port_manager.rs
@@ -73,6 +73,10 @@ impl PortManager {
     }
 
     /// Register a container for port management.
+    ///
+    /// If the container was previously registered (e.g. after a restart),
+    /// all existing port allocations and proxy handles are released first
+    /// so the agent can re-report ports without silent remapping.
     pub fn register_container(
         &mut self,
         container_id: &str,
@@ -81,6 +85,22 @@ impl PortManager {
         ports_attributes: Vec<PortAttributes>,
         other_ports_attributes: Option<PortAttributes>,
     ) {
+        // Release stale allocations and proxies from a previous registration.
+        if self.containers.contains_key(container_id) {
+            let released: Vec<u16> = self
+                .allocation
+                .container_ports(container_id)
+                .iter()
+                .map(|p| p.host_port)
+                .collect();
+            for hp in released {
+                if let Some(handle) = self.proxy_handles.remove(&hp) {
+                    handle.abort();
+                }
+            }
+            self.allocation.release_container(container_id);
+        }
+
         self.containers.insert(
             container_id.to_string(),
             ContainerPorts {
@@ -450,5 +470,23 @@ mod tests {
         // Re-opening should get the same port back, not 3001
         let hp = pm.handle_port_open("c1", 3000, PortProtocol::Tcp, None);
         assert_eq!(hp, Some(3000));
+    }
+
+    #[test]
+    fn re_register_releases_old_allocations() {
+        let mut pm = PortManager::new(false);
+        pm.register_container("c1", "test", None, vec![], None);
+        let hp1 = pm.handle_port_open("c1", 3000, PortProtocol::Tcp, None);
+        assert_eq!(hp1, Some(3000));
+
+        // Re-register simulates a container restart: old allocations must be
+        // released so the agent can reclaim the native port.
+        pm.register_container("c1", "test", None, vec![], None);
+        let hp2 = pm.handle_port_open("c1", 3000, PortProtocol::Tcp, None);
+        assert_eq!(
+            hp2,
+            Some(3000),
+            "port should get native allocation after re-register"
+        );
     }
 }

--- a/crates/cella-doctor/src/checks/container.rs
+++ b/crates/cella-doctor/src/checks/container.rs
@@ -162,16 +162,16 @@ async fn check_single_container(
 }
 
 async fn check_version_skew(
-    _client: &dyn ContainerBackend,
-    _container_id: &str,
+    client: &dyn ContainerBackend,
+    container_id: &str,
     checks: &mut Vec<CheckResult>,
     container_name: &str,
 ) {
     let cli_version = env!("CARGO_PKG_VERSION");
 
-    // Query the daemon for the live agent version from the AgentHello
-    // handshake. This reflects the actual running binary, not a stale
-    // Docker label or shared volume marker.
+    // Prefer the live agent version from the daemon handshake.
+    // Fall back to the Docker label when the agent isn't connected
+    // (unmanaged backend, agent crashed, etc.).
     let agent_version = query_live_agent_version(container_name).await;
 
     match agent_version.as_deref() {
@@ -192,14 +192,29 @@ async fn check_version_skew(
             });
         }
         None => {
-            // Agent not connected — version unknown. The agent connectivity
-            // check will report the connection issue separately.
-            checks.push(CheckResult {
-                name: "version".into(),
-                severity: Severity::Info,
-                detail: "agent not connected (version unknown)".into(),
-                fix_hint: None,
-            });
+            // Fall back to Docker label for unmanaged backends or
+            // disconnected agents.
+            let label_version = client
+                .inspect_container(container_id)
+                .await
+                .ok()
+                .and_then(|info| info.labels.get("dev.cella.version").cloned());
+            let container_version = label_version.as_deref().unwrap_or("unknown");
+            if container_version == cli_version {
+                checks.push(CheckResult {
+                    name: "version".into(),
+                    severity: Severity::Pass,
+                    detail: cli_version.to_string(),
+                    fix_hint: None,
+                });
+            } else {
+                checks.push(CheckResult {
+                    name: "version".into(),
+                    severity: Severity::Warning,
+                    detail: format!("container {container_version} != CLI {cli_version}"),
+                    fix_hint: Some("Run `cella up` to update".into()),
+                });
+            }
         }
     }
 }

--- a/crates/cella-doctor/src/checks/container.rs
+++ b/crates/cella-doctor/src/checks/container.rs
@@ -144,7 +144,7 @@ async fn check_single_container(
     });
 
     // Version skew check
-    check_version_skew(client, container_id, &mut checks).await;
+    check_version_skew(client, container_id, &mut checks, container_name).await;
 
     // Agent/port checks only apply to backends with managed agents
     if client.capabilities().managed_agent {
@@ -162,39 +162,70 @@ async fn check_single_container(
 }
 
 async fn check_version_skew(
-    client: &dyn ContainerBackend,
-    container_id: &str,
+    _client: &dyn ContainerBackend,
+    _container_id: &str,
     checks: &mut Vec<CheckResult>,
+    container_name: &str,
 ) {
-    let Ok(info) = client.inspect_container(container_id).await else {
-        return;
-    };
-
     let cli_version = env!("CARGO_PKG_VERSION");
 
-    // Use the per-container Docker label as the source of truth for version
-    // skew. The shared agent volume marker (/cella/.version) cannot be used
-    // here because it reflects whichever container last ran `cella up`, not
-    // the state of this specific container.
-    let container_version = info
-        .labels
-        .get("dev.cella.version")
-        .map_or("unknown", String::as_str);
+    // Query the daemon for the live agent version from the AgentHello
+    // handshake. This reflects the actual running binary, not a stale
+    // Docker label or shared volume marker.
+    let agent_version = query_live_agent_version(container_name).await;
 
-    if container_version == cli_version {
-        checks.push(CheckResult {
-            name: "version".into(),
-            severity: Severity::Pass,
-            detail: container_version.to_string(),
-            fix_hint: None,
-        });
+    match agent_version.as_deref() {
+        Some(v) if v == cli_version => {
+            checks.push(CheckResult {
+                name: "version".into(),
+                severity: Severity::Pass,
+                detail: cli_version.to_string(),
+                fix_hint: None,
+            });
+        }
+        Some(v) => {
+            checks.push(CheckResult {
+                name: "version".into(),
+                severity: Severity::Warning,
+                detail: format!("agent {v} != CLI {cli_version}"),
+                fix_hint: Some("Run `cella up` to update the agent".into()),
+            });
+        }
+        None => {
+            // Agent not connected — version unknown. The agent connectivity
+            // check will report the connection issue separately.
+            checks.push(CheckResult {
+                name: "version".into(),
+                severity: Severity::Info,
+                detail: "agent not connected (version unknown)".into(),
+                fix_hint: None,
+            });
+        }
+    }
+}
+
+/// Query the daemon for a container's live agent version.
+async fn query_live_agent_version(container_name: &str) -> Option<String> {
+    let data_dir = cella_env::paths::cella_data_dir()?;
+    let mgmt_socket = data_dir.join("daemon.sock");
+    if !mgmt_socket.exists() {
+        return None;
+    }
+
+    let resp = cella_daemon::management::send_management_request(
+        &mgmt_socket,
+        &ManagementRequest::QueryStatus,
+    )
+    .await
+    .ok()?;
+
+    if let ManagementResponse::Status { containers, .. } = resp {
+        containers
+            .into_iter()
+            .find(|c| c.container_name == container_name && c.agent_connected)
+            .and_then(|c| c.agent_version)
     } else {
-        checks.push(CheckResult {
-            name: "version".into(),
-            severity: Severity::Info,
-            detail: format!("created with {container_version} (agent binary auto-updated)"),
-            fix_hint: None,
-        });
+        None
     }
 }
 

--- a/crates/cella-doctor/src/checks/container.rs
+++ b/crates/cella-doctor/src/checks/container.rs
@@ -172,64 +172,29 @@ async fn check_version_skew(
 
     let cli_version = env!("CARGO_PKG_VERSION");
 
-    // Read the agent volume version marker to determine the actual
-    // agent binary version — this is what matters, not the container
-    // creation label (which is immutable after creation).
-    let agent_version = client
-        .exec_command(
-            container_id,
-            &ExecOptions {
-                cmd: vec!["cat".to_string(), "/cella/.version".to_string()],
-                user: None,
-                env: None,
-                working_dir: None,
-            },
-        )
-        .await
-        .ok()
-        .filter(|r| r.exit_code == 0)
-        .map(|r| r.stdout.trim().split('/').next().unwrap_or("").to_string());
+    // Use the per-container Docker label as the source of truth for version
+    // skew. The shared agent volume marker (/cella/.version) cannot be used
+    // here because it reflects whichever container last ran `cella up`, not
+    // the state of this specific container.
+    let container_version = info
+        .labels
+        .get("dev.cella.version")
+        .map_or("unknown", String::as_str);
 
-    match agent_version.as_deref() {
-        Some(v) if v == cli_version => {
-            checks.push(CheckResult {
-                name: "version".into(),
-                severity: Severity::Pass,
-                detail: cli_version.to_string(),
-                fix_hint: None,
-            });
-        }
-        Some(v) => {
-            checks.push(CheckResult {
-                name: "version".into(),
-                severity: Severity::Warning,
-                detail: format!("agent binary {v} != CLI {cli_version}"),
-                fix_hint: Some("Run `cella up` to update the agent binary".into()),
-            });
-        }
-        None => {
-            // Volume marker unreadable (unmanaged backend or missing volume).
-            // Fall back to the container label to preserve skew detection.
-            let container_version = info
-                .labels
-                .get("dev.cella.version")
-                .map_or("unknown", String::as_str);
-            if container_version == cli_version {
-                checks.push(CheckResult {
-                    name: "version".into(),
-                    severity: Severity::Pass,
-                    detail: cli_version.to_string(),
-                    fix_hint: None,
-                });
-            } else {
-                checks.push(CheckResult {
-                    name: "version".into(),
-                    severity: Severity::Warning,
-                    detail: format!("container {container_version} != CLI {cli_version}"),
-                    fix_hint: Some("Run `cella up --rebuild` to recreate the container".into()),
-                });
-            }
-        }
+    if container_version == cli_version {
+        checks.push(CheckResult {
+            name: "version".into(),
+            severity: Severity::Pass,
+            detail: container_version.to_string(),
+            fix_hint: None,
+        });
+    } else {
+        checks.push(CheckResult {
+            name: "version".into(),
+            severity: Severity::Info,
+            detail: format!("created with {container_version} (agent binary auto-updated)"),
+            fix_hint: None,
+        });
     }
 }
 

--- a/crates/cella-doctor/src/checks/container.rs
+++ b/crates/cella-doctor/src/checks/container.rs
@@ -208,17 +208,27 @@ async fn check_version_skew(
             });
         }
         None => {
-            // Fall back to the container label if we can't read the volume.
+            // Volume marker unreadable (unmanaged backend or missing volume).
+            // Fall back to the container label to preserve skew detection.
             let container_version = info
                 .labels
                 .get("dev.cella.version")
                 .map_or("unknown", String::as_str);
-            checks.push(CheckResult {
-                name: "version".into(),
-                severity: Severity::Info,
-                detail: format!("created with {container_version} (agent binary unknown)"),
-                fix_hint: None,
-            });
+            if container_version == cli_version {
+                checks.push(CheckResult {
+                    name: "version".into(),
+                    severity: Severity::Pass,
+                    detail: cli_version.to_string(),
+                    fix_hint: None,
+                });
+            } else {
+                checks.push(CheckResult {
+                    name: "version".into(),
+                    severity: Severity::Warning,
+                    detail: format!("container {container_version} != CLI {cli_version}"),
+                    fix_hint: Some("Run `cella up --rebuild` to recreate the container".into()),
+                });
+            }
         }
     }
 }

--- a/crates/cella-doctor/src/checks/container.rs
+++ b/crates/cella-doctor/src/checks/container.rs
@@ -171,25 +171,55 @@ async fn check_version_skew(
     };
 
     let cli_version = env!("CARGO_PKG_VERSION");
-    let container_version = info
-        .labels
-        .get("dev.cella.version")
-        .map_or("unknown", String::as_str);
 
-    if container_version == cli_version {
-        checks.push(CheckResult {
-            name: "version".into(),
-            severity: Severity::Pass,
-            detail: container_version.to_string(),
-            fix_hint: None,
-        });
-    } else {
-        checks.push(CheckResult {
-            name: "version".into(),
-            severity: Severity::Warning,
-            detail: format!("container {container_version} != CLI {cli_version}"),
-            fix_hint: Some("Run `cella up` to update".into()),
-        });
+    // Read the agent volume version marker to determine the actual
+    // agent binary version — this is what matters, not the container
+    // creation label (which is immutable after creation).
+    let agent_version = client
+        .exec_command(
+            container_id,
+            &ExecOptions {
+                cmd: vec!["cat".to_string(), "/cella/.version".to_string()],
+                user: None,
+                env: None,
+                working_dir: None,
+            },
+        )
+        .await
+        .ok()
+        .filter(|r| r.exit_code == 0)
+        .map(|r| r.stdout.trim().split('/').next().unwrap_or("").to_string());
+
+    match agent_version.as_deref() {
+        Some(v) if v == cli_version => {
+            checks.push(CheckResult {
+                name: "version".into(),
+                severity: Severity::Pass,
+                detail: cli_version.to_string(),
+                fix_hint: None,
+            });
+        }
+        Some(v) => {
+            checks.push(CheckResult {
+                name: "version".into(),
+                severity: Severity::Warning,
+                detail: format!("agent binary {v} != CLI {cli_version}"),
+                fix_hint: Some("Run `cella up` to update the agent binary".into()),
+            });
+        }
+        None => {
+            // Fall back to the container label if we can't read the volume.
+            let container_version = info
+                .labels
+                .get("dev.cella.version")
+                .map_or("unknown", String::as_str);
+            checks.push(CheckResult {
+                name: "version".into(),
+                severity: Severity::Info,
+                detail: format!("created with {container_version} (agent binary unknown)"),
+                fix_hint: None,
+            });
+        }
     }
 }
 

--- a/crates/cella-orchestrator/src/config_map/mod.rs
+++ b/crates/cella-orchestrator/src/config_map/mod.rs
@@ -174,11 +174,16 @@ fn build_entrypoint_cmd(
     // convention, not Docker-specific, so we hardcode it here rather than
     // pulling in a backend-specific crate.
     let agent_path = "/cella/bin/cella-agent";
+    // Restart loop: if the agent crashes, it is restarted after 1 second.
+    // `restart_agent_in_container()` sends `pkill -x cella-agent` which
+    // terminates only the agent process; the loop survives and restarts it.
     let _ = write!(
         script,
         "if [ -x \"{agent_path}\" ]; then\n  \
+         while true; do \
          \"{agent_path}\" daemon \
-         --poll-interval \"${{CELLA_PORT_POLL_INTERVAL:-1000}}\" &\n\
+         --poll-interval \"${{CELLA_PORT_POLL_INTERVAL:-1000}}\" 2>/dev/null; \
+         sleep 1; done &\n\
          fi\n"
     );
 

--- a/crates/cella-orchestrator/src/config_map/mod.rs
+++ b/crates/cella-orchestrator/src/config_map/mod.rs
@@ -175,8 +175,8 @@ fn build_entrypoint_cmd(
     // pulling in a backend-specific crate.
     let agent_path = "/cella/bin/cella-agent";
     // Restart loop: if the agent crashes, it is restarted after 1 second.
-    // `restart_agent_in_container()` sends `pkill -x cella-agent` which
-    // terminates only the agent process; the loop survives and restarts it.
+    // `restart_agent_in_container()` sends `pkill -f 'cella-agent daemon'`
+    // which terminates the daemon process; the loop survives and restarts it.
     let _ = write!(
         script,
         "if [ -x \"{agent_path}\" ]; then\n  \

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -560,8 +560,18 @@ impl EnsureUpContext<'_> {
 
         match start_result {
             Ok(()) => {
-                crate::container_setup::verify_container_running(self.client, &container.id)
-                    .await?;
+                if let Err(e) =
+                    crate::container_setup::verify_container_running(self.client, &container.id)
+                        .await
+                {
+                    // Container exited during startup. Roll back pre-registration.
+                    if capabilities.managed_agent {
+                        self.hooks
+                            .on_container_stopping(self.config.container_name)
+                            .await;
+                    }
+                    return Err(e.into());
+                }
 
                 let container_ip = self
                     .client
@@ -1442,10 +1452,12 @@ async fn restart_agent_in_container(client: &dyn ContainerBackend, container_id:
     let agent_path = "/cella/bin/cella-agent";
     // Kill the daemon, wait for the restart loop (if any) to bring it back,
     // then spawn only if no agent daemon is running.
+    // Uses `pgrep -x cella-agent` (exact process name) instead of `pgrep -f`
+    // to avoid matching the sh -c wrapper that contains the pattern string.
     let script = format!(
         "pkill -f 'cella-agent daemon' 2>/dev/null; \
          sleep 1; \
-         pgrep -f 'cella-agent daemon' >/dev/null 2>&1 || \
+         pgrep -x cella-agent >/dev/null 2>&1 || \
          \"{agent_path}\" daemon \
          --poll-interval \"${{CELLA_PORT_POLL_INTERVAL:-1000}}\" &"
     );

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -409,17 +409,16 @@ impl EnsureUpContext<'_> {
             restart_agent_in_container(self.client, &container.id).await;
         }
 
+        // For running containers, use a non-destructive IP update instead of
+        // full re-registration. Re-registration would release all existing port
+        // allocations and tear down active proxy connections.
         let container_ip = self
             .client
             .get_container_ip(&container.id)
             .await
             .unwrap_or(None);
         self.hooks
-            .on_container_started(
-                &container.id,
-                self.config.container_name,
-                container_ip.as_deref(),
-            )
+            .update_container_ip(&container.id, container_ip.as_deref())
             .await;
 
         let (_probed_env, lifecycle_env) =

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -400,6 +400,12 @@ impl EnsureUpContext<'_> {
             {
                 warn!("Failed to repopulate agent volume: {e}");
             }
+        }
+
+        // Always restart the agent so it picks up the latest .daemon_addr.
+        // Without this, an agent stuck in standalone mode (e.g. after a host
+        // restart where the daemon got a new port) would never reconnect.
+        if capabilities.managed_agent {
             restart_agent_in_container(self.client, &container.id).await;
         }
 

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -600,6 +600,15 @@ impl EnsureUpContext<'_> {
             }
             Err(e) => {
                 warn!("Failed to start existing container: {e}");
+
+                // Roll back the pre-registration so the daemon doesn't hold
+                // stale port allocations for a container that never started.
+                if capabilities.managed_agent {
+                    self.hooks
+                        .on_container_stopping(self.config.container_name)
+                        .await;
+                }
+
                 self.progress
                     .warn(&format!("Could not start existing container: {e}"));
                 self.progress.hint("Recreating container...");

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -1433,19 +1433,19 @@ pub async fn ensure_up(
 /// Restart the in-container agent daemon.
 ///
 /// Kills only the `cella-agent daemon` process (not credential or browser
-/// helpers that exec the same binary) then explicitly starts a replacement.
-/// The explicit respawn is necessary for backward compatibility with
-/// containers created before the entrypoint restart loop was introduced —
-/// on those containers there is no loop to bring the agent back.
-///
-/// On containers that do have the loop, the loop will race with the
-/// explicit spawn; the loser exits harmlessly because the daemon addr
-/// file is already locked by the winner.
+/// helpers that exec the same binary), waits briefly for the entrypoint
+/// restart loop to respawn it, and only explicitly starts a replacement
+/// if nothing came back. This avoids double-launching the daemon on
+/// containers with the restart loop while remaining backward compatible
+/// with containers created before it was introduced.
 async fn restart_agent_in_container(client: &dyn ContainerBackend, container_id: &str) {
     let agent_path = "/cella/bin/cella-agent";
+    // Kill the daemon, wait for the restart loop (if any) to bring it back,
+    // then spawn only if no agent daemon is running.
     let script = format!(
         "pkill -f 'cella-agent daemon' 2>/dev/null; \
-         sleep 0.2; \
+         sleep 1; \
+         pgrep -f 'cella-agent daemon' >/dev/null 2>&1 || \
          \"{agent_path}\" daemon \
          --poll-interval \"${{CELLA_PORT_POLL_INTERVAL:-1000}}\" &"
     );

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -44,11 +44,14 @@ pub trait UpHooks: Send + Sync {
     ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>>;
 
     /// Update a container's IP address with the daemon after pre-registration.
+    /// Returns `true` if the container was found, `false` if unknown (e.g.
+    /// daemon restarted and lost state — caller should fall back to full
+    /// registration via `on_container_started`).
     fn update_container_ip(
         &self,
         container_id: &str,
         container_ip: Option<&str>,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>>;
+    ) -> Pin<Box<dyn Future<Output = bool> + Send + '_>>;
 
     /// Called before stopping or removing a managed container.
     fn on_container_stopping(
@@ -89,8 +92,8 @@ impl UpHooks for NoOpHooks {
         &self,
         _container_id: &str,
         _container_ip: Option<&str>,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
-        Box::pin(async {})
+    ) -> Pin<Box<dyn Future<Output = bool> + Send + '_>> {
+        Box::pin(async { true })
     }
 
     fn on_container_stopping(
@@ -402,24 +405,9 @@ impl EnsureUpContext<'_> {
             }
         }
 
-        // Always restart the agent so it picks up the latest .daemon_addr.
-        // Without this, an agent stuck in standalone mode (e.g. after a host
-        // restart where the daemon got a new port) would never reconnect.
         if capabilities.managed_agent {
-            restart_agent_in_container(self.client, &container.id).await;
+            self.ensure_agent_registered(&container.id).await;
         }
-
-        // For running containers, use a non-destructive IP update instead of
-        // full re-registration. Re-registration would release all existing port
-        // allocations and tear down active proxy connections.
-        let container_ip = self
-            .client
-            .get_container_ip(&container.id)
-            .await
-            .unwrap_or(None);
-        self.hooks
-            .update_container_ip(&container.id, container_ip.as_deref())
-            .await;
 
         let (_probed_env, lifecycle_env) =
             self.prepare_container_env(&container.id, remote_user).await;
@@ -516,6 +504,36 @@ impl EnsureUpContext<'_> {
                 self.progress
                     .hint("Run `cella up --rebuild` to recreate with the updated runtime.");
             }
+        }
+    }
+
+    /// Restart the agent and ensure the container is registered with the daemon.
+    ///
+    /// Restarts the agent so it picks up the latest `.daemon_addr`, then
+    /// tries a non-destructive IP update. If the daemon doesn't know about
+    /// this container (e.g. after a daemon restart), falls back to full
+    /// registration.
+    async fn ensure_agent_registered(&self, container_id: &str) {
+        restart_agent_in_container(self.client, container_id).await;
+
+        let container_ip = self
+            .client
+            .get_container_ip(container_id)
+            .await
+            .unwrap_or(None);
+        let known = self
+            .hooks
+            .update_container_ip(container_id, container_ip.as_deref())
+            .await;
+        if !known {
+            info!("Container not registered with daemon, performing full registration");
+            self.hooks
+                .on_container_started(
+                    container_id,
+                    self.config.container_name,
+                    container_ip.as_deref(),
+                )
+                .await;
         }
     }
 

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -1421,20 +1421,31 @@ pub async fn ensure_up(
     })
 }
 
-/// Kill the running agent process. The entrypoint restart loop will
-/// automatically bring it back within ~1 second with a fresh connection
-/// to the daemon (reading the latest `.daemon_addr` file).
+/// Restart the in-container agent daemon.
 ///
-/// Uses `pkill -x` (exact name match) so only the agent binary is
-/// terminated — not the shell wrapper that runs the restart loop.
+/// Kills only the `cella-agent daemon` process (not credential or browser
+/// helpers that exec the same binary) then explicitly starts a replacement.
+/// The explicit respawn is necessary for backward compatibility with
+/// containers created before the entrypoint restart loop was introduced —
+/// on those containers there is no loop to bring the agent back.
+///
+/// On containers that do have the loop, the loop will race with the
+/// explicit spawn; the loser exits harmlessly because the daemon addr
+/// file is already locked by the winner.
 async fn restart_agent_in_container(client: &dyn ContainerBackend, container_id: &str) {
-    let script = "pkill -x cella-agent 2>/dev/null || true";
+    let agent_path = "/cella/bin/cella-agent";
+    let script = format!(
+        "pkill -f 'cella-agent daemon' 2>/dev/null; \
+         sleep 0.2; \
+         \"{agent_path}\" daemon \
+         --poll-interval \"${{CELLA_PORT_POLL_INTERVAL:-1000}}\" &"
+    );
 
     match client
         .exec_detached(
             container_id,
             &ExecOptions {
-                cmd: vec!["sh".to_string(), "-c".to_string(), script.to_string()],
+                cmd: vec!["sh".to_string(), "-c".to_string(), script],
                 user: Some("root".to_string()),
                 env: None,
                 working_dir: None,

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -43,6 +43,13 @@ pub trait UpHooks: Send + Sync {
         container_ip: Option<&str>,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>>;
 
+    /// Update a container's IP address with the daemon after pre-registration.
+    fn update_container_ip(
+        &self,
+        container_id: &str,
+        container_ip: Option<&str>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>>;
+
     /// Called before stopping or removing a managed container.
     fn on_container_stopping(
         &self,
@@ -73,6 +80,14 @@ impl UpHooks for NoOpHooks {
         &self,
         _container_id: &str,
         _container_name: &str,
+        _container_ip: Option<&str>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async {})
+    }
+
+    fn update_container_ip(
+        &self,
+        _container_id: &str,
         _container_ip: Option<&str>,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(async {})

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -582,8 +582,17 @@ impl EnsureUpContext<'_> {
                     .unwrap_or(None);
 
                 if capabilities.managed_agent {
+                    // Full re-registration with the actual IP. This is the
+                    // authoritative registration — the pre-registration before
+                    // start was best-effort so the agent doesn't race.
+                    // register_container() releases old state, so this is safe
+                    // even if the pre-registration succeeded.
                     self.hooks
-                        .update_container_ip(&container.id, container_ip.as_deref())
+                        .on_container_started(
+                            &container.id,
+                            self.config.container_name,
+                            container_ip.as_deref(),
+                        )
                         .await;
                     restart_agent_in_container(self.client, &container.id).await;
                 }
@@ -1442,13 +1451,13 @@ pub async fn ensure_up(
 async fn restart_agent_in_container(client: &dyn ContainerBackend, container_id: &str) {
     let agent_path = "/cella/bin/cella-agent";
     // Kill the daemon, wait for the restart loop (if any) to bring it back,
-    // then spawn only if no agent daemon is running.
-    // Uses `pgrep -x cella-agent` (exact process name) instead of `pgrep -f`
-    // to avoid matching the sh -c wrapper that contains the pattern string.
+    // then spawn only if no daemon process is running.
+    // The bracket trick `[c]ella-agent` prevents pgrep -f from matching the
+    // sh -c wrapper itself (the bracket changes the literal string).
     let script = format!(
         "pkill -f 'cella-agent daemon' 2>/dev/null; \
          sleep 1; \
-         pgrep -x cella-agent >/dev/null 2>&1 || \
+         pgrep -f '[c]ella-agent daemon' >/dev/null 2>&1 || \
          \"{agent_path}\" daemon \
          --poll-interval \"${{CELLA_PORT_POLL_INTERVAL:-1000}}\" &"
     );

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -1421,19 +1421,20 @@ pub async fn ensure_up(
     })
 }
 
+/// Kill the running agent process. The entrypoint restart loop will
+/// automatically bring it back within ~1 second with a fresh connection
+/// to the daemon (reading the latest `.daemon_addr` file).
+///
+/// Uses `pkill -x` (exact name match) so only the agent binary is
+/// terminated — not the shell wrapper that runs the restart loop.
 async fn restart_agent_in_container(client: &dyn ContainerBackend, container_id: &str) {
-    let agent_path = "/cella/bin/cella-agent";
-    let script = format!(
-        "pkill -f 'cella-agent daemon' 2>/dev/null; \
-         \"{agent_path}\" daemon \
-         --poll-interval \"${{CELLA_PORT_POLL_INTERVAL:-1000}}\" &"
-    );
+    let script = "pkill -x cella-agent 2>/dev/null || true";
 
     match client
         .exec_detached(
             container_id,
             &ExecOptions {
-                cmd: vec!["sh".to_string(), "-c".to_string(), script],
+                cmd: vec!["sh".to_string(), "-c".to_string(), script.to_string()],
                 user: Some("root".to_string()),
                 env: None,
                 working_dir: None,
@@ -1441,7 +1442,7 @@ async fn restart_agent_in_container(client: &dyn ContainerBackend, container_id:
         )
         .await
     {
-        Ok(_) => info!("Agent restarted in container {container_id}"),
+        Ok(_) => info!("Agent restart triggered in container {container_id}"),
         Err(e) => warn!("Failed to restart agent in container: {e}"),
     }
 }

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -496,13 +496,8 @@ impl EnsureUpContext<'_> {
         Ok(())
     }
 
-    async fn handle_stopped(
-        &self,
-        container: &ContainerInfo,
-        remote_user: &str,
-    ) -> Result<Option<UpResult>, Box<dyn std::error::Error + Send + Sync>> {
-        let capabilities = self.client.capabilities();
-
+    /// Emit warnings when the container's config or runtime has drifted.
+    fn warn_config_drift(&self, container: &ContainerInfo) {
         if let Some(old_hash) = &container.config_hash
             && *old_hash != self.config.resolved.config_hash
         {
@@ -523,28 +518,40 @@ impl EnsureUpContext<'_> {
                     .hint("Run `cella up --rebuild` to recreate with the updated runtime.");
             }
         }
+    }
+
+    /// Roll back a daemon pre-registration that was made before a failed start.
+    async fn rollback_preregistration(&self) {
+        if self.client.capabilities().managed_agent {
+            self.hooks
+                .on_container_stopping(self.config.container_name)
+                .await;
+        }
+    }
+
+    async fn handle_stopped(
+        &self,
+        container: &ContainerInfo,
+        remote_user: &str,
+    ) -> Result<Option<UpResult>, Box<dyn std::error::Error + Send + Sync>> {
+        let capabilities = self.client.capabilities();
+
+        self.warn_config_drift(container);
 
         if capabilities.managed_agent {
             let agent_arch = self.detect_arch().await;
-            let version = env!("CARGO_PKG_VERSION");
             run_step_result(
                 &self.progress,
                 "Populating agent volume...",
                 self.client.ensure_agent_provisioned(
-                    version,
+                    env!("CARGO_PKG_VERSION"),
                     &agent_arch,
                     self.config.skip_checksum,
                 ),
             )
             .await?;
             self.hooks.sync_agent_runtime(self.client).await;
-        }
-
-        // Pre-register with daemon BEFORE starting the container so the
-        // agent can report ports immediately without them being dropped.
-        // IP is unknown until the container is running, so pass None here
-        // and update it after start.
-        if capabilities.managed_agent {
+            // Pre-register before start so the agent can report ports immediately.
             self.hooks
                 .on_container_started(&container.id, self.config.container_name, None)
                 .await;
@@ -564,13 +571,8 @@ impl EnsureUpContext<'_> {
                     crate::container_setup::verify_container_running(self.client, &container.id)
                         .await
                 {
-                    // Container exited during startup. Roll back pre-registration.
-                    if capabilities.managed_agent {
-                        self.hooks
-                            .on_container_stopping(self.config.container_name)
-                            .await;
-                    }
-                    return Err(e.into());
+                    self.rollback_preregistration().await;
+                    return Err(e);
                 }
 
                 let container_ip = self
@@ -579,25 +581,22 @@ impl EnsureUpContext<'_> {
                     .await
                     .unwrap_or(None);
 
-                // Update the daemon with the actual container IP now that
-                // the container is running.
                 if capabilities.managed_agent {
                     self.hooks
                         .update_container_ip(&container.id, container_ip.as_deref())
                         .await;
-                }
-
-                if capabilities.managed_agent {
                     restart_agent_in_container(self.client, &container.id).await;
                 }
 
                 self.run_restart_lifecycle(container, remote_user).await?;
 
-                if capabilities.managed_agent {
-                    let prune_version = env!("CARGO_PKG_VERSION");
-                    if let Err(e) = self.client.prune_old_agent_versions(prune_version).await {
-                        debug!("Agent version pruning failed: {e}");
-                    }
+                if capabilities.managed_agent
+                    && let Err(e) = self
+                        .client
+                        .prune_old_agent_versions(env!("CARGO_PKG_VERSION"))
+                        .await
+                {
+                    debug!("Agent version pruning failed: {e}");
                 }
 
                 Ok(Some(UpResult {
@@ -610,15 +609,7 @@ impl EnsureUpContext<'_> {
             }
             Err(e) => {
                 warn!("Failed to start existing container: {e}");
-
-                // Roll back the pre-registration so the daemon doesn't hold
-                // stale port allocations for a container that never started.
-                if capabilities.managed_agent {
-                    self.hooks
-                        .on_container_stopping(self.config.container_name)
-                        .await;
-                }
-
+                self.rollback_preregistration().await;
                 self.progress
                     .warn(&format!("Could not start existing container: {e}"));
                 self.progress.hint("Recreating container...");

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -534,6 +534,16 @@ impl EnsureUpContext<'_> {
             self.hooks.sync_agent_runtime(self.client).await;
         }
 
+        // Pre-register with daemon BEFORE starting the container so the
+        // agent can report ports immediately without them being dropped.
+        // IP is unknown until the container is running, so pass None here
+        // and update it after start.
+        if capabilities.managed_agent {
+            self.hooks
+                .on_container_started(&container.id, self.config.container_name, None)
+                .await;
+        }
+
         let step = self.progress.step("Starting container...");
         let start_result = self.client.start_container(&container.id).await;
         if start_result.is_ok() {
@@ -552,13 +562,14 @@ impl EnsureUpContext<'_> {
                     .get_container_ip(&container.id)
                     .await
                     .unwrap_or(None);
-                self.hooks
-                    .on_container_started(
-                        &container.id,
-                        self.config.container_name,
-                        container_ip.as_deref(),
-                    )
-                    .await;
+
+                // Update the daemon with the actual container IP now that
+                // the container is running.
+                if capabilities.managed_agent {
+                    self.hooks
+                        .update_container_ip(&container.id, container_ip.as_deref())
+                        .await;
+                }
 
                 if capabilities.managed_agent {
                     restart_agent_in_container(self.client, &container.id).await;

--- a/crates/cella-protocol/src/lib.rs
+++ b/crates/cella-protocol/src/lib.rs
@@ -264,6 +264,9 @@ pub struct ContainerSummary {
     pub agent_connected: bool,
     #[serde(default)]
     pub last_seen_secs: u64,
+    /// Agent version from the `AgentHello` handshake, if connected.
+    #[serde(default)]
+    pub agent_version: Option<String>,
 }
 
 /// Messages sent from the host daemon to the in-container agent.
@@ -778,6 +781,7 @@ mod tests {
                 forwarded_port_count: 1,
                 agent_connected: true,
                 last_seen_secs: 1000,
+                agent_version: Some("0.1.0".to_string()),
             }],
             is_orbstack: false,
             daemon_version: "0.1.0".to_string(),

--- a/crates/cella-protocol/src/lib.rs
+++ b/crates/cella-protocol/src/lib.rs
@@ -191,6 +191,14 @@ pub enum ManagementRequest {
     QueryStatus,
     /// Health check.
     Ping,
+    /// Update a container's IP address after it has started.
+    ///
+    /// Sent after pre-registration (with `container_ip: None`) once the
+    /// container is running and its IP is known.
+    UpdateContainerIp {
+        container_id: String,
+        container_ip: Option<String>,
+    },
     /// Request graceful shutdown of the daemon.
     Shutdown,
 }
@@ -228,6 +236,8 @@ pub enum ManagementResponse {
     },
     /// Daemon is shutting down.
     ShuttingDown { pid: u32 },
+    /// Container IP updated.
+    ContainerIpUpdated { container_id: String },
     /// Pong response.
     Pong,
     /// Error response.


### PR DESCRIPTION
## Summary

- Fix agent dying silently after host restart with no recovery (entrypoint restart loop)
- Fix port forwarding broken after `cella down` + `cella up` (orphaned port allocations)
- Fix `cella doctor` showing misleading version warning with unhelpful "Run `cella up` to update" hint
- Fix race condition where agent reports ports before daemon registration
- Always restart agent on `cella up` so standalone-mode agents reconnect after daemon restart

## Root causes

After a host restart + `cella up`, five independent bugs compound:

1. **No agent supervisor** — entrypoint spawns agent with `&` (fire-and-forget), crash = silent death
2. **Agent only restarted on version change** — if daemon restarts but CLI version matches, agent stays stuck in standalone mode
3. **Port allocations orphaned on re-registration** — `register_container()` cleared `detected_ports` but not the allocation table, causing silent port remapping (3000→3001)
4. **Race between container start and daemon registration** — agent reports ports before daemon knows about the container
5. **Misleading doctor output** — compares immutable Docker label to CLI version, suggests `cella up` which can't fix it

## Changes

| Crate | File | Change |
|-------|------|--------|
| cella-orchestrator | `config_map/mod.rs` | Entrypoint restart loop (`while true; do agent; sleep 1; done &`) |
| cella-orchestrator | `up.rs` | Pre-register before start, always restart agent, `ensure_agent_registered()` with `update_container_ip` fallback to full registration |
| cella-daemon | `port_manager.rs` | Release old allocations + return released ports for proxy cleanup, `update_container_ip()` |
| cella-daemon | `management.rs` | Handle `UpdateContainerIp`, stop coordinator-owned proxies on re-registration |
| cella-daemon | `control_server.rs` | Store `agent_version` from handshake, clear on disconnect |
| cella-protocol | `lib.rs` | `UpdateContainerIp` request/response, `agent_version` in `ContainerSummary` |
| cella-cli | `commands/up/mod.rs` | `update_container_ip` hook with fallback detection |
| cella-doctor | `checks/container.rs` | Live agent version from daemon, Docker label fallback |

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings -D clippy::all`
- [x] `cargo test --workspace` (2,744+ tests, 0 failures)
- [ ] Manual: kill agent inside container, verify restart loop brings it back within ~1s
- [ ] Manual: `cella doctor` shows accurate version info
- [ ] Manual: host restart + `cella up` → ports forwarded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)