### PR TITLE
fix(compose): write .daemon_addr before launching the agent

### DIFF
--- a/crates/cella-cli/src/commands/compose_up.rs
+++ b/crates/cella-cli/src/commands/compose_up.rs
@@ -76,6 +76,15 @@ impl ComposeUpHooks for CliComposeUpHooks<'_> {
         })
     }
 
+    fn sync_agent_runtime<'a>(
+        &'a self,
+        client: &'a dyn ContainerBackend,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move {
+            super::up::write_daemon_addr_to_volume(client).await;
+        })
+    }
+
     fn register_container<'a>(
         &'a self,
         _client: &'a dyn ContainerBackend,

--- a/crates/cella-orchestrator/src/compose_up.rs
+++ b/crates/cella-orchestrator/src/compose_up.rs
@@ -90,6 +90,16 @@ pub trait ComposeUpHooks: Send + Sync {
         host_gateway: &'a str,
     ) -> Pin<Box<dyn Future<Output = Vec<String>> + Send + 'a>>;
 
+    /// Synchronize daemon connection details into the shared agent volume
+    /// (writes `/cella/.daemon_addr`). Mirrors the single-container
+    /// `UpHooks::sync_agent_runtime` so an agent can discover a new daemon
+    /// address after a daemon restart without relying on its (immutable)
+    /// env vars from container creation time.
+    fn sync_agent_runtime<'a>(
+        &'a self,
+        client: &'a dyn ContainerBackend,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
+
     /// Register a container with the daemon for port management.
     fn register_container<'a>(
         &'a self,
@@ -405,10 +415,16 @@ async fn finalize_compose(
         )
         .await;
 
-    // 18. Launch agent as background process via exec
+    // 18. Publish daemon address to the shared agent volume before the
+    // agent starts reading it. Without this, the agent is left relying on
+    // the container's (immutable) env vars and has no way to learn about
+    // a daemon restart that changed the port.
+    hooks.sync_agent_runtime(client).await;
+
+    // 19. Launch agent as background process via exec
     hooks.launch_agent(client, &primary.id, agent_arch).await;
 
-    // 19. Run lifecycle phases (primary service only)
+    // 20. Run lifecycle phases (primary service only)
     let metadata = resolved_features.map(|rf| rf.metadata_label.as_str());
     for phase in [
         "onCreateCommand",
@@ -504,6 +520,11 @@ async fn handle_compose_running(
     hooks
         .register_container(client, &container.id, config, cfg.container_name)
         .await;
+
+    // Refresh `.daemon_addr` on the shared volume so any agent still
+    // running inside the already-up container can follow a daemon port
+    // change since the last `cella up` (e.g., daemon binary update).
+    hooks.sync_agent_runtime(client).await;
 
     if let Some(cmd) = config.get("postAttachCommand")
         && !cmd.is_null()


### PR DESCRIPTION
## Summary

The compose code path never wrote \`/cella/.daemon_addr\` into the shared agent volume. The single-container path has been doing so via \`UpHooks::sync_agent_runtime\` — implemented at \`cella-cli/src/commands/up/mod.rs:521\`, called from \`cella-orchestrator/src/up.rs:386, 570, 815\`. The compose \`ComposeUpHooks\` trait had four methods (\`daemon_env\`, \`register_container\`, \`launch_agent\`, \`post_create_setup\`), none of which write \`.daemon_addr\`.

**Consequence**: every compose-launched agent relied exclusively on env vars (\`CELLA_DAEMON_ADDR\`, \`CELLA_DAEMON_TOKEN\`) injected at container creation. Env vars are immutable after creation, so any daemon restart with a different control port — binary update, crash + respawn, port-reclaim collision — orphaned the agent. Worse, the agent's reconnect logic at \`cella-agent/src/reconnecting_client.rs:217\` specifically falls back to re-reading \`.daemon_addr\` for address updates. For compose, that file was never written, so PR #40's reconnect fix was structurally inoperable.

**Fix**:
- Add \`sync_agent_runtime\` to \`ComposeUpHooks\` trait (mirrors the single-container shape exactly).
- Implement it in \`CliComposeUpHooks\` by delegating to the existing \`super::up::write_daemon_addr_to_volume\` helper — no new write path, just plumbing the hook through.
- Call it at two points in the orchestrator:
  - **Primary create flow**, between \`post_create_setup\` and \`launch_agent\` — so the fresh agent reads the file on startup instead of stale env vars.
  - **\`handle_compose_running\`**, after \`register_container\` — so an agent alive inside a reused container can follow daemon-port changes since the last \`cella up\`.

## Test plan

- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings -D clippy::all\` — no warnings
- [x] \`cargo test -p cella-orchestrator\` — 387 passed
- [x] \`cargo test -p cella-cli\` — 435 passed
- [x] Manual on colima (with #43 and #44 also applied for visibility):
  1. Start daemon, \`cella up\` a compose devcontainer, confirm \`/cella/.daemon_addr\` exists and \`cella daemon status\` shows \`agent: connected\`.
  2. Kill the daemon, confirm it respawns with a different port, run \`cella up\` again on the same compose project — \`handle_compose_running\` path fires, \`.daemon_addr\` is rewritten, and the agent reconnects to the new port without needing a container restart.

## Related
Final piece of the compose agent connection bug trilogy:
- #43 — agent infinite-retry (prevents permanent standalone-mode trap).
- #44 — unsilence agent stderr (makes subsequent debugging possible at all).
- This PR — write \`.daemon_addr\` so reconnect logic has an address to find.

Can land independently but is most useful alongside #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)