### PR TITLE
fix(agent): never give up on initial daemon connect

### DIFF
--- a/crates/cella-agent/src/main.rs
+++ b/crates/cella-agent/src/main.rs
@@ -213,7 +213,6 @@ async fn maybe_start_forward_proxy(proxy_config_json: Option<String>) {
 
 async fn run_daemon(poll_interval_ms: u64, proxy_config_json: Option<String>) {
     let poll_interval = Duration::from_millis(poll_interval_ms);
-    let connect_timeout = Duration::from_secs(30);
 
     maybe_start_forward_proxy(proxy_config_json).await;
 
@@ -232,20 +231,13 @@ async fn run_daemon(poll_interval_ms: u64, proxy_config_json: Option<String>) {
     };
     let container_name = std::env::var("CELLA_CONTAINER_NAME").unwrap_or_default();
 
-    // Wait for the host daemon to accept connections (race with cella up).
-    let client = reconnecting_client::ReconnectingClient::connect_with_retry(
-        &addr,
-        &container_name,
-        &token,
-        connect_timeout,
-    )
-    .await;
-
-    if !client.is_connected() {
-        info!("Running in standalone mode (no host daemon connection)");
-        port_watcher::run_standalone(poll_interval).await;
-        return;
-    }
+    // Block until the daemon accepts the handshake. Retries forever so a
+    // late-starting daemon (e.g., the common case where `cella up` spawns
+    // the container before the daemon finishes binding) recovers on its
+    // own instead of falling into permanent standalone mode.
+    let client =
+        reconnecting_client::ReconnectingClient::connect_with_retry(&addr, &container_name, &token)
+            .await;
 
     let control = std::sync::Arc::new(tokio::sync::Mutex::new(client));
     let reconnecting = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));

--- a/crates/cella-agent/src/reconnecting_client.rs
+++ b/crates/cella-agent/src/reconnecting_client.rs
@@ -30,8 +30,11 @@ const BASE_BACKOFF: Duration = Duration::from_secs(2);
 /// A wrapper around [`ControlClient`] that retries the initial connection and
 /// attempts a single reconnect when a send or receive fails.
 ///
-/// The daemon may not have registered the container yet when the agent starts,
-/// so `connect_with_retry` retries TCP connection attempts until timeout.
+/// The daemon may not have started yet when the agent starts, so
+/// `connect_with_retry` blocks until the TCP handshake succeeds. Giving up
+/// and running in standalone mode is a trap: the daemon often comes up
+/// seconds-to-minutes later and the agent needs to pick that up without
+/// external intervention.
 ///
 /// Once connected, any I/O failure on `send` triggers a single reconnect
 /// attempt. If reconnection succeeds the `reconnected` flag is set so callers
@@ -46,62 +49,63 @@ pub struct ReconnectingClient {
     daemon_hello: Option<DaemonHello>,
 }
 
+/// How often to surface a progress log while the initial connect retries.
+const INITIAL_CONNECT_WARN_INTERVAL: Duration = Duration::from_secs(30);
+
 impl ReconnectingClient {
-    /// Try to connect to the daemon, retrying every 500 ms until
-    /// `timeout` elapses.
+    /// Connect to the daemon, retrying indefinitely until the handshake
+    /// succeeds. Re-reads `/cella/.daemon_addr` on every attempt so an
+    /// updated address from a later `cella up` is picked up automatically.
     ///
-    /// Returns a client with `inner = None` (i.e. disconnected) if every
-    /// attempt fails within the timeout window. The caller should check
-    /// [`is_connected`](Self::is_connected) before assuming the connection is
-    /// live.
+    /// The returned client is always connected (its `inner` is `Some`).
     pub async fn connect_with_retry(
-        addr: &str,
+        initial_addr: &str,
         container_name: &str,
-        auth_token: &str,
-        timeout: Duration,
+        initial_token: &str,
     ) -> Self {
-        let deadline = tokio::time::Instant::now() + timeout;
+        let start = tokio::time::Instant::now();
+        let mut last_warn = start;
+        let mut addr = initial_addr.to_string();
+        let mut token = initial_token.to_string();
 
         loop {
-            match ControlClient::connect(addr, container_name, auth_token).await {
+            match ControlClient::connect(&addr, container_name, &token).await {
                 Ok((client, hello)) => {
                     info!("Connected to daemon at {addr}");
                     return Self {
-                        addr: addr.to_string(),
+                        addr,
                         container_name: container_name.to_string(),
-                        auth_token: auth_token.to_string(),
+                        auth_token: token,
                         inner: Some(client),
                         reconnected: false,
                         daemon_hello: Some(hello),
                     };
                 }
                 Err(e) => {
-                    debug!("Daemon connect failed, will retry: {e}");
+                    debug!("Daemon connect to {addr} failed, will retry: {e}");
+                    if last_warn.elapsed() >= INITIAL_CONNECT_WARN_INTERVAL {
+                        warn!(
+                            "Still waiting for daemon at {addr} after {}s ({e})",
+                            start.elapsed().as_secs()
+                        );
+                        last_warn = tokio::time::Instant::now();
+                    }
                 }
             }
 
-            if tokio::time::Instant::now() >= deadline {
-                warn!(
-                    "Timed out waiting for daemon after {:.1}s: {addr}",
-                    timeout.as_secs_f64(),
-                );
-                return Self {
-                    addr: addr.to_string(),
-                    container_name: container_name.to_string(),
-                    auth_token: auth_token.to_string(),
-                    inner: None,
-                    reconnected: false,
-                    daemon_hello: None,
-                };
-            }
-
             tokio::time::sleep(RETRY_INTERVAL).await;
-        }
-    }
 
-    /// Returns `true` if the underlying connection is currently established.
-    pub const fn is_connected(&self) -> bool {
-        self.inner.is_some()
+            if let Some(info) = crate::control::read_daemon_addr_file()
+                && (info.addr != addr || info.token != token)
+            {
+                info!(
+                    "Daemon address updated via .daemon_addr ({} -> {})",
+                    addr, info.addr
+                );
+                addr = info.addr;
+                token = info.token;
+            }
+        }
     }
 
     /// Check if the given daemon info matches the current connection params.
@@ -325,12 +329,18 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn connect_with_retry_returns_disconnected_on_unreachable() {
-        let timeout = Duration::from_millis(100);
-        let client =
-            ReconnectingClient::connect_with_retry("127.0.0.1:1", "test", "token", timeout).await;
-
-        assert!(!client.is_connected());
+    async fn connect_with_retry_blocks_when_daemon_unreachable() {
+        // Regression guard for the permanent-standalone trap: the old
+        // implementation gave up after 30s and returned a disconnected
+        // client. Callers then fell into `run_standalone` with no
+        // reconnect loop, silently ignoring the daemon when it came up
+        // later. The fix is to never return until connected.
+        let fut = ReconnectingClient::connect_with_retry("127.0.0.1:1", "test", "token");
+        let result = tokio::time::timeout(Duration::from_secs(2), fut).await;
+        assert!(
+            result.is_err(),
+            "connect_with_retry must not return while the daemon is unreachable",
+        );
     }
 
     #[tokio::test]
@@ -385,19 +395,6 @@ mod tests {
     }
 
     #[test]
-    fn is_connected_when_disconnected() {
-        let client = ReconnectingClient {
-            addr: "127.0.0.1:1".to_string(),
-            container_name: "test".to_string(),
-            auth_token: "token".to_string(),
-            inner: None,
-            reconnected: false,
-            daemon_hello: None,
-        };
-        assert!(!client.is_connected());
-    }
-
-    #[test]
     fn take_reconnected_false_when_not_set() {
         let mut client = ReconnectingClient {
             addr: "127.0.0.1:1".to_string(),
@@ -422,7 +419,7 @@ mod tests {
         };
         let result = client.try_reconnect().await;
         assert!(result.is_err());
-        assert!(!client.is_connected());
+        assert!(client.inner.is_none());
         assert!(!client.reconnected);
     }
 
@@ -475,7 +472,7 @@ mod tests {
             daemon_hello: None,
         };
 
-        assert!(!client.is_connected());
+        assert!(client.inner.is_none());
         assert!(!client.reconnected);
 
         // install_connection without a real ControlClient — verify


### PR DESCRIPTION
## Summary

Fixes the root cause of a silent, permanent agent<->daemon disconnect seen on colima + compose (but the mechanism is not colima-specific — any race where the daemon starts after the container hits it).

- **Root cause**: `ReconnectingClient::connect_with_retry` had a 30s timeout. On timeout it returned a disconnected client and `cella-agent/src/main.rs` fell through to `port_watcher::run_standalone`, which has **no reconnect loop**. Any agent that lost the initial race was permanently deaf to the daemon — and because `crates/cella-cli/src/commands/compose_up.rs:135` launches the agent with `> /dev/null 2>&1`, the user never sees a single log line explaining it.
- **Symptom**: `cella daemon status` shows the container registered with `agent: no connection` indefinitely, even while the daemon is up, the TCP port is reachable from the container, env vars are correct, DNS resolves, and `host.docker.internal:host-gateway` is in `/etc/hosts`. Killing the agent (the container's restart loop respawns it) recovers it — but only until the next race.
- **Fix**: `connect_with_retry` now loops indefinitely, re-reading `/cella/.daemon_addr` on each iteration so a later `cella up` or daemon restart is picked up automatically. The "no address available at all" branch still falls to standalone mode — that's a genuine nowhere-to-connect case, not a race.
- Removes the now-unused `is_connected()` helper (only meaningful while the method could return a disconnected client) and adjusts the tests to inspect the struct's `inner` field directly.

**Not fixed by this PR** (separate follow-ups worth filing):
1. Compose path never writes `/cella/.daemon_addr` — the agent relies on env vars, which are immutable after container creation. Needed so daemon-port changes across restarts actually propagate.
2. Compose launches the agent with `> /dev/null 2>&1`, hiding all its log output. This single line cost several hours of diagnostic work on this issue alone.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings -D clippy::all` — no warnings
- [x] `cargo test -p cella-agent` — 231 tests pass, including the new regression guard `connect_with_retry_blocks_when_daemon_unreachable` which uses `tokio::time::timeout` to verify the function does *not* return within 2s when the target is unreachable.
- [x] Manual verification: on colima, stop the daemon, start a fresh compose devcontainer, confirm the agent log shows periodic "Still waiting for daemon" warnings (once per 30s) instead of falling to standalone. Start the daemon; agent should log "Connected to daemon" within ~500ms and `cella daemon status` should flip to connected. (Requires follow-up #2 above to actually see the agent logs — until then, verify by running `docker exec $CID pkill -f "cella-agent daemon"` and confirming `cella daemon status` flips to connected after the restart-loop respawns the agent with the new binary.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)