### PR TITLE
fix: compose shell runs as root despite Dockerfile USER

### DIFF
--- a/crates/cella-compose/src/dockerfile.rs
+++ b/crates/cella-compose/src/dockerfile.rs
@@ -169,6 +169,11 @@ struct FromEntry {
     line_index: usize,
     /// The stage name after AS, if present.
     stage_name: Option<String>,
+    /// The source image token (the `<image>` in `FROM <image> [AS <name>]`).
+    ///
+    /// Can be another stage name from this Dockerfile or an external image
+    /// reference (e.g. `node:18`, `$_DEV_CONTAINERS_BASE_IMAGE`).
+    source_image: Option<String>,
 }
 
 /// Parse all FROM lines from the Dockerfile, extracting stage names.
@@ -211,6 +216,12 @@ fn parse_from_lines(lines: &[&str]) -> Vec<FromEntry> {
             .position(|p| !p.starts_with("--"))
             .map_or(parts.len(), |pos| pos + 1);
 
+        let source_image = if non_flag_start < parts.len() {
+            Some(parts[non_flag_start].to_string())
+        } else {
+            None
+        };
+
         let stage_name = if non_flag_start < parts.len()
             && non_flag_start + 2 < parts.len()
             && parts[non_flag_start + 1].eq_ignore_ascii_case("AS")
@@ -223,10 +234,127 @@ fn parse_from_lines(lines: &[&str]) -> Vec<FromEntry> {
         entries.push(FromEntry {
             line_index: idx,
             stage_name,
+            source_image,
         });
     }
 
     entries
+}
+
+/// Statically resolve the effective USER for a Dockerfile target stage.
+///
+/// Walks the selected stage (by name, or the last `FROM` if `target_stage`
+/// is `None`) looking for the last `USER` instruction before the next
+/// `FROM`. Strips any `:group` suffix so the result is a bare user name
+/// suitable for Docker's `USER` instruction and the UID-remap `sed` pattern.
+///
+/// If the stage has no `USER`, follows its `FROM <image>` reference: when
+/// `<image>` is another named stage in this Dockerfile, walks into that
+/// stage; otherwise returns `None` so the caller can fall back to inspecting
+/// the external base image.
+///
+/// Returns `None` when:
+/// - No `USER` directive is found (even after walking stages)
+/// - The `USER` argument contains `$` (variable substitution — we don't
+///   resolve these; caller should fall back to inspecting the built image)
+/// - The target stage is not found
+/// - A cycle is detected in the stage chain (defense against malformed input)
+#[must_use]
+pub fn find_user_statement(content: &str, target_stage: Option<&str>) -> Option<String> {
+    let lines: Vec<&str> = content.lines().collect();
+    let from_entries = parse_from_lines(&lines);
+
+    if from_entries.is_empty() {
+        return None;
+    }
+
+    let start_idx = if let Some(target) = target_stage {
+        from_entries
+            .iter()
+            .position(|e| e.stage_name.as_deref() == Some(target))?
+    } else {
+        from_entries.len() - 1
+    };
+
+    let mut seen = std::collections::HashSet::new();
+    let mut current_idx = start_idx;
+
+    loop {
+        if !seen.insert(current_idx) {
+            return None;
+        }
+
+        let entry = &from_entries[current_idx];
+        let stage_start = entry.line_index + 1;
+        let stage_end = from_entries
+            .get(current_idx + 1)
+            .map_or(lines.len(), |next| next.line_index);
+
+        if let Some(user) = find_last_user_in_range(&lines, stage_start, stage_end) {
+            return parse_user_token(&user);
+        }
+
+        let source = entry.source_image.as_deref()?;
+        current_idx = from_entries
+            .iter()
+            .position(|e| e.stage_name.as_deref() == Some(source))?;
+    }
+}
+
+/// Return the argument of the last `USER` instruction in `lines[start..end]`,
+/// or `None` if no `USER` is present in the range.
+///
+/// Supports line continuations (`\` at end of line) only at the instruction
+/// boundary — the argument itself must fit on one line (matching Docker's
+/// behavior for `USER`).
+fn find_last_user_in_range(lines: &[&str], start: usize, end: usize) -> Option<String> {
+    let mut last: Option<String> = None;
+
+    for line in lines.iter().take(end).skip(start) {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        let without_comment = trimmed
+            .find('#')
+            .map_or(trimmed, |hash_pos| trimmed[..hash_pos].trim());
+
+        let mut tokens = without_comment.split_whitespace();
+        let Some(instr) = tokens.next() else {
+            continue;
+        };
+
+        if !instr.eq_ignore_ascii_case("USER") {
+            continue;
+        }
+
+        let arg: String = tokens.collect::<Vec<_>>().join(" ");
+        if !arg.is_empty() {
+            last = Some(arg);
+        }
+    }
+
+    last
+}
+
+/// Extract the bare username from a `USER` argument.
+///
+/// - `node` → `Some("node")`
+/// - `node:node` → `Some("node")` (strips `:group`)
+/// - `$FOO` or anything containing `$` → `None` (unresolved variable)
+/// - empty → `None`
+fn parse_user_token(arg: &str) -> Option<String> {
+    let trimmed = arg.trim();
+    if trimmed.is_empty() || trimmed.contains('$') {
+        return None;
+    }
+    let user = trimmed.split(':').next()?.trim();
+    if user.is_empty() {
+        None
+    } else {
+        Some(user.to_string())
+    }
 }
 
 #[cfg(test)]
@@ -491,5 +619,179 @@ RUN echo hello
     fn directive_offset_only_directives() {
         let content = "# syntax=docker/dockerfile:1\n# check=skip=all\n";
         assert_eq!(find_directive_end_offset(content), content.len());
+    }
+
+    // ---------------------------------------------------------------
+    // find_user_statement
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn user_statement_last_user_wins() {
+        let dockerfile = "\
+FROM ubuntu:22.04
+USER root
+RUN apt-get update
+USER node
+";
+        assert_eq!(
+            find_user_statement(dockerfile, None),
+            Some("node".to_string())
+        );
+    }
+
+    #[test]
+    fn user_statement_strips_group() {
+        let dockerfile = "FROM node:18\nUSER node:node\n";
+        assert_eq!(
+            find_user_statement(dockerfile, None),
+            Some("node".to_string())
+        );
+    }
+
+    #[test]
+    fn user_statement_strips_numeric_group() {
+        let dockerfile = "FROM node:18\nUSER 1000:1000\n";
+        assert_eq!(
+            find_user_statement(dockerfile, None),
+            Some("1000".to_string())
+        );
+    }
+
+    #[test]
+    fn user_statement_walks_from_chain() {
+        let dockerfile = "\
+FROM ubuntu:22.04 AS base
+USER vscode
+
+FROM base AS dev
+RUN echo hello
+";
+        assert_eq!(
+            find_user_statement(dockerfile, Some("dev")),
+            Some("vscode".to_string())
+        );
+    }
+
+    #[test]
+    fn user_statement_variable_returns_none() {
+        let dockerfile = "FROM node:18\nUSER $FOO\n";
+        assert_eq!(find_user_statement(dockerfile, None), None);
+    }
+
+    #[test]
+    fn user_statement_braced_variable_returns_none() {
+        let dockerfile = "FROM node:18\nUSER ${FOO}\n";
+        assert_eq!(find_user_statement(dockerfile, None), None);
+    }
+
+    #[test]
+    fn user_statement_target_not_found() {
+        let dockerfile = "FROM node:18 AS base\n";
+        assert_eq!(find_user_statement(dockerfile, Some("missing")), None);
+    }
+
+    #[test]
+    fn user_statement_no_user_anywhere() {
+        let dockerfile = "FROM node:18\nRUN echo hi\n";
+        assert_eq!(find_user_statement(dockerfile, None), None);
+    }
+
+    #[test]
+    fn user_statement_cycle_returns_none() {
+        // Two stages referencing each other via their stage names — malformed
+        // but should not panic or loop forever.
+        let dockerfile = "\
+FROM b AS a
+RUN echo a
+
+FROM a AS b
+RUN echo b
+";
+        assert_eq!(find_user_statement(dockerfile, Some("a")), None);
+    }
+
+    #[test]
+    fn user_statement_case_insensitive_keyword() {
+        let dockerfile = "FROM node:18\nuser node\n";
+        assert_eq!(
+            find_user_statement(dockerfile, None),
+            Some("node".to_string())
+        );
+    }
+
+    #[test]
+    fn user_statement_whitespace_tolerant() {
+        let dockerfile = "FROM node:18\n   USER    node   \n";
+        assert_eq!(
+            find_user_statement(dockerfile, None),
+            Some("node".to_string())
+        );
+    }
+
+    #[test]
+    fn user_statement_ignores_comments() {
+        let dockerfile = "\
+FROM node:18
+# USER root — just a comment
+USER node
+";
+        assert_eq!(
+            find_user_statement(dockerfile, None),
+            Some("node".to_string())
+        );
+    }
+
+    #[test]
+    fn user_statement_strips_inline_comment() {
+        let dockerfile = "FROM node:18\nUSER node # runtime user\n";
+        assert_eq!(
+            find_user_statement(dockerfile, None),
+            Some("node".to_string())
+        );
+    }
+
+    #[test]
+    fn user_statement_stops_at_next_from() {
+        // USER in the second stage must not leak into the first stage's result.
+        let dockerfile = "\
+FROM ubuntu:22.04 AS first
+RUN echo first
+
+FROM alpine:3.18 AS second
+USER nobody
+";
+        assert_eq!(find_user_statement(dockerfile, Some("first")), None);
+        assert_eq!(
+            find_user_statement(dockerfile, Some("second")),
+            Some("nobody".to_string())
+        );
+    }
+
+    #[test]
+    fn user_statement_defaults_to_last_stage_when_no_target() {
+        let dockerfile = "\
+FROM ubuntu:22.04 AS builder
+USER root
+
+FROM alpine:3.18
+USER user
+";
+        assert_eq!(
+            find_user_statement(dockerfile, None),
+            Some("user".to_string())
+        );
+    }
+
+    #[test]
+    fn user_statement_no_from_lines() {
+        assert_eq!(find_user_statement("# just a comment\n", None), None);
+    }
+
+    #[test]
+    fn user_statement_walks_external_base_returns_none() {
+        // When a stage has no USER and its FROM is an external image (not a
+        // named stage), the caller is expected to fall back to image inspect.
+        let dockerfile = "FROM ubuntu:22.04 AS base\nRUN echo hi\n";
+        assert_eq!(find_user_statement(dockerfile, Some("base")), None);
     }
 }

--- a/crates/cella-compose/src/dockerfile.rs
+++ b/crates/cella-compose/src/dockerfile.rs
@@ -83,10 +83,12 @@ pub fn synthetic_dockerfile(image: &str) -> (String, String) {
 
 /// Generate a combined Dockerfile: original content + feature layers.
 ///
-/// Inserts a global-scope `ARG _DEV_CONTAINERS_BASE_IMAGE=<base_image>`
-/// after any parser directives but before the first `FROM`, so that the
-/// feature layers' `FROM $_DEV_CONTAINERS_BASE_IMAGE` resolves correctly
-/// in `docker compose build` (which cannot pass `--build-arg`).
+/// Inserts global-scope `ARG _DEV_CONTAINERS_BASE_IMAGE=<base_image>` and
+/// `ARG _DEV_CONTAINERS_IMAGE_USER=<image_user>` after any parser directives
+/// but before the first `FROM`, so that the feature layers' final
+/// `USER $_DEV_CONTAINERS_IMAGE_USER` resolves to the user's Dockerfile USER
+/// (and `FROM $_DEV_CONTAINERS_BASE_IMAGE` resolves across stages) in
+/// `docker compose build`, which cannot accept `--build-arg` via the override.
 ///
 /// The `feature_dockerfile` should be the output of
 /// `cella_features::dockerfile::generate_dockerfile()` called with the
@@ -96,10 +98,12 @@ pub fn generate_combined_dockerfile(
     original_content: &str,
     feature_dockerfile: &str,
     base_image: &str,
+    image_user: &str,
 ) -> String {
     let directive_end = find_directive_end_offset(original_content);
     let mut global_arg = String::new();
     writeln!(global_arg, "ARG _DEV_CONTAINERS_BASE_IMAGE={base_image}").unwrap();
+    writeln!(global_arg, "ARG _DEV_CONTAINERS_IMAGE_USER={image_user}").unwrap();
 
     let mut combined = String::with_capacity(
         original_content.len() + global_arg.len() + feature_dockerfile.len() + 2,
@@ -107,7 +111,9 @@ pub fn generate_combined_dockerfile(
 
     // Preserve parser directives at the top
     combined.push_str(&original_content[..directive_end]);
-    // Global ARG so FROM $_DEV_CONTAINERS_BASE_IMAGE resolves across stages
+    // Global ARGs so FROM $_DEV_CONTAINERS_BASE_IMAGE resolves across stages
+    // and the features target stage's `ARG _DEV_CONTAINERS_IMAGE_USER` (without
+    // a stage-local default) inherits this value.
     combined.push_str(&global_arg);
     // Rest of original Dockerfile
     combined.push_str(&original_content[directive_end..]);
@@ -338,6 +344,58 @@ fn find_last_user_in_range(lines: &[&str], start: usize, end: usize) -> Option<S
     last
 }
 
+/// Return the external base image for a named stage, after resolving any
+/// in-Dockerfile stage chain.
+///
+/// Walks `FROM <image> AS <stage>` references: if `<image>` names another
+/// stage in this Dockerfile, recurses; otherwise returns `<image>`. Returns
+/// `None` when the image token contains `$` (unresolved variable), the
+/// target stage is missing, or a cycle is detected.
+///
+/// Used by callers that need to inspect the external base image's
+/// `Config.User` when the Dockerfile does not declare a `USER` itself.
+#[must_use]
+pub fn find_stage_base_image(content: &str, target_stage: Option<&str>) -> Option<String> {
+    let lines: Vec<&str> = content.lines().collect();
+    let from_entries = parse_from_lines(&lines);
+
+    if from_entries.is_empty() {
+        return None;
+    }
+
+    let start_idx = if let Some(target) = target_stage {
+        from_entries
+            .iter()
+            .position(|e| e.stage_name.as_deref() == Some(target))?
+    } else {
+        from_entries.len() - 1
+    };
+
+    let mut seen = std::collections::HashSet::new();
+    let mut current_idx = start_idx;
+
+    loop {
+        if !seen.insert(current_idx) {
+            return None;
+        }
+
+        let source = from_entries[current_idx].source_image.as_deref()?;
+        if source.contains('$') {
+            return None;
+        }
+
+        if let Some(next) = from_entries
+            .iter()
+            .position(|e| e.stage_name.as_deref() == Some(source))
+        {
+            current_idx = next;
+            continue;
+        }
+
+        return Some(source.to_string());
+    }
+}
+
 /// Extract the bare username from a `USER` argument.
 ///
 /// - `node` → `Some("node")`
@@ -492,13 +550,23 @@ RUN echo hello
     fn combined_dockerfile() {
         let original = "FROM node:18 AS base\nRUN npm install\n";
         let features = "ARG _DEV_CONTAINERS_BASE_IMAGE=base\nFROM $_DEV_CONTAINERS_BASE_IMAGE AS dev_containers_target_stage\nUSER root\n";
-        let combined = generate_combined_dockerfile(original, features, "base");
-        // Global ARG should appear before the first FROM
-        let arg_pos = combined
+        let combined = generate_combined_dockerfile(original, features, "base", "node");
+        // Global ARGs should appear before the first FROM
+        let base_arg_pos = combined
             .find("ARG _DEV_CONTAINERS_BASE_IMAGE=base")
             .unwrap();
+        let user_arg_pos = combined
+            .find("ARG _DEV_CONTAINERS_IMAGE_USER=node")
+            .unwrap();
         let from_pos = combined.find("FROM node:18 AS base").unwrap();
-        assert!(arg_pos < from_pos, "global ARG must precede first FROM");
+        assert!(
+            base_arg_pos < from_pos,
+            "global base ARG must precede first FROM"
+        );
+        assert!(
+            user_arg_pos < from_pos,
+            "global user ARG must precede first FROM"
+        );
         assert!(
             combined.contains("FROM $_DEV_CONTAINERS_BASE_IMAGE AS dev_containers_target_stage")
         );
@@ -508,8 +576,10 @@ RUN echo hello
     fn combined_adds_newline_separator() {
         let original = "FROM node:18";
         let features = "FROM node:18 AS target";
-        let combined = generate_combined_dockerfile(original, features, "node:18");
-        assert!(combined.contains("ARG _DEV_CONTAINERS_BASE_IMAGE=node:18\nFROM node:18"));
+        let combined = generate_combined_dockerfile(original, features, "node:18", "root");
+        assert!(
+            combined.contains("ARG _DEV_CONTAINERS_BASE_IMAGE=node:18\nARG _DEV_CONTAINERS_IMAGE_USER=root\nFROM node:18")
+        );
         assert!(combined.contains("\n\nFROM node:18 AS target"));
     }
 
@@ -517,7 +587,7 @@ RUN echo hello
     fn combined_with_syntax_directive() {
         let original = "# syntax=docker/dockerfile:1\nFROM node:18 AS base\nRUN npm install\n";
         let features = "ARG _DEV_CONTAINERS_BASE_IMAGE=base\nFROM $_DEV_CONTAINERS_BASE_IMAGE AS dev_containers_target_stage\nUSER root\n";
-        let combined = generate_combined_dockerfile(original, features, "base");
+        let combined = generate_combined_dockerfile(original, features, "base", "root");
 
         // Parser directive must remain at the very top
         assert!(combined.starts_with("# syntax=docker/dockerfile:1\n"));
@@ -525,17 +595,24 @@ RUN echo hello
         let arg_pos = combined
             .find("ARG _DEV_CONTAINERS_BASE_IMAGE=base")
             .unwrap();
+        let user_arg_pos = combined
+            .find("ARG _DEV_CONTAINERS_IMAGE_USER=root")
+            .unwrap();
         let syntax_pos = combined.find("# syntax=docker/dockerfile:1").unwrap();
         let from_pos = combined.find("FROM node:18 AS base").unwrap();
         assert!(syntax_pos < arg_pos, "directive must precede global ARG");
         assert!(arg_pos < from_pos, "global ARG must precede first FROM");
+        assert!(
+            user_arg_pos < from_pos,
+            "global user ARG must precede first FROM"
+        );
     }
 
     #[test]
     fn combined_with_multiple_directives() {
         let original = "# syntax=docker/dockerfile:1\n# escape=\\\nFROM ubuntu:22.04 AS base\nRUN apt-get update\n";
         let features = "ARG _DEV_CONTAINERS_BASE_IMAGE=base\nFROM $_DEV_CONTAINERS_BASE_IMAGE AS dev_containers_target_stage\n";
-        let combined = generate_combined_dockerfile(original, features, "base");
+        let combined = generate_combined_dockerfile(original, features, "base", "root");
 
         assert!(combined.starts_with("# syntax=docker/dockerfile:1\n# escape=\\\n"));
         let arg_pos = combined
@@ -549,11 +626,11 @@ RUN echo hello
     fn combined_no_directives() {
         let original = "FROM alpine:3.18 AS base\nRUN echo hello\n";
         let features = "ARG _DEV_CONTAINERS_BASE_IMAGE=base\nFROM $_DEV_CONTAINERS_BASE_IMAGE AS dev_containers_target_stage\n";
-        let combined = generate_combined_dockerfile(original, features, "base");
+        let combined = generate_combined_dockerfile(original, features, "base", "root");
 
-        assert!(
-            combined.starts_with("ARG _DEV_CONTAINERS_BASE_IMAGE=base\nFROM alpine:3.18 AS base")
-        );
+        assert!(combined.starts_with(
+            "ARG _DEV_CONTAINERS_BASE_IMAGE=base\nARG _DEV_CONTAINERS_IMAGE_USER=root\nFROM alpine:3.18 AS base"
+        ));
     }
 
     #[test]
@@ -561,7 +638,7 @@ RUN echo hello
         // Original has ARG before FROM (common pattern)
         let original = "ARG BASE=node:18\nFROM $BASE AS builder\nRUN npm install\n";
         let features = "ARG _DEV_CONTAINERS_BASE_IMAGE=builder\nFROM $_DEV_CONTAINERS_BASE_IMAGE AS dev_containers_target_stage\n";
-        let combined = generate_combined_dockerfile(original, features, "builder");
+        let combined = generate_combined_dockerfile(original, features, "builder", "root");
 
         let global_arg_pos = combined
             .find("ARG _DEV_CONTAINERS_BASE_IMAGE=builder")
@@ -571,6 +648,17 @@ RUN echo hello
             global_arg_pos < first_from_pos,
             "global ARG must precede first FROM"
         );
+    }
+
+    #[test]
+    fn combined_passes_image_user_to_global_arg() {
+        // Regression: the user's Dockerfile USER must be exposed as a global
+        // ARG so the features stage's `ARG _DEV_CONTAINERS_IMAGE_USER` (no
+        // local default) inherits it.
+        let original = "FROM node:18 AS base\nUSER node:node\n";
+        let features = "FROM $_DEV_CONTAINERS_BASE_IMAGE AS dev_containers_target_stage\nARG _DEV_CONTAINERS_IMAGE_USER\nUSER $_DEV_CONTAINERS_IMAGE_USER\n";
+        let combined = generate_combined_dockerfile(original, features, "base", "node");
+        assert!(combined.contains("ARG _DEV_CONTAINERS_IMAGE_USER=node\n"));
     }
 
     // ---------------------------------------------------------------
@@ -793,5 +881,67 @@ USER user
         // named stage), the caller is expected to fall back to image inspect.
         let dockerfile = "FROM ubuntu:22.04 AS base\nRUN echo hi\n";
         assert_eq!(find_user_statement(dockerfile, Some("base")), None);
+    }
+
+    // ---------------------------------------------------------------
+    // find_stage_base_image
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn stage_base_image_simple() {
+        let dockerfile = "FROM mcr.microsoft.com/devcontainers/typescript-node:4.0 AS base\n";
+        assert_eq!(
+            find_stage_base_image(dockerfile, Some("base")),
+            Some("mcr.microsoft.com/devcontainers/typescript-node:4.0".to_string())
+        );
+    }
+
+    #[test]
+    fn stage_base_image_walks_chain_to_external() {
+        let dockerfile = "\
+FROM ubuntu:22.04 AS base
+
+FROM base AS mid
+
+FROM mid AS final
+";
+        assert_eq!(
+            find_stage_base_image(dockerfile, Some("final")),
+            Some("ubuntu:22.04".to_string())
+        );
+    }
+
+    #[test]
+    fn stage_base_image_variable_returns_none() {
+        let dockerfile = "FROM $BASE_IMAGE AS base\n";
+        assert_eq!(find_stage_base_image(dockerfile, Some("base")), None);
+    }
+
+    #[test]
+    fn stage_base_image_missing_target_returns_none() {
+        let dockerfile = "FROM ubuntu:22.04 AS base\n";
+        assert_eq!(find_stage_base_image(dockerfile, Some("other")), None);
+    }
+
+    #[test]
+    fn stage_base_image_cycle_returns_none() {
+        let dockerfile = "\
+FROM b AS a
+
+FROM a AS b
+";
+        assert_eq!(find_stage_base_image(dockerfile, Some("a")), None);
+    }
+
+    #[test]
+    fn stage_base_image_defaults_to_last_stage() {
+        let dockerfile = "\
+FROM ubuntu:22.04 AS builder
+FROM alpine:3.18
+";
+        assert_eq!(
+            find_stage_base_image(dockerfile, None),
+            Some("alpine:3.18".to_string())
+        );
     }
 }

--- a/crates/cella-compose/src/integration_tests/phase_tests.rs
+++ b/crates/cella-compose/src/integration_tests/phase_tests.rs
@@ -127,6 +127,7 @@ fn combined_dockerfile_global_arg_before_from() {
         &named_content,
         &feature_dockerfile,
         &stage_name,
+        "root",
     );
 
     // Global ARG must appear before first FROM

--- a/crates/cella-compose/src/lib.rs
+++ b/crates/cella-compose/src/lib.rs
@@ -20,8 +20,8 @@ pub mod project;
 pub use cli::{ComposeCommand, ComposeServiceStatus, check_compose_features_support};
 pub use config::{ResolvedComposeConfig, ServiceBuildInfo, extract_service_build_info};
 pub use dockerfile::{
-    AUTO_STAGE_NAME, FEATURES_TARGET_STAGE, ensure_stage_named, generate_combined_dockerfile,
-    synthetic_dockerfile,
+    AUTO_STAGE_NAME, FEATURES_TARGET_STAGE, ensure_stage_named, find_user_statement,
+    generate_combined_dockerfile, synthetic_dockerfile,
 };
 pub use error::CellaComposeError;
 pub use override_file::{ComposeSecret, OverrideConfig};

--- a/crates/cella-compose/src/lib.rs
+++ b/crates/cella-compose/src/lib.rs
@@ -20,8 +20,8 @@ pub mod project;
 pub use cli::{ComposeCommand, ComposeServiceStatus, check_compose_features_support};
 pub use config::{ResolvedComposeConfig, ServiceBuildInfo, extract_service_build_info};
 pub use dockerfile::{
-    AUTO_STAGE_NAME, FEATURES_TARGET_STAGE, ensure_stage_named, find_user_statement,
-    generate_combined_dockerfile, synthetic_dockerfile,
+    AUTO_STAGE_NAME, FEATURES_TARGET_STAGE, ensure_stage_named, find_stage_base_image,
+    find_user_statement, generate_combined_dockerfile, synthetic_dockerfile,
 };
 pub use error::CellaComposeError;
 pub use override_file::{ComposeSecret, OverrideConfig};

--- a/crates/cella-features/src/dockerfile.rs
+++ b/crates/cella-features/src/dockerfile.rs
@@ -225,7 +225,11 @@ fn write_cleanup_and_user_reset(out: &mut String) {
     .unwrap();
 
     writeln!(out).unwrap();
-    writeln!(out, "ARG _DEV_CONTAINERS_IMAGE_USER=root").unwrap();
+    // Re-declare the ARG without a default so the features target stage
+    // inherits the global-scope `ARG _DEV_CONTAINERS_IMAGE_USER` injected by
+    // `cella_compose::generate_combined_dockerfile`. A stage-local default
+    // here would shadow the global value and force the container to root.
+    writeln!(out, "ARG _DEV_CONTAINERS_IMAGE_USER").unwrap();
     writeln!(out, "USER $_DEV_CONTAINERS_IMAGE_USER").unwrap();
 }
 

--- a/crates/cella-features/src/snapshots/cella_features__dockerfile__tests__dockerfile_with_entrypoint.snap
+++ b/crates/cella-features/src/snapshots/cella_features__dockerfile__tests__dockerfile_with_entrypoint.snap
@@ -28,5 +28,5 @@ RUN chmod +x /usr/local/share/docker-init.sh
 
 RUN rm -rf /tmp/dev-container-features && chmod 1777 /tmp
 
-ARG _DEV_CONTAINERS_IMAGE_USER=root
+ARG _DEV_CONTAINERS_IMAGE_USER
 USER $_DEV_CONTAINERS_IMAGE_USER

--- a/crates/cella-features/src/snapshots/cella_features__dockerfile__tests__dockerfile_with_metadata_only_entrypoint.snap
+++ b/crates/cella-features/src/snapshots/cella_features__dockerfile__tests__dockerfile_with_metadata_only_entrypoint.snap
@@ -28,5 +28,5 @@ RUN chmod +x /usr/local/share/docker-init.sh
 
 RUN rm -rf /tmp/dev-container-features && chmod 1777 /tmp
 
-ARG _DEV_CONTAINERS_IMAGE_USER=root
+ARG _DEV_CONTAINERS_IMAGE_USER
 USER $_DEV_CONTAINERS_IMAGE_USER

--- a/crates/cella-features/src/snapshots/cella_features__dockerfile__tests__feature_with_container_env.snap
+++ b/crates/cella-features/src/snapshots/cella_features__dockerfile__tests__feature_with_container_env.snap
@@ -27,5 +27,5 @@ RUN chmod -R 0755 /tmp/dev-container-features/node \
 
 RUN rm -rf /tmp/dev-container-features && chmod 1777 /tmp
 
-ARG _DEV_CONTAINERS_IMAGE_USER=root
+ARG _DEV_CONTAINERS_IMAGE_USER
 USER $_DEV_CONTAINERS_IMAGE_USER

--- a/crates/cella-features/src/snapshots/cella_features__dockerfile__tests__feature_with_container_user.snap
+++ b/crates/cella-features/src/snapshots/cella_features__dockerfile__tests__feature_with_container_user.snap
@@ -24,5 +24,5 @@ RUN chmod -R 0755 /tmp/dev-container-features/custom-tool \
 
 RUN rm -rf /tmp/dev-container-features && chmod 1777 /tmp
 
-ARG _DEV_CONTAINERS_IMAGE_USER=root
+ARG _DEV_CONTAINERS_IMAGE_USER
 USER $_DEV_CONTAINERS_IMAGE_USER

--- a/crates/cella-features/src/snapshots/cella_features__dockerfile__tests__feature_with_no_options.snap
+++ b/crates/cella-features/src/snapshots/cella_features__dockerfile__tests__feature_with_no_options.snap
@@ -24,5 +24,5 @@ RUN chmod -R 0755 /tmp/dev-container-features/minimal \
 
 RUN rm -rf /tmp/dev-container-features && chmod 1777 /tmp
 
-ARG _DEV_CONTAINERS_IMAGE_USER=root
+ARG _DEV_CONTAINERS_IMAGE_USER
 USER $_DEV_CONTAINERS_IMAGE_USER

--- a/crates/cella-features/src/snapshots/cella_features__dockerfile__tests__metadata_only_feature_skipped.snap
+++ b/crates/cella-features/src/snapshots/cella_features__dockerfile__tests__metadata_only_feature_skipped.snap
@@ -24,5 +24,5 @@ RUN chmod -R 0755 /tmp/dev-container-features/node \
 
 RUN rm -rf /tmp/dev-container-features && chmod 1777 /tmp
 
-ARG _DEV_CONTAINERS_IMAGE_USER=root
+ARG _DEV_CONTAINERS_IMAGE_USER
 USER $_DEV_CONTAINERS_IMAGE_USER

--- a/crates/cella-features/src/snapshots/cella_features__dockerfile__tests__mixed_user_transitions.snap
+++ b/crates/cella-features/src/snapshots/cella_features__dockerfile__tests__mixed_user_transitions.snap
@@ -40,5 +40,5 @@ RUN chmod -R 0755 /tmp/dev-container-features/another-root \
 
 RUN rm -rf /tmp/dev-container-features && chmod 1777 /tmp
 
-ARG _DEV_CONTAINERS_IMAGE_USER=root
+ARG _DEV_CONTAINERS_IMAGE_USER
 USER $_DEV_CONTAINERS_IMAGE_USER

--- a/crates/cella-features/src/snapshots/cella_features__dockerfile__tests__multiple_features_in_order.snap
+++ b/crates/cella-features/src/snapshots/cella_features__dockerfile__tests__multiple_features_in_order.snap
@@ -32,5 +32,5 @@ RUN chmod -R 0755 /tmp/dev-container-features/python \
 
 RUN rm -rf /tmp/dev-container-features && chmod 1777 /tmp
 
-ARG _DEV_CONTAINERS_IMAGE_USER=root
+ARG _DEV_CONTAINERS_IMAGE_USER
 USER $_DEV_CONTAINERS_IMAGE_USER

--- a/crates/cella-features/src/snapshots/cella_features__dockerfile__tests__no_redundant_user_root.snap
+++ b/crates/cella-features/src/snapshots/cella_features__dockerfile__tests__no_redundant_user_root.snap
@@ -24,5 +24,5 @@ RUN chmod -R 0755 /tmp/dev-container-features/tool \
 
 RUN rm -rf /tmp/dev-container-features && chmod 1777 /tmp
 
-ARG _DEV_CONTAINERS_IMAGE_USER=root
+ARG _DEV_CONTAINERS_IMAGE_USER
 USER $_DEV_CONTAINERS_IMAGE_USER

--- a/crates/cella-features/src/snapshots/cella_features__dockerfile__tests__single_feature_with_options.snap
+++ b/crates/cella-features/src/snapshots/cella_features__dockerfile__tests__single_feature_with_options.snap
@@ -24,5 +24,5 @@ RUN chmod -R 0755 /tmp/dev-container-features/node \
 
 RUN rm -rf /tmp/dev-container-features && chmod 1777 /tmp
 
-ARG _DEV_CONTAINERS_IMAGE_USER=root
+ARG _DEV_CONTAINERS_IMAGE_USER
 USER $_DEV_CONTAINERS_IMAGE_USER

--- a/crates/cella-features/src/snapshots/cella_features__dockerfile__tests__user_reset_at_end.snap
+++ b/crates/cella-features/src/snapshots/cella_features__dockerfile__tests__user_reset_at_end.snap
@@ -24,5 +24,5 @@ RUN chmod -R 0755 /tmp/dev-container-features/tool \
 
 RUN rm -rf /tmp/dev-container-features && chmod 1777 /tmp
 
-ARG _DEV_CONTAINERS_IMAGE_USER=root
+ARG _DEV_CONTAINERS_IMAGE_USER
 USER $_DEV_CONTAINERS_IMAGE_USER

--- a/crates/cella-orchestrator/src/compose_features.rs
+++ b/crates/cella-orchestrator/src/compose_features.rs
@@ -184,31 +184,33 @@ pub async fn resolve_compose_features(
     )?))
 }
 
-/// Resolve the effective USER for a build-based compose service.
+/// Resolve the effective USER and base-image metadata for a build-based
+/// compose service.
 ///
-/// Mirrors the devcontainer CLI's resolution:
+/// Mirrors the devcontainer CLI's `internalGetImageBuildInfoFromDockerfile`:
+/// always inspects the external base image (for `devcontainer.metadata`),
+/// and picks the user as:
+///
 /// 1. Static parse of the Dockerfile target stage's last `USER` directive.
-/// 2. Pull + inspect the external base image's `Config.User`. Pulling is
-///    acceptable because the user is about to build anyway.
-/// 3. Fall back to `"root"`.
+/// 2. The base image's `Config.User` from inspect.
+/// 3. `"root"` fallback.
 ///
-/// Also returns the base image's `devcontainer.metadata` label when step 2
-/// succeeds, mirroring how the image-only arm populates metadata.
+/// The base image's `devcontainer.metadata` label is returned regardless of
+/// which source set `image_user`, so downstream `resolve_remote_user` can
+/// apply the full spec precedence (config.remoteUser > config.containerUser >
+/// image metadata remoteUser > image metadata containerUser > image USER).
 async fn resolve_build_image_user(
     client: &dyn ContainerBackend,
     dockerfile_content: &str,
     target_stage: Option<&str>,
     progress: &ProgressSender,
 ) -> (String, Option<String>) {
-    if let Some(user) = cella_compose::find_user_statement(dockerfile_content, target_stage) {
-        debug!("Resolved image user from Dockerfile USER directive: {user}");
-        return (user, None);
-    }
+    let parsed_user = cella_compose::find_user_statement(dockerfile_content, target_stage);
 
     let Some(base_image) = cella_compose::find_stage_base_image(dockerfile_content, target_stage)
     else {
-        debug!("Could not resolve a base image to inspect; defaulting image user to root");
-        return ("root".to_string(), None);
+        debug!("Could not resolve a base image to inspect for metadata");
+        return (parsed_user.unwrap_or_else(|| "root".to_string()), None);
     };
 
     if matches!(client.image_exists(&base_image).await, Ok(false))
@@ -220,22 +222,48 @@ async fn resolve_build_image_user(
         .await
     {
         warn!("Failed to pull base image '{base_image}' for user inspection: {e}");
-        return ("root".to_string(), None);
+        return (parsed_user.unwrap_or_else(|| "root".to_string()), None);
     }
 
     match client.inspect_image_details(&base_image).await {
         Ok(details) => {
-            debug!(
-                "Resolved image user from base image '{base_image}' inspect: {}",
-                details.user
+            let (user, metadata) = pick_image_user_and_metadata(
+                parsed_user.as_deref(),
+                Some(details.user.as_str()),
+                details.metadata,
             );
-            (details.user, details.metadata)
+            debug!(
+                "Resolved image user: {user} (has metadata: {})",
+                metadata.is_some()
+            );
+            (user, metadata)
         }
         Err(e) => {
             warn!("Failed to inspect base image '{base_image}': {e}");
-            ("root".to_string(), None)
+            (parsed_user.unwrap_or_else(|| "root".to_string()), None)
         }
     }
+}
+
+/// Combine a Dockerfile-parsed USER with a base-image inspect result into the
+/// final `(image_user, base_image_metadata)` tuple.
+///
+/// - `image_user` precedence: parser > inspect (non-empty) > `"root"`.
+/// - `base_image_metadata` is returned as-is; the caller always wants it
+///   when inspect succeeded, regardless of which source set `image_user`.
+///
+/// Extracted so it can be unit-tested without a `ContainerBackend` mock.
+fn pick_image_user_and_metadata(
+    parser_user: Option<&str>,
+    inspect_user: Option<&str>,
+    inspect_metadata: Option<String>,
+) -> (String, Option<String>) {
+    let inspect_nonempty = inspect_user.filter(|u| !u.is_empty());
+    let user = parser_user
+        .or(inspect_nonempty)
+        .unwrap_or("root")
+        .to_string();
+    (user, inspect_metadata)
 }
 
 /// Generate the combined Dockerfile and write it to disk.
@@ -490,5 +518,70 @@ RUN echo hi
             find_user_statement(dockerfile, Some("base")),
             Some("1000".to_string())
         );
+    }
+
+    // ---------------------------------------------------------------
+    // pick_image_user_and_metadata
+    //
+    // Regression coverage for the Codex stop-time review: the parser-hit
+    // path must NOT drop the base image's devcontainer.metadata label. The
+    // helper always returns the inspect metadata when inspect succeeded,
+    // regardless of which source set image_user.
+    // ---------------------------------------------------------------
+
+    use super::pick_image_user_and_metadata;
+
+    #[test]
+    fn picker_parser_wins_and_metadata_preserved() {
+        // Parser found USER node — inspect user is vscode. Parser wins for
+        // image_user, BUT the metadata from inspect must still be returned
+        // so resolve_remote_user can apply the full spec precedence.
+        let (user, metadata) = pick_image_user_and_metadata(
+            Some("node"),
+            Some("vscode"),
+            Some("{\"remoteUser\":\"vscode\"}".to_string()),
+        );
+        assert_eq!(user, "node");
+        assert_eq!(
+            metadata.as_deref(),
+            Some("{\"remoteUser\":\"vscode\"}"),
+            "metadata must survive the parser-hit path"
+        );
+    }
+
+    #[test]
+    fn picker_falls_back_to_inspect_user_when_parser_empty() {
+        let (user, metadata) =
+            pick_image_user_and_metadata(None, Some("vscode"), Some("{\"k\":1}".to_string()));
+        assert_eq!(user, "vscode");
+        assert_eq!(metadata.as_deref(), Some("{\"k\":1}"));
+    }
+
+    #[test]
+    fn picker_falls_back_to_root_when_both_empty() {
+        let (user, metadata) = pick_image_user_and_metadata(None, Some(""), None);
+        assert_eq!(user, "root");
+        assert!(metadata.is_none());
+    }
+
+    #[test]
+    fn picker_ignores_empty_inspect_user() {
+        // Empty Config.User (most Docker images) must not short-circuit to
+        // "" — we need to fall back to the final `"root"` default.
+        let (user, _) = pick_image_user_and_metadata(None, Some(""), None);
+        assert_eq!(user, "root");
+    }
+
+    #[test]
+    fn picker_returns_metadata_even_with_root_user() {
+        // Base image USER=root but has metadata (e.g. mcr devcontainers with
+        // spec-compliant metadata label). Metadata must flow through.
+        let (user, metadata) = pick_image_user_and_metadata(
+            None,
+            Some("root"),
+            Some("{\"containerUser\":\"node\"}".to_string()),
+        );
+        assert_eq!(user, "root");
+        assert_eq!(metadata.as_deref(), Some("{\"containerUser\":\"node\"}"));
     }
 }

--- a/crates/cella-orchestrator/src/compose_features.rs
+++ b/crates/cella-orchestrator/src/compose_features.rs
@@ -354,3 +354,141 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! Regression tests for compose + features user resolution.
+    //!
+    //! Pure-function tests; the `resolve_build_image_user` paths that call
+    //! `inspect_image_details` are covered by integration tests gated on the
+    //! `integration-tests` feature of `cella-compose`.
+
+    use cella_compose::{FEATURES_TARGET_STAGE, find_stage_base_image, find_user_statement};
+    use cella_features::dockerfile::generate_dockerfile;
+
+    /// End-to-end reproduction of the original bug: a Dockerfile ending with
+    /// `USER node:node` plus features must produce a combined Dockerfile
+    /// whose final `USER` instruction resolves to `node`, not `root`.
+    #[test]
+    fn combined_dockerfile_preserves_non_root_user_with_features() {
+        // Representative user Dockerfile: ends with `USER node:node` and then
+        // a few more non-USER instructions (like the reporter's case).
+        let original = "\
+FROM mcr.microsoft.com/devcontainers/typescript-node:4.0 AS base
+RUN echo install-as-root
+USER node:node
+RUN echo install-as-node
+";
+
+        let resolved_user =
+            find_user_statement(original, Some("base")).expect("USER node:node must be parseable");
+        assert_eq!(resolved_user, "node");
+
+        // Feature Dockerfile (no real features needed to exercise the
+        // user-reset path — use a synthetic feature with an install script).
+        let feature = cella_features::ResolvedFeature {
+            id: "marker".to_string(),
+            original_ref: "marker".to_string(),
+            metadata: cella_features::FeatureMetadata::default(),
+            user_options: std::collections::HashMap::new(),
+            artifact_dir: std::path::PathBuf::from("/tmp/marker"),
+            has_install_script: true,
+        };
+        let feature_dockerfile =
+            generate_dockerfile("base", &resolved_user, "node", "node", &[feature], true);
+
+        // Features target stage's final ARG must now be bare (no default),
+        // so it inherits the global value.
+        assert!(
+            feature_dockerfile
+                .contains("\nARG _DEV_CONTAINERS_IMAGE_USER\nUSER $_DEV_CONTAINERS_IMAGE_USER\n"),
+            "features closing ARG must be bare to inherit from global: got\n{feature_dockerfile}"
+        );
+        assert!(
+            !feature_dockerfile.contains("ARG _DEV_CONTAINERS_IMAGE_USER=root"),
+            "features closing ARG must not shadow the global with =root"
+        );
+
+        let combined = cella_compose::generate_combined_dockerfile(
+            original,
+            &feature_dockerfile,
+            "base",
+            &resolved_user,
+        );
+
+        // Global ARG carries the resolved user.
+        assert!(
+            combined.contains("ARG _DEV_CONTAINERS_IMAGE_USER=node\n"),
+            "global ARG must set _DEV_CONTAINERS_IMAGE_USER=node so the features stage inherits it"
+        );
+
+        // Global ARG precedes the first FROM (true global scope).
+        let global_pos = combined
+            .find("ARG _DEV_CONTAINERS_IMAGE_USER=node")
+            .unwrap();
+        let first_from_pos = combined.find("FROM ").unwrap();
+        assert!(
+            global_pos < first_from_pos,
+            "global user ARG must appear before the first FROM"
+        );
+
+        // Features target stage is present and ends with the USER directive
+        // that references the now-global-inherited ARG.
+        assert!(combined.contains(&format!("AS {FEATURES_TARGET_STAGE}")));
+        assert!(
+            combined
+                .trim_end()
+                .ends_with("USER $_DEV_CONTAINERS_IMAGE_USER"),
+            "combined Dockerfile must end on the inherited-USER line: got tail\n{}",
+            combined
+                .lines()
+                .rev()
+                .take(5)
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+    }
+
+    /// When the Dockerfile has no `USER` directive but the target stage's
+    /// FROM references a resolvable external base image, `find_user_statement`
+    /// returns None so the caller can fall back to image inspect.
+    /// `find_stage_base_image` must return that external image reference.
+    #[test]
+    fn fallback_path_exposes_external_base_image() {
+        let dockerfile = "\
+FROM mcr.microsoft.com/devcontainers/base:ubuntu AS base
+RUN echo nothing-user-related
+";
+        assert_eq!(find_user_statement(dockerfile, Some("base")), None);
+        assert_eq!(
+            find_stage_base_image(dockerfile, Some("base")),
+            Some("mcr.microsoft.com/devcontainers/base:ubuntu".to_string())
+        );
+    }
+
+    /// When the target stage has no `USER` and its FROM is a variable
+    /// reference we cannot resolve statically, the helpers hand back None
+    /// for both directions so the caller ends up using the `"root"` fallback.
+    #[test]
+    fn fallback_chain_terminates_on_variable_from() {
+        let dockerfile = "\
+ARG BASE_IMAGE=ubuntu:22.04
+FROM $BASE_IMAGE AS base
+RUN echo hi
+";
+        assert_eq!(find_user_statement(dockerfile, Some("base")), None);
+        assert_eq!(find_stage_base_image(dockerfile, Some("base")), None);
+    }
+
+    /// Target stage with `USER numeric:gid` should be parsed and stripped
+    /// down to just the user portion — this is what the UID remap `sed`
+    /// pattern expects.
+    #[test]
+    fn numeric_user_group_is_stripped() {
+        let dockerfile = "FROM alpine:3.18 AS base\nUSER 1000:1000\n";
+        assert_eq!(
+            find_user_statement(dockerfile, Some("base")),
+            Some("1000".to_string())
+        );
+    }
+}

--- a/crates/cella-orchestrator/src/compose_features.rs
+++ b/crates/cella-orchestrator/src/compose_features.rs
@@ -8,7 +8,7 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use cella_backend::{ContainerBackend, image_name_with_features};
 use cella_compose::{
@@ -108,11 +108,14 @@ pub async fn resolve_compose_features(
                 dockerfile_path.display()
             );
 
-            // For build-based services, we can't easily inspect the image user
-            // before building. Default to "root" — features resolve the correct
-            // user from the image metadata after build, and the devcontainer CLI
-            // also defaults to "root" for Dockerfile-based services.
-            (named_content, name, "root".to_string(), None)
+            // Resolve the effective image user via parse → base-image inspect
+            // → "root". Mirrors the devcontainer CLI's findUserStatement +
+            // imageBuildInfoFromDockerfile fallback chain so the features
+            // stage's final USER matches the Dockerfile's declared user.
+            let (image_user, base_image_metadata) =
+                resolve_build_image_user(client, &named_content, Some(&name), progress).await;
+
+            (named_content, name, image_user, base_image_metadata)
         }
         ServiceBuildInfo::Image { image } => {
             // Pull image if needed for inspection
@@ -166,6 +169,7 @@ pub async fn resolve_compose_features(
         &original_dockerfile,
         &resolved.dockerfile,
         &stage_name,
+        &image_user,
     )?;
 
     // 7. Assemble build context overrides and return.
@@ -180,17 +184,73 @@ pub async fn resolve_compose_features(
     )?))
 }
 
+/// Resolve the effective USER for a build-based compose service.
+///
+/// Mirrors the devcontainer CLI's resolution:
+/// 1. Static parse of the Dockerfile target stage's last `USER` directive.
+/// 2. Pull + inspect the external base image's `Config.User`. Pulling is
+///    acceptable because the user is about to build anyway.
+/// 3. Fall back to `"root"`.
+///
+/// Also returns the base image's `devcontainer.metadata` label when step 2
+/// succeeds, mirroring how the image-only arm populates metadata.
+async fn resolve_build_image_user(
+    client: &dyn ContainerBackend,
+    dockerfile_content: &str,
+    target_stage: Option<&str>,
+    progress: &ProgressSender,
+) -> (String, Option<String>) {
+    if let Some(user) = cella_compose::find_user_statement(dockerfile_content, target_stage) {
+        debug!("Resolved image user from Dockerfile USER directive: {user}");
+        return (user, None);
+    }
+
+    let Some(base_image) = cella_compose::find_stage_base_image(dockerfile_content, target_stage)
+    else {
+        debug!("Could not resolve a base image to inspect; defaulting image user to root");
+        return ("root".to_string(), None);
+    };
+
+    if matches!(client.image_exists(&base_image).await, Ok(false))
+        && let Err(e) = run_step_result(
+            progress,
+            "Pulling base image for user inspection...",
+            client.pull_image(&base_image),
+        )
+        .await
+    {
+        warn!("Failed to pull base image '{base_image}' for user inspection: {e}");
+        return ("root".to_string(), None);
+    }
+
+    match client.inspect_image_details(&base_image).await {
+        Ok(details) => {
+            debug!(
+                "Resolved image user from base image '{base_image}' inspect: {}",
+                details.user
+            );
+            (details.user, details.metadata)
+        }
+        Err(e) => {
+            warn!("Failed to inspect base image '{base_image}': {e}");
+            ("root".to_string(), None)
+        }
+    }
+}
+
 /// Generate the combined Dockerfile and write it to disk.
 fn write_combined_dockerfile(
     project_name: &str,
     original_dockerfile: &str,
     features_dockerfile: &str,
     stage_name: &str,
+    image_user: &str,
 ) -> Result<PathBuf, Box<dyn std::error::Error + Send + Sync>> {
     let combined = cella_compose::generate_combined_dockerfile(
         original_dockerfile,
         features_dockerfile,
         stage_name,
+        image_user,
     );
     let combined_path = compose_dockerfile_path(project_name);
     if let Some(parent) = combined_path.parent() {


### PR DESCRIPTION
## Summary

- Cella hard-coded `image_user = "root"` for build-based compose services with features, which got baked into the combined Dockerfile's ARG and pinned the final image USER to root regardless of what the user's Dockerfile declared. `cella shell` and `cella exec` then dropped the user into a root prompt even when their Dockerfile ended with `USER node`.
- Fix mirrors the devcontainer CLI: statically parse the last `USER` directive in the target stage (walking in-file `FROM` chains), fall back to inspecting the external base image's `Config.User`, then `"root"`. Inject the resolved user at **true global scope** in the combined Dockerfile and drop the stage-local `=root` default on the features target stage's ARG so it inherits the global.
- Base-image `devcontainer.metadata` is now always consulted, even on the parser-hit path, so spec-compliant images whose metadata label carries `remoteUser`/`containerUser` keep the full `resolve_remote_user` precedence chain working.

## Commits

1. `feat(compose): add find_user_statement to parse Dockerfile USER` — parser + `find_stage_base_image` with 23 unit tests
2. `fix(compose): resolve Dockerfile USER for compose + features builds` — parser chain, global-scope ARG, drops stage-local `=root`
3. `test(orchestrator): regression tests for compose + features user resolution` — 4 pure-function end-to-end tests
4. `fix(compose): preserve base-image metadata on Dockerfile-USER path` — extracts `pick_image_user_and_metadata`, 5 unit tests

## Out of scope (known limitation)

Compose service `user:` override (`services.<svc>.user:` in docker-compose.yaml) is still not honored — `ResolvedService` has no `user` field. Separate bug, separate PR.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings -D clippy::all`
- [x] `cargo test --workspace` (all ~3000 tests pass)
- [x] `cargo insta test --workspace --check --unreferenced=reject` — not runnable in the dev container; snapshot diffs verified via `cargo test` (11 feature-dockerfile snapshots, each a single-line diff)
- [x] Manual end-to-end on the reporter's setup (`USER node:node` Dockerfile + 4 features):
  - [x] `cella up` succeeds
  - [x] `docker inspect <container> --format '{{.Config.User}} {{index .Config.Labels "dev.cella.remote_user"}}'` → `node node`
  - [x] `cella exec whoami` → `node`
  - [x] `cella shell` drops into a `node@...` prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)