### PR TITLE
feat: add terminal title integration

### DIFF
--- a/crates/cella-cli/src/commands/branch.rs
+++ b/crates/cella-cli/src/commands/branch.rs
@@ -93,6 +93,8 @@ impl BranchArgs {
             self.output.clone(),
         )
         .await?;
+        let _title_guard =
+            crate::title::push_for_name(&ctx.container_nm, Some(&self.name), "branch");
 
         // Remove any leftover container from a previous failed attempt so
         // ensure_up always runs the full first-create path (lifecycle hooks,

--- a/crates/cella-cli/src/commands/branch.rs
+++ b/crates/cella-cli/src/commands/branch.rs
@@ -93,8 +93,15 @@ impl BranchArgs {
             self.output.clone(),
         )
         .await?;
-        let _title_guard =
-            crate::title::push_for_name(&ctx.container_nm, Some(&self.name), "branch");
+        let _title_guard = crate::title::push_for_workspace(
+            ctx.client.as_ref(),
+            wt_path,
+            &ctx.container_nm,
+            None,
+            Some(&self.name),
+            "branch",
+        )
+        .await;
 
         // Remove any leftover container from a previous failed attempt so
         // ensure_up always runs the full first-create path (lifecycle hooks,

--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -77,8 +77,7 @@ impl BuildArgs {
 
         let config = &resolved.config;
         let config_name = config.get("name").and_then(|v| v.as_str());
-        let title_name = container_name(&resolved.workspace_root, config_name);
-        let _title_guard = crate::title::push_for_name(&title_name, None, "build");
+        let fallback_name = container_name(&resolved.workspace_root, config_name);
         let secrets: Vec<BuildSecret> = self
             .secrets
             .iter()
@@ -88,6 +87,15 @@ impl BuildArgs {
 
         let client = self.backend.resolve_client().await?;
         client.ping().await?;
+        let _title_guard = crate::title::push_for_workspace(
+            client.as_ref(),
+            &resolved.workspace_root,
+            &fallback_name,
+            None,
+            None,
+            "build",
+        )
+        .await;
 
         // Docker Compose path: delegate to orchestrator
         if config.get("dockerComposeFile").is_some() {

--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -6,7 +6,7 @@ use tracing::{info, warn};
 
 use super::{ComposePullPolicy, ImagePullPolicy, OutputFormat};
 
-use cella_backend::BuildSecret;
+use cella_backend::{BuildSecret, container_name};
 use cella_config::devcontainer::resolve;
 use cella_orchestrator::image::EnsureImageInput;
 
@@ -77,6 +77,8 @@ impl BuildArgs {
 
         let config = &resolved.config;
         let config_name = config.get("name").and_then(|v| v.as_str());
+        let title_name = container_name(&resolved.workspace_root, config_name);
+        let _title_guard = crate::title::push_for_name(&title_name, None, "build");
         let secrets: Vec<BuildSecret> = self
             .secrets
             .iter()

--- a/crates/cella-cli/src/commands/code.rs
+++ b/crates/cella-cli/src/commands/code.rs
@@ -68,7 +68,15 @@ impl CodeArgs {
         let mut up = self.up;
         picker::resolve_up_workspace(&mut up).await;
         let ctx = UpContext::new(&up, progress).await?;
-        let _title_guard = crate::title::push_for_name(&ctx.container_nm, None, "code");
+        let _title_guard = crate::title::push_for_workspace(
+            ctx.client.as_ref(),
+            &ctx.resolved.workspace_root,
+            &ctx.container_nm,
+            self.service.as_deref(),
+            None,
+            "code",
+        )
+        .await;
 
         // Reject non-Docker backends — VS Code attach URI is Docker-specific
         if ctx.client.kind() != cella_backend::BackendKind::Docker {

--- a/crates/cella-cli/src/commands/code.rs
+++ b/crates/cella-cli/src/commands/code.rs
@@ -68,6 +68,7 @@ impl CodeArgs {
         let mut up = self.up;
         picker::resolve_up_workspace(&mut up).await;
         let ctx = UpContext::new(&up, progress).await?;
+        let _title_guard = crate::title::push_for_name(&ctx.container_nm, None, "code");
 
         // Reject non-Docker backends — VS Code attach URI is Docker-specific
         if ctx.client.kind() != cella_backend::BackendKind::Docker {

--- a/crates/cella-cli/src/commands/exec.rs
+++ b/crates/cella-cli/src/commands/exec.rs
@@ -8,6 +8,7 @@ use cella_orchestrator::env_cache::{ensure_ssh_auth_sock, read_probed_env_cache}
 use cella_orchestrator::shell_detect::{detect_shell, wrap_in_login_shell};
 
 use crate::picker;
+use crate::title::push_for_container;
 
 /// Execute a command inside the running dev container.
 #[derive(Args)]
@@ -160,7 +161,7 @@ impl ExecArgs {
                 .await?;
             println!("{exec_id}");
         } else {
-            let is_tty = std::io::IsTerminal::is_terminal(&std::io::stdin());
+            let title_guard = push_for_container(&container, self.service.as_deref(), "exec");
             let exit_code = client
                 .as_ref()
                 .exec_interactive(
@@ -170,10 +171,11 @@ impl ExecArgs {
                         user: Some(user),
                         env: Some(env),
                         working_dir,
-                        tty: is_tty,
+                        tty: std::io::IsTerminal::is_terminal(&std::io::stdin()),
                     },
                 )
                 .await?;
+            drop(title_guard);
             std::process::exit(i32::try_from(exit_code).unwrap_or(125));
         }
 

--- a/crates/cella-cli/src/commands/nvim.rs
+++ b/crates/cella-cli/src/commands/nvim.rs
@@ -8,6 +8,7 @@ use super::OutputFormat;
 use super::up::{UpArgs, UpContext};
 
 use crate::picker;
+use crate::title::push_for_container;
 
 /// Open neovim inside the dev container.
 ///
@@ -81,6 +82,7 @@ impl NvimArgs {
 
         // 5. Build environment
         let container = ctx.client.inspect_container(&container_id).await?;
+        let title_guard = push_for_container(&container, self.service.as_deref(), "nvim");
         let label_env: Vec<String> = container
             .labels
             .get("dev.cella.remote_env")
@@ -135,6 +137,7 @@ impl NvimArgs {
             )
             .await?;
 
+        drop(title_guard);
         std::process::exit(i32::try_from(exit_code).unwrap_or(125));
     }
 }

--- a/crates/cella-cli/src/commands/shell.rs
+++ b/crates/cella-cli/src/commands/shell.rs
@@ -69,6 +69,13 @@ impl ShellArgs {
             super::resolve_service_container(client.as_ref(), container, self.service.as_deref())
                 .await?;
 
+        let title_guard = crate::title::TitleGuard::push(&crate::title::TitleContent {
+            name: crate::title::title_name(&container.name).to_string(),
+            service: self.service.clone(),
+            branch: container.labels.get("dev.cella.branch").cloned(),
+            subcommand: "shell",
+        });
+
         super::ensure_cella_daemon().await;
 
         // Read exec metadata from container labels
@@ -143,6 +150,8 @@ impl ShellArgs {
             )
             .await?;
 
+        // process::exit skips Drop, so pop the title explicitly first.
+        drop(title_guard);
         std::process::exit(i32::try_from(exit_code).unwrap_or(125));
     }
 }

--- a/crates/cella-cli/src/commands/shell.rs
+++ b/crates/cella-cli/src/commands/shell.rs
@@ -69,12 +69,8 @@ impl ShellArgs {
             super::resolve_service_container(client.as_ref(), container, self.service.as_deref())
                 .await?;
 
-        let title_guard = crate::title::TitleGuard::push(&crate::title::TitleContent {
-            name: crate::title::title_name(&container.name).to_string(),
-            service: self.service.clone(),
-            branch: container.labels.get("dev.cella.branch").cloned(),
-            subcommand: "shell",
-        });
+        let title_guard =
+            crate::title::push_for_container(&container, self.service.as_deref(), "shell");
 
         super::ensure_cella_daemon().await;
 

--- a/crates/cella-cli/src/commands/tmux.rs
+++ b/crates/cella-cli/src/commands/tmux.rs
@@ -10,6 +10,7 @@ use super::OutputFormat;
 use super::up::{UpArgs, UpContext};
 
 use crate::picker;
+use crate::title::push_for_container;
 
 /// Open a persistent tmux session inside the dev container.
 ///
@@ -50,14 +51,10 @@ impl TmuxArgs {
         let ctx = UpContext::new(&up, progress).await?;
         let result = ctx.ensure_up(build_no_cache, &strict).await?;
         let container_id = if self.service.is_some() {
-            let container = ctx.client.inspect_container(&result.container_id).await?;
-            let resolved = super::resolve_service_container(
-                ctx.client.as_ref(),
-                container,
-                self.service.as_deref(),
-            )
-            .await?;
-            resolved.id
+            let c = ctx.client.inspect_container(&result.container_id).await?;
+            super::resolve_service_container(ctx.client.as_ref(), c, self.service.as_deref())
+                .await?
+                .id
         } else {
             result.container_id.clone()
         };
@@ -87,6 +84,7 @@ impl TmuxArgs {
         }
 
         let container = ctx.client.inspect_container(&container_id).await?;
+        let title_guard = push_for_container(&container, self.service.as_deref(), "tmux");
         let label_env: Vec<String> = container
             .labels
             .get("dev.cella.remote_env")
@@ -147,6 +145,7 @@ impl TmuxArgs {
             )
             .await?;
 
+        drop(title_guard);
         std::process::exit(i32::try_from(exit_code).unwrap_or(125));
     }
 }

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -739,6 +739,7 @@ impl UpArgs {
             self.output.clone(),
         )
         .await?;
+        let _title_guard = crate::title::push_for_name(&ctx.container_nm, Some(branch_name), "up");
         ctx.remove_container = self.build.rebuild || self.build.remove_existing_container;
         ctx.build_no_cache = self.build.build_no_cache;
         ctx.skip_checksum = self.skip_checksum;
@@ -776,6 +777,7 @@ impl UpArgs {
         }
 
         let ctx = UpContext::new(&self, progress).await?;
+        let _title_guard = crate::title::push_for_name(&ctx.container_nm, None, "up");
 
         // Docker Compose branch: if dockerComposeFile is present, delegate to compose flow
         if ctx.config().get("dockerComposeFile").is_some() {

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -739,7 +739,15 @@ impl UpArgs {
             self.output.clone(),
         )
         .await?;
-        let _title_guard = crate::title::push_for_name(&ctx.container_nm, Some(branch_name), "up");
+        let _title_guard = crate::title::push_for_workspace(
+            ctx.client.as_ref(),
+            &wt.path,
+            &ctx.container_nm,
+            None,
+            Some(branch_name),
+            "up",
+        )
+        .await;
         ctx.remove_container = self.build.rebuild || self.build.remove_existing_container;
         ctx.build_no_cache = self.build.build_no_cache;
         ctx.skip_checksum = self.skip_checksum;
@@ -777,7 +785,15 @@ impl UpArgs {
         }
 
         let ctx = UpContext::new(&self, progress).await?;
-        let _title_guard = crate::title::push_for_name(&ctx.container_nm, None, "up");
+        let _title_guard = crate::title::push_for_workspace(
+            ctx.client.as_ref(),
+            &ctx.resolved.workspace_root,
+            &ctx.container_nm,
+            None,
+            None,
+            "up",
+        )
+        .await;
 
         // Docker Compose branch: if dockerComposeFile is present, delegate to compose flow
         if ctx.config().get("dockerComposeFile").is_some() {

--- a/crates/cella-cli/src/main.rs
+++ b/crates/cella-cli/src/main.rs
@@ -4,6 +4,7 @@ pub mod picker;
 pub mod progress;
 pub mod style;
 mod table;
+mod title;
 
 use std::io::IsTerminal;
 

--- a/crates/cella-cli/src/title.rs
+++ b/crates/cella-cli/src/title.rs
@@ -94,35 +94,74 @@ impl TitleGuard {
 
 /// Convenience: build a guard from a resolved container. Pulls `branch` from
 /// the `dev.cella.branch` label when present, and `service` from the caller's
-/// explicit flag.
+/// explicit flag. For compose containers, prefers the `com.docker.compose.project`
+/// label as the name source so the title reads as the project (not
+/// `<project>-<service>-<index>` which would duplicate the service suffix).
 pub fn push_for_container(
     container: &cella_backend::ContainerInfo,
     service: Option<&str>,
     subcommand: &'static str,
 ) -> Option<TitleGuard> {
     TitleGuard::push(&TitleContent {
-        name: title_name(&container.name).to_string(),
+        name: title_name(base_name(container)).to_string(),
         service: service.map(str::to_string),
         branch: container.labels.get("dev.cella.branch").cloned(),
         subcommand,
     })
 }
 
-/// Convenience: build a guard from a container name alone. Used by commands
-/// that know the deterministic container name (via [`cella_backend::container_name`]
-/// or `UpContext::container_nm`) without having a full [`cella_backend::ContainerInfo`]
-/// to pull labels from.
+/// Build a guard from a container name. Used as a fallback by
+/// [`push_for_workspace`] when no live container exists yet (e.g. first
+/// `cella up` / `cella build` before creation).
 pub fn push_for_name(
     container_name: &str,
+    service: Option<&str>,
     branch: Option<&str>,
     subcommand: &'static str,
 ) -> Option<TitleGuard> {
     TitleGuard::push(&TitleContent {
         name: title_name(container_name).to_string(),
-        service: None,
+        service: service.map(str::to_string),
         branch: branch.map(str::to_string),
         subcommand,
     })
+}
+
+/// Look up the existing container for `workspace_root` and derive a guard from
+/// its labels (compose project, branch). Falls back to `fallback_name` and
+/// `fallback_branch` when the container doesn't exist yet.
+///
+/// Use this for long-running commands that may be operating on a worktree or
+/// compose devcontainer — it ensures the title reflects the container's
+/// actual identity (branch, project) when available, instead of only the
+/// deterministic name derived from the workspace path.
+pub async fn push_for_workspace(
+    client: &dyn cella_backend::ContainerBackend,
+    workspace_root: &std::path::Path,
+    fallback_name: &str,
+    service: Option<&str>,
+    fallback_branch: Option<&str>,
+    subcommand: &'static str,
+) -> Option<TitleGuard> {
+    client
+        .find_container(workspace_root)
+        .await
+        .ok()
+        .flatten()
+        .map_or_else(
+            || push_for_name(fallback_name, service, fallback_branch, subcommand),
+            |container| push_for_container(&container, service, subcommand),
+        )
+}
+
+/// Prefer the compose project label so that compose containers surface as
+/// `<project>` (e.g. `cella-myrepo-a1b2c3d4`) instead of
+/// `<project>-<service>-<index>` (e.g. `cella-myrepo-a1b2c3d4-api-1`).
+fn base_name(container: &cella_backend::ContainerInfo) -> &str {
+    container
+        .labels
+        .get("com.docker.compose.project")
+        .map_or(container.name.as_str(), String::as_str)
 }
 
 impl Drop for TitleGuard {
@@ -334,6 +373,87 @@ mod tests {
         assert_eq!(
             tmux_wrap(b"\x1bA\x1bB"),
             b"\x1bPtmux;\x1b\x1bA\x1b\x1bB\x1b\\"
+        );
+    }
+
+    // ── base_name selection (compose project vs container name) ─────
+
+    fn container_with_labels(name: &str, labels: &[(&str, &str)]) -> cella_backend::ContainerInfo {
+        let labels: std::collections::HashMap<String, String> = labels
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        cella_backend::ContainerInfo {
+            id: "id".to_string(),
+            name: name.to_string(),
+            state: cella_backend::ContainerState::Running,
+            exit_code: None,
+            labels,
+            config_hash: None,
+            ports: vec![],
+            created_at: None,
+            container_user: None,
+            image: None,
+            mounts: vec![],
+            backend: cella_backend::BackendKind::Docker,
+        }
+    }
+
+    #[test]
+    fn base_name_prefers_compose_project_label() {
+        // Compose container: actual name has -<service>-<index> suffix, but
+        // `com.docker.compose.project` points at the clean project name.
+        let c = container_with_labels(
+            "cella-myrepo-a1b2c3d4-api-1",
+            &[("com.docker.compose.project", "cella-myrepo-a1b2c3d4")],
+        );
+        assert_eq!(base_name(&c), "cella-myrepo-a1b2c3d4");
+    }
+
+    #[test]
+    fn base_name_falls_back_to_container_name_when_no_compose_label() {
+        let c = container_with_labels("cella-myrepo-a1b2c3d4", &[]);
+        assert_eq!(base_name(&c), "cella-myrepo-a1b2c3d4");
+    }
+
+    #[test]
+    fn push_for_container_compose_title_has_no_redundant_service_suffix() {
+        // Compose + explicit --service api: title should show project + :api,
+        // NOT project-api-1:api. (Regression: codex stop-time review caught
+        // this.)
+        let c = container_with_labels(
+            "cella-myrepo-a1b2c3d4-api-1",
+            &[
+                ("com.docker.compose.project", "cella-myrepo-a1b2c3d4"),
+                ("com.docker.compose.service", "api"),
+            ],
+        );
+        // Format directly (no OSC emission under non-TTY) to verify composition.
+        let content = TitleContent {
+            name: title_name(base_name(&c)).to_string(),
+            service: Some("api".to_string()),
+            branch: None,
+            subcommand: "shell",
+        };
+        assert_eq!(content.format(), "myrepo-a1b2c3d4:api \u{2014} cella shell");
+    }
+
+    #[test]
+    fn push_for_container_worktree_surfaces_branch_label() {
+        // Container exists with dev.cella.branch label set by `cella branch`.
+        let c = container_with_labels(
+            "cella-myrepo-deadbe12",
+            &[("dev.cella.branch", "feat/auth")],
+        );
+        let content = TitleContent {
+            name: title_name(base_name(&c)).to_string(),
+            service: None,
+            branch: c.labels.get("dev.cella.branch").cloned(),
+            subcommand: "up",
+        };
+        assert_eq!(
+            content.format(),
+            "myrepo-deadbe12@feat/auth \u{2014} cella up"
         );
     }
 

--- a/crates/cella-cli/src/title.rs
+++ b/crates/cella-cli/src/title.rs
@@ -1,0 +1,324 @@
+//! Terminal title integration.
+//!
+//! Emits OSC escape sequences to set the terminal window title for the duration
+//! of interactive or long-running `cella` commands, and restores the prior
+//! title on exit using the xterm push/pop title stack (OSC 22 / 23).
+//!
+//! See the design doc at `docs/…` — or, more practically, the tests below for
+//! the exact byte-level behavior.
+//!
+//! Title shape: `<name>[:service][@branch] \u{2014} cella <subcommand>`.
+//!
+//! The emitted bytes go to `stderr`, and emission is gated on `stderr` being a
+//! TTY. When cella is run inside `tmux` (detected via `$TMUX`), every escape
+//! sequence is wrapped in a DCS passthrough so the outer terminal's title
+//! actually updates.
+
+use std::io::{self, IsTerminal, Write};
+
+/// Strip the `"cella-"` prefix so the title doesn't repeat the brand already
+/// present in the `" \u{2014} cella <subcommand>"` suffix. No-op if the prefix
+/// is absent.
+pub fn title_name(container_name: &str) -> &str {
+    container_name
+        .strip_prefix("cella-")
+        .unwrap_or(container_name)
+}
+
+/// Inputs to title rendering. Constructed by call sites from the resolved
+/// container name, labels, and CLI args.
+pub struct TitleContent {
+    /// Container short-name with `cella-` prefix already stripped (use
+    /// [`title_name`]).
+    pub name: String,
+    /// Compose service, only populated when the user passed `--service <x>`.
+    pub service: Option<String>,
+    /// Branch label, only populated when the container carries the
+    /// `dev.cella.branch` label (i.e. a worktree container).
+    pub branch: Option<String>,
+    /// Clap subcommand literal — `"shell"`, `"up"`, etc. Never includes
+    /// arguments.
+    pub subcommand: &'static str,
+}
+
+impl TitleContent {
+    /// Render to the final title string (without any escape bytes).
+    pub fn format(&self) -> String {
+        let mut s = self.name.clone();
+        if let Some(svc) = &self.service {
+            s.push(':');
+            s.push_str(svc);
+        }
+        if let Some(br) = &self.branch {
+            s.push('@');
+            s.push_str(br);
+        }
+        s.push_str(" \u{2014} cella ");
+        s.push_str(self.subcommand);
+        s
+    }
+}
+
+/// RAII guard that sets the terminal title on construction and pops it on
+/// drop. Returns `None` when `stderr` isn't a TTY, so the common pattern
+///
+/// ```ignore
+/// let _guard = TitleGuard::push(&content);
+/// ```
+///
+/// is always safe regardless of environment.
+///
+/// **Note on `std::process::exit`:** the stdlib `exit` function skips Drop.
+/// Commands that call `process::exit` must `drop(guard)` explicitly before the
+/// exit call, mirroring the `RawModeGuard` pattern in `cella-docker`.
+#[must_use = "binding required to keep title set until the guard is dropped"]
+pub struct TitleGuard(());
+
+impl TitleGuard {
+    /// Emit OSC 22 (push) + OSC 0 (set). Skips emission entirely when
+    /// `stderr` is not a TTY.
+    pub fn push(content: &TitleContent) -> Option<Self> {
+        if !io::stderr().is_terminal() {
+            return None;
+        }
+        let tmux = in_tmux();
+        let mut stderr = io::stderr().lock();
+        // Best-effort: if a write fails (e.g. the terminal vanished),
+        // we still want to hand out the guard so Drop's pop is attempted.
+        let _ = emit_push(&mut stderr, tmux);
+        let _ = emit_set(&mut stderr, &content.format(), tmux);
+        let _ = stderr.flush();
+        Some(Self(()))
+    }
+}
+
+impl Drop for TitleGuard {
+    fn drop(&mut self) {
+        let tmux = in_tmux();
+        let mut stderr = io::stderr().lock();
+        let _ = emit_pop(&mut stderr, tmux);
+        let _ = stderr.flush();
+    }
+}
+
+fn in_tmux() -> bool {
+    std::env::var_os("TMUX").is_some()
+}
+
+fn emit_push(w: &mut impl Write, in_tmux: bool) -> io::Result<()> {
+    // CSI 22 ; 0 t — save both icon name and window title to the terminal's stack.
+    let bytes: &[u8] = b"\x1b[22;0t";
+    if in_tmux {
+        w.write_all(&tmux_wrap(bytes))
+    } else {
+        w.write_all(bytes)
+    }
+}
+
+fn emit_set(w: &mut impl Write, title: &str, in_tmux: bool) -> io::Result<()> {
+    // OSC 0 — set both icon name and window title. BEL terminator is preferred
+    // over ST because it doesn't collide with the DCS terminator when wrapped.
+    let mut bytes = b"\x1b]0;".to_vec();
+    bytes.extend_from_slice(title.as_bytes());
+    bytes.push(0x07);
+    if in_tmux {
+        w.write_all(&tmux_wrap(&bytes))
+    } else {
+        w.write_all(&bytes)
+    }
+}
+
+fn emit_pop(w: &mut impl Write, in_tmux: bool) -> io::Result<()> {
+    // CSI 23 ; 0 t — restore icon name and window title from the stack.
+    let bytes: &[u8] = b"\x1b[23;0t";
+    if in_tmux {
+        w.write_all(&tmux_wrap(bytes))
+    } else {
+        w.write_all(bytes)
+    }
+}
+
+/// Wrap an escape sequence in a tmux DCS passthrough envelope so the outer
+/// terminal receives the inner sequence. Each ESC inside is doubled per tmux
+/// convention.
+fn tmux_wrap(inner: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(inner.len() + 10);
+    out.extend_from_slice(b"\x1bPtmux;");
+    for &b in inner {
+        if b == 0x1b {
+            out.push(0x1b);
+        }
+        out.push(b);
+    }
+    out.extend_from_slice(b"\x1b\\");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── title_name ──────────────────────────────────────────────────
+
+    #[test]
+    fn title_name_strips_prefix() {
+        assert_eq!(title_name("cella-foo-abcd1234"), "foo-abcd1234");
+    }
+
+    #[test]
+    fn title_name_no_prefix_unchanged() {
+        assert_eq!(title_name("other"), "other");
+    }
+
+    #[test]
+    fn title_name_empty_string() {
+        assert_eq!(title_name(""), "");
+    }
+
+    #[test]
+    fn title_name_just_prefix() {
+        assert_eq!(title_name("cella-"), "");
+    }
+
+    #[test]
+    fn title_name_prefix_without_trailing() {
+        // "cella" without the trailing dash is NOT a match — strip is literal.
+        assert_eq!(title_name("cella"), "cella");
+    }
+
+    // ── TitleContent::format ────────────────────────────────────────
+
+    #[test]
+    fn format_name_only() {
+        let c = TitleContent {
+            name: "x".to_string(),
+            service: None,
+            branch: None,
+            subcommand: "shell",
+        };
+        assert_eq!(c.format(), "x \u{2014} cella shell");
+    }
+
+    #[test]
+    fn format_with_service() {
+        let c = TitleContent {
+            name: "x".to_string(),
+            service: Some("api".to_string()),
+            branch: None,
+            subcommand: "shell",
+        };
+        assert_eq!(c.format(), "x:api \u{2014} cella shell");
+    }
+
+    #[test]
+    fn format_with_branch() {
+        let c = TitleContent {
+            name: "x".to_string(),
+            service: None,
+            branch: Some("feat/auth".to_string()),
+            subcommand: "shell",
+        };
+        assert_eq!(c.format(), "x@feat/auth \u{2014} cella shell");
+    }
+
+    #[test]
+    fn format_all_three() {
+        let c = TitleContent {
+            name: "myrepo-a1b2c3d4".to_string(),
+            service: Some("api".to_string()),
+            branch: Some("feat/auth".to_string()),
+            subcommand: "up",
+        };
+        assert_eq!(
+            c.format(),
+            "myrepo-a1b2c3d4:api@feat/auth \u{2014} cella up"
+        );
+    }
+
+    // ── emit_* plain ────────────────────────────────────────────────
+
+    #[test]
+    fn emit_push_plain_bytes() {
+        let mut out = Vec::new();
+        emit_push(&mut out, false).unwrap();
+        assert_eq!(out, b"\x1b[22;0t");
+    }
+
+    #[test]
+    fn emit_set_plain_bytes() {
+        let mut out = Vec::new();
+        emit_set(&mut out, "x \u{2014} cella shell", false).unwrap();
+        // Em dash is UTF-8 0xE2 0x80 0x94.
+        assert_eq!(out, b"\x1b]0;x \xe2\x80\x94 cella shell\x07");
+    }
+
+    #[test]
+    fn emit_pop_plain_bytes() {
+        let mut out = Vec::new();
+        emit_pop(&mut out, false).unwrap();
+        assert_eq!(out, b"\x1b[23;0t");
+    }
+
+    // ── emit_* tmux-wrapped ─────────────────────────────────────────
+
+    #[test]
+    fn emit_push_tmux_bytes() {
+        let mut out = Vec::new();
+        emit_push(&mut out, true).unwrap();
+        // DCS envelope with doubled ESC inside.
+        assert_eq!(out, b"\x1bPtmux;\x1b\x1b[22;0t\x1b\\");
+    }
+
+    #[test]
+    fn emit_set_tmux_bytes() {
+        let mut out = Vec::new();
+        emit_set(&mut out, "x", true).unwrap();
+        // Inner OSC \x1b]0;x\x07 becomes \x1b\x1b]0;x\x07 inside the envelope.
+        assert_eq!(out, b"\x1bPtmux;\x1b\x1b]0;x\x07\x1b\\");
+    }
+
+    #[test]
+    fn emit_pop_tmux_bytes() {
+        let mut out = Vec::new();
+        emit_pop(&mut out, true).unwrap();
+        assert_eq!(out, b"\x1bPtmux;\x1b\x1b[23;0t\x1b\\");
+    }
+
+    // ── tmux_wrap ───────────────────────────────────────────────────
+
+    #[test]
+    fn tmux_wrap_no_escapes_in_inner() {
+        assert_eq!(tmux_wrap(b"hello"), b"\x1bPtmux;hello\x1b\\");
+    }
+
+    #[test]
+    fn tmux_wrap_single_escape_is_doubled() {
+        assert_eq!(tmux_wrap(b"\x1b[X"), b"\x1bPtmux;\x1b\x1b[X\x1b\\");
+    }
+
+    #[test]
+    fn tmux_wrap_multiple_escapes_each_doubled() {
+        assert_eq!(
+            tmux_wrap(b"\x1bA\x1bB"),
+            b"\x1bPtmux;\x1b\x1bA\x1b\x1bB\x1b\\"
+        );
+    }
+
+    // ── public API reachability ──────────────────────────────────────
+
+    #[test]
+    fn title_guard_push_is_reachable() {
+        // Smoke test: exercises the public `push` + Drop path. In headless
+        // test environments stderr is not a TTY so `push` returns None and
+        // no bytes are emitted. In an interactive `cargo test`, it returns
+        // `Some` and the guard is dropped immediately, popping the title.
+        // Either outcome is fine; this test only asserts the call is sound.
+        let content = TitleContent {
+            name: "t".to_string(),
+            service: None,
+            branch: None,
+            subcommand: "test",
+        };
+        drop(TitleGuard::push(&content));
+    }
+}

--- a/crates/cella-cli/src/title.rs
+++ b/crates/cella-cli/src/title.rs
@@ -110,48 +110,37 @@ pub fn push_for_container(
     })
 }
 
-/// Build a guard from a container name. Used as a fallback by
-/// [`push_for_workspace`] when no live container exists yet (e.g. first
-/// `cella up` / `cella build` before creation).
-pub fn push_for_name(
-    container_name: &str,
-    service: Option<&str>,
-    branch: Option<&str>,
-    subcommand: &'static str,
-) -> Option<TitleGuard> {
-    TitleGuard::push(&TitleContent {
-        name: title_name(container_name).to_string(),
-        service: service.map(str::to_string),
-        branch: branch.map(str::to_string),
-        subcommand,
-    })
-}
-
 /// Look up the existing container for `workspace_root` and derive a guard from
-/// its labels (compose project, branch). Falls back to `fallback_name` and
-/// `fallback_branch` when the container doesn't exist yet.
+/// its labels (compose project, branch). Falls back to `fallback_name` when no
+/// container exists yet.
 ///
-/// Use this for long-running commands that may be operating on a worktree or
-/// compose devcontainer — it ensures the title reflects the container's
-/// actual identity (branch, project) when available, instead of only the
-/// deterministic name derived from the workspace path.
+/// `branch` is the caller's authoritative branch (e.g. from `--branch <b>` or
+/// from `cella branch <name>`). When provided, it always wins over whatever
+/// `dev.cella.branch` label the live container happens to carry — a fresh
+/// `cella branch` creation has no container label yet, and a retry after a
+/// partial failure may see a stale or mismatched one. `None` means the caller
+/// doesn't know the branch a priori, so the container label (if any) is used.
 pub async fn push_for_workspace(
     client: &dyn cella_backend::ContainerBackend,
     workspace_root: &std::path::Path,
     fallback_name: &str,
     service: Option<&str>,
-    fallback_branch: Option<&str>,
+    branch: Option<&str>,
     subcommand: &'static str,
 ) -> Option<TitleGuard> {
-    client
-        .find_container(workspace_root)
-        .await
-        .ok()
-        .flatten()
-        .map_or_else(
-            || push_for_name(fallback_name, service, fallback_branch, subcommand),
-            |container| push_for_container(&container, service, subcommand),
-        )
+    let container = client.find_container(workspace_root).await.ok().flatten();
+    let name = title_name(container.as_ref().map_or(fallback_name, base_name)).to_string();
+    let effective_branch = branch.map(String::from).or_else(|| {
+        container
+            .as_ref()
+            .and_then(|c| c.labels.get("dev.cella.branch").cloned())
+    });
+    TitleGuard::push(&TitleContent {
+        name,
+        service: service.map(str::to_string),
+        branch: effective_branch,
+        subcommand,
+    })
 }
 
 /// Prefer the compose project label so that compose containers surface as
@@ -455,6 +444,48 @@ mod tests {
             content.format(),
             "myrepo-deadbe12@feat/auth \u{2014} cella up"
         );
+    }
+
+    /// Mirrors the branch-merge logic inside `push_for_workspace` so it can be
+    /// unit-tested without a mock `ContainerBackend`.
+    fn effective_branch(explicit: Option<&str>, container_label: Option<&str>) -> Option<String> {
+        explicit
+            .map(String::from)
+            .or_else(|| container_label.map(String::from))
+    }
+
+    #[test]
+    fn explicit_branch_wins_over_container_label() {
+        // `cella branch feat/new` with a stale leftover container labelled
+        // `feat/old` must title as feat/new (the user's intent), not feat/old.
+        assert_eq!(
+            effective_branch(Some("feat/new"), Some("feat/old")),
+            Some("feat/new".to_string())
+        );
+    }
+
+    #[test]
+    fn explicit_branch_used_when_no_container() {
+        // `cella branch feat/auth` on a fresh worktree (no container yet).
+        assert_eq!(
+            effective_branch(Some("feat/auth"), None),
+            Some("feat/auth".to_string())
+        );
+    }
+
+    #[test]
+    fn container_label_used_when_no_explicit_branch() {
+        // `cella up` (no --branch) in an existing worktree container.
+        assert_eq!(
+            effective_branch(None, Some("feat/auth")),
+            Some("feat/auth".to_string())
+        );
+    }
+
+    #[test]
+    fn no_branch_without_explicit_or_label() {
+        // Plain `cella up` in a non-worktree with no existing container.
+        assert_eq!(effective_branch(None, None), None);
     }
 
     // ── public API reachability ──────────────────────────────────────

--- a/crates/cella-cli/src/title.rs
+++ b/crates/cella-cli/src/title.rs
@@ -108,6 +108,23 @@ pub fn push_for_container(
     })
 }
 
+/// Convenience: build a guard from a container name alone. Used by commands
+/// that know the deterministic container name (via [`cella_backend::container_name`]
+/// or `UpContext::container_nm`) without having a full [`cella_backend::ContainerInfo`]
+/// to pull labels from.
+pub fn push_for_name(
+    container_name: &str,
+    branch: Option<&str>,
+    subcommand: &'static str,
+) -> Option<TitleGuard> {
+    TitleGuard::push(&TitleContent {
+        name: title_name(container_name).to_string(),
+        service: None,
+        branch: branch.map(str::to_string),
+        subcommand,
+    })
+}
+
 impl Drop for TitleGuard {
     fn drop(&mut self) {
         let tmux = in_tmux();

--- a/crates/cella-cli/src/title.rs
+++ b/crates/cella-cli/src/title.rs
@@ -92,6 +92,22 @@ impl TitleGuard {
     }
 }
 
+/// Convenience: build a guard from a resolved container. Pulls `branch` from
+/// the `dev.cella.branch` label when present, and `service` from the caller's
+/// explicit flag.
+pub fn push_for_container(
+    container: &cella_backend::ContainerInfo,
+    service: Option<&str>,
+    subcommand: &'static str,
+) -> Option<TitleGuard> {
+    TitleGuard::push(&TitleContent {
+        name: title_name(&container.name).to_string(),
+        service: service.map(str::to_string),
+        branch: container.labels.get("dev.cella.branch").cloned(),
+        subcommand,
+    })
+}
+
 impl Drop for TitleGuard {
     fn drop(&mut self) {
         let tmux = in_tmux();


### PR DESCRIPTION
## Summary

- `cella shell`/`exec`/`tmux`/`nvim`/`code`/`up`/`build`/`branch` now set the terminal title for the duration of the command and restore the prior title on exit via the xterm OSC 22/23 push/pop stack. Beats `claude-code`'s "clear to empty on quit" behavior.
- Title shape: `<name>[:service][@branch] — cella <subcommand>`. `<name>` is the container short-name with the `cella-` prefix stripped (hash retained). `:service` only when `--service` is explicitly passed. `@branch` for worktrees (from `dev.cella.branch` label, or from explicit CLI args like `cella branch <name>` / `cella up --branch <b>`).
- Self-contained `cella-cli/src/title.rs` module (no new crate). Auto-detects `$TMUX` and wraps OSC in DCS passthrough. TTY-gated on `stderr().is_terminal()` so OSC bytes never leak into piped logs. Explicit `drop(guard)` before every `std::process::exit` to mirror the existing `RawModeGuard` pattern.

## Commits

```
60399a1 fix: explicit branch wins over container label in title
e249e05 fix: correct title for compose service targets and worktrees
0e819ed feat: set terminal title during cella up, build, code, branch
6fdef36 feat: set terminal title during cella tmux and nvim
c1d7e65 feat: set terminal title during cella exec (interactive mode)
6eafdc4 feat: set terminal title during cella shell
```

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings -D clippy::all`
- [x] `cargo test --workspace` (all test binaries green; 27 new tests in `title.rs` covering format composition, plain/tmux byte emission, compose project label selection, worktree branch surfacing, explicit-branch-wins-over-label)
- [x] Manual in a real terminal: `cella shell` — tab title becomes `<name> — cella shell`, restores on exit.
- [x] Manual: `cella branch feat/test` — title becomes `<name>@feat/test — cella branch` during creation.
- [x] Manual in a compose devcontainer: `cella exec --service api <cmd>` — title becomes `<project>:api — cella exec` (project name, not `<project>-api-1:api`).
- [x] Manual with `TMUX` set: verify outer terminal title updates (DCS passthrough working).
- [x] Manual with redirected stderr (`cella up 2>/tmp/log`) — `/tmp/log` contains no OSC bytes.

## Notes for reviewers

- Interviewed design is in the session's plan file; key decisions: container short-name with hash (not devcontainer.json `name` alone) for disambiguation; OSC 22/23 push/pop for clean restore; "set once, don't fight the shell" — we don't inject shell rc snippets to keep the title pinned during `cella shell`.
- `code.rs` execute() is a few lines under clippy's `too_many_lines` threshold; any future edit there may need a split.
- Two fix commits responded to Codex stop-time review findings (compose service duplication, worktree label precedence).