### PR TITLE
fix(doctor): reconcile host/in-container views; inject BROWSER on compose

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,7 @@ dependencies = [
  "rustls-native-certs",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",

--- a/crates/cella-agent/Cargo.toml
+++ b/crates/cella-agent/Cargo.toml
@@ -26,5 +26,8 @@ tokio-rustls.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [lints]
 workspace = true

--- a/crates/cella-agent/src/cli.rs
+++ b/crates/cella-agent/src/cli.rs
@@ -421,51 +421,57 @@ async fn run_doctor() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 }
 
 fn report_main_agent_status() {
-    let path = std::path::Path::new(crate::state::DEFAULT_STATE_FILE);
-    let Some(snap) = crate::state::read_snapshot(path) else {
-        eprintln!(
-            "  \u{2717} main agent: state file missing at {}",
-            crate::state::DEFAULT_STATE_FILE
+    let snapshot =
+        crate::state::read_snapshot(std::path::Path::new(crate::state::DEFAULT_STATE_FILE));
+    let lines = format_main_agent_status(
+        snapshot.as_ref(),
+        crate::state::DEFAULT_STATE_FILE,
+        crate::state::pid_alive,
+        now_unix_secs(),
+    );
+    eprint!("{lines}");
+}
+
+/// Render the doctor's main-agent status line(s). Pure — no I/O, no globals.
+/// Takes a snapshot (or `None` if file missing) and a closure to check PID
+/// liveness so tests can inject any state without touching `/proc`.
+fn format_main_agent_status(
+    snapshot: Option<&crate::state::AgentStateSnapshot>,
+    state_file_path: &str,
+    pid_alive: impl Fn(u32) -> bool,
+    now_unix: u64,
+) -> String {
+    let Some(snap) = snapshot else {
+        return format!(
+            "  \u{2717} main agent: state file missing at {state_file_path}\n    Main `cella-agent daemon` process may not be running\n"
         );
-        eprintln!("    Main `cella-agent daemon` process may not be running");
-        return;
     };
 
-    if !crate::state::pid_alive(snap.pid) {
-        eprintln!(
-            "  \u{2717} main agent: process gone (pid {} no longer in /proc)",
+    if !pid_alive(snap.pid) {
+        return format!(
+            "  \u{2717} main agent: process gone (pid {} no longer in /proc)\n    Container needs restart or rebuild\n",
             snap.pid
         );
-        eprintln!("    Container needs restart or rebuild");
-        return;
     }
 
-    let age = now_unix_secs().saturating_sub(snap.last_heartbeat_unix);
+    let age = now_unix.saturating_sub(snap.last_heartbeat_unix);
     match snap.state {
-        crate::state::AgentState::Connected if age < 30 => {
-            eprintln!(
-                "  \u{2713} main agent: connected (pid {}, heartbeat {age}s ago)",
-                snap.pid
-            );
-        }
-        crate::state::AgentState::Connected => {
-            eprintln!(
-                "  \u{26a0} main agent: connected but heartbeat stale (pid {}, {age}s ago)",
-                snap.pid
-            );
-        }
-        crate::state::AgentState::Reconnecting => {
-            eprintln!(
-                "  \u{26a0} main agent: reconnecting (pid {}, last heartbeat {age}s ago)",
-                snap.pid
-            );
-        }
-        crate::state::AgentState::Disconnected => {
-            eprintln!(
-                "  \u{26a0} main agent: disconnected (pid {}, last heartbeat {age}s ago)",
-                snap.pid
-            );
-        }
+        crate::state::AgentState::Connected if age < 30 => format!(
+            "  \u{2713} main agent: connected (pid {}, heartbeat {age}s ago)\n",
+            snap.pid
+        ),
+        crate::state::AgentState::Connected => format!(
+            "  \u{26a0} main agent: connected but heartbeat stale (pid {}, {age}s ago)\n",
+            snap.pid
+        ),
+        crate::state::AgentState::Reconnecting => format!(
+            "  \u{26a0} main agent: reconnecting (pid {}, last heartbeat {age}s ago)\n",
+            snap.pid
+        ),
+        crate::state::AgentState::Disconnected => format!(
+            "  \u{26a0} main agent: disconnected (pid {}, last heartbeat {age}s ago)\n",
+            snap.pid
+        ),
     }
 }
 
@@ -474,6 +480,84 @@ fn now_unix_secs() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod doctor_tests {
+    use super::*;
+    use crate::state::{AgentState, AgentStateSnapshot};
+
+    fn snap(state: AgentState, pid: u32, last_heartbeat_unix: u64) -> AgentStateSnapshot {
+        AgentStateSnapshot {
+            pid,
+            state,
+            daemon_addr: Some("host.docker.internal:60000".to_string()),
+            agent_version: "0.0.28".to_string(),
+            started_at_unix: 1_700_000_000,
+            last_heartbeat_unix,
+        }
+    }
+
+    #[test]
+    fn status_missing_file() {
+        let out = format_main_agent_status(None, "/tmp/cella-agent.state", |_| true, 0);
+        assert!(out.contains("\u{2717} main agent: state file missing"));
+        assert!(out.contains("/tmp/cella-agent.state"));
+    }
+
+    #[test]
+    fn status_pid_gone() {
+        let s = snap(AgentState::Connected, 12345, 1_700_000_100);
+        let out =
+            format_main_agent_status(Some(&s), "/tmp/cella-agent.state", |_| false, 1_700_000_100);
+        assert!(out.contains("\u{2717} main agent: process gone"));
+        assert!(out.contains("pid 12345"));
+    }
+
+    #[test]
+    fn status_connected_fresh() {
+        let now = 1_700_000_100;
+        let s = snap(AgentState::Connected, 25, now - 5);
+        let out = format_main_agent_status(Some(&s), "/tmp/cella-agent.state", |_| true, now);
+        assert!(out.contains("\u{2713} main agent: connected (pid 25"));
+        assert!(out.contains("heartbeat 5s ago"));
+    }
+
+    #[test]
+    fn status_connected_stale() {
+        let now = 1_700_000_100;
+        // age > 30 triggers the stale branch.
+        let s = snap(AgentState::Connected, 25, now - 45);
+        let out = format_main_agent_status(Some(&s), "/tmp/cella-agent.state", |_| true, now);
+        assert!(out.contains("\u{26a0} main agent: connected but heartbeat stale"));
+        assert!(out.contains("45s ago"));
+    }
+
+    #[test]
+    fn status_reconnecting() {
+        let now = 1_700_000_100;
+        let s = snap(AgentState::Reconnecting, 25, now - 3);
+        let out = format_main_agent_status(Some(&s), "/tmp/cella-agent.state", |_| true, now);
+        assert!(out.contains("\u{26a0} main agent: reconnecting (pid 25"));
+        assert!(out.contains("3s ago"));
+    }
+
+    #[test]
+    fn status_disconnected() {
+        let now = 1_700_000_100;
+        let s = snap(AgentState::Disconnected, 25, now - 1);
+        let out = format_main_agent_status(Some(&s), "/tmp/cella-agent.state", |_| true, now);
+        assert!(out.contains("\u{26a0} main agent: disconnected (pid 25"));
+    }
+
+    #[test]
+    fn status_connected_exactly_at_threshold_is_stale() {
+        // Boundary: age == 30 is not "< 30", so treated as stale.
+        let now = 1_700_000_100;
+        let s = snap(AgentState::Connected, 25, now - 30);
+        let out = format_main_agent_status(Some(&s), "/tmp/cella-agent.state", |_| true, now);
+        assert!(out.contains("connected but heartbeat stale"));
+    }
 }
 
 async fn run_branch(

--- a/crates/cella-agent/src/cli.rs
+++ b/crates/cella-agent/src/cli.rs
@@ -405,6 +405,9 @@ async fn run_doctor() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         }
     }
 
+    // 4b. Main agent process liveness (read state file written by cella-agent daemon)
+    report_main_agent_status();
+
     // 5. Credential helper
     let browser = std::env::var("BROWSER").unwrap_or_default();
     if browser.contains("cella") {
@@ -415,6 +418,62 @@ async fn run_doctor() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     eprintln!();
     Ok(())
+}
+
+fn report_main_agent_status() {
+    let path = std::path::Path::new(crate::state::DEFAULT_STATE_FILE);
+    let Some(snap) = crate::state::read_snapshot(path) else {
+        eprintln!(
+            "  \u{2717} main agent: state file missing at {}",
+            crate::state::DEFAULT_STATE_FILE
+        );
+        eprintln!("    Main `cella-agent daemon` process may not be running");
+        return;
+    };
+
+    if !crate::state::pid_alive(snap.pid) {
+        eprintln!(
+            "  \u{2717} main agent: process gone (pid {} no longer in /proc)",
+            snap.pid
+        );
+        eprintln!("    Container needs restart or rebuild");
+        return;
+    }
+
+    let age = now_unix_secs().saturating_sub(snap.last_heartbeat_unix);
+    match snap.state {
+        crate::state::AgentState::Connected if age < 30 => {
+            eprintln!(
+                "  \u{2713} main agent: connected (pid {}, heartbeat {age}s ago)",
+                snap.pid
+            );
+        }
+        crate::state::AgentState::Connected => {
+            eprintln!(
+                "  \u{26a0} main agent: connected but heartbeat stale (pid {}, {age}s ago)",
+                snap.pid
+            );
+        }
+        crate::state::AgentState::Reconnecting => {
+            eprintln!(
+                "  \u{26a0} main agent: reconnecting (pid {}, last heartbeat {age}s ago)",
+                snap.pid
+            );
+        }
+        crate::state::AgentState::Disconnected => {
+            eprintln!(
+                "  \u{26a0} main agent: disconnected (pid {}, last heartbeat {age}s ago)",
+                snap.pid
+            );
+        }
+    }
+}
+
+fn now_unix_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
 }
 
 async fn run_branch(

--- a/crates/cella-agent/src/main.rs
+++ b/crates/cella-agent/src/main.rs
@@ -20,6 +20,7 @@ mod port_proxy;
 mod port_watcher;
 mod proxy_config;
 mod reconnecting_client;
+mod state;
 
 use std::time::Duration;
 
@@ -216,6 +217,15 @@ async fn run_daemon(poll_interval_ms: u64, proxy_config_json: Option<String>) {
 
     maybe_start_forward_proxy(proxy_config_json).await;
 
+    // Publish Disconnected early so an in-container `cella doctor` run before
+    // the handshake completes can tell the process is alive and still trying.
+    let state_writer = state::spawn_state_writer(
+        std::path::PathBuf::from(state::DEFAULT_STATE_FILE),
+        env!("CARGO_PKG_VERSION").to_string(),
+        state::AgentState::Disconnected,
+        Duration::from_secs(10),
+    );
+
     // Read connection info: .daemon_addr file is authoritative (updated on
     // every `cella up`), env vars are fallback (may be stale after restart).
     let (addr, token) = if let Some(info) = control::read_daemon_addr_file() {
@@ -238,6 +248,9 @@ async fn run_daemon(poll_interval_ms: u64, proxy_config_json: Option<String>) {
     let client =
         reconnecting_client::ReconnectingClient::connect_with_retry(&addr, &container_name, &token)
             .await;
+
+    state_writer.set_daemon_addr(Some(addr.clone()));
+    state_writer.set_state(state::AgentState::Connected);
 
     let control = std::sync::Arc::new(tokio::sync::Mutex::new(client));
     let reconnecting = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));

--- a/crates/cella-agent/src/main.rs
+++ b/crates/cella-agent/src/main.rs
@@ -263,8 +263,9 @@ async fn run_daemon(poll_interval_ms: u64, proxy_config_json: Option<String>) {
     let rc = reconnecting.clone();
     let pm: port_watcher::PortMap =
         std::sync::Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new()));
+    let sw_for_watcher = state_writer.clone();
     let watcher_handle = tokio::spawn(async move {
-        port_watcher::run(poll_interval, ctrl, pd, pm, rc).await;
+        port_watcher::run(poll_interval, ctrl, pd, pm, rc, Some(sw_for_watcher)).await;
     });
 
     // Spawn plugin manifest sync watcher (reverse-rewrites paths back to host)
@@ -277,6 +278,7 @@ async fn run_daemon(poll_interval_ms: u64, proxy_config_json: Option<String>) {
     let ctrl = control.clone();
     let pd = ports_detected.clone();
     let rc = reconnecting.clone();
+    let sw_for_health = state_writer.clone();
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(Duration::from_secs(60));
         loop {
@@ -290,7 +292,11 @@ async fn run_daemon(poll_interval_ms: u64, proxy_config_json: Option<String>) {
             if let Err(e) = c.send(&msg).await {
                 tracing::warn!("Health report failed: {e}");
                 drop(c);
-                reconnecting_client::spawn_background_reconnect(ctrl.clone(), rc.clone());
+                reconnecting_client::spawn_background_reconnect(
+                    ctrl.clone(),
+                    rc.clone(),
+                    Some(sw_for_health.clone()),
+                );
             }
         }
     });

--- a/crates/cella-agent/src/main.rs
+++ b/crates/cella-agent/src/main.rs
@@ -249,8 +249,7 @@ async fn run_daemon(poll_interval_ms: u64, proxy_config_json: Option<String>) {
         reconnecting_client::ReconnectingClient::connect_with_retry(&addr, &container_name, &token)
             .await;
 
-    state_writer.set_daemon_addr(Some(addr.clone()));
-    state_writer.set_state(state::AgentState::Connected);
+    state_writer.set_connected(addr.clone());
 
     let control = std::sync::Arc::new(tokio::sync::Mutex::new(client));
     let reconnecting = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));

--- a/crates/cella-agent/src/port_watcher.rs
+++ b/crates/cella-agent/src/port_watcher.rs
@@ -121,14 +121,21 @@ async fn process_port_open_response(
     }
 }
 
+/// Shared immutable context for port event handlers. Groups references so
+/// the inner functions stay under the clippy argument limit.
+struct PortWatcherCtx<'a> {
+    control: &'a Arc<Mutex<ReconnectingClient>>,
+    port_map: &'a PortMap,
+    reconnecting: &'a Arc<std::sync::atomic::AtomicBool>,
+    state_writer: Option<&'a crate::state::StateWriter>,
+}
+
 /// Send a `PortOpen` message to the daemon and process the port mapping response.
 async fn send_port_open_and_record(
     listener: &DetectedListener,
     process: Option<String>,
     agent_proxy_port: Option<u16>,
-    control: &Arc<Mutex<ReconnectingClient>>,
-    port_map: &PortMap,
-    reconnecting: &Arc<std::sync::atomic::AtomicBool>,
+    ctx: &PortWatcherCtx<'_>,
 ) -> bool {
     let msg = AgentMessage::PortOpen {
         port: listener.port,
@@ -138,17 +145,21 @@ async fn send_port_open_and_record(
         proxy_port: agent_proxy_port,
     };
 
-    let mut ctrl = control.lock().await;
+    let mut ctrl = ctx.control.lock().await;
     if let Err(e) = ctrl.send(&msg).await {
         warn!("Failed to report port open: {e}");
         drop(ctrl);
-        reconnecting_client::spawn_background_reconnect(control.clone(), reconnecting.clone());
+        reconnecting_client::spawn_background_reconnect(
+            ctx.control.clone(),
+            ctx.reconnecting.clone(),
+            ctx.state_writer.cloned(),
+        );
         return false;
     }
 
     let response = ctrl.recv().await;
     drop(ctrl);
-    process_port_open_response(response, port_map).await;
+    process_port_open_response(response, ctx.port_map).await;
     true
 }
 
@@ -158,11 +169,9 @@ async fn send_port_open_and_record(
 /// Returns `true` if the listener was successfully reported and should be tracked.
 async fn handle_new_listener(
     listener: &DetectedListener,
-    control: &Arc<Mutex<ReconnectingClient>>,
-    port_map: &PortMap,
+    ctx: &PortWatcherCtx<'_>,
     proxy_handles: &mut HashMap<u16, tokio::task::JoinHandle<()>>,
     proxy_ports: &mut HashMap<u16, u16>,
-    reconnecting: &Arc<std::sync::atomic::AtomicBool>,
 ) -> bool {
     let process = cella_port::detection::process_name_for_inode(listener.inode);
     info!(
@@ -172,26 +181,16 @@ async fn handle_new_listener(
 
     let agent_proxy_port = maybe_start_localhost_proxy(listener, proxy_handles, proxy_ports).await;
 
-    send_port_open_and_record(
-        listener,
-        process,
-        agent_proxy_port,
-        control,
-        port_map,
-        reconnecting,
-    )
-    .await
+    send_port_open_and_record(listener, process, agent_proxy_port, ctx).await
 }
 
 /// Handle a single closed listener: report to daemon and clean up proxies.
 async fn handle_closed_listener(
     key: (u16, PortProtocol),
-    control: &Arc<Mutex<ReconnectingClient>>,
+    ctx: &PortWatcherCtx<'_>,
     ports_detected: &AtomicUsize,
-    port_map: &PortMap,
     proxy_handles: &mut HashMap<u16, tokio::task::JoinHandle<()>>,
     proxy_ports: &mut HashMap<u16, u16>,
-    reconnecting: &Arc<std::sync::atomic::AtomicBool>,
 ) {
     info!("Listener closed: port {} ({:?})", key.0, key.1);
 
@@ -200,15 +199,19 @@ async fn handle_closed_listener(
         protocol: key.1,
     };
     {
-        let mut ctrl = control.lock().await;
+        let mut ctrl = ctx.control.lock().await;
         if let Err(e) = ctrl.send(&msg).await {
             warn!("Failed to report port closed: {e}");
             drop(ctrl);
-            reconnecting_client::spawn_background_reconnect(control.clone(), reconnecting.clone());
+            reconnecting_client::spawn_background_reconnect(
+                ctx.control.clone(),
+                ctx.reconnecting.clone(),
+                ctx.state_writer.cloned(),
+            );
         } else {
             ports_detected.fetch_sub(1, Ordering::Relaxed);
-            port_map.lock().await.remove(&key.0);
-            write_port_map(port_map).await;
+            ctx.port_map.lock().await.remove(&key.0);
+            write_port_map(ctx.port_map).await;
         }
     }
 
@@ -237,6 +240,7 @@ pub async fn run(
     ports_detected: Arc<AtomicUsize>,
     port_map: PortMap,
     reconnecting: Arc<std::sync::atomic::AtomicBool>,
+    state_writer: Option<crate::state::StateWriter>,
 ) {
     let proc_path = Path::new("/proc");
     let mut known: HashMap<(u16, PortProtocol), DetectedListener> = HashMap::new();
@@ -253,6 +257,13 @@ pub async fn run(
             continue;
         };
 
+        let ctx = PortWatcherCtx {
+            control: &control,
+            port_map: &port_map,
+            reconnecting: &reconnecting,
+            state_writer: state_writer.as_ref(),
+        };
+
         // Detect new listeners
         for listener in &current {
             let key = (listener.port, listener.protocol);
@@ -260,15 +271,8 @@ pub async fn run(
                 continue;
             }
 
-            let send_ok = handle_new_listener(
-                listener,
-                &control,
-                &port_map,
-                &mut proxy_handles,
-                &mut proxy_ports,
-                &reconnecting,
-            )
-            .await;
+            let send_ok =
+                handle_new_listener(listener, &ctx, &mut proxy_handles, &mut proxy_ports).await;
 
             if send_ok {
                 ports_detected.fetch_add(1, Ordering::Relaxed);
@@ -283,12 +287,10 @@ pub async fn run(
             known.remove(&key);
             handle_closed_listener(
                 key,
-                &control,
+                &ctx,
                 &ports_detected,
-                &port_map,
                 &mut proxy_handles,
                 &mut proxy_ports,
-                &reconnecting,
             )
             .await;
         }

--- a/crates/cella-agent/src/reconnecting_client.rs
+++ b/crates/cella-agent/src/reconnecting_client.rs
@@ -265,9 +265,14 @@ fn next_backoff(attempt: u32, elapsed: Duration) -> Duration {
 /// The task runs outside any lock — connect attempts don't block the port
 /// watcher or health reporter. On success it briefly locks the mutex to
 /// install the new connection.
+///
+/// When `state_writer` is provided, emits `Reconnecting` at task entry and
+/// `Connected` (with the successful address) once a new connection is
+/// installed.
 pub fn spawn_background_reconnect(
     control: Arc<Mutex<ReconnectingClient>>,
     reconnecting: Arc<AtomicBool>,
+    state_writer: Option<crate::state::StateWriter>,
 ) {
     if reconnecting
         .compare_exchange(false, true, AtomicOrdering::SeqCst, AtomicOrdering::SeqCst)
@@ -275,6 +280,10 @@ pub fn spawn_background_reconnect(
     {
         debug!("Background reconnection already in progress");
         return;
+    }
+
+    if let Some(w) = &state_writer {
+        w.set_state(crate::state::AgentState::Reconnecting);
     }
 
     let reconnecting_flag = reconnecting;
@@ -308,7 +317,11 @@ pub fn spawn_background_reconnect(
                     control
                         .lock()
                         .await
-                        .install_connection(client, hello, addr, token);
+                        .install_connection(client, hello, addr.clone(), token);
+                    if let Some(w) = &state_writer {
+                        w.set_daemon_addr(Some(addr));
+                        w.set_state(crate::state::AgentState::Connected);
+                    }
                     reconnecting_flag.store(false, AtomicOrdering::SeqCst);
                     return;
                 }

--- a/crates/cella-agent/src/reconnecting_client.rs
+++ b/crates/cella-agent/src/reconnecting_client.rs
@@ -319,8 +319,7 @@ pub fn spawn_background_reconnect(
                         .await
                         .install_connection(client, hello, addr.clone(), token);
                     if let Some(w) = &state_writer {
-                        w.set_daemon_addr(Some(addr));
-                        w.set_state(crate::state::AgentState::Connected);
+                        w.set_connected(addr);
                     }
                     reconnecting_flag.store(false, AtomicOrdering::SeqCst);
                     return;

--- a/crates/cella-agent/src/state.rs
+++ b/crates/cella-agent/src/state.rs
@@ -66,8 +66,10 @@ pub struct AgentStateSnapshot {
 pub enum StateUpdate {
     /// Replace the transport state.
     SetState(AgentState),
-    /// Replace the daemon address (e.g., on reconnect with a new addr).
-    SetDaemonAddr(Option<String>),
+    /// Atomic transition: set both state and daemon address in a single
+    /// writer-loop iteration. Avoids the brief intermediate snapshot that
+    /// would otherwise be written between two separate updates.
+    Connected { daemon_addr: String },
 }
 
 /// Handle to the state writer task. Cloneable so multiple producers can share
@@ -86,14 +88,18 @@ impl StateWriter {
         }
     }
 
-    /// Convenience: push a new transport state.
+    /// Convenience: push a new transport state without touching the daemon
+    /// address. Used for `Reconnecting` and `Disconnected` transitions where
+    /// the addr either stays or becomes irrelevant.
     pub fn set_state(&self, state: AgentState) {
         self.update(StateUpdate::SetState(state));
     }
 
-    /// Convenience: push a new daemon address.
-    pub fn set_daemon_addr(&self, addr: Option<String>) {
-        self.update(StateUpdate::SetDaemonAddr(addr));
+    /// Convenience: atomically transition to `Connected` with the given
+    /// daemon address. Preferred over two separate updates to avoid a
+    /// half-written intermediate snapshot.
+    pub fn set_connected(&self, daemon_addr: String) {
+        self.update(StateUpdate::Connected { daemon_addr });
     }
 }
 
@@ -156,7 +162,10 @@ async fn writer_loop(
             maybe_update = rx.recv() => {
                 match maybe_update {
                     Some(StateUpdate::SetState(s)) => current_state = s,
-                    Some(StateUpdate::SetDaemonAddr(a)) => daemon_addr = a,
+                    Some(StateUpdate::Connected { daemon_addr: a }) => {
+                        current_state = AgentState::Connected;
+                        daemon_addr = Some(a);
+                    }
                     None => {
                         // All senders dropped — process is shutting down.
                         return;
@@ -326,11 +335,11 @@ mod tests {
         let initial = read_snapshot(&path).unwrap();
         assert!(matches!(initial.state, AgentState::Disconnected));
 
-        writer.set_state(AgentState::Connected);
-        writer.set_daemon_addr(Some("host.docker.internal:60000".to_string()));
+        writer.set_connected("host.docker.internal:60000".to_string());
 
-        // After two updates (two select iterations), a Connected snapshot
-        // with the addr must be on disk.
+        // The atomic Connected update should produce a snapshot with BOTH
+        // state=Connected and the daemon address in a single write — never
+        // a torn {Disconnected, Some(addr)} intermediate.
         let start = std::time::Instant::now();
         loop {
             let snap = read_snapshot(&path).unwrap();
@@ -339,11 +348,63 @@ mod tests {
             {
                 break;
             }
+            // If state is Connected, daemon_addr must already be set — never
+            // Connected without an addr (would mean torn write).
+            if matches!(snap.state, AgentState::Connected) {
+                assert_eq!(
+                    snap.daemon_addr.as_deref(),
+                    Some("host.docker.internal:60000"),
+                    "Connected without daemon_addr indicates torn write"
+                );
+            }
             assert!(
                 start.elapsed() < Duration::from_secs(2),
-                "writer did not reflect updates within 2s"
+                "writer did not reflect update within 2s"
             );
             tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn set_connected_is_atomic() {
+        // Regression for the two-message race: with separate set_state +
+        // set_daemon_addr calls, the writer could emit a {Disconnected,
+        // Some(addr)} snapshot between the two updates. `set_connected`
+        // fuses them into a single StateUpdate so no intermediate exists.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let writer = spawn_state_writer(
+            path.clone(),
+            "0.0.28".to_string(),
+            AgentState::Disconnected,
+            Duration::from_secs(60),
+        );
+
+        for _ in 0..100 {
+            if path.exists() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        writer.set_connected("host.docker.internal:60000".to_string());
+
+        let start = std::time::Instant::now();
+        loop {
+            let snap = read_snapshot(&path).unwrap();
+            // Invariant: if state is Connected, daemon_addr must be Some.
+            if matches!(snap.state, AgentState::Connected) {
+                assert_eq!(
+                    snap.daemon_addr.as_deref(),
+                    Some("host.docker.internal:60000")
+                );
+                return;
+            }
+            assert!(
+                start.elapsed() < Duration::from_secs(2),
+                "Connected state never observed within 2s"
+            );
+            tokio::time::sleep(Duration::from_millis(5)).await;
         }
     }
 

--- a/crates/cella-agent/src/state.rs
+++ b/crates/cella-agent/src/state.rs
@@ -1,0 +1,379 @@
+//! Agent-local state snapshot exposed for the in-container doctor.
+//!
+//! The host daemon has an authoritative view of whether an agent is currently
+//! connected (see [`cella_daemon::control_server::AgentConnectionState`]). The
+//! in-container `cella doctor` cannot query the daemon's management socket —
+//! that socket lives on the host — so without this module it could only probe
+//! the daemon by opening its own TCP handshake. That probe says nothing about
+//! the long-running `cella-agent daemon` process inside the container.
+//!
+//! This module exposes a tiny file at [`DEFAULT_STATE_FILE`] that the main
+//! agent process writes on startup, on every transport-state transition, and
+//! every 10s while alive. The in-container doctor reads the file, verifies the
+//! PID is still in `/proc`, and reports the last-known state with a freshness
+//! age. A single writer task owns the file so concurrent transitions never
+//! race.
+//!
+//! # File format
+//!
+//! The file is JSON; see [`AgentStateSnapshot`]. Writes are atomic via
+//! temp-file-rename to avoid torn reads.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+
+/// Default location of the state file. Chosen inside the container's local
+/// `/tmp` (NOT the shared `/cella` volume) so writes don't affect sibling
+/// containers.
+pub const DEFAULT_STATE_FILE: &str = "/tmp/cella-agent.state";
+
+/// Transport-layer state of the main agent's daemon connection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AgentState {
+    /// Handshake completed and connection is healthy.
+    Connected,
+    /// Connection dropped; background task is retrying.
+    Reconnecting,
+    /// No connection has been established yet, or the agent is shutting down.
+    Disconnected,
+}
+
+/// A point-in-time snapshot of the main agent's state. Read by the
+/// in-container doctor.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentStateSnapshot {
+    /// PID of the main `cella-agent daemon` process that wrote this file.
+    pub pid: u32,
+    /// Transport state.
+    pub state: AgentState,
+    /// Current daemon address (if any). `None` while `Disconnected`.
+    pub daemon_addr: Option<String>,
+    /// Version of the agent binary (`CARGO_PKG_VERSION` at build time).
+    pub agent_version: String,
+    /// Unix seconds when the agent started.
+    pub started_at_unix: u64,
+    /// Unix seconds of the most recent write (heartbeat or transition).
+    pub last_heartbeat_unix: u64,
+}
+
+/// Mutation applied to the state writer's local view.
+#[derive(Debug, Clone)]
+pub enum StateUpdate {
+    /// Replace the transport state.
+    SetState(AgentState),
+    /// Replace the daemon address (e.g., on reconnect with a new addr).
+    SetDaemonAddr(Option<String>),
+}
+
+/// Handle to the state writer task. Cloneable so multiple producers can share
+/// it without locking.
+#[derive(Clone)]
+pub struct StateWriter {
+    tx: mpsc::Sender<StateUpdate>,
+}
+
+impl StateWriter {
+    /// Send a best-effort state update. If the writer task has exited, the
+    /// send fails silently — doctor staleness will surface the stall instead.
+    pub fn update(&self, update: StateUpdate) {
+        if let Err(e) = self.tx.try_send(update) {
+            debug!("state writer channel full or closed: {e}");
+        }
+    }
+
+    /// Convenience: push a new transport state.
+    pub fn set_state(&self, state: AgentState) {
+        self.update(StateUpdate::SetState(state));
+    }
+
+    /// Convenience: push a new daemon address.
+    pub fn set_daemon_addr(&self, addr: Option<String>) {
+        self.update(StateUpdate::SetDaemonAddr(addr));
+    }
+}
+
+/// Spawn the single-writer state task. The task owns [`path`] for the life of
+/// the process, writes heartbeats every [`heartbeat_interval`], and flushes on
+/// every [`StateUpdate`].
+///
+/// Returns a cloneable [`StateWriter`] used by all callers.
+pub fn spawn_state_writer(
+    path: PathBuf,
+    agent_version: String,
+    initial_state: AgentState,
+    heartbeat_interval: Duration,
+) -> StateWriter {
+    let (tx, rx) = mpsc::channel(16);
+    let pid = std::process::id();
+    let started = now_unix();
+    tokio::spawn(async move {
+        writer_loop(
+            path,
+            pid,
+            agent_version,
+            started,
+            initial_state,
+            rx,
+            heartbeat_interval,
+        )
+        .await;
+    });
+    StateWriter { tx }
+}
+
+async fn writer_loop(
+    path: PathBuf,
+    pid: u32,
+    agent_version: String,
+    started_at_unix: u64,
+    mut current_state: AgentState,
+    mut rx: mpsc::Receiver<StateUpdate>,
+    heartbeat_interval: Duration,
+) {
+    let mut daemon_addr: Option<String> = None;
+    let mut interval = tokio::time::interval(heartbeat_interval);
+
+    loop {
+        let snapshot = AgentStateSnapshot {
+            pid,
+            state: current_state,
+            daemon_addr: daemon_addr.clone(),
+            agent_version: agent_version.clone(),
+            started_at_unix,
+            last_heartbeat_unix: now_unix(),
+        };
+        if let Err(e) = write_snapshot_atomic(&path, &snapshot) {
+            warn!("Failed to write agent state to {}: {e}", path.display());
+        }
+
+        tokio::select! {
+            _ = interval.tick() => {}
+            maybe_update = rx.recv() => {
+                match maybe_update {
+                    Some(StateUpdate::SetState(s)) => current_state = s,
+                    Some(StateUpdate::SetDaemonAddr(a)) => daemon_addr = a,
+                    None => {
+                        // All senders dropped — process is shutting down.
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Write a snapshot atomically (temp-file + rename) at `path`.
+///
+/// # Errors
+///
+/// Returns an `io::Error` if any filesystem operation fails.
+pub fn write_snapshot_atomic(path: &Path, snapshot: &AgentStateSnapshot) -> std::io::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("cella-agent.state");
+    let tmp_path = parent.join(format!("{file_name}.tmp.{}", std::process::id()));
+
+    let mut json = serde_json::to_vec_pretty(snapshot)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    json.push(b'\n');
+
+    {
+        let mut f = std::fs::File::create(&tmp_path)?;
+        f.write_all(&json)?;
+        f.sync_all()?;
+    }
+
+    std::fs::rename(&tmp_path, path)
+}
+
+/// Read a snapshot from `path`. Returns `None` if the file doesn't exist or is
+/// malformed.
+#[must_use]
+pub fn read_snapshot(path: &Path) -> Option<AgentStateSnapshot> {
+    let bytes = std::fs::read(path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+/// Return `true` if `/proc/{pid}` exists. Linux-only; the agent only runs in
+/// Linux containers.
+#[must_use]
+pub fn pid_alive(pid: u32) -> bool {
+    Path::new(&format!("/proc/{pid}")).exists()
+}
+
+/// Current Unix time in seconds (saturating; clock moving backwards returns 0).
+fn now_unix() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(state: AgentState) -> AgentStateSnapshot {
+        AgentStateSnapshot {
+            pid: 42,
+            state,
+            daemon_addr: Some("host.docker.internal:60000".to_string()),
+            agent_version: "0.0.28".to_string(),
+            started_at_unix: 1_700_000_000,
+            last_heartbeat_unix: 1_700_000_100,
+        }
+    }
+
+    #[test]
+    fn write_read_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let snap = sample(AgentState::Connected);
+        write_snapshot_atomic(&path, &snap).unwrap();
+        let read = read_snapshot(&path).unwrap();
+        assert_eq!(read.pid, snap.pid);
+        assert!(matches!(read.state, AgentState::Connected));
+        assert_eq!(
+            read.daemon_addr.as_deref(),
+            Some("host.docker.internal:60000")
+        );
+        assert_eq!(read.agent_version, "0.0.28");
+    }
+
+    #[test]
+    fn write_overwrites_existing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        write_snapshot_atomic(&path, &sample(AgentState::Connected)).unwrap();
+        write_snapshot_atomic(&path, &sample(AgentState::Reconnecting)).unwrap();
+        let read = read_snapshot(&path).unwrap();
+        assert!(matches!(read.state, AgentState::Reconnecting));
+    }
+
+    #[test]
+    fn read_missing_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("does-not-exist.json");
+        assert!(read_snapshot(&path).is_none());
+    }
+
+    #[test]
+    fn read_malformed_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.json");
+        std::fs::write(&path, b"{not valid json").unwrap();
+        assert!(read_snapshot(&path).is_none());
+    }
+
+    #[test]
+    fn write_leaves_no_temp_on_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        write_snapshot_atomic(&path, &sample(AgentState::Connected)).unwrap();
+        // After atomic rename, the temp should be gone.
+        let entries: Vec<_> = std::fs::read_dir(dir.path()).unwrap().collect();
+        assert_eq!(entries.len(), 1, "only the final file should remain");
+    }
+
+    #[test]
+    fn pid_alive_true_for_self() {
+        assert!(pid_alive(std::process::id()));
+    }
+
+    #[test]
+    fn pid_alive_false_for_bogus_pid() {
+        assert!(!pid_alive(4_000_000_000));
+    }
+
+    #[test]
+    fn agent_state_serializes_stably() {
+        // Guard against accidental rename of the enum variants — a rename would
+        // break the in-container doctor's ability to read an older agent's
+        // state file (or vice versa) during a staggered rollout.
+        let j = serde_json::to_string(&AgentState::Connected).unwrap();
+        assert_eq!(j, "\"Connected\"");
+        let j = serde_json::to_string(&AgentState::Reconnecting).unwrap();
+        assert_eq!(j, "\"Reconnecting\"");
+        let j = serde_json::to_string(&AgentState::Disconnected).unwrap();
+        assert_eq!(j, "\"Disconnected\"");
+    }
+
+    #[tokio::test]
+    async fn writer_loop_writes_on_update() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let writer = spawn_state_writer(
+            path.clone(),
+            "0.0.28".to_string(),
+            AgentState::Disconnected,
+            Duration::from_secs(60), // long interval — force write via update
+        );
+
+        // Wait for the initial write.
+        for _ in 0..100 {
+            if path.exists() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        let initial = read_snapshot(&path).unwrap();
+        assert!(matches!(initial.state, AgentState::Disconnected));
+
+        writer.set_state(AgentState::Connected);
+        writer.set_daemon_addr(Some("host.docker.internal:60000".to_string()));
+
+        // After two updates (two select iterations), a Connected snapshot
+        // with the addr must be on disk.
+        let start = std::time::Instant::now();
+        loop {
+            let snap = read_snapshot(&path).unwrap();
+            if matches!(snap.state, AgentState::Connected)
+                && snap.daemon_addr.as_deref() == Some("host.docker.internal:60000")
+            {
+                break;
+            }
+            assert!(
+                start.elapsed() < Duration::from_secs(2),
+                "writer did not reflect updates within 2s"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn writer_loop_heartbeats_on_interval() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let _writer = spawn_state_writer(
+            path.clone(),
+            "0.0.28".to_string(),
+            AgentState::Connected,
+            Duration::from_millis(50),
+        );
+
+        // Wait for the initial write.
+        for _ in 0..100 {
+            if path.exists() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        let first = read_snapshot(&path).unwrap();
+        let first_hb = first.last_heartbeat_unix;
+
+        // Wait long enough for at least one heartbeat tick beyond the first.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let second = read_snapshot(&path).unwrap();
+        assert!(
+            second.last_heartbeat_unix >= first_hb,
+            "heartbeat should not go backwards"
+        );
+    }
+}

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -250,6 +250,11 @@ where
         message: format!("hello flush error: {e}"),
     })?;
 
+    agent_state.connected.store(true, Ordering::Relaxed);
+    agent_state
+        .last_seen_secs
+        .store(current_time_secs(), Ordering::Relaxed);
+
     let workspace_path = hello.workspace_path.clone();
 
     Ok(Some(HandshakeResult {

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -2233,6 +2233,118 @@ mod tests {
         assert!(!handle.agent_state.connected.load(Ordering::Relaxed));
     }
 
+    // -- perform_handshake --
+
+    fn test_control_context(
+        handles: Arc<Mutex<HashMap<String, ContainerHandle>>>,
+        auth_token: &str,
+    ) -> ControlContext {
+        let (proxy_tx, _proxy_rx) = tokio::sync::mpsc::channel(16);
+        ControlContext {
+            auth_token: auth_token.to_string(),
+            port_manager: Arc::new(Mutex::new(PortManager::new(false))),
+            browser_handler: Arc::new(BrowserHandler::new()),
+            container_handles: handles,
+            proxy_cmd_tx: proxy_tx,
+            task_manager: crate::task_manager::new_shared(),
+            cella_bin: std::path::PathBuf::from("/nonexistent"),
+        }
+    }
+
+    #[tokio::test]
+    async fn perform_handshake_marks_connected_without_follow_up_message() {
+        use tokio::io::AsyncWriteExt;
+
+        let agent_state = Arc::new(AgentConnectionState::new());
+        let handles = {
+            let mut map = HashMap::new();
+            map.insert(
+                "test-container".to_string(),
+                ContainerHandle {
+                    container_id: "container-id-123".to_string(),
+                    agent_state: agent_state.clone(),
+                    backend_kind: Some("docker".to_string()),
+                    docker_host: None,
+                },
+            );
+            Arc::new(Mutex::new(map))
+        };
+        let ctx = test_control_context(handles, "test-token");
+
+        let (mut agent_side, daemon_side) = tokio::io::duplex(4096);
+        let (daemon_r, mut daemon_w) = tokio::io::split(daemon_side);
+        let mut daemon_reader = BufReader::new(daemon_r);
+
+        let hello = AgentHello {
+            protocol_version: PROTOCOL_VERSION,
+            agent_version: "0.0.28".to_string(),
+            container_name: "test-container".to_string(),
+            auth_token: "test-token".to_string(),
+        };
+        let mut json = serde_json::to_string(&hello).unwrap();
+        json.push('\n');
+        agent_side.write_all(json.as_bytes()).await.unwrap();
+        agent_side.flush().await.unwrap();
+
+        assert!(
+            !agent_state.connected.load(Ordering::Relaxed),
+            "pre-condition: connected starts false"
+        );
+
+        let mut line = String::new();
+        let result = perform_handshake(&mut daemon_reader, &mut daemon_w, &mut line, &ctx).await;
+
+        let hs = result
+            .expect("handshake should not error")
+            .expect("handshake should return Some");
+        assert_eq!(hs.container_name, "test-container");
+        assert!(
+            agent_state.connected.load(Ordering::Relaxed),
+            "connected must be true immediately after handshake, before any message"
+        );
+        assert_ne!(
+            agent_state.last_seen_secs.load(Ordering::Relaxed),
+            0,
+            "last_seen_secs must be set on handshake"
+        );
+        assert_eq!(
+            agent_state.agent_version.lock().unwrap().as_deref(),
+            Some("0.0.28"),
+            "agent_version must be recorded from AgentHello"
+        );
+    }
+
+    #[tokio::test]
+    async fn perform_handshake_unknown_container_does_not_mark_connected() {
+        use tokio::io::AsyncWriteExt;
+
+        let handles = Arc::new(Mutex::new(HashMap::new()));
+        let ctx = test_control_context(handles, "test-token");
+
+        let (mut agent_side, daemon_side) = tokio::io::duplex(4096);
+        let (daemon_r, mut daemon_w) = tokio::io::split(daemon_side);
+        let mut daemon_reader = BufReader::new(daemon_r);
+
+        let hello = AgentHello {
+            protocol_version: PROTOCOL_VERSION,
+            agent_version: "0.0.28".to_string(),
+            container_name: "not-registered".to_string(),
+            auth_token: "test-token".to_string(),
+        };
+        let mut json = serde_json::to_string(&hello).unwrap();
+        json.push('\n');
+        agent_side.write_all(json.as_bytes()).await.unwrap();
+        agent_side.flush().await.unwrap();
+
+        let mut line = String::new();
+        let result = perform_handshake(&mut daemon_reader, &mut daemon_w, &mut line, &ctx).await;
+
+        assert!(
+            matches!(result, Ok(None)),
+            "handshake must reject and return Ok(None) for unknown container"
+        );
+    }
+
     // ---------------------------------------------------------------
     // extract_port
     // ---------------------------------------------------------------

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -503,7 +503,6 @@ pub(crate) async fn handle_agent_message(
     ctx: &AgentHandlerContext<'_>,
     agent_state: &Arc<AgentConnectionState>,
 ) -> Option<DaemonMessage> {
-    agent_state.connected.store(true, Ordering::Relaxed);
     agent_state
         .last_seen_secs
         .store(current_time_secs(), Ordering::Relaxed);
@@ -2843,6 +2842,8 @@ branch refs/heads/feat-b
         let pm = Arc::new(Mutex::new(PortManager::new(false)));
         let browser = Arc::new(BrowserHandler::new());
         let state = Arc::new(AgentConnectionState::new());
+        // Post-handshake invariant: connected is owned by perform_handshake.
+        state.connected.store(true, Ordering::Relaxed);
         let ctx = AgentHandlerContext {
             port_manager: &pm,
             browser_handler: &browser,
@@ -2857,7 +2858,6 @@ branch refs/heads/feat-b
         };
         let result = handle_agent_message(msg, &ctx, &state).await;
         assert!(result.is_none());
-        // Should update state
         assert!(state.connected.load(Ordering::Relaxed));
         assert!(state.last_seen_secs.load(Ordering::Relaxed) > 0);
     }
@@ -2927,15 +2927,16 @@ branch refs/heads/feat-b
     }
 
     // ---------------------------------------------------------------
-    // handle_agent_message updates agent_state
+    // handle_agent_message updates last_seen_secs (connected owned by handshake)
     // ---------------------------------------------------------------
 
     #[tokio::test]
-    async fn agent_state_updated_on_message() {
+    async fn handle_agent_message_updates_last_seen_preserves_connected() {
         let pm = Arc::new(Mutex::new(PortManager::new(false)));
         let browser = Arc::new(BrowserHandler::new());
         let state = Arc::new(AgentConnectionState::new());
-        assert!(!state.connected.load(Ordering::Relaxed));
+        // Simulate post-handshake invariant: connected is owned by perform_handshake.
+        state.connected.store(true, Ordering::Relaxed);
         assert_eq!(state.last_seen_secs.load(Ordering::Relaxed), 0);
 
         let ctx = AgentHandlerContext {
@@ -2952,7 +2953,10 @@ branch refs/heads/feat-b
         };
         let _ = handle_agent_message(msg, &ctx, &state).await;
 
-        assert!(state.connected.load(Ordering::Relaxed));
+        assert!(
+            state.connected.load(Ordering::Relaxed),
+            "connected should remain true"
+        );
         let ts = state.last_seen_secs.load(Ordering::Relaxed);
         assert!(ts > 0, "last_seen_secs should be non-zero after message");
     }

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -2313,6 +2313,86 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn control_server_marks_connected_via_real_tcp_handshake() {
+        use tokio::io::AsyncWriteExt;
+        use tokio::net::TcpStream;
+
+        let agent_state = Arc::new(AgentConnectionState::new());
+        let handles = {
+            let mut map = HashMap::new();
+            map.insert(
+                "int-test-container".to_string(),
+                ContainerHandle {
+                    container_id: "int-container-id".to_string(),
+                    agent_state: agent_state.clone(),
+                    backend_kind: Some("docker".to_string()),
+                    docker_host: None,
+                },
+            );
+            Arc::new(Mutex::new(map))
+        };
+        let ctx = test_control_context(handles, "int-test-token");
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let last_activity = Arc::new(AtomicU64::new(0));
+        let la = last_activity.clone();
+        let server = tokio::spawn(async move {
+            run_control_server(listener, ctx, la, shutdown_rx).await;
+        });
+
+        let mut stream = TcpStream::connect(addr).await.unwrap();
+        let hello = AgentHello {
+            protocol_version: PROTOCOL_VERSION,
+            agent_version: "0.0.28".to_string(),
+            container_name: "int-test-container".to_string(),
+            auth_token: "int-test-token".to_string(),
+        };
+        let mut json = serde_json::to_string(&hello).unwrap();
+        json.push('\n');
+        stream.write_all(json.as_bytes()).await.unwrap();
+        stream.flush().await.unwrap();
+
+        let mut reader = BufReader::new(&mut stream);
+        let mut daemon_resp = String::new();
+        reader.read_line(&mut daemon_resp).await.unwrap();
+        let daemon_hello: DaemonHello = serde_json::from_str(daemon_resp.trim()).unwrap();
+        assert!(
+            daemon_hello.error.is_none(),
+            "daemon rejected handshake: {:?}",
+            daemon_hello.error
+        );
+
+        let start = std::time::Instant::now();
+        while !agent_state.connected.load(Ordering::Relaxed) {
+            assert!(
+                start.elapsed() <= std::time::Duration::from_secs(1),
+                "agent_state.connected never became true within 1s of handshake"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+
+        assert_ne!(
+            agent_state.last_seen_secs.load(Ordering::Relaxed),
+            0,
+            "last_seen_secs should be updated at handshake"
+        );
+        assert_eq!(
+            agent_state.agent_version.lock().unwrap().as_deref(),
+            Some("0.0.28"),
+        );
+
+        drop(stream);
+        let _ = shutdown_tx.send(true);
+        // Nudge the listener so the select! observes the shutdown.
+        let _ = TcpStream::connect(addr).await;
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(1), server).await;
+    }
+
     #[tokio::test]
     async fn perform_handshake_unknown_container_does_not_mark_connected() {
         use tokio::io::AsyncWriteExt;

--- a/crates/cella-daemon/src/management.rs
+++ b/crates/cella-daemon/src/management.rs
@@ -623,4 +623,90 @@ mod tests {
 
         server_handle.abort();
     }
+
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn query_status_reports_connected_after_bare_handshake() {
+        use tokio::io::AsyncWriteExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("mgmt.sock");
+
+        let ctrl_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let ctrl_port = ctrl_listener.local_addr().unwrap().port();
+
+        let sock = socket_path.clone();
+        let server_handle = tokio::spawn({
+            let (ctx, srx) = test_management_context(ctrl_port);
+            async move {
+                let _ = run_management_server(&sock, ctx, srx, ctrl_listener).await;
+            }
+        });
+
+        for _ in 0..50 {
+            if socket_path.exists() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+
+        send_management_request(
+            &socket_path,
+            &ManagementRequest::RegisterContainer(Box::new(
+                cella_protocol::ContainerRegistrationData {
+                    container_id: "hs-container-id".to_string(),
+                    container_name: "hs-container".to_string(),
+                    container_ip: Some("172.20.0.5".to_string()),
+                    ports_attributes: vec![],
+                    other_ports_attributes: None,
+                    forward_ports: vec![],
+                    shutdown_action: None,
+                    backend_kind: Some("docker".to_string()),
+                    docker_host: None,
+                },
+            )),
+        )
+        .await
+        .unwrap();
+
+        let mut stream = tokio::net::TcpStream::connect(("127.0.0.1", ctrl_port))
+            .await
+            .unwrap();
+        let hello = cella_protocol::AgentHello {
+            protocol_version: cella_protocol::PROTOCOL_VERSION,
+            agent_version: "0.0.28".to_string(),
+            container_name: "hs-container".to_string(),
+            auth_token: "test-token".to_string(),
+        };
+        let mut json = serde_json::to_string(&hello).unwrap();
+        json.push('\n');
+        stream.write_all(json.as_bytes()).await.unwrap();
+        stream.flush().await.unwrap();
+
+        let start = std::time::Instant::now();
+        let mut observed = None;
+        while start.elapsed() < std::time::Duration::from_secs(1) {
+            let resp = send_management_request(&socket_path, &ManagementRequest::QueryStatus)
+                .await
+                .unwrap();
+            if let ManagementResponse::Status { containers, .. } = resp
+                && let Some(c) = containers
+                    .into_iter()
+                    .find(|c| c.container_name == "hs-container")
+                && c.agent_connected
+            {
+                observed = Some(c);
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        let summary =
+            observed.expect("QueryStatus should show agent_connected=true within 1s of handshake");
+        assert!(summary.agent_connected);
+        assert_eq!(summary.agent_version.as_deref(), Some("0.0.28"));
+
+        drop(stream);
+        server_handle.abort();
+    }
 }

--- a/crates/cella-doctor/src/checks/container.rs
+++ b/crates/cella-doctor/src/checks/container.rs
@@ -149,7 +149,7 @@ async fn check_single_container(
     // Agent/port checks only apply to backends with managed agents
     if client.capabilities().managed_agent {
         // Agent connectivity via daemon
-        check_agent_connectivity(client, container_id, &mut checks, container_name).await;
+        check_agent_connectivity(&mut checks, container_name).await;
 
         // Credential forwarding
         check_credentials(client, container_id, &mut checks).await;
@@ -244,12 +244,7 @@ async fn query_live_agent_version(container_name: &str) -> Option<String> {
     }
 }
 
-async fn check_agent_connectivity(
-    client: &dyn ContainerBackend,
-    container_id: &str,
-    checks: &mut Vec<CheckResult>,
-    container_name: &str,
-) {
+async fn check_agent_connectivity(checks: &mut Vec<CheckResult>, container_name: &str) {
     let Some(data_dir) = cella_env::paths::cella_data_dir() else {
         return;
     };
@@ -273,17 +268,11 @@ async fn check_agent_connectivity(
                     fix_hint: None,
                 });
             } else {
-                let label_missing = client
-                    .inspect_container(container_id)
-                    .await
-                    .ok()
-                    .and_then(|info| info.labels.get("dev.cella.version").cloned())
-                    .is_none();
                 checks.push(CheckResult {
                     name: "agent".into(),
                     severity: Severity::Warning,
                     detail: "not connected".into(),
-                    fix_hint: Some(agent_not_connected_hint(label_missing)),
+                    fix_hint: Some("Check container logs: `cella logs`".into()),
                 });
             }
         }
@@ -295,18 +284,6 @@ async fn check_agent_connectivity(
                 fix_hint: None,
             });
         }
-    }
-}
-
-/// Pick the remedy hint for an "agent not connected" result. Containers that
-/// predate the `dev.cella.version` label were created before this release
-/// could register them with the daemon; their only fix is a rebuild, not a
-/// log check.
-fn agent_not_connected_hint(label_missing: bool) -> String {
-    if label_missing {
-        "Container was created by an older cella; run `cella up --rebuild` to re-register".into()
-    } else {
-        "Check container logs: `cella logs`".into()
     }
 }
 
@@ -496,31 +473,5 @@ mod tests {
         let reports = check_containers(&ctx, true).await;
         assert_eq!(reports.len(), 1);
         assert_eq!(reports[0].checks[0].name, "skipped");
-    }
-
-    #[test]
-    fn agent_not_connected_hint_suggests_rebuild_when_label_missing() {
-        let hint = agent_not_connected_hint(true);
-        assert!(
-            hint.contains("cella up --rebuild"),
-            "legacy container hint must point at rebuild; got {hint:?}"
-        );
-        assert!(
-            hint.contains("older cella"),
-            "legacy container hint must explain the why; got {hint:?}"
-        );
-    }
-
-    #[test]
-    fn agent_not_connected_hint_points_to_logs_when_label_present() {
-        let hint = agent_not_connected_hint(false);
-        assert!(
-            hint.contains("cella logs"),
-            "non-legacy hint should point to `cella logs`; got {hint:?}"
-        );
-        assert!(
-            !hint.contains("--rebuild"),
-            "non-legacy hint must NOT suggest rebuild; got {hint:?}"
-        );
     }
 }

--- a/crates/cella-doctor/src/checks/container.rs
+++ b/crates/cella-doctor/src/checks/container.rs
@@ -149,7 +149,7 @@ async fn check_single_container(
     // Agent/port checks only apply to backends with managed agents
     if client.capabilities().managed_agent {
         // Agent connectivity via daemon
-        check_agent_connectivity(&mut checks, container_name).await;
+        check_agent_connectivity(client, container_id, &mut checks, container_name).await;
 
         // Credential forwarding
         check_credentials(client, container_id, &mut checks).await;
@@ -244,7 +244,12 @@ async fn query_live_agent_version(container_name: &str) -> Option<String> {
     }
 }
 
-async fn check_agent_connectivity(checks: &mut Vec<CheckResult>, container_name: &str) {
+async fn check_agent_connectivity(
+    client: &dyn ContainerBackend,
+    container_id: &str,
+    checks: &mut Vec<CheckResult>,
+    container_name: &str,
+) {
     let Some(data_dir) = cella_env::paths::cella_data_dir() else {
         return;
     };
@@ -268,11 +273,17 @@ async fn check_agent_connectivity(checks: &mut Vec<CheckResult>, container_name:
                     fix_hint: None,
                 });
             } else {
+                let label_missing = client
+                    .inspect_container(container_id)
+                    .await
+                    .ok()
+                    .and_then(|info| info.labels.get("dev.cella.version").cloned())
+                    .is_none();
                 checks.push(CheckResult {
                     name: "agent".into(),
                     severity: Severity::Warning,
                     detail: "not connected".into(),
-                    fix_hint: Some("Check container logs: `cella logs`".into()),
+                    fix_hint: Some(agent_not_connected_hint(label_missing)),
                 });
             }
         }
@@ -284,6 +295,18 @@ async fn check_agent_connectivity(checks: &mut Vec<CheckResult>, container_name:
                 fix_hint: None,
             });
         }
+    }
+}
+
+/// Pick the remedy hint for an "agent not connected" result. Containers that
+/// predate the `dev.cella.version` label were created before this release
+/// could register them with the daemon; their only fix is a rebuild, not a
+/// log check.
+fn agent_not_connected_hint(label_missing: bool) -> String {
+    if label_missing {
+        "Container was created by an older cella; run `cella up --rebuild` to re-register".into()
+    } else {
+        "Check container logs: `cella logs`".into()
     }
 }
 

--- a/crates/cella-doctor/src/checks/container.rs
+++ b/crates/cella-doctor/src/checks/container.rs
@@ -497,4 +497,30 @@ mod tests {
         assert_eq!(reports.len(), 1);
         assert_eq!(reports[0].checks[0].name, "skipped");
     }
+
+    #[test]
+    fn agent_not_connected_hint_suggests_rebuild_when_label_missing() {
+        let hint = agent_not_connected_hint(true);
+        assert!(
+            hint.contains("cella up --rebuild"),
+            "legacy container hint must point at rebuild; got {hint:?}"
+        );
+        assert!(
+            hint.contains("older cella"),
+            "legacy container hint must explain the why; got {hint:?}"
+        );
+    }
+
+    #[test]
+    fn agent_not_connected_hint_points_to_logs_when_label_present() {
+        let hint = agent_not_connected_hint(false);
+        assert!(
+            hint.contains("cella logs"),
+            "non-legacy hint should point to `cella logs`; got {hint:?}"
+        );
+        assert!(
+            !hint.contains("--rebuild"),
+            "non-legacy hint must NOT suggest rebuild; got {hint:?}"
+        );
+    }
 }

--- a/crates/cella-orchestrator/src/compose_up.rs
+++ b/crates/cella-orchestrator/src/compose_up.rs
@@ -12,7 +12,7 @@ use std::pin::Pin;
 use tracing::{debug, info, warn};
 
 use cella_backend::{
-    ContainerBackend, ContainerInfo, ContainerState, LifecycleContext, MountSpec,
+    ContainerBackend, ContainerInfo, ContainerState, LifecycleContext, MountSpec, agent_env_vars,
     run_lifecycle_phase,
 };
 use cella_compose::{ComposeCommand, ComposeProject, OverrideConfig, ServiceBuildInfo};
@@ -318,7 +318,14 @@ async fn prepare_and_start(
     info!("Resolved remote user: {remote_user} (image user: {image_user})");
 
     // 11-12. Build extra env vars and labels for the primary service.
-    let extra_env = build_extra_env(daemon_env, &env_fwd, cfg.remote_env);
+    let mut extra_env = build_extra_env(daemon_env, &env_fwd, cfg.remote_env);
+    // BROWSER=/cella/bin/cella-browser is required for in-container URL
+    // forwarding. The non-compose path injects it explicitly (up.rs); without
+    // this the compose path ships containers with BROWSER unset and host
+    // `cella doctor` reports "browser helper not configured".
+    if client.capabilities().managed_agent {
+        extra_env.extend(agent_env_vars());
+    }
     let mut labels = build_compose_labels(cfg, project, &remote_user);
 
     let settings = cella_config::settings::Settings::load(cfg.workspace_root);

--- a/crates/cella-orchestrator/src/compose_up.rs
+++ b/crates/cella-orchestrator/src/compose_up.rs
@@ -318,14 +318,8 @@ async fn prepare_and_start(
     info!("Resolved remote user: {remote_user} (image user: {image_user})");
 
     // 11-12. Build extra env vars and labels for the primary service.
-    let mut extra_env = build_extra_env(daemon_env, &env_fwd, cfg.remote_env);
-    // BROWSER=/cella/bin/cella-browser is required for in-container URL
-    // forwarding. The non-compose path injects it explicitly (up.rs); without
-    // this the compose path ships containers with BROWSER unset and host
-    // `cella doctor` reports "browser helper not configured".
-    if client.capabilities().managed_agent {
-        extra_env.extend(agent_env_vars());
-    }
+    let managed = client.capabilities().managed_agent;
+    let extra_env = build_extra_env(daemon_env, &env_fwd, cfg.remote_env, managed);
     let mut labels = build_compose_labels(cfg, project, &remote_user);
 
     let settings = cella_config::settings::Settings::load(cfg.workspace_root);
@@ -830,15 +824,21 @@ fn build_compose_labels(
 /// Assemble the extra environment variable list for the compose service.
 ///
 /// Combines daemon-injected env vars, forwarded env vars (SSH/GPG agent sockets,
-/// etc.), and user-specified `remote_env` overrides in precedence order.
+/// etc.), user-specified `remote_env` overrides, and — when the backend has a
+/// managed agent — the agent env vars (notably `BROWSER=/cella/bin/cella-browser`)
+/// in precedence order.
 fn build_extra_env(
     daemon_env: Vec<String>,
     env_fwd: &cella_env::EnvForwarding,
     remote_env: &[String],
+    managed_agent: bool,
 ) -> Vec<String> {
     let mut extra_env = daemon_env;
     extra_env.extend(env_fwd.env.iter().map(|e| format!("{}={}", e.key, e.value)));
     extra_env.extend(remote_env.iter().cloned());
+    if managed_agent {
+        extra_env.extend(agent_env_vars());
+    }
     extra_env
 }
 
@@ -1065,5 +1065,67 @@ where
             step.fail(&error.to_string());
             Err(error)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_extra_env_injects_browser_when_managed_agent() {
+        let env_fwd = cella_env::EnvForwarding::default();
+        let extra = build_extra_env(vec![], &env_fwd, &[], true);
+        assert!(
+            extra
+                .iter()
+                .any(|v| v == "BROWSER=/cella/bin/cella-browser"),
+            "managed_agent=true must inject BROWSER; got {extra:?}"
+        );
+        assert!(
+            extra.iter().any(|v| v.starts_with("CELLA_AGENT_VERSION=")),
+            "managed_agent=true must inject CELLA_AGENT_VERSION; got {extra:?}"
+        );
+    }
+
+    #[test]
+    fn build_extra_env_omits_browser_when_not_managed() {
+        let env_fwd = cella_env::EnvForwarding::default();
+        let extra = build_extra_env(vec![], &env_fwd, &[], false);
+        assert!(
+            !extra.iter().any(|v| v.starts_with("BROWSER=")),
+            "managed_agent=false must NOT inject BROWSER; got {extra:?}"
+        );
+    }
+
+    #[test]
+    fn build_extra_env_preserves_precedence_order() {
+        // daemon_env first, then env_fwd, then remote_env, then agent vars.
+        let env_fwd = cella_env::EnvForwarding {
+            env: vec![cella_env::ForwardEnv {
+                key: "FWD_KEY".into(),
+                value: "fwd_val".into(),
+            }],
+            ..Default::default()
+        };
+        let extra = build_extra_env(
+            vec!["CELLA_DAEMON_ADDR=h:1".to_string()],
+            &env_fwd,
+            &["USER_KEY=user_val".to_string()],
+            true,
+        );
+        let daemon_idx = extra
+            .iter()
+            .position(|v| v == "CELLA_DAEMON_ADDR=h:1")
+            .unwrap();
+        let fwd_idx = extra.iter().position(|v| v == "FWD_KEY=fwd_val").unwrap();
+        let user_idx = extra.iter().position(|v| v == "USER_KEY=user_val").unwrap();
+        let browser_idx = extra
+            .iter()
+            .position(|v| v == "BROWSER=/cella/bin/cella-browser")
+            .unwrap();
+        assert!(daemon_idx < fwd_idx);
+        assert!(fwd_idx < user_idx);
+        assert!(user_idx < browser_idx);
     }
 }

--- a/crates/cella-orchestrator/src/compose_up.rs
+++ b/crates/cella-orchestrator/src/compose_up.rs
@@ -787,6 +787,19 @@ fn build_compose_labels(
 
     // Cella-specific labels.
     labels.insert("dev.cella.tool".to_string(), "cella".to_string());
+    // `dev.cella.version` mirrors what the non-compose path stamps at
+    // up.rs:686. Two existing readers consult it:
+    //   - cella-doctor's check_version_skew falls back to this label when
+    //     the agent isn't connected; without it, compose containers show
+    //     "container unknown != CLI <ver>" every time the daemon restarts.
+    //   - cella-orchestrator's up.rs uses it to detect version skew and
+    //     decide whether to repopulate the agent volume on `cella up`.
+    // Both readers treat a missing label as "unknown", so this is a
+    // best-effort fallback, not an authoritative source of truth.
+    labels.insert(
+        "dev.cella.version".to_string(),
+        env!("CARGO_PKG_VERSION").to_string(),
+    );
     labels.insert(
         "dev.cella.workspace_path".to_string(),
         workspace_str.clone(),
@@ -1096,6 +1109,54 @@ mod tests {
             !extra.iter().any(|v| v.starts_with("BROWSER=")),
             "managed_agent=false must NOT inject BROWSER; got {extra:?}"
         );
+    }
+
+    #[test]
+    fn build_compose_labels_stamps_cella_version() {
+        // Parity with up.rs:686. Doctor's version-skew check falls back to
+        // `dev.cella.version` when the live agent can't be reached; missing
+        // label makes the fallback show "container unknown != CLI <ver>".
+        // The label is best-effort (can go stale on CLI upgrade) — its
+        // absence is handled gracefully but its presence gives users useful
+        // info when the daemon is down.
+        let config = serde_json::json!({});
+        let config_path = PathBuf::from("/tmp/devcontainer.json");
+        let workspace_root = PathBuf::from("/tmp/workspace");
+        let cfg = ComposeUpConfig {
+            config: &config,
+            config_path: &config_path,
+            workspace_root: &workspace_root,
+            container_name: "test-container",
+            remote_env: &[],
+            remove_container: false,
+            build_no_cache: false,
+            skip_checksum: false,
+            profiles: vec![],
+            env_files: vec![],
+            pull_policy: None,
+        };
+        let project = ComposeProject {
+            project_name: "cella-test".to_string(),
+            compose_files: vec![],
+            override_file: PathBuf::from("/tmp/override.yaml"),
+            primary_service: "app".to_string(),
+            run_services: None,
+            shutdown_action: cella_compose::ShutdownAction::StopCompose,
+            override_command: false,
+            workspace_folder: "/workspace".to_string(),
+            config_dir: PathBuf::from("/tmp"),
+            workspace_root: workspace_root.clone(),
+            config_hash: "hash123".to_string(),
+            profiles: vec![],
+            env_files: vec![],
+            pull_policy: None,
+        };
+
+        let labels = build_compose_labels(&cfg, &project, "vscode");
+        let version = labels
+            .get("dev.cella.version")
+            .expect("compose labels must include dev.cella.version");
+        assert_eq!(version, env!("CARGO_PKG_VERSION"));
     }
 
     #[test]

--- a/crates/cella-orchestrator/src/compose_up.rs
+++ b/crates/cella-orchestrator/src/compose_up.rs
@@ -787,15 +787,6 @@ fn build_compose_labels(
 
     // Cella-specific labels.
     labels.insert("dev.cella.tool".to_string(), "cella".to_string());
-    // `dev.cella.version` is the authoritative create-time version stamp.
-    // The host doctor falls back to this label when the agent isn't
-    // connected; without it, brand-new compose containers are misclassified
-    // as pre-versioned legacy containers and doctor suggests `cella up
-    // --rebuild` incorrectly.
-    labels.insert(
-        "dev.cella.version".to_string(),
-        env!("CARGO_PKG_VERSION").to_string(),
-    );
     labels.insert(
         "dev.cella.workspace_path".to_string(),
         workspace_str.clone(),
@@ -1105,52 +1096,6 @@ mod tests {
             !extra.iter().any(|v| v.starts_with("BROWSER=")),
             "managed_agent=false must NOT inject BROWSER; got {extra:?}"
         );
-    }
-
-    #[test]
-    fn build_compose_labels_stamps_cella_version() {
-        // Regression: compose containers used to ship without
-        // `dev.cella.version`, which the host doctor then read as missing
-        // and misclassified as a pre-versioned legacy container —
-        // recommending `cella up --rebuild` on brand-new containers.
-        let config = serde_json::json!({});
-        let config_path = PathBuf::from("/tmp/devcontainer.json");
-        let workspace_root = PathBuf::from("/tmp/workspace");
-        let cfg = ComposeUpConfig {
-            config: &config,
-            config_path: &config_path,
-            workspace_root: &workspace_root,
-            container_name: "test-container",
-            remote_env: &[],
-            remove_container: false,
-            build_no_cache: false,
-            skip_checksum: false,
-            profiles: vec![],
-            env_files: vec![],
-            pull_policy: None,
-        };
-        let project = ComposeProject {
-            project_name: "cella-test".to_string(),
-            compose_files: vec![],
-            override_file: PathBuf::from("/tmp/override.yaml"),
-            primary_service: "app".to_string(),
-            run_services: None,
-            shutdown_action: cella_compose::ShutdownAction::StopCompose,
-            override_command: false,
-            workspace_folder: "/workspace".to_string(),
-            config_dir: PathBuf::from("/tmp"),
-            workspace_root: workspace_root.clone(),
-            config_hash: "hash123".to_string(),
-            profiles: vec![],
-            env_files: vec![],
-            pull_policy: None,
-        };
-
-        let labels = build_compose_labels(&cfg, &project, "vscode");
-        let version = labels
-            .get("dev.cella.version")
-            .expect("compose labels must include dev.cella.version");
-        assert_eq!(version, env!("CARGO_PKG_VERSION"));
     }
 
     #[test]

--- a/crates/cella-orchestrator/src/compose_up.rs
+++ b/crates/cella-orchestrator/src/compose_up.rs
@@ -787,6 +787,15 @@ fn build_compose_labels(
 
     // Cella-specific labels.
     labels.insert("dev.cella.tool".to_string(), "cella".to_string());
+    // `dev.cella.version` is the authoritative create-time version stamp.
+    // The host doctor falls back to this label when the agent isn't
+    // connected; without it, brand-new compose containers are misclassified
+    // as pre-versioned legacy containers and doctor suggests `cella up
+    // --rebuild` incorrectly.
+    labels.insert(
+        "dev.cella.version".to_string(),
+        env!("CARGO_PKG_VERSION").to_string(),
+    );
     labels.insert(
         "dev.cella.workspace_path".to_string(),
         workspace_str.clone(),
@@ -1096,6 +1105,52 @@ mod tests {
             !extra.iter().any(|v| v.starts_with("BROWSER=")),
             "managed_agent=false must NOT inject BROWSER; got {extra:?}"
         );
+    }
+
+    #[test]
+    fn build_compose_labels_stamps_cella_version() {
+        // Regression: compose containers used to ship without
+        // `dev.cella.version`, which the host doctor then read as missing
+        // and misclassified as a pre-versioned legacy container —
+        // recommending `cella up --rebuild` on brand-new containers.
+        let config = serde_json::json!({});
+        let config_path = PathBuf::from("/tmp/devcontainer.json");
+        let workspace_root = PathBuf::from("/tmp/workspace");
+        let cfg = ComposeUpConfig {
+            config: &config,
+            config_path: &config_path,
+            workspace_root: &workspace_root,
+            container_name: "test-container",
+            remote_env: &[],
+            remove_container: false,
+            build_no_cache: false,
+            skip_checksum: false,
+            profiles: vec![],
+            env_files: vec![],
+            pull_policy: None,
+        };
+        let project = ComposeProject {
+            project_name: "cella-test".to_string(),
+            compose_files: vec![],
+            override_file: PathBuf::from("/tmp/override.yaml"),
+            primary_service: "app".to_string(),
+            run_services: None,
+            shutdown_action: cella_compose::ShutdownAction::StopCompose,
+            override_command: false,
+            workspace_folder: "/workspace".to_string(),
+            config_dir: PathBuf::from("/tmp"),
+            workspace_root: workspace_root.clone(),
+            config_hash: "hash123".to_string(),
+            profiles: vec![],
+            env_files: vec![],
+            pull_policy: None,
+        };
+
+        let labels = build_compose_labels(&cfg, &project, "vscode");
+        let version = labels
+            .get("dev.cella.version")
+            .expect("compose labels must include dev.cella.version");
+        assert_eq!(version, env!("CARGO_PKG_VERSION"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes three independent bugs that surfaced as `cella doctor` giving inconsistent answers between the in-container and host views:

- **Daemon (`connected` flag was set too late)** — `agent_state.connected` flipped to `true` only on the first post-handshake message, so a freshly-handshaken agent appeared "not connected" for up to 60s (until the Health heartbeat). Now set the instant `perform_handshake` succeeds. This alone fixes the `⚠ version: container unknown != CLI …` and `⚠ agent: not connected` warnings the bug report led with, in the common case.
- **In-container doctor couldn't see main-agent liveness** — the existing `cella doctor` run inside the container opened its *own* fresh TCP handshake, which succeeded even if the long-running `cella-agent daemon` process had crashed. Added a single-writer state actor that publishes `/tmp/cella-agent.state` (PID, transport state, heartbeat) every 10s and on every state transition. Doctor now reports `connected | reconnecting | disconnected | process gone | state file missing` with a freshness age, using `/proc/{pid}` as the liveness authority.
- **Compose path wasn't injecting `BROWSER`** — the non-compose up-path at `up.rs:820` calls `agent_env_vars()` explicitly, but the compose path's `build_extra_env` never did, so every compose container shipped with `BROWSER` unset. Gated injection on `capabilities().managed_agent`. Also stamps `dev.cella.version` for parity with non-compose so the doctor's version-skew fallback doesn't read "unknown" on compose when the daemon's in-memory registration is transiently lost.

12 net commits (one added, one reverted, one re-added with better reasoning after a Codex stop-time review caught a mis-signal). History shows the evolution explicitly rather than rebase-squashing.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --features integration-tests -- -D warnings -D clippy::all`
- [x] `cargo test --workspace` — all unit tests pass (247 agent, 435 daemon, 391 orchestrator, 144 doctor)
- [x] `cargo test --features integration-tests` — new `control_server_marks_connected_via_real_tcp_handshake` (real TCP handshake) and `query_status_reports_connected_after_bare_handshake` (end-to-end through the management socket) pass
- [ ] **Manual, real container + daemon (host):** rebuild and reinstall cella, restart daemon, then on a compose project:
  - Host `cella doctor` under `Container:` shows `✓ version: 0.0.28` and `✓ agent connected` without waiting 60s
  - In-container `cella doctor` shows the new `✓ main agent: connected (pid X, heartbeat Ys ago)` line plus `✓ browser helper configured`
  - `docker exec <container> env | grep BROWSER` returns `BROWSER=/cella/bin/cella-browser`
- [ ] **Manual, simulated agent crash:** `docker exec <container> pkill -9 cella-agent`. In-container `cella doctor` should show `✗ main agent: process gone` even while its own fresh-handshake probe to the daemon still succeeds.

Pre-existing failure unrelated to this branch: `cella-compose::integration_tests::phase_tests::override_file_exists_before_compose_uses_it` fails with `PermissionDenied`. Verified failing on `main` as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)