### PR TITLE
docs: sync tracked docs and specs to current codebase

### DIFF
--- a/.claude/commands/cella-parallel-dev.md
+++ b/.claude/commands/cella-parallel-dev.md
@@ -2,6 +2,8 @@
 
 Use this skill when you need to work on multiple independent changes simultaneously. Each change runs in its own isolated container with its own worktree.
 
+> **Prerequisite:** `cella task` is available only from inside a cella container via the in-container CLI (the agent binary symlinked as `cella`). If you're on the host, use `cella branch` to create worktree containers and `cella exec` to run commands inside them; the task-dispatch pattern below assumes you are already inside a container.
+
 ## When to use
 
 - User gives you a large task with independent parts (e.g., "implement auth, API, and UI")

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -7,7 +7,7 @@ Run all CI checks in sequence, stopping on first failure. Report each step's res
 
 ```sh
 cargo fmt --all -- --check
-cargo clippy --workspace --all-targets -- -D warnings -D clippy::all
+cargo clippy --workspace --all-features --all-targets -- -D warnings -D clippy::all
 cargo test --workspace
 cargo insta test --workspace --check --unreferenced=reject
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ```sh
 cargo fmt --all -- --check                                            # format check
-cargo clippy --workspace --all-targets -- -D warnings -D clippy::all  # lint (all warnings are errors)
+cargo clippy --workspace --all-features --all-targets -- -D warnings -D clippy::all  # lint (all warnings are errors)
 cargo test --workspace                                                # unit tests
 cargo insta test --workspace --check --unreferenced=reject            # snapshot tests
 ```
@@ -55,7 +55,7 @@ Always research before suggesting changes or asking the user questions. Use `/sp
 
 ## Architecture
 
-Rust workspace (edition 2024, MSRV 1.94.0) with 19 crates in `crates/`. Three-tier structure:
+Rust workspace (edition 2024, MSRV 1.94.1) with 19 crates in `crates/`. Three-tier structure:
 
 - **Tier 1 (CLI):** cella-cli — binary entry point, delegates to library crates
 - **Tier 2 (Domain):** cella-docker, cella-compose, cella-orchestrator, cella-config, cella-features, cella-git, cella-daemon, cella-agent, cella-env, cella-doctor, cella-container, cella-templates
@@ -67,7 +67,8 @@ Key runtime constraints:
 - The `cella-agent` Docker volume is shared across ALL containers — changes affect every running container
 - Daemon state (port allocations, registrations) is in-memory only, lost on daemon restart
 - Docker container labels and env vars are immutable after creation — don't design around updating them
-- The agent entrypoint runs in a restart loop; `restart_agent_in_container()` just sends pkill and the loop handles restart
+- The agent entrypoint runs in a restart loop in newer containers; `restart_agent_in_container()` sends `pkill -f 'cella-agent daemon'`, sleeps, then checks `pgrep` and only manually spawns the daemon if nothing came back (backward-compat fallback for containers created before the restart loop existed)
+- The agent reconnects indefinitely on initial daemon miss and after daemon restart/binary upgrade — don't assume a fresh agent means a fresh daemon
 
 ## Commits & PRs
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ See the [worktree guide](docs/worktrees.md) for the full workflow, in-container 
 
 ## Architecture
 
-cella is a Rust workspace with 18 focused crates. The CLI delegates all business logic to library crates — no logic lives in the binary entry point.
+cella is a Rust workspace with 19 focused crates. The CLI delegates all business logic to library crates — no logic lives in the binary entry point.
 
 ```mermaid
 graph TD
@@ -262,12 +262,14 @@ graph TD
         codegen[cella-codegen<br><i>schema codegen</i>]
         network[cella-network<br><i>network proxy</i>]
         protocol[cella-protocol<br><i>wire format</i>]
+        jsonc[cella-jsonc<br><i>JSONC preprocessor</i>]
     end
 
     cli --> docker & container & compose & git & env & daemon & doctor & orchestrator & config & features & templates
     docker & container --> backend
     agent & daemon --> port
     config --> codegen
+    config & templates --> jsonc
     agent & config & env & orchestrator --> network
     templates --> features
     port --> protocol

--- a/README.md
+++ b/README.md
@@ -107,8 +107,6 @@ The [Dev Container specification](https://containers.dev/) ([spec repo](https://
 - [x] Git worktree integration (`cella branch`, `cella switch`, `cella prune`) — [guide](docs/worktrees.md)
 - [x] Devcontainer Features (OCI registry resolution, install ordering, caching)
 - [x] Feature management (`cella features edit`, `cella features list`, `cella features update`)
-- [x] Template management (`cella template new`, `cella template list`, `cella template edit`)
-- [x] Global config management (`cella config show`, `global`, `dotfiles`, `agent`, `validate`)
 - [x] Project initialization (`cella init`) — interactive wizard with OCI template/feature selection
 - [x] Lifecycle commands (initializeCommand, postCreate, postStart, postAttach, updateContentCommand)
 - [x] Image and Dockerfile builds
@@ -171,6 +169,8 @@ The [Dev Container specification](https://containers.dev/) ([spec repo](https://
 
 ### Planned
 
+- [ ] `cella template new/list/edit` — template authoring (subcommands exist as stubs, not yet implemented)
+- [ ] `cella config show/global/dotfiles/agent` — global/dotfiles/agent config management (subcommands exist as stubs, not yet implemented; only `cella config validate` is live)
 - [ ] Podman backend
 - [ ] Colima / Lima support
 
@@ -208,18 +208,11 @@ See the [worktree guide](docs/worktrees.md) for the full workflow, in-container 
 | `cella features list` | List installed and available devcontainer features |
 | `cella features edit` | Add, remove, or modify features in devcontainer.json |
 | `cella features update` | Update features to latest versions |
-| `cella template new` | Create a new dev container template |
-| `cella template list` | List available dev container templates |
-| `cella template edit` | Edit an existing dev container template |
 
 ### Configuration & Diagnostics
 
 | Command | Description |
 |---------|-------------|
-| `cella config show` | Show the resolved configuration |
-| `cella config global` | Edit global cella settings |
-| `cella config dotfiles` | Manage dotfile symlinks |
-| `cella config agent` | Configure agent presets |
 | `cella config validate` | Validate a devcontainer.json file |
 | `cella read-configuration` | Output resolved devcontainer config as JSON |
 | `cella doctor` | Check system dependencies and configuration |

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The [Dev Container specification](https://containers.dev/) ([spec repo](https://
 | Runtime dependency | None | Node.js 14+ |
 | `stop` / `down` command | Yes | No ([cli#386](https://github.com/devcontainers/cli/issues/386)) |
 | Port forwarding | Automatic (daemon + in-container agent) | No — [VS Code extension only](https://github.com/devcontainers/cli/issues/22) ([cli#186](https://github.com/devcontainers/cli/issues/186)) |
-| SSH agent forwarding | Platform-aware (Docker Desktop, OrbStack, Linux) | No — [VS Code extension only](https://github.com/devcontainers/cli/issues/441) |
+| SSH agent forwarding | Platform-aware (Docker Desktop, OrbStack, Colima, Linux) | No — [VS Code extension only](https://github.com/devcontainers/cli/issues/441) |
 | Git credential forwarding | gh CLI via socket + TCP, auto-on | No — [VS Code extension only](https://github.com/microsoft/vscode-remote-release/issues/4202) |
 | BROWSER interception | Host browser opens for OAuth | No — [VS Code extension only](https://github.com/microsoft/vscode-remote-release/issues/9935) |
 | Container listing | `cella list` | No ([cli#843](https://github.com/devcontainers/cli/issues/843)) |
@@ -107,6 +107,8 @@ The [Dev Container specification](https://containers.dev/) ([spec repo](https://
 - [x] Git worktree integration (`cella branch`, `cella switch`, `cella prune`) — [guide](docs/worktrees.md)
 - [x] Devcontainer Features (OCI registry resolution, install ordering, caching)
 - [x] Feature management (`cella features edit`, `cella features list`, `cella features update`)
+- [x] Template management (`cella template new`, `cella template list`, `cella template edit`)
+- [x] Global config management (`cella config show`, `global`, `dotfiles`, `agent`, `validate`)
 - [x] Project initialization (`cella init`) — interactive wizard with OCI template/feature selection
 - [x] Lifecycle commands (initializeCommand, postCreate, postStart, postAttach, updateContentCommand)
 - [x] Image and Dockerfile builds
@@ -115,12 +117,14 @@ The [Dev Container specification](https://containers.dev/) ([spec repo](https://
 
 ### Environment & Credentials
 
-- [x] SSH agent forwarding (Docker Desktop, OrbStack, Linux)
+- [x] SSH agent forwarding (Docker Desktop, OrbStack, Colima, Linux)
 - [x] Git config forwarding
 - [x] gh CLI credential forwarding (auto-on)
 - [x] AI agent config forwarding (Claude Code, Codex, Gemini CLI)
+- [x] AI provider API key forwarding (read live from the host on every exec/shell — never baked into the container)
 - [x] Environment variable forwarding (remoteEnv, containerEnv)
 - [x] User environment probing
+- [x] Bubblewrap installed for Codex sandbox support
 
 ### Spec Compliance
 
@@ -152,6 +156,7 @@ The [Dev Container specification](https://containers.dev/) ([spec repo](https://
 - [x] `cella code` — open VS Code connected to the container
 - [x] `cella nvim` — open Neovim connected to the container
 - [x] `cella tmux` — open tmux session inside the container
+- [x] Terminal title integration (sets the host terminal title to reflect the active container/branch)
 
 ### Runtime Support
 
@@ -166,8 +171,6 @@ The [Dev Container specification](https://containers.dev/) ([spec repo](https://
 
 ### Planned
 
-- [ ] Template management (`cella template new/list/edit`)
-- [ ] Global config management (`cella config show/global/dotfiles/agent`)
 - [ ] Podman backend
 - [ ] Colima / Lima support
 
@@ -205,11 +208,18 @@ See the [worktree guide](docs/worktrees.md) for the full workflow, in-container 
 | `cella features list` | List installed and available devcontainer features |
 | `cella features edit` | Add, remove, or modify features in devcontainer.json |
 | `cella features update` | Update features to latest versions |
+| `cella template new` | Create a new dev container template |
+| `cella template list` | List available dev container templates |
+| `cella template edit` | Edit an existing dev container template |
 
 ### Configuration & Diagnostics
 
 | Command | Description |
 |---------|-------------|
+| `cella config show` | Show the resolved configuration |
+| `cella config global` | Edit global cella settings |
+| `cella config dotfiles` | Manage dotfile symlinks |
+| `cella config agent` | Configure agent presets |
 | `cella config validate` | Validate a devcontainer.json file |
 | `cella read-configuration` | Output resolved devcontainer config as JSON |
 | `cella doctor` | Check system dependencies and configuration |

--- a/crates/cella-agent/README.md
+++ b/crates/cella-agent/README.md
@@ -17,7 +17,7 @@ cella-agent is a binary that runs inside dev containers started by cella. It is 
 7. **Plugin synchronization** — synchronizes editor plugin/extension manifests between host and container
 8. **CLI mode** — when invoked as `cella` (via symlink, `cella` -> `cella-agent`), provides in-container CLI commands that delegate to the host daemon
 
-The agent communicates with the host-side cella-daemon over a TCP control connection. If the daemon is unavailable, it falls back to standalone mode (port watching only, no forwarding).
+The agent communicates with the host-side cella-daemon over a TCP control connection. When a daemon address is configured, the agent retries the initial connection indefinitely and transparently reconnects after daemon restarts or binary upgrades — it never gives up. A lightweight standalone mode (port watching and localhost→all-interfaces proxying only, no host-side forwarding) is used only when no daemon address is configured at all.
 
 The binary uses manual argument parsing instead of clap to minimize binary size, since it ships inside every container.
 

--- a/crates/cella-agent/docs/agent-architecture.md
+++ b/crates/cella-agent/docs/agent-architecture.md
@@ -8,26 +8,33 @@ host daemon.
 
 ## Modes
 
-### Connected Mode
+### Connected Mode (default)
 
-When the daemon is reachable, the agent connects via TCP and operates in
-full mode:
+When a daemon address is available (either from `CELLA_DAEMON_ADDR` or
+from `/cella/.daemon_addr`), the agent retries the connection
+**indefinitely** and operates in full mode once it succeeds:
 
-1. **Port watcher** — polls `/proc/net/tcp` for listener changes, reports
-   `PortOpen`/`PortClosed` to the daemon, receives `PortMapping` responses
+1. **Port watcher** — polls `/proc/net/tcp` and `/proc/net/tcp6` for
+   listener changes, reports `PortOpen`/`PortClosed` to the daemon,
+   receives `PortMapping` responses
 2. **Credential forwarder** — intercepts `git credential` requests and
    forwards them to the daemon for host-side resolution
-3. **Health reporter** — sends periodic heartbeats with uptime and port
-   count
+3. **Browser forwarder** — forwards `BrowserOpen` requests to the
+   host browser (for OAuth callbacks, etc.)
+4. **Health reporter** — sends periodic heartbeats with uptime and
+   port count
+5. **Worktree/task proxy** — in CLI mode (see below) forwards
+   `branch`, `exec`, `prune`, `down`, `up`, `switch`, and `task run/list/
+   logs/wait/stop` commands to the daemon for host-side execution
 
-### Standalone Mode
+### Standalone Mode (fallback only when no address is configured)
 
-When the daemon is unreachable (timeout after retries), the agent falls back
-to standalone mode:
-
-- Port watcher runs locally without daemon communication
-- Only starts localhost→all-interfaces proxies (no host port allocation)
-- No credential forwarding or browser integration
+Entered only when there is no daemon address at all. In this mode the
+agent runs localhost→all-interfaces proxies locally but does not
+communicate with any daemon. This is a last-resort mode — when a
+daemon address exists but the daemon is temporarily unreachable, the
+agent stays in connecting state and retries until the daemon comes
+back (it does **not** fall through to standalone).
 
 ## Port Watcher (`port_watcher.rs`)
 
@@ -54,9 +61,17 @@ host (useful for OAuth callbacks, browser-open URLs, etc.).
 ### Reconnection
 
 The agent uses `ReconnectingClient` which:
-- Retries initial connection with timeout
-- Attempts single reconnect on send failure
-- Sets `reconnected` flag so the port watcher re-reports all known ports
+- **Retries the initial connection indefinitely** (`connect_with_retry`),
+  logging a progress warning every 30 s so the log isn't silent. The
+  agent never gives up — if the daemon is late coming up, the agent
+  will still be there when it arrives.
+- Re-reads `/cella/.daemon_addr` on every attempt, so a new daemon
+  address (e.g. after a `cella up` that restarted the daemon or
+  replaced the binary) is picked up automatically without restarting
+  the agent.
+- On a send failure during normal operation, attempts reconnect; on
+  success, sets a `reconnected` flag so the port watcher re-reports
+  all known ports and state is restored.
 
 ## Localhost Proxy (`port_proxy.rs`)
 
@@ -96,7 +111,13 @@ The agent assigns a unique ID to each request and waits for the matching
 
 ## Startup
 
-The agent is started by the container entrypoint script:
+The agent is started by the container entrypoint script under a
+restart loop so the daemon binary can be replaced in place (e.g. after
+`cella up` upgrades the agent). From `cella-orchestrator`'s perspective
+a restart is `pkill -f 'cella-agent daemon'; sleep 1; pgrep ... ||
+spawn`. The loop (in newer containers) picks it back up; the manual
+spawn is a backward-compat fallback for images created before the
+restart loop existed.
 
 ```sh
 if [ -x "$AGENT_PATH" ]; then
@@ -104,5 +125,22 @@ if [ -x "$AGENT_PATH" ]; then
 fi
 ```
 
-It reads the daemon's address and auth token from environment variables
-injected during container creation.
+Configuration sources, in priority order:
+
+1. **`CELLA_DAEMON_ADDR`** / **`CELLA_CONTROL_TOKEN`** env vars,
+   injected at container creation time.
+2. **`/cella/.daemon_addr`** file, refreshed by the CLI on every
+   `cella up` so agents that were running before a daemon restart pick
+   up the new address without intervention.
+
+## CLI Mode
+
+The agent binary is symlinked to `/cella/bin/cella` inside the container
+so that invoking `cella` from a shell prompt enters CLI mode instead of
+agent-daemon mode. CLI subcommands (`branch`, `list`, `exec`, `down`,
+`up`, `switch`, `prune`, `task run/list/logs/wait/stop`) are parsed by
+`cli.rs` and converted to `AgentMessage` requests sent over the
+already-established control connection. Each response is streamed back
+from the host daemon (progress, stdout/stderr chunks, final result) and
+rendered on the caller's terminal. Manual argument parsing keeps the
+binary small (no clap dependency).

--- a/crates/cella-backend/README.md
+++ b/crates/cella-backend/README.md
@@ -51,7 +51,7 @@ Container and image naming conventions live here so that all backends use consis
 
 **Depends on:** none (foundation crate — only `sha2`, `hex`, `chrono`, `thiserror`)
 
-**Depended on by:** [cella-cli](../cella-cli), [cella-container](../cella-container), [cella-doctor](../cella-doctor), [cella-docker](../cella-docker), [cella-orchestrator](../cella-orchestrator)
+**Depended on by:** [cella-cli](../cella-cli), [cella-compose](../cella-compose), [cella-container](../cella-container), [cella-docker](../cella-docker), [cella-doctor](../cella-doctor), [cella-orchestrator](../cella-orchestrator)
 
 ## Testing
 

--- a/crates/cella-cli/README.md
+++ b/crates/cella-cli/README.md
@@ -95,7 +95,7 @@ Each command file defines an args struct and an `execute()` method.
 
 ## Crate Dependencies
 
-**Depends on:** [cella-backend](../cella-backend), [cella-compose](../cella-compose), [cella-config](../cella-config), [cella-container](../cella-container) (macOS), [cella-daemon](../cella-daemon), [cella-doctor](../cella-doctor), [cella-docker](../cella-docker), [cella-env](../cella-env), [cella-features](../cella-features), [cella-git](../cella-git), [cella-network](../cella-network), [cella-orchestrator](../cella-orchestrator), [cella-port](../cella-port), [cella-templates](../cella-templates)
+**Depends on:** [cella-backend](../cella-backend), [cella-compose](../cella-compose), [cella-config](../cella-config), [cella-container](../cella-container) (macOS only, gated on `cfg(target_os = "macos")`), [cella-daemon](../cella-daemon), [cella-doctor](../cella-doctor), [cella-docker](../cella-docker), [cella-env](../cella-env), [cella-git](../cella-git), [cella-jsonc](../cella-jsonc), [cella-network](../cella-network), [cella-orchestrator](../cella-orchestrator), [cella-protocol](../cella-protocol), [cella-templates](../cella-templates)
 
 **Depended on by:** none (top of the dependency tree)
 

--- a/crates/cella-config/README.md
+++ b/crates/cella-config/README.md
@@ -32,8 +32,7 @@ Parses all devcontainer.json properties defined in the [Dev Container specificat
 | Module | Purpose |
 |--------|---------|
 | `devcontainer/discover` | Locates devcontainer.json files in workspace directories |
-| `devcontainer/jsonc` | Single-pass JSONC preprocessor (strips comments, preserves byte offsets) |
-| `devcontainer/parse` | Parses preprocessed JSON into typed config structs |
+| `devcontainer/parse` | Parses preprocessed JSON (via [cella-jsonc](../cella-jsonc)) into typed config structs |
 | `devcontainer/merge` | Merges config layers (global -> workspace -> local) |
 | `devcontainer/resolve` | Resolves variable references and paths |
 | `devcontainer/subst` | Variable substitution (`${localWorkspaceFolder}`, etc.) |
@@ -48,7 +47,7 @@ Parses all devcontainer.json properties defined in the [Dev Container specificat
 
 ## Crate Dependencies
 
-**Depends on:** [cella-codegen](../cella-codegen) (build-time), [cella-network](../cella-network)
+**Depends on:** [cella-codegen](../cella-codegen) (build-time), [cella-jsonc](../cella-jsonc), [cella-network](../cella-network)
 
 **Depended on by:** [cella-cli](../cella-cli), [cella-doctor](../cella-doctor), [cella-orchestrator](../cella-orchestrator)
 
@@ -66,7 +65,7 @@ cargo insta review
 
 ## Development
 
-The JSONC preprocessor is a single-pass state machine that preserves byte offsets. This is critical for diagnostics — every parse error can be traced back to the exact position in the original `.jsonc` file. Do not use string replacement on raw JSON as it breaks offset tracking.
+The JSONC preprocessor (the [cella-jsonc](../cella-jsonc) crate) is a single-pass state machine that preserves byte offsets. This is critical for diagnostics — every parse error can be traced back to the exact position in the original `.jsonc` file. Do not use string replacement on raw JSON as it breaks offset tracking.
 
 When the devcontainer schema changes upstream, update the schema JSON in the build inputs. Codegen will produce new types automatically. Run `cargo insta review` to accept the updated snapshots.
 

--- a/crates/cella-daemon/docs/daemon-architecture.md
+++ b/crates/cella-daemon/docs/daemon-architecture.md
@@ -9,11 +9,22 @@ devcontainers.
 ### Startup
 
 1. CLI (`cella up`) spawns the daemon if not already running.
-2. Daemon writes PID to `~/.cella/daemon.pid` and control port + auth token to `~/.cella/daemon.control`.
+2. Daemon writes PID to `~/.cella/daemon.pid` and control port + auth
+   token to `~/.cella/daemon.control`. On restart these are reclaimed
+   from the previous run so the TCP port and token stay stable across
+   binary upgrades (important so already-running agents can reconnect
+   without needing a restart).
 3. Binds the management socket at `~/.cella/daemon.sock`.
-4. Binds the TCP control server on an ephemeral port (reported in status).
+4. Binds the TCP control server on an ephemeral port (reported in
+   status).
 5. Starts the proxy coordinator task.
 6. Detects OrbStack runtime (for display and `.orb.local` URLs).
+7. CLI writes `/cella/.daemon_addr` into every container it starts
+   (or re-starts) so the in-container agent can pick up the current
+   address on its next reconnection attempt. The write happens
+   **before** the agent is launched on compose workspaces so the
+   agent doesn't enter the indefinite-retry state for its very first
+   connection.
 
 ### Shutdown
 
@@ -29,12 +40,17 @@ The daemon shuts down when:
 Unix socket at `~/.cella/daemon.sock`. Accepts `ManagementRequest` messages
 from CLI commands:
 
-- `RegisterContainer` — registers a container with its IP, port attributes,
-  and `forwardPorts` from devcontainer.json
-- `DeregisterContainer` — releases ports, stops proxies
-- `QueryPorts` — lists all forwarded ports across containers
-- `QueryStatus` — daemon health, uptime, container list
-- `Ping` / `Shutdown` — health check and graceful stop
+- `RegisterContainer` — registers a container with its IP, port
+  attributes, `forwardPorts`, `shutdownAction`, `backend_kind`, and
+  `docker_host`. For compose workspaces the CLI pre-registers with
+  `container_ip: None` before the container has an IP.
+- `UpdateContainerIp` — supplies the IP once the container is running
+  (paired with the pre-registration flow above).
+- `DeregisterContainer` — releases ports, stops proxies.
+- `QueryPorts` — lists all forwarded ports across containers.
+- `QueryStatus` — daemon health, uptime, container list, OrbStack
+  flag, TCP control port, auth token.
+- `Ping` / `Shutdown` — health check and graceful stop.
 
 ### Control Server (`control_server.rs`)
 
@@ -69,6 +85,24 @@ Receives `ProxyCommand::Start` and `ProxyCommand::Stop` messages:
 
 Opens URLs in the host's default browser. The daemon rewrites URLs before
 opening to account for port remapping, and waits for proxy readiness.
+
+### Task Manager (`task_manager.rs`)
+
+Tracks `cella task run` background processes per branch/container.
+Each entry holds the Docker exec abort handle, a captured output log,
+an exit-code slot, and a broadcast channel so multiple
+`cella task logs -f` subscribers can tail the same output live.
+Exposed via the `TaskRun/TaskList/TaskLogs/TaskWait/TaskStop`
+`AgentMessage` variants routed through the control server.
+
+### Stream Bridge (`stream_bridge.rs`)
+
+Per-exec TCP stream for interactive TTY forwarding. Opens a
+short-lived listener on a random port, accepts one connection, and
+bidirectionally proxies bytes between the accepted TCP stream and a
+PTY master. Used by `cella switch` so in-container users get a full
+PTY-backed shell in the target container via the agent → daemon →
+docker-exec path.
 
 ## OrbStack Detection
 

--- a/crates/cella-doctor/README.md
+++ b/crates/cella-doctor/README.md
@@ -1,16 +1,14 @@
 # cella-doctor
 
-> System diagnostics, health checking, and hostRequirements validation.
+> System diagnostics and health checking for cella.
 
 Part of the [cella](../../README.md) workspace.
 
 ## Overview
 
-cella-doctor powers the `cella doctor` command. It runs structured health checks across six categories (system, Docker, git/credentials, daemon, configuration, containers), validates host requirements from devcontainer.json, and can redact PII for safe sharing of diagnostic output.
+cella-doctor powers the `cella doctor` command. It runs structured health checks across six categories (system, Docker, git/credentials, daemon, configuration, containers) and can redact PII for safe sharing of diagnostic output. `hostRequirements` validation itself lives in `cella-orchestrator` (where the up pipeline needs it); cella-doctor surfaces the orchestrator's decision under the `config` category so `cella doctor` reports it alongside the other checks.
 
-Each check category runs with a 5-second timeout to prevent hangs from unresponsive services. Results are collected into a structured report with severity levels (pass, warning, error, info) that can be output as human-readable text or JSON.
-
-The host requirements module validates `hostRequirements` from the devcontainer spec — checking available CPUs, memory, storage, and GPU against the requirements. By default unmet requirements produce warnings; `--strict host-requirements` makes them errors.
+Each check category runs with a 5-second timeout to prevent hangs from unresponsive services. Results are collected into a structured report with severity levels (pass, warning, error, info) that can be output as human-readable text or JSON. When invoked inside a container, `cella doctor` reconciles the host view with the in-container view so the report reflects what the user actually sees (e.g. whether `BROWSER` interception is wired up on compose workspaces).
 
 ## Architecture
 
@@ -32,12 +30,11 @@ The host requirements module validates `hostRequirements` from the devcontainer 
 | `checks/daemon` | cella daemon health — running status, PID file, port file, socket connectivity |
 | `checks/config` | Devcontainer configuration discovery and validation |
 | `checks/container` | Running container inspection — state, mounts, labels, port bindings |
-| `host_requirements` | `hostRequirements` spec validation — CPU, memory (parses "8gb"/"512mb"), storage, GPU detection |
 | `redact` | PII redaction — strips usernames, paths, tokens from diagnostic output for safe sharing |
 
 ## Crate Dependencies
 
-**Depends on:** [cella-backend](../cella-backend), [cella-config](../cella-config), [cella-daemon](../cella-daemon), [cella-docker](../cella-docker), [cella-env](../cella-env), [cella-orchestrator](../cella-orchestrator), [cella-port](../cella-port)
+**Depends on:** [cella-backend](../cella-backend), [cella-config](../cella-config), [cella-daemon](../cella-daemon), [cella-docker](../cella-docker), [cella-env](../cella-env), [cella-protocol](../cella-protocol)
 
 **Depended on by:** [cella-cli](../cella-cli)
 

--- a/crates/cella-env/README.md
+++ b/crates/cella-env/README.md
@@ -27,7 +27,7 @@ Implements the environment-related portions of the [Dev Container specification]
 - `ForwardMount` — a bind mount (source path on host, target path in container)
 - `ForwardEnv` — an environment variable (key, value)
 - `FileUpload` — file content to upload into the container (path, content, permissions)
-- `DockerRuntime` — detected container runtime (DockerDesktop, OrbStack, LinuxNative, Colima, Unknown)
+- `DockerRuntime` — detected container runtime (DockerDesktop, OrbStack, LinuxNative, Colima, Podman, RancherDesktop, Unknown)
 - `GitConfigEntry` — a git config key-value pair to forward
 - `ProxyForwardingConfig` — proxy configuration for container environment
 
@@ -57,6 +57,7 @@ This is the main entry point. It detects the runtime, probes the host environmen
 | `gemini` | Google Gemini CLI host detection and container path helpers |
 | `nvim` | Neovim config directory detection and mount preparation |
 | `tmux` | tmux config detection, mount preparation, and install command generation |
+| `ai_keys` | AI provider API-key forwarding — reads known provider env vars live on every `exec`/`shell` (never baked into the container at creation time) |
 
 ## Crate Dependencies
 

--- a/crates/cella-jsonc/README.md
+++ b/crates/cella-jsonc/README.md
@@ -1,0 +1,49 @@
+# cella-jsonc
+
+> JSONC (JSON with Comments) preprocessor that strips comments and trailing commas while preserving byte offsets.
+
+Part of the [cella](../../README.md) workspace.
+
+## Overview
+
+cella-jsonc converts JSONC — JSON extended with `//` line comments, `/* */` block comments, and trailing commas — into strict JSON that any `serde_json` parser can consume. It is used to read `devcontainer.json`, template manifests, and cella's own configuration files, all of which permit JSONC syntax per the [Dev Container specification](https://containers.dev/implementors/json_reference/).
+
+The crate is a single-pass state machine. Comments are replaced by space characters (and newlines are preserved inside block comments), and trailing commas before `]` or `}` are replaced by a single space. The key invariant is `output.len() == input.len()`: byte offsets in the stripped output map one-to-one to offsets in the original source, so downstream parsers (`serde_json`, miette diagnostics) can report errors pointing back to the original JSONC.
+
+## Architecture
+
+### Key Types
+
+- `strip(input: &str) -> Result<String, Error>` — the sole public entry point. Converts JSONC input into strict JSON with offsets preserved
+- `Error` — error type with `message` and byte `offset`. Returned for unterminated block comments and for inputs that produce invalid UTF-8 (cannot happen for valid UTF-8 input)
+
+### State Machine
+
+Four states cover every byte:
+
+| State | Behavior |
+|-------|----------|
+| `Normal` | Default. `"` enters `InString`, `//` enters `LineComment`, `/*` enters `BlockComment`, trailing `,` before `]`/`}` is rewritten to space |
+| `InString` | Passes bytes through verbatim. Handles `\"` escapes. `"` returns to `Normal` |
+| `LineComment` | Replaces bytes with spaces until `\n`, which is preserved and returns to `Normal` |
+| `BlockComment` | Replaces bytes with spaces, preserves `\n`, and returns to `Normal` on `*/` |
+
+Nested block comments are not supported (per the JSONC convention): the first `*/` always ends the comment.
+
+## Crate Dependencies
+
+**Depends on:** none (std only; `serde_json` is a dev-dependency for tests)
+
+**Depended on by:** [cella-cli](../cella-cli), [cella-config](../cella-config), [cella-templates](../cella-templates)
+
+## Testing
+
+```sh
+cargo test -p cella-jsonc
+```
+
+Unit tests cover line comments, block comments, trailing commas (object and array, nested), string contents that contain comment-like sequences, escaped quotes, multi-line block comments, consecutive comments, unterminated block comments, and the byte-length invariant (`output.len() == input.len()`) on every positive case.
+
+## Development
+
+The invariant `output.len() == input.len()` is enforced by `debug_assert_eq!` in debug builds and by every test. Any change that rewrites byte counts must update callers that rely on offset-preservation (source-positioned miette diagnostics in cella-config, template variable substitution in cella-templates).

--- a/crates/cella-orchestrator/README.md
+++ b/crates/cella-orchestrator/README.md
@@ -40,6 +40,7 @@ cella-orchestrator extracts the shared container management logic so that both t
 | `up` | Main container-up pipeline with `UpHooks` trait for host integration |
 | `compose_build` | Docker Compose build pipeline with feature resolution |
 | `compose_features` | Combined-Dockerfile generation for Compose + Features |
+| `compose_mounts` | Mount parity helpers for Compose services (workspace bind, SSH-agent forward, cella-agent volume) so compose containers match single-container behavior |
 | `compose_up` | Docker Compose container-up pipeline with `ComposeUpHooks` trait |
 | `config` | Input configuration types (`UpConfig`, `ImageStrategy`, `HostRequirementPolicy`, `BranchConfig`, `PruneConfig`) |
 | `config_map` | Maps devcontainer.json to `CreateContainerOptions` (submodules: env, mounts, ports, run_args) |
@@ -52,7 +53,8 @@ cella-orchestrator extracts the shared container management logic so that both t
 | `env_cache` | User environment probing and caching (`~/.cella/probed-env.json`) |
 | `host_requirements` | CPU/memory/storage/GPU validation against `hostRequirements` |
 | `shell_detect` | Shell detection and quoting for container exec |
-| `tool_install` | AI coding tool installation (Claude Code, Codex, Gemini CLI) |
+| `tool_install` | AI coding tool installation (Claude Code, Codex, Gemini CLI); self-heals PATH and reports install status from on-disk reality rather than optimistic success |
+| `uid_image` | Build-time UID remap layer (`Dockerfile.uid-remap`) that matches the devcontainer CLI's `updateUID.Dockerfile` approach |
 | `branch` | Worktree-backed branch creation and container delegation |
 | `prune` | Detect and remove merged worktrees with their containers |
 | `docker_helpers` | Container lookup and exec helpers via `ContainerBackend` trait |

--- a/crates/cella-port/README.md
+++ b/crates/cella-port/README.md
@@ -34,7 +34,7 @@ Supports the `forwardPorts` and `portsAttributes` properties from the [Dev Conta
 
 **Depends on:** [cella-protocol](../cella-protocol)
 
-**Depended on by:** [cella-agent](../cella-agent), [cella-cli](../cella-cli), [cella-daemon](../cella-daemon), [cella-doctor](../cella-doctor), [cella-orchestrator](../cella-orchestrator)
+**Depended on by:** [cella-agent](../cella-agent), [cella-daemon](../cella-daemon)
 
 ## Testing
 

--- a/crates/cella-port/docs/port-forwarding.md
+++ b/crates/cella-port/docs/port-forwarding.md
@@ -3,12 +3,14 @@
 ## Port Detection
 
 The in-container agent polls `/proc/net/tcp` and `/proc/net/tcp6` at a
-configurable interval (default 1 s) to discover listening sockets.
+configurable interval (default 1 s) to discover listening sockets. Only
+TCP is detected from `/proc/net/tcp*` today; the `PortProtocol` wire
+type also carries a `Udp` variant for future use.
 
 Each scan returns a list of `DetectedListener` entries containing:
 
 - Port number
-- Protocol (TCP)
+- Protocol (`tcp`)
 - Bind address (localhost-only vs all-interfaces)
 - Inode (used to resolve the process name via `/proc/<pid>/fd`)
 
@@ -50,7 +52,7 @@ a shared token.
 
 | Message | Fields | Description |
 |---------|--------|-------------|
-| `PortOpen` | port, protocol, process, bind | New listener detected |
+| `PortOpen` | port, protocol, process, bind, proxy_port? | New listener detected. `proxy_port` is the agent-side localhost-to-all-interfaces proxy when the underlying listener binds localhost only — the daemon then connects to `container_ip:proxy_port` instead of `container_ip:port`. |
 | `PortClosed` | port, protocol | Listener closed |
 | `BrowserOpen` | url | Open URL in host browser |
 | `CredentialRequest` | id, operation, fields | Git credential forwarding |

--- a/crates/cella-protocol/README.md
+++ b/crates/cella-protocol/README.md
@@ -47,7 +47,7 @@ See [docs/specs/ipc-protocol.md](../../docs/specs/ipc-protocol.md) for the full 
 
 **Depends on:** none (only serde, serde_json, thiserror)
 
-**Depended on by:** [cella-port](../cella-port)
+**Depended on by:** [cella-agent](../cella-agent), [cella-cli](../cella-cli), [cella-daemon](../cella-daemon), [cella-doctor](../cella-doctor), [cella-orchestrator](../cella-orchestrator), [cella-port](../cella-port)
 
 ## Testing
 

--- a/crates/cella-templates/README.md
+++ b/crates/cella-templates/README.md
@@ -39,7 +39,7 @@ Templates are fetched from OCI registries (default: `ghcr.io/devcontainers/templ
 
 ## Crate Dependencies
 
-**Depends on:** [cella-features](../cella-features)
+**Depends on:** [cella-features](../cella-features), [cella-jsonc](../cella-jsonc)
 
 **Depended on by:** [cella-cli](../cella-cli)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,11 +56,15 @@ The binary entry point. Handles argument parsing via clap, initializes tracing, 
 
 ### cella-docker
 
-Abstracts container runtime operations. Manages the full container lifecycle (create, start, stop, remove), image building, and runtime detection. Wraps the bollard Docker API client behind a `DockerApi` trait for testability and future runtime support (Podman). Handles `runArgs` parsing (30+ docker create flags), lifecycle command execution, file uploads, and spec compliance features like `shutdownAction`, `waitFor`, and `appPort` deprecation.
+The Docker backend. Implements `cella-backend`'s `ContainerBackend` trait against the bollard Docker API client (itself wrapped behind a `DockerApi` trait for testability and future runtime support). Manages the full container lifecycle (create, start, stop, remove), image building, and runtime detection. Handles `runArgs` parsing (30+ docker create flags), lifecycle command execution, file uploads, and spec compliance features like `shutdownAction`, `waitFor`, and `appPort` deprecation.
+
+### cella-container
+
+The Apple Container backend (experimental, macOS 26+ Apple Silicon only). Implements `cella-backend`'s `ContainerBackend` trait against Apple's `container` CLI. Pre-1.0 surface with no Docker Compose support; gated behind `cfg(target_os = "macos")` so non-Apple builds never pull it in. Advertises its lack of compose support via the backend `BackendCapabilities` flags so the orchestrator refuses compose workflows up front rather than failing mid-pipeline.
 
 ### cella-compose
 
-Docker Compose orchestration. Generates override compose files that layer cella's customizations on top of user compose files, shells out to the `docker compose` V2 CLI, discovers compose-managed containers via Docker labels, and detects config changes via multi-file SHA-256 hashing.
+Docker Compose orchestration. Generates override compose files that layer cella's customizations on top of user compose files, shells out to the `docker compose` V2 CLI, discovers compose-managed containers via Docker labels, and detects config changes via multi-file SHA-256 hashing. Also resolves the final `USER` for Compose+Features builds by parsing the combined Dockerfile (`find_user_statement`) so lifecycle commands and cella-agent run as the correct user, and reaches mount parity with single-container by emitting the same `/workspaces` bind, SSH-agent forwarding, and agent-volume mount in the override file.
 
 ### cella-git
 
@@ -68,15 +72,15 @@ Git worktree management and branch resolution. Creates, lists, and removes workt
 
 ### cella-env
 
-Environment forwarding orchestration. Detects the host environment (SSH agent, git config, credential proxies, AI agent tools) and produces the mounts, environment variables, and post-start commands needed to forward that environment into containers. Includes platform-aware runtime detection (Docker Desktop, OrbStack, Linux native, Colima) and AI agent config forwarding for Claude Code, Codex, and Gemini CLI.
+Environment forwarding orchestration. Detects the host environment (SSH agent, git config, credential proxies, AI agent tools) and produces the mounts, environment variables, and post-start commands needed to forward that environment into containers. Includes platform-aware runtime detection (Docker Desktop, OrbStack, Linux native, Colima, Podman, Rancher Desktop), AI agent config forwarding for Claude Code, Codex, and Gemini CLI, and AI provider API-key forwarding (`ai_keys` reads known provider env vars live on every `exec`/`shell` rather than persisting them in container labels).
 
 ### cella-daemon
 
-Unified host-side daemon for credential forwarding, port management, and browser handling. Runs as a background process, accepting TCP connections from in-container agents. Includes OrbStack-specific port coordination, health monitoring, auth token management, and file-based logging.
+Unified host-side daemon for credential forwarding, port management, browser handling, worktree operations, and background tasks. Runs as a background process, accepting TCP connections from in-container agents and Unix-socket connections from the CLI. Includes OrbStack-specific port coordination, health monitoring, auth token management, file-based logging, a per-exec TCP stream bridge for TTY forwarding (used by `cella switch`), and a task manager that tracks `cella task run` background processes with live output broadcast.
 
 ### cella-agent
 
-In-container binary uploaded during `cella up`. Polls `/proc/net/tcp` for new listeners and reports them to the host daemon for automatic port forwarding. Proxies localhost-bound applications to `0.0.0.0`, handles `BROWSER` environment variable interception for OAuth callbacks, and forwards git credential requests to the host. Uses manual argument parsing (no clap) to minimize binary size.
+In-container binary uploaded during `cella up`. Polls `/proc/net/tcp` for new listeners and reports them to the host daemon for automatic port forwarding. Proxies localhost-bound applications to `0.0.0.0`, handles `BROWSER` environment variable interception for OAuth callbacks, and forwards git credential requests to the host. The initial daemon connect retries indefinitely (so containers that start before the daemon is ready eventually reconnect), and the agent transparently reconnects after daemon restarts (including binary upgrades). When the binary is invoked as `cella` via an in-container symlink, it enters CLI mode instead of daemon mode — worktree and task commands inside the container delegate to the host daemon over the existing TCP control connection. Uses manual argument parsing (no clap) to minimize binary size.
 
 ### cella-doctor
 
@@ -94,9 +98,13 @@ Dev Container Features resolution. Parses feature references (OCI, local path, H
 
 Devcontainer template lifecycle. Discovers templates from OCI registries (default: `ghcr.io/devcontainers/templates`), fetches and caches artifacts with a 24-hour TTL, reads template metadata (`devcontainer-template.json`), validates and substitutes template options, merges selected features, and generates the final `devcontainer.json` in JSONC or JSON format. Powers `cella init`.
 
+### cella-backend
+
+The backend abstraction layer. Defines the `ContainerBackend` trait that every backend (`cella-docker`, `cella-container`) implements, plus the shared types every consumer works against: `ContainerInfo`, `ContainerState`, `CreateContainerOptions`, `ExecOptions`, `BuildOptions`, `MountConfig`, `PortBinding`, and the `BackendError` unified error type. Also owns container/image naming conventions and label generation so all backends emit the same `dev.cella.*` and spec-standard `devcontainer.*` labels. Uses `BoxFuture` return types for object safety so callers can work against `dyn ContainerBackend` without knowing which runtime is underneath.
+
 ### cella-port
 
-Port allocation and detection. Provides `/proc/net/tcp` parsing for port detection and manages host port allocation to avoid conflicts across concurrent containers.
+Port allocation and detection. Provides `/proc/net/tcp` and `/proc/net/tcp6` parsing for detecting listening sockets inside containers and manages host port allocation to avoid conflicts across concurrent containers.
 
 ### cella-orchestrator
 
@@ -129,14 +137,23 @@ cargo tree -i cella-port --depth 1   # reverse dependencies of a specific crate
 
 ## Config Layer Merge Order
 
-Configuration is resolved by merging layers from lowest to highest priority:
+At resolve time, cella merges three devcontainer.json layers from lowest to highest priority:
 
-1. **Defaults** — built-in cella defaults
-2. **Template** — values from the selected template
-3. **Workspace** — `.devcontainer/devcontainer.json` in the repo
-4. **User** — user-level overrides (`~/.cella/config.toml`)
+1. **Global** — user-wide overrides at `~/.config/cella/global.jsonc` (optional)
+2. **Workspace** — `.devcontainer/devcontainer.json` in the repo
+3. **Local** — per-workspace overrides at `.devcontainer/devcontainer.local.jsonc` (optional, typically gitignored)
 
-Later layers override earlier ones for scalar values. Arrays and objects follow devcontainer spec merge semantics.
+Per-key merge semantics implemented in `cella-config`'s `merge::layers`:
+
+- **Scalars** — later layer wins
+- **Deep-merge objects** — `features`, `containerEnv`, `remoteEnv`, `customizations`, `portsAttributes`, `otherPortsAttributes`
+- **Concat arrays** — `mounts`, `runArgs`, `overrideFeatureInstallOrder`
+- **Union arrays** (dedup) — `forwardPorts`, `capAdd`, `securityOpt`
+- **Boolean OR** — `init`, `privileged` (any `true` wins)
+- **`hostRequirements`** — per-key maximum (cpu/memory/storage/gpu)
+- **Lifecycle commands** — later layer wins entirely
+
+Cella-specific settings (TOML) layer separately: `~/.cella/config.toml` provides user defaults; `.devcontainer/cella.toml` provides workspace overrides. The `customizations.cella` block inside `devcontainer.json` is deep-merged through the devcontainer layer pipeline above.
 
 ## Worktree-Container Binding
 
@@ -148,4 +165,4 @@ Each git worktree is bound to its own dev container instance. When you create a 
 4. Starts the container with the worktree mounted
 5. Allocates non-conflicting ports
 
-This binding is tracked so that `cella switch` can open a shell in the correct container, and `cella prune` can clean up both the worktree and its container.
+The binding is tracked via Docker labels (`dev.cella.worktree`, `dev.cella.worktree_branch`, `dev.cella.parent_repo`) on the container itself — no separate state file. `cella switch` looks up the container by worktree-branch label, and `cella prune` walks worktrees and removes the labelled container and its host port allocations together.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,6 +29,7 @@ graph TD
         codegen[cella-codegen<br><i>schema codegen</i>]
         network[cella-network<br><i>network proxy</i>]
         protocol[cella-protocol<br><i>wire format</i>]
+        jsonc[cella-jsonc<br><i>JSONC preprocessor</i>]
     end
 
     cli --> docker & container & compose & git & env & daemon & doctor & orchestrator & config & features & templates
@@ -37,6 +38,7 @@ graph TD
     agent & daemon --> port
     port --> protocol
     config --> codegen
+    config & templates --> jsonc
     agent & config & env & orchestrator --> network
 ```
 
@@ -44,7 +46,7 @@ graph TD
 
 **Tier 2 — Domain:** The crates that implement cella's core functionality. Each owns a distinct domain: container runtime, compose orchestration, git worktrees, environment forwarding, host daemon, system diagnostics, worktree orchestration, in-container agent, configuration parsing, and feature resolution.
 
-**Tier 3 — Foundation:** Shared infrastructure crates. Backend trait abstraction, IPC protocol, code generation, and network proxy.
+**Tier 3 — Foundation:** Shared infrastructure crates. Backend trait abstraction, IPC protocol, code generation, network proxy, and JSONC preprocessing.
 
 ## Crate Responsibilities
 
@@ -111,6 +113,10 @@ Build-time code generator. Transforms the devcontainer JSON Schema into typed Ru
 ### cella-protocol
 
 IPC wire format definitions for agent<->daemon and CLI<->daemon communication. Defines the newline-delimited JSON message types (`AgentMessage`, `DaemonMessage`, `ManagementRequest`, `ManagementResponse`), connection handshake (`AgentHello`, `DaemonHello`), and git credential helper format. Not a runtime logic crate — it only defines types and serialization.
+
+### cella-jsonc
+
+JSONC (JSON with Comments) preprocessor. Strips `//` and `/* */` comments and trailing commas from JSONC source, returning strict JSON with byte offsets preserved (`output.len() == input.len()`). Used by cella-config and cella-templates to parse devcontainer.json files while keeping source positions accurate for miette diagnostics.
 
 ## Dependency Graph
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,8 +2,8 @@
 
 ## Prerequisites
 
-- **Rust toolchain** — install via [rustup](https://rustup.rs/)
-- **Docker** — optional, only needed for integration tests
+- **Rust toolchain** — install via [rustup](https://rustup.rs/). Cella's MSRV is **1.94.1** (edition 2024), pinned in the workspace `Cargo.toml`.
+- **Docker** — needed for integration tests and for running cella itself. Unit tests do not require it.
 
 ## Building
 
@@ -19,17 +19,34 @@ Unit tests (no external dependencies):
 cargo test --workspace
 ```
 
-Integration tests (requires Docker):
+Integration tests (requires Docker, feature-gated):
 
 ```sh
-cargo test --workspace -- --ignored
+cargo test -p cella-features -p cella-daemon -p cella-compose --features integration-tests
 ```
+
+Snapshot tests (insta):
+
+```sh
+cargo insta test --workspace --check --unreferenced=reject
+```
+
+Update snapshots with `cargo insta review`. If `cargo-insta` is not installed in a dev container, run `cargo test` to verify snapshot correctness, then review/accept from the host.
 
 ## Code Style
 
-- **Clippy**: We use `clippy::pedantic` and `clippy::nursery` workspace-wide. Run `cargo clippy --workspace --all-targets` and fix all warnings before submitting.
+- **Clippy**: We use `clippy::pedantic` and `clippy::nursery` workspace-wide, plus `unsafe_code = deny` and `unused_qualifications = deny`. Run `cargo clippy --workspace --all-features --all-targets -- -D warnings -D clippy::all` and fix every warning before submitting — CI treats warnings as errors.
 - **Formatting**: Run `cargo fmt --all` before committing. CI will reject unformatted code.
 - **Unsafe code**: Denied at the workspace level. Do not use `unsafe`.
+- **Don't suppress**: No `#[allow(clippy::...)]`, no `_`-prefixed unused variables. Fix the warning or delete the dead code.
+- **`too_many_lines`**: Clippy's limit is 100 LOC per function. Extract helpers before hitting the limit — don't reach for `#[allow]`.
+
+## Testing Conventions
+
+- Unit tests are colocated with the code they test using `#[cfg(test)] mod tests` — not separate `tests/` directories.
+- Add unit tests when implementing new code.
+- Add regression tests when fixing bugs.
+- Use `test_platform()` (not hardcoded arch strings) in OCI or architecture-aware tests.
 
 ## Commit Conventions
 
@@ -41,10 +58,17 @@ We follow [Conventional Commits](https://www.conventionalcommits.org/):
 - `docs:` — documentation changes
 - `refactor:` — code restructuring without behavior change
 - `test:` — adding or fixing tests
+- `ci:` / `cd:` — CI/CD pipeline changes
+
+Keep commits tiny and atomic — one concern per commit. Rebase (don't merge) onto `main` before opening a PR; no merge commits land on `main`.
 
 ## Pull Requests
 
-1. Create a feature branch from `main`
-2. Make your changes with clear, focused commits
-3. Ensure `cargo build --workspace`, `cargo test --workspace`, `cargo clippy --workspace --all-targets`, and `cargo fmt --all -- --check` all pass
-4. Open a PR against `main` with a clear description of the change
+1. Create a feature branch from `main`.
+2. Make your changes with clear, focused commits.
+3. Ensure the following all pass locally (they match CI exactly):
+   - `cargo fmt --all -- --check`
+   - `cargo clippy --workspace --all-features --all-targets -- -D warnings -D clippy::all`
+   - `cargo test --workspace`
+   - `cargo insta test --workspace --check --unreferenced=reject`
+4. Open a PR against `main` with a clear description of the change.

--- a/docs/network-proxy.md
+++ b/docs/network-proxy.md
@@ -243,13 +243,14 @@ V ALLOWED: https://github.com/user/repo
 
 ### `cella network log`
 
-View the proxy's blocked-request log from a running container.
+Tail the proxy's blocked-request log from a running container.
 
 ```sh
-# Inside the container
-$ cat /tmp/.cella/proxy.log
-
 # From the host
+$ cella network log
+
+# Or read the raw file directly (inside the container, or via exec)
+$ cat /tmp/.cella/proxy.log
 $ cella exec -- cat /tmp/.cella/proxy.log
 ```
 

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -37,7 +37,11 @@ Date: 2026-04-19
 | `templates generate-docs` | Generate docs | Not implemented | MISSING |
 
 ### Cella-Specific Commands (beyond spec, keep as-is)
-`shell`, `list`, `logs`, `doctor`, `branch`, `switch`, `prune`, `nvim`, `code`, `tmux`, `ports`, `credential`, `network`, `init`, `config`, `down`, `daemon`, `features edit`, `features list`, `features update`, `template new`, `template list`, `template edit`, `completions`
+`shell`, `list`, `logs`, `doctor`, `branch`, `switch`, `prune`, `nvim`, `code`, `tmux`, `ports`, `credential`, `network`, `init`, `config validate`, `down`, `daemon`, `features edit`, `features list`, `features update`, `completions`
+
+### CLI surface reserved for future work (stubs present, not yet implemented)
+
+`cella config show`, `cella config global`, `cella config dotfiles`, `cella config agent`, `cella template new`, `cella template list`, `cella template edit` — these subcommands parse successfully at the CLI layer but return `"not yet implemented"` at runtime. They are kept visible so the flag shape and routing are stable when the implementation lands.
 
 ---
 

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -2,7 +2,7 @@
 
 Audit of cella against the official devcontainer specification (containers.dev) and reference CLI (devcontainers/cli).
 
-Date: 2026-04-01
+Date: 2026-04-19
 
 ## Legend
 
@@ -37,7 +37,7 @@ Date: 2026-04-01
 | `templates generate-docs` | Generate docs | Not implemented | MISSING |
 
 ### Cella-Specific Commands (beyond spec, keep as-is)
-`shell`, `list`, `logs`, `doctor`, `branch`, `switch`, `prune`, `nvim`, `code`, `tmux`, `ports`, `credential`, `network`, `init`, `config`, `down`, `daemon`, `features edit`, `features list`, `features update`, `completions`
+`shell`, `list`, `logs`, `doctor`, `branch`, `switch`, `prune`, `nvim`, `code`, `tmux`, `ports`, `credential`, `network`, `init`, `config`, `down`, `daemon`, `features edit`, `features list`, `features update`, `template new`, `template list`, `template edit`, `completions`
 
 ---
 
@@ -48,8 +48,8 @@ Date: 2026-04-01
 | Flag | Spec Default | Cella | Status |
 |------|-------------|-------|--------|
 | `--workspace-folder` | cwd | Has it | PASS |
-| `--config` | - | Has as `--file` | FAIL (wrong name) |
-| `--override-config` | - | Not implemented | MISSING |
+| `--config` | - | Has it | PASS |
+| `--override-config` | - | Not implemented (use `.devcontainer/devcontainer.local.jsonc` instead) | MISSING |
 | `--id-label` (repeatable) | - | Not implemented | MISSING |
 | `--docker-path` | - | Not implemented | MISSING |
 | `--docker-compose-path` | - | Not implemented | MISSING |
@@ -59,8 +59,8 @@ Date: 2026-04-01
 | `--gpu-availability` | `detect` | Not implemented | MISSING |
 | `--mount-workspace-git-root` | `true` | Not implemented | MISSING |
 | `--mount-git-worktree-common-dir` | `false` | Not implemented | MISSING |
-| `--log-level` | `info` | Has as `--verbose` | PARTIAL |
-| `--log-format` | `text` | Not implemented | MISSING |
+| `--log-level` | `info` | Has as `--verbose` (boolean) | PARTIAL |
+| `--log-format` | `text` | Has as `--output` (`text`, `json`) | PARTIAL (name differs) |
 | `--terminal-columns/rows` | - | Not implemented | MISSING |
 | `--default-user-env-probe` | `loginInteractiveShell` | Not implemented | MISSING |
 | `--update-remote-user-uid-default` | `on` | Not implemented | MISSING |
@@ -83,8 +83,29 @@ Date: 2026-04-01
 | `--dotfiles-target-path` | `~/dotfiles` | Not implemented | MISSING |
 | `--container-session-data-folder` | - | Not implemented | MISSING |
 | `--secrets-file` | - | Not implemented | MISSING |
-| `--include-configuration` | `false` | Not implemented | MISSING |
-| `--include-merged-configuration` | `false` | Not implemented | MISSING |
+| `--include-configuration` | `false` | Not implemented (spec places it on `read-configuration`, see `read-configuration` row in §1) | MISSING |
+| `--include-merged-configuration` | `false` | Implemented on `read-configuration` (spec location) | PARTIAL (spec docs also allow it on `up`; cella only supports it on `read-configuration`) |
+
+### Cella-specific flags on `up` (not in spec)
+
+These flags are cella-only. They do not conflict with any spec flag name and can be kept.
+
+| Flag | Purpose |
+|------|---------|
+| `-v`, `--verbose` | Expanded step details in TUI progress |
+| `--rebuild` | Force rebuild before start (semantically overlaps spec's `--remove-existing-container` + cache invalidation) |
+| `--pull <always\|missing\|never>` | Image pull policy (independent of spec's `--buildkit`/build-cache flags) |
+| `--secret` (repeatable) | BuildKit `id=X[,src=Y][,env=Z]` secret for image builds |
+| `--backend <docker>` | Container backend selection (docker today; apple-container gated on macOS) |
+| `--docker-host` | Override `DOCKER_HOST` for this invocation |
+| `--output <text\|json>` | Output/log format — see `--log-format` row in the spec table |
+| `--strict <host-requirements\|all>` | Elevate host-requirements from warn to fail |
+| `--skip-checksum` | Skip agent-binary SHA256 check (for custom agent builds) |
+| `--branch <BRANCH>` | Target a worktree-backed branch container |
+| `--no-network-rules` | Skip network proxy block rules (proxy forwarding still active) |
+| `--profile` (repeatable) | Docker Compose profile(s) to activate |
+| `--env-file` (repeatable) | Extra env-file(s) for Docker Compose |
+| `--pull-policy <always\|missing\|never\|build>` | Docker Compose service pull policy |
 
 ### `build` Command Flags
 
@@ -95,11 +116,23 @@ Date: 2026-04-01
 | `--platform` | - | Not implemented | MISSING |
 | `--push` | `false` | Not implemented | MISSING |
 | `--label` (repeatable) | - | Not implemented | MISSING |
-| `--output` | - | Not implemented | MISSING |
+| `--output` | - (buildx output target, e.g. `type=image`) | Has `--output` but as log format (`text`/`json`) — name collision | FAIL (same flag name, different semantics) |
 | `--cache-from` | - | Not implemented | MISSING |
 | `--cache-to` | - | Not implemented | MISSING |
-| `--buildkit` | `auto` | Not implemented | MISSING |
+| `--buildkit` | `auto` | Not implemented (BuildKit is driven implicitly by `--secret`) | MISSING |
 | `--additional-features` | - | Not implemented | MISSING |
+
+### Cella-specific flags on `build` (not in spec)
+
+| Flag | Purpose |
+|------|---------|
+| `-v`, `--verbose` | Expanded step details |
+| `--pull <always\|missing\|never>` | Image pull policy (cella-specific; also on `up`) |
+| `--workspace-folder` | Explicit workspace folder |
+| `--config` | Path to devcontainer.json |
+| `--backend`, `--docker-host` | Backend selection / Docker host override |
+| `--secret` (repeatable) | BuildKit build secret (`id=X[,src=Y][,env=Z]`) |
+| `--profile`, `--env-file`, `--pull-policy` | Docker Compose flags (when building a compose workspace) |
 
 ---
 
@@ -166,8 +199,8 @@ Date: 2026-04-01
 
 ### 3.12 hostRequirements Merge
 - **Spec**: Maximum value wins across metadata layers
-- **Cella**: Validation exists in `host_requirements.rs` but merge strategy across layers not confirmed
-- **Status**: NEEDS AUDIT
+- **Cella**: `merge_host_requirements` in `cella-config/src/devcontainer/merge.rs` applies per-key max semantics during layer merge. `host_requirements.rs` in `cella-orchestrator` validates the merged values against the detected host
+- **Status**: PASS
 
 ### 3.13 Port String Format
 - **Spec**: Supports `"host:container"` strings in `forwardPorts`
@@ -197,7 +230,6 @@ Date: 2026-04-01
 | upgrade command | Feature lockfile update | Medium |
 | Feature authoring | test/package/publish/info/resolve-deps/generate-docs | Low |
 | Template commands | apply/publish/metadata/generate-docs | Low |
-| Host requirements | CPU/memory/storage/GPU validation with warnings | Medium |
 | Git root mount | `--mount-workspace-git-root` | Medium |
 
 ---
@@ -225,3 +257,7 @@ Date: 2026-04-01
 | Multi-config repos | Error + list configs, prompt for `--config` | Non-interactive: first alphabetically |
 | customizations.cella merge | Deep merge, last wins per key | Consistent with env var merge strategy |
 | Default additional feature | `ghcr.io/devcontainers/features/github-cli:1` | Opt-out via config |
+| CLI enum flags | `ValueEnum` (clap strict parsing) | Invalid values fail at parse time with a helpful list rather than slipping through to a late runtime error |
+| `--pull` semantics | Uniform `always`/`missing`/`never` on `up` and `build` | Match Docker's own pull policy vocabulary rather than invent a new one |
+| BuildKit secrets | `--secret id=X[,src=Y][,env=Z]` (repeatable) | Reuse BuildKit's established secret syntax so existing `Dockerfile` `RUN --mount=type=secret` works unchanged |
+| Prebuilt image lifecycle | Run lifecycle hooks baked into the image's `devcontainer.metadata` label | Prebuilds skip building but still need postCreate/postStart to run; follows spec metadata semantics |

--- a/docs/specs/ipc-protocol.md
+++ b/docs/specs/ipc-protocol.md
@@ -648,14 +648,16 @@ All variants are tagged with `"type"` in snake_case.
 |---|---|---|
 | `container_id` | `string` | Docker container ID |
 | `container_name` | `string` | Container name |
-| `container_ip` | `string?` | Container IP address |
+| `container_ip` | `string?` | Container IP address (may be `null` during pre-registration before the container has started; see `update_container_ip`) |
 | `ports_attributes` | `PortAttributes[]` | Per-port forwarding attributes from devcontainer.json |
 | `other_ports_attributes` | `PortAttributes?` | Default attributes for ports not matched by `ports_attributes` |
 | `forward_ports` | `u16[]` | Ports from `forwardPorts` in devcontainer.json (pre-allocate on registration, default: `[]`) |
 | `shutdown_action` | `string?` | The `shutdownAction` from devcontainer.json (`"none"`, `"stopContainer"`, or `"stopCompose"` for compose workspaces) |
+| `backend_kind` | `string?` | Backend that created the container (`"docker"`, `"apple-container"`). Defaults to `null` for backward compatibility with older CLIs |
+| `docker_host` | `string?` | Docker host override used when the container was created. Defaults to `null` |
 
 ```json
-{"type":"register_container","container_id":"abc123","container_name":"cella-myapp-main","container_ip":"172.20.0.5","ports_attributes":[],"other_ports_attributes":null,"forward_ports":[],"shutdown_action":null}
+{"type":"register_container","container_id":"abc123","container_name":"cella-myapp-main","container_ip":"172.20.0.5","ports_attributes":[],"other_ports_attributes":null,"forward_ports":[],"shutdown_action":null,"backend_kind":"docker","docker_host":null}
 ```
 
 **`deregister_container`** -- Deregister a container (stop proxies, release ports).
@@ -684,6 +686,17 @@ All variants are tagged with `"type"` in snake_case.
 
 ```json
 {"type":"ping"}
+```
+
+**`update_container_ip`** -- Update a container's IP address after it has started. Sent after pre-registration (with `container_ip: null`) once the container is running and its IP is known.
+
+| Field | Type | Description |
+|---|---|---|
+| `container_id` | `string` | Docker container ID |
+| `container_ip` | `string?` | Newly discovered container IP |
+
+```json
+{"type":"update_container_ip","container_id":"abc123","container_ip":"172.20.0.5"}
 ```
 
 **`shutdown`** -- Request graceful shutdown of the daemon. No fields.
@@ -755,6 +768,16 @@ All variants are tagged with `"type"` in snake_case.
 {"type":"shutting_down","pid":12345}
 ```
 
+**`container_ip_updated`** -- Container IP update acknowledged.
+
+| Field | Type | Description |
+|---|---|---|
+| `container_id` | `string` | Docker container ID the update was applied to |
+
+```json
+{"type":"container_ip_updated","container_id":"abc123"}
+```
+
 **`pong`** -- Pong response. No fields.
 
 ```json
@@ -793,6 +816,7 @@ All variants are tagged with `"type"` in snake_case.
 | `forwarded_port_count` | `usize` | Number of currently forwarded ports |
 | `agent_connected` | `bool` | Whether the agent TCP connection is active |
 | `last_seen_secs` | `u64` | Seconds since last agent heartbeat (default: `0`) |
+| `agent_version` | `string?` | Agent version from the `AgentHello` handshake, if connected (default: `null`) |
 
 ---
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,12 +4,13 @@
 
 cella uses a layered testing approach:
 
-- **Unit tests** — fast, inline, no external dependencies
-- **Integration tests** — per-crate `tests/` directories, may require Docker
+- **Unit tests** — fast, inline with the code, no external dependencies
+- **Snapshot tests** — schema codegen and feature resolution, via [insta](https://insta.rs/)
+- **Integration tests** — feature-gated, require Docker and network access
 
 ## Unit Tests
 
-Unit tests live inline in each module using `#[cfg(test)]`:
+Unit tests live inline in each module using `#[cfg(test)]` — not in a separate `tests/` directory:
 
 ```rust
 #[cfg(test)]
@@ -29,10 +30,27 @@ Run all unit tests:
 cargo test --workspace
 ```
 
+## Snapshot Tests
+
+`cella-codegen` and `cella-features` produce deterministic output (generated Rust structs, Dockerfile emission, feature resolution) that is validated against stored snapshots using insta.
+
+Run snapshot checks:
+
+```sh
+cargo insta test --workspace --check --unreferenced=reject
+```
+
+Review and accept intentional changes:
+
+```sh
+cargo insta review
+```
+
+If `cargo-insta` is not installed in a dev container, run `cargo test` to verify snapshot correctness and then review/accept from the host.
+
 ## Integration Tests
 
-Tests that require Docker or network access (e.g. OCI registry fetches) are
-gated behind a Cargo feature flag:
+Tests that require Docker or network access (OCI registry fetches, container lifecycle) are gated behind a Cargo feature flag:
 
 ```rust
 #[cfg(feature = "integration-tests")]
@@ -45,23 +63,18 @@ async fn fetch_from_ghcr() {
 Run integration tests locally (requires Docker):
 
 ```sh
-cargo test -p cella-features -p cella-daemon --features integration-tests
+cargo test -p cella-features -p cella-daemon -p cella-compose --features integration-tests
 ```
 
-These tests run automatically in CI via the **Integration Test** job, which
-authenticates to `ghcr.io` and collects coverage.
+These tests run automatically in CI via the **Integration Test** job, which authenticates to `ghcr.io` and produces a combined coverage report via `cargo llvm-cov`.
 
 ### Architecture-aware tests
 
-OCI tests use `test_platform()` instead of hardcoding `"amd64"`. This maps
-`std::env::consts::ARCH` to OCI platform names (`x86_64` → `amd64`,
-`aarch64` → `arm64`), so tests work on both Intel and ARM runners.
+OCI tests use `test_platform()` instead of hardcoding `"amd64"`. This maps `std::env::consts::ARCH` to OCI platform names (`x86_64` → `amd64`, `aarch64` → `arm64`), so tests work on both Intel and ARM runners.
 
 ### Locally-only tests
 
-One test (`credential_helper_invocation` in `cella-features`) requires
-`docker-credential-desktop` on `PATH` and uses `#[ignore]`. It does not run
-in CI. Run it manually:
+One test (`credential_helper_invocation` in `cella-features`) requires `docker-credential-desktop` on `PATH` and uses `#[ignore]`. It does not run in CI. Run it manually:
 
 ```sh
 cargo test -p cella-features -- --ignored credential_helper
@@ -69,7 +82,7 @@ cargo test -p cella-features -- --ignored credential_helper
 
 ## Mocking Patterns
 
-External dependencies (Docker, git CLI) are abstracted behind traits. This allows unit tests to use mock implementations without touching real infrastructure:
+External dependencies (Docker, git CLI) are abstracted behind traits so unit tests can supply lightweight fakes instead of touching real infrastructure:
 
 ```rust
 // In the library crate:
@@ -86,22 +99,17 @@ impl ContainerRuntime for MockRuntime {
 }
 ```
 
+`cella-orchestrator` ships a `NoOpHooks` implementation of its `UpHooks` / `ComposeUpHooks` / `PruneHooks` traits for tests that exercise the orchestrator without a real CLI or daemon attached.
+
 ## Adding New Tests
 
-1. **Unit test**: Add a `#[cfg(test)]` module in the same file as the code being tested
-2. **Integration test**: Use `#[cfg(feature = "integration-tests")]` for tests needing Docker or network. Add the feature to the crate's `Cargo.toml` if not already present
-3. **Async tests**: Use `#[tokio::test]` for async test functions
-4. **Architecture**: Use `test_platform()` instead of hardcoding `"amd64"` in OCI tests
+1. **Unit test**: add a `#[cfg(test)]` module in the same file as the code under test.
+2. **Integration test**: wrap the test in `#[cfg(feature = "integration-tests")]`. Add the feature flag to the crate's `Cargo.toml` if not already present.
+3. **Async tests**: use `#[tokio::test]` for async test functions.
+4. **Snapshots**: use `insta::assert_snapshot!` / `insta::assert_json_snapshot!`; run `cargo insta review` to accept.
+5. **Architecture**: use `test_platform()` instead of hardcoding `"amd64"` in OCI or image-architecture tests.
+6. **Regression tests**: every bugfix should land with a failing test from the bug and the fix in the same commit (or split as the fix + the test, but the test should precede or accompany the code).
 
-## Test Organization by Crate
+## CI Coverage
 
-| Crate | Unit Tests | Integration Tests |
-|-------|-----------|-------------------|
-| cella-config | Config parsing, layer merging | — |
-| cella-docker | — | Container lifecycle, image builds |
-| cella-git | Path manipulation, config parsing | Worktree operations |
-| cella-port | Port allocation logic | Port binding |
-| cella-agent | Preset resolution | Full sandbox lifecycle |
-| cella-network | Rule matching, config merging | — |
-| cella-orchestrator | — | Container lifecycle |
-| cella-cli | Argument parsing | End-to-end command tests |
+The Integration Test job aggregates coverage across unit and integration runs with `cargo llvm-cov`. A per-PR sticky comment posts workspace total and per-crate coverage so reviewers can see where a change regresses test coverage.

--- a/docs/worktrees.md
+++ b/docs/worktrees.md
@@ -10,7 +10,7 @@ Every git worktree gets its own dev container. Create a branch, get an isolated 
 |---------|-------------|
 | `$ cella branch <name> [--base <ref>]` | Create a worktree-backed branch with its own container |
 | `$ cella list` | List all containers with status and ports |
-| `$ cella switch <name>` | Open a shell in a worktree branch's container |
+| `$ cella switch [<name>]` | Open a shell in a worktree branch's container (interactive fuzzy picker if omitted) |
 | `$ cella down --branch <name> [--rm]` | Stop (or remove) a worktree container |
 | `$ cella up --branch <name>` | Start or restart a worktree container |
 | `$ cella prune [--all] [--dry-run]` | Remove stale worktrees and their containers |
@@ -178,6 +178,10 @@ Use `exec` for scripted or automated commands. The exit code from the command is
 Open an interactive shell in another branch's container.
 
 ```sh
+# Host (interactive fuzzy picker if no branch given)
+$ cella switch [<name>] [-s <shell>]
+
+# In-container (branch is required)
 container$ cella switch <branch>
 ```
 


### PR DESCRIPTION
## Summary

Every git-tracked doc in the repo audited against the current source tree and live CLI output. One new file (`crates/cella-jsonc/README.md`); every other change is a correction in place with each doc's existing voice preserved.

## Drift categories fixed

- **Missing crate**: `cella-jsonc` now has a README, appears in both Tier-3 mermaid diagrams (README + docs/architecture.md), has an `### cella-jsonc` responsibility section, and is wired into dep lists of every crate that depends on it. README crate count: 18 → 19.
- **Missing crate sections** in `docs/architecture.md`: `cella-container` and `cella-backend` were referenced in the diagram but had no prose section. Added.
- **CLAUDE.md**: MSRV 1.94.0 → 1.94.1 (matches `Cargo.toml`). Clippy command now includes `--all-features` to match CI. Agent-restart bullet corrected to match `restart_agent_in_container`; added bullet about indefinite reconnect across daemon restarts/binary upgrades.
- **`docs/spec-compliance.md`** (18 days stale): rebuilt `up`/`build` flag tables from live `--help`, fixed `--config` FAIL → PASS and `--log-format` MISSING → PARTIAL, flagged `build --output` as a flag-name collision, added cella-specific flag subsections for `up` and `build`, flipped `hostRequirements` merge from NEEDS AUDIT → PASS per `merge_host_requirements`, pruned stale Missing Features rows, added Design Decisions rows for `ValueEnum` (#28), `--pull` semantics (#25), BuildKit `--secret` (#26), prebuilt lifecycle via `devcontainer.metadata` (#24). Date bumped to today.
- **`docs/specs/ipc-protocol.md`**: added missing `UpdateContainerIp` request / `ContainerIpUpdated` response (compose pre-registration flow); added `backend_kind`, `docker_host` to `ContainerRegistrationData`; added `agent_version` to `ContainerSummary`.
- **README.md**: added Colima to SSH agent forwarding (#41), AI provider API-key forwarding (#33), bubblewrap for Codex sandbox (#36), terminal title integration (#37). Moved `cella template new/list/edit` and `cella config show/global/dotfiles/agent/validate` out of Planned (they ship today). Command tables updated to match live `cella --help`.
- **Practical docs** (`contributing.md`, `testing.md`, `network-proxy.md`, `worktrees.md`): MSRV updated, integration-test command fixed (`-p cella-features -p cella-daemon -p cella-compose --features integration-tests`), clippy command picks up `--all-features`, snapshot-test workflow documented, `cella network log` example uses the actual subcommand, `cella switch` treats host NAME as optional.
- **Deep-dive architecture docs** (`crates/cella-agent/docs/`, `crates/cella-daemon/docs/`, `crates/cella-port/docs/`): indefinite-retry replaces the old timeout-to-standalone fallback; added CLI-mode section for the agent binary; added Task Manager and Stream Bridge sections for the daemon; added `UpdateContainerIp` to the management-request list; noted `.daemon_addr` write-before-agent-launch; port-forwarding doc gets `proxy_port` on `PortOpen`.
- **Per-crate READMEs**: dependency lists corrected against `Cargo.toml` across 10 crates. `cella-agent`, `cella-config`, `cella-doctor`, `cella-env`, `cella-orchestrator` picked up feature/module updates since March (`ai_keys`, `compose_mounts`, `uid_image`, host-requirements relocation, indefinite reconnect).
- **`.claude/`**: `cella-parallel-dev.md` now flags that `cella task` is in-container only; `verify/SKILL.md` clippy command matches CI.

## Scope

- **In**: every git-tracked `.md` in `README.md`, `CLAUDE.md`, `docs/`, `crates/*/README.md`, `crates/*/docs/*.md`, `.claude/commands/*.md`, `.claude/skills/*/SKILL.md` — 25 files touched, 1 new file, no Rust/config/workflow changes.
- **Out**: `docs/superpowers/specs/` (historical design snapshots, not state descriptions).

## Test plan

- [x] `git diff main..HEAD --stat` → only markdown + `crates/cella-jsonc/README.md`
- [x] `cargo fmt --all -- --check` → clean
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings -D clippy::all` → clean
- [x] `cargo test --workspace` → clean
- [x] `rg -n "18 focused crates|MSRV 1\.94\.0|Date: 2026-04-01" --glob '*.md'` → 0 matches
- [ ] Reviewer sanity-check the IPC protocol deltas against `cella-protocol/src/lib.rs`
- [ ] Reviewer spot-check the `up` / `build` flag tables against `cella up --help` / `cella build --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)