### PR TITLE
feat: Docker Compose support for nvim, code, tmux, and branch

### DIFF
--- a/crates/cella-backend/src/traits.rs
+++ b/crates/cella-backend/src/traits.rs
@@ -260,6 +260,41 @@ pub trait ContainerBackend: Send + Sync {
         })
     }
 
+    /// Connect a container to a named Docker network.
+    ///
+    /// Returns `NotSupported` on backends that don't use Docker networks.
+    fn connect_to_network<'a>(
+        &'a self,
+        container_id: &'a str,
+        network_name: &'a str,
+    ) -> BoxFuture<'a, Result<(), BackendError>> {
+        let kind = self.kind();
+        Box::pin(async move {
+            let _ = (container_id, network_name);
+            Err(BackendError::NotSupported {
+                backend: kind.to_string(),
+                operation: "connect_to_network".to_string(),
+            })
+        })
+    }
+
+    /// Check whether a named Docker network exists.
+    ///
+    /// Returns `NotSupported` on backends that don't use Docker networks.
+    fn network_exists<'a>(
+        &'a self,
+        network_name: &'a str,
+    ) -> BoxFuture<'a, Result<bool, BackendError>> {
+        let kind = self.kind();
+        Box::pin(async move {
+            let _ = network_name;
+            Err(BackendError::NotSupported {
+                backend: kind.to_string(),
+                operation: "network_exists".to_string(),
+            })
+        })
+    }
+
     // -- Agent provisioning --
 
     /// Ensure the cella-agent binary is available for containers.

--- a/crates/cella-cli/src/commands/branch.rs
+++ b/crates/cella-cli/src/commands/branch.rs
@@ -85,7 +85,7 @@ impl BranchArgs {
         let extra_labels = worktree_labels(&self.name, repo_root);
 
         // Create the container using the up pipeline
-        let ctx = UpContext::for_workspace(
+        let mut ctx = UpContext::for_workspace(
             wt_path,
             &self.backend,
             extra_labels,
@@ -120,7 +120,11 @@ impl BranchArgs {
             let _ = ctx.client.remove_container(&existing.id, false).await;
         }
 
-        let create_result = ctx.ensure_up(false, &[]).await?;
+        let create_result = if ctx.is_compose() {
+            run_compose_branch(&mut ctx, repo_root, progress, false, &[]).await?
+        } else {
+            ctx.ensure_up(false, &[]).await?
+        };
 
         // If --exec provided, run the command in the new container
         if let Some(ref exec_cmd) = self.exec_cmd {
@@ -167,4 +171,79 @@ impl BranchArgs {
 
         Ok(())
     }
+}
+
+/// Build compose image, create a standalone container, and connect to the
+/// parent project's compose network.
+///
+/// Used by both `cella branch` and `cella up --branch` for compose projects.
+pub(super) async fn run_compose_branch(
+    ctx: &mut UpContext,
+    repo_root: &std::path::Path,
+    progress: &crate::progress::Progress,
+    build_no_cache: bool,
+    strict: &[super::StrictnessLevel],
+) -> Result<super::up::UpResult, Box<dyn std::error::Error + Send + Sync>> {
+    let project = cella_compose::ComposeProject::from_resolved(
+        ctx.config(),
+        &ctx.resolved.config_path,
+        &ctx.resolved.workspace_root,
+    )?;
+    let service = project.primary_service.clone();
+
+    let step = progress.step("Building compose image...");
+    let compose_cmd = cella_compose::ComposeCommand::without_override(&project);
+    compose_cmd
+        .build(Some(std::slice::from_ref(&service)), build_no_cache)
+        .await?;
+    step.finish();
+
+    let resolved_compose = compose_cmd.config().await?;
+    let build_info = cella_compose::extract_service_build_info(&resolved_compose, &service)?;
+    let image_name = match &build_info {
+        cella_compose::ServiceBuildInfo::Image { image } => image.clone(),
+        cella_compose::ServiceBuildInfo::Build { .. } => {
+            format!("{}-{}", project.project_name, service)
+        }
+    };
+
+    let parent_config_name = ctx
+        .config()
+        .get("name")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    let parent_project_name =
+        cella_backend::compose_project_name(repo_root, parent_config_name.as_deref());
+    let parent_network = format!("{parent_project_name}_default");
+
+    let network_ok = ctx
+        .client
+        .network_exists(&parent_network)
+        .await
+        .unwrap_or(false);
+    if !network_ok {
+        progress.warn(&format!(
+            "Parent compose network '{parent_network}' not found. \
+             Run `cella up` first to create it."
+        ));
+    }
+
+    // Swap the config to an image-based one so ensure_up creates a standalone
+    // container instead of rejecting the compose config.
+    let obj = ctx
+        .resolved
+        .config
+        .as_object_mut()
+        .expect("config is an object");
+    obj.remove("dockerComposeFile");
+    obj.remove("service");
+    obj.insert("image".to_string(), serde_json::Value::String(image_name));
+
+    // Register the parent compose network so the orchestrator connects
+    // the container before lifecycle hooks run.
+    if network_ok {
+        ctx.extra_networks.push(parent_network);
+    }
+
+    ctx.ensure_up(build_no_cache, strict).await
 }

--- a/crates/cella-cli/src/commands/branch.rs
+++ b/crates/cella-cli/src/commands/branch.rs
@@ -245,12 +245,12 @@ pub(super) async fn run_compose_branch(
         ctx.extra_networks.push(parent_network);
     }
 
-    // The compose build already handled --no-cache. Pass false so
-    // ensure_up doesn't try to pull the local-only compose image.
-    // Force container recreation when no-cache was requested so the
-    // fresh image is picked up.
+    // The compose image is local-only — prevent ensure_up from
+    // trying to pull it. build_no_cache still flows through so the
+    // features layer rebuilds without cache when requested.
     if build_no_cache {
         ctx.remove_container = true;
     }
-    ctx.ensure_up(false, strict).await
+    ctx.pull_policy = Some("never".to_string());
+    ctx.ensure_up(build_no_cache, strict).await
 }

--- a/crates/cella-cli/src/commands/branch.rs
+++ b/crates/cella-cli/src/commands/branch.rs
@@ -200,6 +200,7 @@ pub(super) async fn run_compose_branch(
 
     let resolved_compose = compose_cmd.config().await?;
     let build_info = cella_compose::extract_service_build_info(&resolved_compose, &service)?;
+    let is_local_image = matches!(&build_info, cella_compose::ServiceBuildInfo::Build { .. });
     let image_name = match &build_info {
         cella_compose::ServiceBuildInfo::Image { image } => image.clone(),
         cella_compose::ServiceBuildInfo::Build { .. } => {
@@ -245,12 +246,13 @@ pub(super) async fn run_compose_branch(
         ctx.extra_networks.push(parent_network);
     }
 
-    // The compose image is local-only — prevent ensure_up from
-    // trying to pull it. build_no_cache still flows through so the
-    // features layer rebuilds without cache when requested.
     if build_no_cache {
         ctx.remove_container = true;
     }
-    ctx.pull_policy = Some("never".to_string());
+    // Local-only images (from build:) must not be pulled. Registry
+    // images (from image:) need normal pull behavior.
+    if is_local_image {
+        ctx.pull_policy = Some("never".to_string());
+    }
     ctx.ensure_up(build_no_cache, strict).await
 }

--- a/crates/cella-cli/src/commands/branch.rs
+++ b/crates/cella-cli/src/commands/branch.rs
@@ -245,5 +245,12 @@ pub(super) async fn run_compose_branch(
         ctx.extra_networks.push(parent_network);
     }
 
-    ctx.ensure_up(build_no_cache, strict).await
+    // The compose build already handled --no-cache. Pass false so
+    // ensure_up doesn't try to pull the local-only compose image.
+    // Force container recreation when no-cache was requested so the
+    // fresh image is picked up.
+    if build_no_cache {
+        ctx.remove_container = true;
+    }
+    ctx.ensure_up(false, strict).await
 }

--- a/crates/cella-cli/src/commands/code.rs
+++ b/crates/cella-cli/src/commands/code.rs
@@ -84,7 +84,11 @@ impl CodeArgs {
                 "cella code requires the Docker backend (VS Code attach is Docker-specific)".into(),
             );
         }
-        let result = ctx.ensure_up(build_no_cache, &strict).await?;
+        let result = if ctx.is_compose() {
+            super::compose_up::compose_ensure_up(&ctx).await?
+        } else {
+            ctx.ensure_up(build_no_cache, &strict).await?
+        };
 
         // 4. Resolve compose service if needed
         let container_id = if self.service.is_some() {

--- a/crates/cella-cli/src/commands/compose_up.rs
+++ b/crates/cella-cli/src/commands/compose_up.rs
@@ -14,11 +14,14 @@ use cella_orchestrator::compose_up::{ComposeUpConfig, ComposeUpHooks, ComposeUpO
 
 use super::up::{UpContext, output_result};
 
-/// Run the Docker Compose orchestration flow.
+/// Ensure the compose stack is up and return the result without printing.
 ///
-/// Called from `UpArgs::execute()` when the resolved config contains `dockerComposeFile`.
-pub async fn compose_up(ctx: UpContext) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let hooks = CliComposeUpHooks { ctx: &ctx };
+/// Used by `nvim`, `code`, `tmux`, and `up --branch` to auto-up compose
+/// projects the same way `ensure_up` does for Dockerfile-based ones.
+pub async fn compose_ensure_up(
+    ctx: &UpContext,
+) -> Result<super::up::UpResult, Box<dyn std::error::Error + Send + Sync>> {
+    let hooks = CliComposeUpHooks { ctx };
     let cfg = ComposeUpConfig {
         config: ctx.config(),
         config_path: &ctx.resolved.config_path,
@@ -41,19 +44,31 @@ pub async fn compose_up(ctx: UpContext) -> Result<(), Box<dyn std::error::Error 
     let _ = renderer.await;
     let result = result.map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })?;
 
-    let outcome = match result.outcome {
-        ComposeUpOutcome::Created => "created",
-        ComposeUpOutcome::Running => "running",
-    };
+    Ok(super::up::UpResult {
+        container_id: result.container_id,
+        remote_user: result.remote_user,
+        workspace_folder: result.workspace_folder,
+        outcome: match result.outcome {
+            ComposeUpOutcome::Created => "created".to_string(),
+            ComposeUpOutcome::Running => "running".to_string(),
+        },
+        ssh_agent_proxy: result.ssh_agent_proxy,
+    })
+}
+
+/// Run the Docker Compose orchestration flow.
+///
+/// Called from `UpArgs::execute()` when the resolved config contains `dockerComposeFile`.
+pub async fn compose_up(ctx: UpContext) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let result = compose_ensure_up(&ctx).await?;
     output_result(
         &ctx.output,
-        outcome,
+        &result.outcome,
         &result.container_id,
         &result.remote_user,
         &result.workspace_folder,
         result.ssh_agent_proxy.as_ref(),
     );
-
     Ok(())
 }
 

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -335,6 +335,45 @@ pub const TERMINAL_ENV_VARS: &[&str] = &[
     "LINES",
 ];
 
+/// Build the container environment for interactive sessions (nvim, tmux, etc.).
+///
+/// Merges label env, probed env cache, SSH auth sock, and host terminal vars.
+pub async fn build_container_env(
+    client: &dyn cella_backend::ContainerBackend,
+    container: &cella_backend::ContainerInfo,
+    container_id: &str,
+    remote_user: &str,
+) -> Vec<String> {
+    let label_env: Vec<String> = container
+        .labels
+        .get("dev.cella.remote_env")
+        .and_then(|v| serde_json::from_str(v).ok())
+        .unwrap_or_default();
+
+    let base_env = if let Some(probed) =
+        cella_orchestrator::env_cache::read_probed_env_cache(client, container_id, remote_user)
+            .await
+    {
+        cella_env::user_env_probe::merge_env(&probed, &label_env)
+    } else {
+        label_env
+    };
+    let mut env = base_env;
+    cella_orchestrator::env_cache::ensure_ssh_auth_sock(
+        client,
+        container_id,
+        remote_user,
+        &mut env,
+    )
+    .await;
+    for var in TERMINAL_ENV_VARS {
+        if let Ok(val) = std::env::var(var) {
+            env.push(format!("{var}={val}"));
+        }
+    }
+    env
+}
+
 /// Ensure the cella daemon is running and version-compatible.
 ///
 /// Starts it as a background process if not already running.

--- a/crates/cella-cli/src/commands/nvim.rs
+++ b/crates/cella-cli/src/commands/nvim.rs
@@ -44,7 +44,11 @@ impl NvimArgs {
         let mut up = self.up;
         picker::resolve_up_workspace(&mut up).await;
         let ctx = UpContext::new(&up, progress).await?;
-        let result = ctx.ensure_up(build_no_cache, &strict).await?;
+        let result = if ctx.is_compose() {
+            super::compose_up::compose_ensure_up(&ctx).await?
+        } else {
+            ctx.ensure_up(build_no_cache, &strict).await?
+        };
 
         // 2. Resolve compose service if needed
         let container_id = if self.service.is_some() {
@@ -83,38 +87,13 @@ impl NvimArgs {
         // 5. Build environment
         let container = ctx.client.inspect_container(&container_id).await?;
         let title_guard = push_for_container(&container, self.service.as_deref(), "nvim");
-        let label_env: Vec<String> = container
-            .labels
-            .get("dev.cella.remote_env")
-            .and_then(|v| serde_json::from_str(v).ok())
-            .unwrap_or_default();
-
-        let base_env = if let Some(probed) = cella_orchestrator::env_cache::read_probed_env_cache(
+        let env = super::build_container_env(
             ctx.client.as_ref(),
+            &container,
             &container_id,
             &result.remote_user,
-        )
-        .await
-        {
-            cella_env::user_env_probe::merge_env(&probed, &label_env)
-        } else {
-            label_env
-        };
-        let mut env = base_env;
-
-        cella_orchestrator::env_cache::ensure_ssh_auth_sock(
-            ctx.client.as_ref(),
-            &container_id,
-            &result.remote_user,
-            &mut env,
         )
         .await;
-
-        for var in super::TERMINAL_ENV_VARS {
-            if let Ok(val) = std::env::var(var) {
-                env.push(format!("{var}={val}"));
-            }
-        }
 
         // 6. Build command
         let mut cmd = vec!["nvim".to_string()];

--- a/crates/cella-cli/src/commands/tmux.rs
+++ b/crates/cella-cli/src/commands/tmux.rs
@@ -49,7 +49,11 @@ impl TmuxArgs {
         let mut up = self.up;
         picker::resolve_up_workspace(&mut up).await;
         let ctx = UpContext::new(&up, progress).await?;
-        let result = ctx.ensure_up(build_no_cache, &strict).await?;
+        let result = if ctx.is_compose() {
+            super::compose_up::compose_ensure_up(&ctx).await?
+        } else {
+            ctx.ensure_up(build_no_cache, &strict).await?
+        };
         let container_id = if self.service.is_some() {
             let c = ctx.client.inspect_container(&result.container_id).await?;
             super::resolve_service_container(ctx.client.as_ref(), c, self.service.as_deref())
@@ -85,36 +89,13 @@ impl TmuxArgs {
 
         let container = ctx.client.inspect_container(&container_id).await?;
         let title_guard = push_for_container(&container, self.service.as_deref(), "tmux");
-        let label_env: Vec<String> = container
-            .labels
-            .get("dev.cella.remote_env")
-            .and_then(|v| serde_json::from_str(v).ok())
-            .unwrap_or_default();
-
-        let base_env = if let Some(probed) = cella_orchestrator::env_cache::read_probed_env_cache(
+        let env = super::build_container_env(
             ctx.client.as_ref(),
+            &container,
             &container_id,
             &result.remote_user,
-        )
-        .await
-        {
-            cella_env::user_env_probe::merge_env(&probed, &label_env)
-        } else {
-            label_env
-        };
-        let mut env = base_env;
-        cella_orchestrator::env_cache::ensure_ssh_auth_sock(
-            ctx.client.as_ref(),
-            &container_id,
-            &result.remote_user,
-            &mut env,
         )
         .await;
-        for var in super::TERMINAL_ENV_VARS {
-            if let Ok(val) = std::env::var(var) {
-                env.push(format!("{var}={val}"));
-            }
-        }
 
         let cmd = if self.extra_args.is_empty() {
             // Default: attach-or-create named session

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -128,6 +128,8 @@ pub struct UpContext {
     pub(crate) compose_pull_policy: Option<String>,
     /// `BuildKit` secrets for image builds.
     build_secrets: Vec<BuildSecret>,
+    /// Extra Docker networks to connect after container start (before lifecycle hooks).
+    pub(crate) extra_networks: Vec<String>,
 }
 
 impl UpContext {
@@ -208,6 +210,7 @@ impl UpContext {
             compose_env_files: args.env_file.clone(),
             compose_pull_policy: args.pull_policy.as_ref().map(|p| p.as_str().to_string()),
             build_secrets,
+            extra_networks: Vec::new(),
         })
     }
 
@@ -275,11 +278,16 @@ impl UpContext {
             compose_env_files: Vec::new(),
             compose_pull_policy: None,
             build_secrets: vec![],
+            extra_networks: Vec::new(),
         })
     }
 
     pub(crate) const fn config(&self) -> &serde_json::Value {
         &self.resolved.config
+    }
+
+    pub(crate) fn is_compose(&self) -> bool {
+        self.config().get("dockerComposeFile").is_some()
     }
 
     pub(crate) fn workspace_folder(&self) -> Option<&str> {
@@ -688,6 +696,7 @@ impl UpContext {
             network_rule_policy: self.network_rules,
             pull_policy: self.pull_policy.as_deref(),
             build_secrets: self.build_secrets.clone(),
+            extra_networks: self.extra_networks.clone(),
         };
 
         let result =
@@ -767,9 +776,20 @@ impl UpArgs {
             NetworkRulePolicy::Enforce
         };
 
-        let result = ctx
-            .ensure_up(self.build.build_no_cache, &self.strict)
-            .await?;
+        let result = if ctx.is_compose() {
+            let progress = ctx.progress.clone();
+            super::branch::run_compose_branch(
+                &mut ctx,
+                &repo_info.root,
+                &progress,
+                self.build.build_no_cache,
+                &self.strict,
+            )
+            .await?
+        } else {
+            ctx.ensure_up(self.build.build_no_cache, &self.strict)
+                .await?
+        };
         output_result(
             &ctx.output,
             &result.outcome,

--- a/crates/cella-compose/src/cli.rs
+++ b/crates/cella-compose/src/cli.rs
@@ -166,9 +166,16 @@ impl ComposeCommand {
     ///
     /// Returns an error if the `docker compose` CLI is not found or if the
     /// command exits with a non-zero status.
-    pub async fn build(&self, services: Option<&[String]>) -> Result<(), CellaComposeError> {
+    pub async fn build(
+        &self,
+        services: Option<&[String]>,
+        no_cache: bool,
+    ) -> Result<(), CellaComposeError> {
         let mut cmd = self.base_command();
         cmd.arg("build");
+        if no_cache {
+            cmd.arg("--no-cache");
+        }
         if let Some(ref policy) = self.pull_policy
             && policy == "always"
         {

--- a/crates/cella-compose/src/integration_tests/smoke_tests.rs
+++ b/crates/cella-compose/src/integration_tests/smoke_tests.rs
@@ -54,7 +54,7 @@ async fn plain_compose_lifecycle() {
     let cmd = ComposeCommand::new(&project);
 
     // Build (pulls images)
-    cmd.build(None).await.expect("compose build failed");
+    cmd.build(None, false).await.expect("compose build failed");
 
     // Up
     cmd.up(None, false).await.expect("compose up failed");

--- a/crates/cella-docker/src/docker_api_impl.rs
+++ b/crates/cella-docker/src/docker_api_impl.rs
@@ -375,6 +375,33 @@ impl ContainerBackend for DockerClient {
         })
     }
 
+    fn connect_to_network<'a>(
+        &'a self,
+        container_id: &'a str,
+        network_name: &'a str,
+    ) -> BoxFuture<'a, Result<(), BackendError>> {
+        Box::pin(async move {
+            crate::network::connect_container_to_named_network(
+                self.inner(),
+                container_id,
+                network_name,
+            )
+            .await
+            .map_err(BackendError::from)
+        })
+    }
+
+    fn network_exists<'a>(
+        &'a self,
+        network_name: &'a str,
+    ) -> BoxFuture<'a, Result<bool, BackendError>> {
+        Box::pin(async move {
+            crate::network::named_network_exists(self.inner(), network_name)
+                .await
+                .map_err(BackendError::from)
+        })
+    }
+
     // -- Agent provisioning --
 
     fn ensure_agent_provisioned<'a>(

--- a/crates/cella-docker/src/network.rs
+++ b/crates/cella-docker/src/network.rs
@@ -73,15 +73,7 @@ pub async fn connect_container(
     docker: &Docker,
     container_id: &str,
 ) -> Result<(), CellaDockerError> {
-    let config = bollard::models::NetworkConnectRequest {
-        container: container_id.to_string(),
-        ..Default::default()
-    };
-
-    docker.connect_network(CELLA_NETWORK_NAME, config).await?;
-
-    debug!("Connected container {container_id} to '{CELLA_NETWORK_NAME}' network");
-    Ok(())
+    connect_container_to_named_network(docker, container_id, CELLA_NETWORK_NAME).await
 }
 
 /// Check if a container is already connected to the cella network.
@@ -314,6 +306,43 @@ pub async fn remove_network_if_orphan(
         Err(bollard::errors::Error::DockerResponseServerError {
             status_code: 404, ..
         }) => Ok(RemovalOutcome::NotFound),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Connect a container to an arbitrary named network.
+///
+/// # Errors
+///
+/// Returns error if the Docker API call fails.
+pub async fn connect_container_to_named_network(
+    docker: &Docker,
+    container_id: &str,
+    network_name: &str,
+) -> Result<(), CellaDockerError> {
+    let config = bollard::models::NetworkConnectRequest {
+        container: container_id.to_string(),
+        ..Default::default()
+    };
+    docker.connect_network(network_name, config).await?;
+    debug!("Connected container {container_id} to network '{network_name}'");
+    Ok(())
+}
+
+/// Check whether a named Docker network exists.
+///
+/// # Errors
+///
+/// Returns error if the Docker API call fails (other than 404).
+pub async fn named_network_exists(
+    docker: &Docker,
+    network_name: &str,
+) -> Result<bool, CellaDockerError> {
+    match docker.inspect_network(network_name, None).await {
+        Ok(_) => Ok(true),
+        Err(bollard::errors::Error::DockerResponseServerError {
+            status_code: 404, ..
+        }) => Ok(false),
         Err(e) => Err(e.into()),
     }
 }

--- a/crates/cella-orchestrator/src/compose_build.rs
+++ b/crates/cella-orchestrator/src/compose_build.rs
@@ -113,12 +113,11 @@ pub async fn compose_build(
 
     // Run docker compose build
     let compose_cmd = cella_compose::ComposeCommand::new(&project);
-    compose_cmd
-        .build(None)
-        .await
-        .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {
+    compose_cmd.build(None, false).await.map_err(
+        |e| -> Box<dyn std::error::Error + Send + Sync> {
             format!("docker compose build failed: {e}").into()
-        })?;
+        },
+    )?;
 
     let had_features = features_build.is_some();
     let image_name = features_build

--- a/crates/cella-orchestrator/src/compose_up.rs
+++ b/crates/cella-orchestrator/src/compose_up.rs
@@ -384,7 +384,7 @@ async fn prepare_and_start(
     run_step_result(
         progress,
         "Building compose services...",
-        compose_cmd.build(None),
+        compose_cmd.build(None, cfg.build_no_cache),
     )
     .await?;
 

--- a/crates/cella-orchestrator/src/config.rs
+++ b/crates/cella-orchestrator/src/config.rs
@@ -34,6 +34,9 @@ pub struct UpConfig<'a> {
     pub pull_policy: Option<&'a str>,
     /// `BuildKit` secrets to inject during image builds.
     pub build_secrets: Vec<BuildSecret>,
+    /// Extra Docker networks to connect the container to after start,
+    /// before lifecycle hooks run (e.g. parent compose network for worktrees).
+    pub extra_networks: Vec<String>,
 }
 
 /// How the up pipeline should handle the container image.

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -937,6 +937,12 @@ impl EnsureUpContext<'_> {
             warn!("Failed to connect container to networks: {e}");
         }
 
+        for net in &self.config.extra_networks {
+            if let Err(e) = self.client.connect_to_network(container_id, net).await {
+                warn!("Failed to connect container to extra network '{net}': {e}");
+            }
+        }
+
         let container_ip = self
             .client
             .get_container_ip(container_id)


### PR DESCRIPTION
## Summary

- **nvim/code/tmux** now auto-up compose stacks instead of erroring with "not yet supported"
- **branch/up --branch** builds a standalone container from the compose image and joins the parent's compose network, avoiding duplicate stacks and port conflicts
- **--build-no-cache** flows through to `docker compose build` on all compose paths

## Changes

- Extract `compose_ensure_up()` to share the compose-up-and-return-result logic across commands
- Add `UpContext::is_compose()` and `build_container_env()` helpers to reduce duplication
- Add `connect_to_network` / `network_exists` to the backend trait (Docker-implemented)
- Add `extra_networks` to `UpConfig` so the orchestrator connects them before lifecycle hooks
- Add `no_cache` param to `ComposeCommand::build()` and wire it through

## Test plan

- [x] `cargo fmt/clippy/test` all pass
- [x] `cella up` on a compose devcontainer (already worked, regression check)
- [x] `cella nvim` on a compose devcontainer (was broken, now works)
- [x] `cella code` on a compose devcontainer (was broken, now works)
- [x] `cella tmux` on a compose devcontainer (was broken, now works)
- [x] `cella branch foo` on a compose devcontainer (standalone container, joins compose network)
- [x] `cella up --branch foo` re-ups the worktree container
- [x] `--service` flag with compose for nvim/code/tmux

🤖 Generated with [Claude Code](https://claude.com/claude-code)