### PR TITLE
feat: install bubblewrap for Codex sandbox support

### DIFF
--- a/crates/cella-orchestrator/src/tool_install.rs
+++ b/crates/cella-orchestrator/src/tool_install.rs
@@ -453,7 +453,8 @@ pub async fn ensure_codex_sandbox_deps(client: &dyn ContainerBackend, container_
 
 /// Install `OpenAI` Codex CLI inside the container via npm.
 ///
-/// Checks if already installed, then runs `npm install -g @openai/codex`.
+/// Ensures bubblewrap is available for sandbox support, then checks if
+/// Codex is already installed before running `npm install -g @openai/codex`.
 /// Caller must ensure Node.js/npm are available before calling this.
 pub async fn install_codex(
     client: &dyn ContainerBackend,
@@ -462,6 +463,8 @@ pub async fn install_codex(
     settings: &cella_config::settings::Codex,
     probed_env: Option<&ProbedEnv>,
 ) {
+    ensure_codex_sandbox_deps(client, container_id).await;
+
     if is_npm_tool_installed(
         client,
         container_id,
@@ -474,8 +477,6 @@ pub async fn install_codex(
     {
         return;
     }
-
-    ensure_codex_sandbox_deps(client, container_id).await;
 
     debug!("Installing Codex ({})...", settings.version);
     let result = npm_install_global(

--- a/crates/cella-orchestrator/src/tool_install.rs
+++ b/crates/cella-orchestrator/src/tool_install.rs
@@ -385,6 +385,72 @@ pub fn log_npm_install_result(tool_name: &str, result: Result<ExecResult, Backen
 
 // ── Codex ────────────────────────────────────────────────────────────────────
 
+/// Ensure bubblewrap is available in the container for Codex sandbox support.
+///
+/// Checks if `bwrap` is already on PATH. If not, installs the `bubblewrap`
+/// package via the system package manager (apt-get or apk). Runs as root.
+/// Returns `true` if bwrap is available after the check.
+pub async fn ensure_codex_sandbox_deps(client: &dyn ContainerBackend, container_id: &str) -> bool {
+    let bwrap_check = client
+        .exec_command(
+            container_id,
+            &ExecOptions {
+                cmd: vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    "command -v bwrap".to_string(),
+                ],
+                user: Some("root".to_string()),
+                env: None,
+                working_dir: None,
+            },
+        )
+        .await;
+
+    if bwrap_check.is_ok_and(|r| r.exit_code == 0) {
+        debug!("bubblewrap already installed");
+        return true;
+    }
+
+    debug!("bubblewrap not found, installing...");
+    let install_cmd = if is_alpine_container(client, container_id).await {
+        "apk add --no-cache bubblewrap"
+    } else {
+        "apt-get update -qq && apt-get install -y -qq bubblewrap"
+    };
+
+    let result = client
+        .exec_command(
+            container_id,
+            &ExecOptions {
+                cmd: vec!["sh".to_string(), "-c".to_string(), install_cmd.to_string()],
+                user: Some("root".to_string()),
+                env: None,
+                working_dir: None,
+            },
+        )
+        .await;
+
+    match &result {
+        Ok(r) if r.exit_code == 0 => {
+            debug!("bubblewrap installed successfully");
+            true
+        }
+        Ok(r) => {
+            warn!(
+                "bubblewrap installation failed (exit {}): {}",
+                r.exit_code,
+                r.stderr.trim()
+            );
+            false
+        }
+        Err(e) => {
+            warn!("bubblewrap installation failed: {e}");
+            false
+        }
+    }
+}
+
 /// Install `OpenAI` Codex CLI inside the container via npm.
 ///
 /// Checks if already installed, then runs `npm install -g @openai/codex`.

--- a/crates/cella-orchestrator/src/tool_install.rs
+++ b/crates/cella-orchestrator/src/tool_install.rs
@@ -974,4 +974,327 @@ mod tests {
         });
         log_npm_install_result("TestTool", result);
     }
+
+    // ── MockBackend for ensure_codex_sandbox_deps tests ─────────────────────
+
+    use std::collections::VecDeque;
+    use std::io::Write;
+    use std::path::Path;
+    use std::sync::Mutex;
+
+    use cella_backend::{
+        BackendCapabilities, BackendKind, BoxFuture, BuildOptions, ContainerInfo,
+        CreateContainerOptions, FileToUpload, ImageDetails, InteractiveExecOptions, Platform,
+    };
+
+    /// Minimal mock that replays pre-configured `exec_command` responses in order.
+    struct MockBackend {
+        responses: Mutex<VecDeque<Result<ExecResult, BackendError>>>,
+    }
+
+    impl MockBackend {
+        fn new(responses: Vec<Result<ExecResult, BackendError>>) -> Self {
+            Self {
+                responses: Mutex::new(VecDeque::from(responses)),
+            }
+        }
+    }
+
+    impl ContainerBackend for MockBackend {
+        fn kind(&self) -> BackendKind {
+            unimplemented!()
+        }
+
+        fn capabilities(&self) -> BackendCapabilities {
+            unimplemented!()
+        }
+
+        fn find_container<'a>(
+            &'a self,
+            _: &'a Path,
+        ) -> BoxFuture<'a, Result<Option<ContainerInfo>, BackendError>> {
+            unimplemented!()
+        }
+
+        fn create_container<'a>(
+            &'a self,
+            _: &'a CreateContainerOptions,
+        ) -> BoxFuture<'a, Result<String, BackendError>> {
+            unimplemented!()
+        }
+
+        fn start_container<'a>(&'a self, _: &'a str) -> BoxFuture<'a, Result<(), BackendError>> {
+            unimplemented!()
+        }
+
+        fn stop_container<'a>(&'a self, _: &'a str) -> BoxFuture<'a, Result<(), BackendError>> {
+            unimplemented!()
+        }
+
+        fn remove_container<'a>(
+            &'a self,
+            _: &'a str,
+            _: bool,
+        ) -> BoxFuture<'a, Result<(), BackendError>> {
+            unimplemented!()
+        }
+
+        fn inspect_container<'a>(
+            &'a self,
+            _: &'a str,
+        ) -> BoxFuture<'a, Result<ContainerInfo, BackendError>> {
+            unimplemented!()
+        }
+
+        fn list_cella_containers(
+            &self,
+            _: bool,
+        ) -> BoxFuture<'_, Result<Vec<ContainerInfo>, BackendError>> {
+            unimplemented!()
+        }
+
+        fn find_compose_service<'a>(
+            &'a self,
+            _: &'a str,
+            _: &'a str,
+        ) -> BoxFuture<'a, Result<Option<ContainerInfo>, BackendError>> {
+            unimplemented!()
+        }
+
+        fn find_container_by_label<'a>(
+            &'a self,
+            _: &'a str,
+        ) -> BoxFuture<'a, Result<Option<ContainerInfo>, BackendError>> {
+            unimplemented!()
+        }
+
+        fn container_logs<'a>(
+            &'a self,
+            _: &'a str,
+            _: u32,
+        ) -> BoxFuture<'a, Result<String, BackendError>> {
+            unimplemented!()
+        }
+
+        fn exec_command<'a>(
+            &'a self,
+            _container_id: &'a str,
+            _opts: &'a ExecOptions,
+        ) -> BoxFuture<'a, Result<ExecResult, BackendError>> {
+            let response = self
+                .responses
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("MockBackend: no more responses");
+            Box::pin(async move { response })
+        }
+
+        fn exec_stream<'a>(
+            &'a self,
+            _: &'a str,
+            _: &'a ExecOptions,
+            _: Box<dyn Write + Send + 'a>,
+            _: Box<dyn Write + Send + 'a>,
+        ) -> BoxFuture<'a, Result<ExecResult, BackendError>> {
+            unimplemented!()
+        }
+
+        fn exec_interactive<'a>(
+            &'a self,
+            _: &'a str,
+            _: &'a InteractiveExecOptions,
+        ) -> BoxFuture<'a, Result<i64, BackendError>> {
+            unimplemented!()
+        }
+
+        fn exec_detached<'a>(
+            &'a self,
+            _: &'a str,
+            _: &'a ExecOptions,
+        ) -> BoxFuture<'a, Result<String, BackendError>> {
+            unimplemented!()
+        }
+
+        fn pull_image<'a>(&'a self, _: &'a str) -> BoxFuture<'a, Result<(), BackendError>> {
+            unimplemented!()
+        }
+
+        fn build_image<'a>(
+            &'a self,
+            _: &'a BuildOptions,
+        ) -> BoxFuture<'a, Result<String, BackendError>> {
+            unimplemented!()
+        }
+
+        fn image_exists<'a>(&'a self, _: &'a str) -> BoxFuture<'a, Result<bool, BackendError>> {
+            unimplemented!()
+        }
+
+        fn inspect_image_details<'a>(
+            &'a self,
+            _: &'a str,
+        ) -> BoxFuture<'a, Result<ImageDetails, BackendError>> {
+            unimplemented!()
+        }
+
+        fn upload_files<'a>(
+            &'a self,
+            _: &'a str,
+            _: &'a [FileToUpload],
+        ) -> BoxFuture<'a, Result<(), BackendError>> {
+            unimplemented!()
+        }
+
+        fn ping(&self) -> BoxFuture<'_, Result<(), BackendError>> {
+            unimplemented!()
+        }
+
+        fn host_gateway(&self) -> &'static str {
+            unimplemented!()
+        }
+
+        fn detect_platform(&self) -> BoxFuture<'_, Result<Platform, BackendError>> {
+            unimplemented!()
+        }
+
+        fn detect_container_arch(&self) -> BoxFuture<'_, Result<String, BackendError>> {
+            unimplemented!()
+        }
+
+        fn inspect_image_env<'a>(
+            &'a self,
+            _: &'a str,
+        ) -> BoxFuture<'a, Result<Vec<String>, BackendError>> {
+            unimplemented!()
+        }
+
+        fn inspect_image_user<'a>(
+            &'a self,
+            _: &'a str,
+        ) -> BoxFuture<'a, Result<String, BackendError>> {
+            unimplemented!()
+        }
+
+        fn ensure_network(&self) -> BoxFuture<'_, Result<(), BackendError>> {
+            unimplemented!()
+        }
+
+        fn ensure_container_network<'a>(
+            &'a self,
+            _: &'a str,
+            _: &'a Path,
+        ) -> BoxFuture<'a, Result<(), BackendError>> {
+            unimplemented!()
+        }
+
+        fn get_container_ip<'a>(
+            &'a self,
+            _: &'a str,
+        ) -> BoxFuture<'a, Result<Option<String>, BackendError>> {
+            unimplemented!()
+        }
+
+        fn ensure_agent_provisioned<'a>(
+            &'a self,
+            _: &'a str,
+            _: &'a str,
+            _: bool,
+        ) -> BoxFuture<'a, Result<(), BackendError>> {
+            unimplemented!()
+        }
+
+        fn write_agent_addr<'a>(
+            &'a self,
+            _: &'a str,
+            _: &'a str,
+            _: &'a str,
+        ) -> BoxFuture<'a, Result<(), BackendError>> {
+            unimplemented!()
+        }
+
+        fn agent_volume_mount(&self) -> (String, String, bool) {
+            unimplemented!()
+        }
+
+        fn prune_old_agent_versions<'a>(
+            &'a self,
+            _: &'a str,
+        ) -> BoxFuture<'a, Result<(), BackendError>> {
+            unimplemented!()
+        }
+    }
+
+    fn ok_exit(code: i64) -> Result<ExecResult, BackendError> {
+        Ok(ExecResult {
+            exit_code: code,
+            stdout: String::new(),
+            stderr: String::new(),
+        })
+    }
+
+    fn err_exit(code: i64, stderr: &str) -> Result<ExecResult, BackendError> {
+        Ok(ExecResult {
+            exit_code: code,
+            stdout: String::new(),
+            stderr: stderr.to_string(),
+        })
+    }
+
+    // Call sequence for ensure_codex_sandbox_deps:
+    // 1. exec: "command -v bwrap"          (bwrap check)
+    // 2. exec: "test -f /etc/alpine-release" (alpine check, only if bwrap missing)
+    // 3. exec: install command               (only if bwrap missing)
+
+    #[tokio::test]
+    async fn ensure_codex_sandbox_deps_bwrap_already_installed() {
+        // bwrap found on PATH -> return true, no further calls
+        let backend = MockBackend::new(vec![ok_exit(0)]);
+        let result = ensure_codex_sandbox_deps(&backend, "test-container").await;
+        assert!(result);
+    }
+
+    #[tokio::test]
+    async fn ensure_codex_sandbox_deps_debian_install_success() {
+        let backend = MockBackend::new(vec![
+            ok_exit(1), // bwrap not found
+            ok_exit(1), // not alpine (test -f /etc/alpine-release fails)
+            ok_exit(0), // apt-get install succeeds
+        ]);
+        let result = ensure_codex_sandbox_deps(&backend, "test-container").await;
+        assert!(result);
+    }
+
+    #[tokio::test]
+    async fn ensure_codex_sandbox_deps_alpine_install_success() {
+        let backend = MockBackend::new(vec![
+            ok_exit(1), // bwrap not found
+            ok_exit(0), // is alpine (test -f /etc/alpine-release succeeds)
+            ok_exit(0), // apk add succeeds
+        ]);
+        let result = ensure_codex_sandbox_deps(&backend, "test-container").await;
+        assert!(result);
+    }
+
+    #[tokio::test]
+    async fn ensure_codex_sandbox_deps_debian_install_failure() {
+        let backend = MockBackend::new(vec![
+            ok_exit(1),                                              // bwrap not found
+            ok_exit(1),                                              // not alpine
+            err_exit(100, "E: Unable to locate package bubblewrap"), // apt-get fails
+        ]);
+        let result = ensure_codex_sandbox_deps(&backend, "test-container").await;
+        assert!(!result);
+    }
+
+    #[tokio::test]
+    async fn ensure_codex_sandbox_deps_alpine_install_failure() {
+        let backend = MockBackend::new(vec![
+            ok_exit(1),                                      // bwrap not found
+            ok_exit(0),                                      // is alpine
+            err_exit(1, "ERROR: unable to select packages"), // apk add fails
+        ]);
+        let result = ensure_codex_sandbox_deps(&backend, "test-container").await;
+        assert!(!result);
+    }
 }

--- a/crates/cella-orchestrator/src/tool_install.rs
+++ b/crates/cella-orchestrator/src/tool_install.rs
@@ -1225,20 +1225,20 @@ mod tests {
         }
     }
 
-    fn ok_exit(code: i64) -> Result<ExecResult, BackendError> {
-        Ok(ExecResult {
+    fn ok_exit(code: i64) -> ExecResult {
+        ExecResult {
             exit_code: code,
             stdout: String::new(),
             stderr: String::new(),
-        })
+        }
     }
 
-    fn err_exit(code: i64, stderr: &str) -> Result<ExecResult, BackendError> {
-        Ok(ExecResult {
+    fn fail_exit(code: i64, stderr: &str) -> ExecResult {
+        ExecResult {
             exit_code: code,
             stdout: String::new(),
             stderr: stderr.to_string(),
-        })
+        }
     }
 
     // Call sequence for ensure_codex_sandbox_deps:
@@ -1249,7 +1249,7 @@ mod tests {
     #[tokio::test]
     async fn ensure_codex_sandbox_deps_bwrap_already_installed() {
         // bwrap found on PATH -> return true, no further calls
-        let backend = MockBackend::new(vec![ok_exit(0)]);
+        let backend = MockBackend::new(vec![Ok(ok_exit(0))]);
         let result = ensure_codex_sandbox_deps(&backend, "test-container").await;
         assert!(result);
     }
@@ -1257,9 +1257,9 @@ mod tests {
     #[tokio::test]
     async fn ensure_codex_sandbox_deps_debian_install_success() {
         let backend = MockBackend::new(vec![
-            ok_exit(1), // bwrap not found
-            ok_exit(1), // not alpine (test -f /etc/alpine-release fails)
-            ok_exit(0), // apt-get install succeeds
+            Ok(ok_exit(1)), // bwrap not found
+            Ok(ok_exit(1)), // not alpine (test -f /etc/alpine-release fails)
+            Ok(ok_exit(0)), // apt-get install succeeds
         ]);
         let result = ensure_codex_sandbox_deps(&backend, "test-container").await;
         assert!(result);
@@ -1268,9 +1268,9 @@ mod tests {
     #[tokio::test]
     async fn ensure_codex_sandbox_deps_alpine_install_success() {
         let backend = MockBackend::new(vec![
-            ok_exit(1), // bwrap not found
-            ok_exit(0), // is alpine (test -f /etc/alpine-release succeeds)
-            ok_exit(0), // apk add succeeds
+            Ok(ok_exit(1)), // bwrap not found
+            Ok(ok_exit(0)), // is alpine (test -f /etc/alpine-release succeeds)
+            Ok(ok_exit(0)), // apk add succeeds
         ]);
         let result = ensure_codex_sandbox_deps(&backend, "test-container").await;
         assert!(result);
@@ -1279,9 +1279,9 @@ mod tests {
     #[tokio::test]
     async fn ensure_codex_sandbox_deps_debian_install_failure() {
         let backend = MockBackend::new(vec![
-            ok_exit(1),                                              // bwrap not found
-            ok_exit(1),                                              // not alpine
-            err_exit(100, "E: Unable to locate package bubblewrap"), // apt-get fails
+            Ok(ok_exit(1)),                                               // bwrap not found
+            Ok(ok_exit(1)),                                               // not alpine
+            Ok(fail_exit(100, "E: Unable to locate package bubblewrap")), // apt-get fails
         ]);
         let result = ensure_codex_sandbox_deps(&backend, "test-container").await;
         assert!(!result);
@@ -1290,9 +1290,9 @@ mod tests {
     #[tokio::test]
     async fn ensure_codex_sandbox_deps_alpine_install_failure() {
         let backend = MockBackend::new(vec![
-            ok_exit(1),                                      // bwrap not found
-            ok_exit(0),                                      // is alpine
-            err_exit(1, "ERROR: unable to select packages"), // apk add fails
+            Ok(ok_exit(1)),                                       // bwrap not found
+            Ok(ok_exit(0)),                                       // is alpine
+            Ok(fail_exit(1, "ERROR: unable to select packages")), // apk add fails
         ]);
         let result = ensure_codex_sandbox_deps(&backend, "test-container").await;
         assert!(!result);

--- a/crates/cella-orchestrator/src/tool_install.rs
+++ b/crates/cella-orchestrator/src/tool_install.rs
@@ -475,6 +475,8 @@ pub async fn install_codex(
         return;
     }
 
+    ensure_codex_sandbox_deps(client, container_id).await;
+
     debug!("Installing Codex ({})...", settings.version);
     let result = npm_install_global(
         client,


### PR DESCRIPTION
## Summary
- Install `bubblewrap` (`bwrap`) as an OS-level prerequisite for Codex sandbox support on Linux containers
- Codex previously logged a warning and fell back to a vendored bubblewrap when the system package was missing
- Supports both Alpine (`apk`) and Debian (`apt-get`) containers

## Design
- New `ensure_codex_sandbox_deps()` in `crates/cella-orchestrator/src/tool_install.rs`
- Pre-checks `command -v bwrap` before installing to avoid unnecessary `apt-get update` calls
- Runs before the `is_npm_tool_installed` check, so existing Codex installs still get bubblewrap
- Failure is non-fatal: warns and continues, Codex falls back to its vendored copy
- Mirrors the existing `ensure_alpine_claude_deps()` pattern

Spec: `docs/superpowers/specs/2026-04-12-codex-bubblewrap-install-design.md`

## Test plan
- [x] 5 new mock-based unit tests covering: bwrap present, Debian success, Alpine success, Debian failure, Alpine failure
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings -D clippy::all`
- [x] `cargo test --workspace`
- [ ] Manual verification: `cella up` on a container where Codex is already installed but bubblewrap is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)