### PR TITLE
Add agent network policy integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -122,6 +122,26 @@ jobs:
           -p cella-agent
           --features integration-tests
 
+      - name: Run Docker integration tests with coverage
+        run: >
+          cargo llvm-cov --no-report
+          -p cella-docker
+          --features integration-tests
+          -- --ignored --test-threads=1
+
+      - name: Run Compose integration tests with coverage
+        run: >
+          cargo llvm-cov --no-report
+          -p cella-compose
+          --features integration-tests
+          -- --ignored --test-threads=1
+
+      - name: Run template registry integration tests with coverage
+        run: >
+          cargo llvm-cov --no-report
+          -p cella-templates
+          --features integration-tests
+
       - name: Generate combined coverage report
         run: cargo llvm-cov report > coverage-report.txt
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,6 +119,7 @@ jobs:
           -p cella-features
           -p cella-daemon
           -p cella-compose
+          -p cella-agent
           --features integration-tests
 
       - name: Generate combined coverage report

--- a/crates/cella-agent/Cargo.toml
+++ b/crates/cella-agent/Cargo.toml
@@ -29,5 +29,8 @@ tracing-subscriber.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 
+[features]
+integration-tests = []
+
 [lints]
 workspace = true

--- a/crates/cella-agent/src/forward_proxy.rs
+++ b/crates/cella-agent/src/forward_proxy.rs
@@ -5,6 +5,7 @@
 //! Evaluates blocking rules against each request.
 
 use std::io;
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader, copy_bidirectional};
@@ -13,6 +14,15 @@ use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
 use crate::proxy_config::AgentProxyConfig;
+
+/// Running forward proxy listener.
+pub struct ForwardProxyHandle {
+    /// Address the proxy actually bound to.
+    pub local_addr: SocketAddr,
+    /// Background accept-loop task.
+    #[allow(dead_code)]
+    pub task: JoinHandle<()>,
+}
 
 /// Start the forward proxy server.
 ///
@@ -24,12 +34,13 @@ use crate::proxy_config::AgentProxyConfig;
 /// Returns an error if binding fails.
 pub async fn start_forward_proxy(
     config: Arc<AgentProxyConfig>,
-) -> Result<JoinHandle<()>, io::Error> {
+) -> Result<ForwardProxyHandle, io::Error> {
     let port = config.listen_port;
     let listener = TcpListener::bind(("127.0.0.1", port)).await?;
-    info!("Forward proxy listening on 127.0.0.1:{port}");
+    let local_addr = listener.local_addr()?;
+    info!("Forward proxy listening on {local_addr}");
 
-    let handle = tokio::spawn(async move {
+    let task = tokio::spawn(async move {
         loop {
             match listener.accept().await {
                 Ok((stream, peer)) => {
@@ -44,7 +55,7 @@ pub async fn start_forward_proxy(
         }
     });
 
-    Ok(handle)
+    Ok(ForwardProxyHandle { local_addr, task })
 }
 
 /// Handle a single proxy connection.

--- a/crates/cella-agent/src/integration_tests.rs
+++ b/crates/cella-agent/src/integration_tests.rs
@@ -1,0 +1,212 @@
+//! Integration tests for proxy-mediated network policy enforcement.
+
+use std::net::SocketAddr;
+use std::path::Path;
+use std::sync::Arc;
+
+use serde_json::Value;
+use tempfile::TempDir;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::task::JoinHandle;
+
+use crate::forward_proxy::{self, ForwardProxyHandle};
+use crate::proxy_config::AgentProxyConfig;
+
+struct UpstreamServer {
+    addr: SocketAddr,
+    task: JoinHandle<()>,
+}
+
+async fn start_upstream_server() -> UpstreamServer {
+    let listener = TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .expect("bind upstream server");
+    let addr = listener.local_addr().expect("upstream local addr");
+
+    let task = tokio::spawn(async move {
+        loop {
+            let Ok((mut stream, _peer)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                let mut headers = Vec::new();
+                let mut byte = [0_u8; 1];
+                while stream.read_exact(&mut byte).await.is_ok() {
+                    headers.push(byte[0]);
+                    if headers.ends_with(b"\r\n\r\n") || headers.ends_with(b"\n\n") {
+                        break;
+                    }
+                }
+
+                let body = b"upstream ok";
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+                let _ = stream.write_all(body).await;
+            });
+        }
+    });
+
+    UpstreamServer { addr, task }
+}
+
+async fn start_proxy(config_json: &str) -> ForwardProxyHandle {
+    let config = AgentProxyConfig::from_json(config_json).expect("parse proxy config");
+    forward_proxy::start_forward_proxy(Arc::new(config))
+        .await
+        .expect("start forward proxy")
+}
+
+fn proxy_config_json(mode: &str, rules: &[Value], log_path: &Path) -> String {
+    serde_json::json!({
+        "listen_port": 0,
+        "mode": mode,
+        "rules": rules,
+        "upstream_proxy": null,
+        "ca_cert_pem": null,
+        "ca_key_pem": null,
+        "log_path": log_path.to_string_lossy().into_owned(),
+    })
+    .to_string()
+}
+
+fn rule(domain: &str, paths: &[&str], action: &str) -> Value {
+    if paths.is_empty() {
+        serde_json::json!({
+            "domain": domain,
+            "action": action,
+        })
+    } else {
+        serde_json::json!({
+            "domain": domain,
+            "paths": paths,
+            "action": action,
+        })
+    }
+}
+
+async fn proxy_http_request(
+    proxy_addr: SocketAddr,
+    upstream_addr: SocketAddr,
+    path: &str,
+) -> String {
+    let mut stream = TcpStream::connect(proxy_addr)
+        .await
+        .expect("connect to proxy");
+    let target = format!("http://127.0.0.1:{}{path}", upstream_addr.port());
+    let request = format!(
+        "GET {target} HTTP/1.1\r\nHost: 127.0.0.1:{}\r\nConnection: close\r\n\r\n",
+        upstream_addr.port()
+    );
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .expect("write proxy request");
+
+    let mut response = Vec::new();
+    stream
+        .read_to_end(&mut response)
+        .await
+        .expect("read proxy response");
+    String::from_utf8(response).expect("utf8 proxy response")
+}
+
+async fn proxy_connect_request(proxy_addr: SocketAddr, port: u16) -> String {
+    let mut stream = TcpStream::connect(proxy_addr)
+        .await
+        .expect("connect to proxy");
+    let request = format!("CONNECT 127.0.0.1:{port} HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\n\r\n");
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .expect("write CONNECT request");
+
+    let mut response = Vec::new();
+    stream
+        .read_to_end(&mut response)
+        .await
+        .expect("read CONNECT response");
+    String::from_utf8(response).expect("utf8 CONNECT response")
+}
+
+#[tokio::test]
+async fn denylist_path_rule_blocks_matching_http_request() {
+    let log_dir = TempDir::new().expect("temp log dir");
+    let log_path = log_dir.path().join("proxy.log");
+    let upstream = start_upstream_server().await;
+    let config_json = proxy_config_json(
+        "denylist",
+        &[rule("127.0.0.1", &["/blocked/**"], "block")],
+        &log_path,
+    );
+    let proxy = start_proxy(&config_json).await;
+
+    let blocked = proxy_http_request(proxy.local_addr, upstream.addr, "/blocked/secret").await;
+    assert!(
+        blocked.starts_with("HTTP/1.1 403 Forbidden"),
+        "blocked response was {blocked:?}"
+    );
+
+    let allowed = proxy_http_request(proxy.local_addr, upstream.addr, "/allowed").await;
+    assert!(
+        allowed.starts_with("HTTP/1.1 200 OK"),
+        "allowed response was {allowed:?}"
+    );
+    assert!(allowed.contains("upstream ok"));
+
+    let log = std::fs::read_to_string(&log_path).expect("blocked-request log");
+    assert!(log.contains("BLOCKED\t127.0.0.1\t/blocked/secret"));
+
+    proxy.task.abort();
+    upstream.task.abort();
+}
+
+#[tokio::test]
+async fn allowlist_mode_blocks_unmatched_http_request() {
+    let log_dir = TempDir::new().expect("temp log dir");
+    let log_path = log_dir.path().join("proxy.log");
+    let upstream = start_upstream_server().await;
+    let config_json = proxy_config_json(
+        "allowlist",
+        &[rule("127.0.0.1", &["/allowed/**"], "allow")],
+        &log_path,
+    );
+    let proxy = start_proxy(&config_json).await;
+
+    let allowed = proxy_http_request(proxy.local_addr, upstream.addr, "/allowed/resource").await;
+    assert!(
+        allowed.starts_with("HTTP/1.1 200 OK"),
+        "allowed response was {allowed:?}"
+    );
+
+    let blocked = proxy_http_request(proxy.local_addr, upstream.addr, "/other").await;
+    assert!(
+        blocked.starts_with("HTTP/1.1 403 Forbidden"),
+        "blocked response was {blocked:?}"
+    );
+
+    proxy.task.abort();
+    upstream.task.abort();
+}
+
+#[tokio::test]
+async fn connect_domain_rule_is_blocked_before_upstream_connection() {
+    let log_dir = TempDir::new().expect("temp log dir");
+    let log_path = log_dir.path().join("proxy.log");
+    let config_json = proxy_config_json("denylist", &[rule("127.0.0.1", &[], "block")], &log_path);
+    let proxy = start_proxy(&config_json).await;
+
+    let blocked = proxy_connect_request(proxy.local_addr, 9).await;
+    assert!(
+        blocked.starts_with("HTTP/1.1 403 Forbidden"),
+        "CONNECT response was {blocked:?}"
+    );
+
+    let log = std::fs::read_to_string(&log_path).expect("blocked-request log");
+    assert!(log.contains("BLOCKED\t127.0.0.1\t/"));
+
+    proxy.task.abort();
+}

--- a/crates/cella-agent/src/main.rs
+++ b/crates/cella-agent/src/main.rs
@@ -204,7 +204,7 @@ async fn maybe_start_forward_proxy(proxy_config_json: Option<String>) {
             Ok(config) => {
                 let config = std::sync::Arc::new(config);
                 match forward_proxy::start_forward_proxy(config).await {
-                    Ok(_handle) => info!("Forward proxy started"),
+                    Ok(handle) => info!("Forward proxy started on {}", handle.local_addr),
                     Err(e) => error!("Failed to start forward proxy: {e}"),
                 }
             }

--- a/crates/cella-agent/src/main.rs
+++ b/crates/cella-agent/src/main.rs
@@ -14,6 +14,8 @@ mod cli;
 mod control;
 mod credential;
 mod forward_proxy;
+#[cfg(all(test, feature = "integration-tests"))]
+mod integration_tests;
 mod mitm;
 mod plugin_sync;
 mod port_proxy;

--- a/crates/cella-agent/src/proxy_config.rs
+++ b/crates/cella-agent/src/proxy_config.rs
@@ -235,4 +235,42 @@ mod tests {
         // Should not panic even if log file is available or not.
         config.log_blocked("evil.com", "/", "test reason");
     }
+
+    #[test]
+    fn from_json_with_custom_log_path_writes_blocked_request() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested").join("proxy.log");
+        let json = make_json(
+            "denylist",
+            "",
+            &format!(r#","log_path":"{}""#, path.display()),
+        );
+        let config = AgentProxyConfig::from_json(&json).unwrap();
+
+        config.log_blocked("blocked.example", "/secret", "matched deny rule");
+
+        let log = std::fs::read_to_string(path).unwrap();
+        assert!(log.contains("\tBLOCKED\tblocked.example\t/secret\tmatched deny rule"));
+    }
+
+    #[test]
+    fn log_blocked_appends_to_existing_custom_log_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("proxy.log");
+        std::fs::write(&path, "existing\n").unwrap();
+        let json = make_json(
+            "denylist",
+            "",
+            &format!(r#","log_path":"{}""#, path.display()),
+        );
+        let config = AgentProxyConfig::from_json(&json).unwrap();
+
+        config.log_blocked("one.example", "/", "first");
+        config.log_blocked("two.example", "/two", "second");
+
+        let log = std::fs::read_to_string(path).unwrap();
+        assert!(log.starts_with("existing\n"));
+        assert!(log.contains("\tBLOCKED\tone.example\t/\tfirst"));
+        assert!(log.contains("\tBLOCKED\ttwo.example\t/two\tsecond"));
+    }
 }

--- a/crates/cella-agent/src/proxy_config.rs
+++ b/crates/cella-agent/src/proxy_config.rs
@@ -4,6 +4,7 @@
 //! and builds the rule matcher for request evaluation.
 
 use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use cella_network::config::{NetworkConfig, NetworkMode, NetworkRule, RuleAction};
@@ -60,7 +61,7 @@ impl AgentProxyConfig {
         let matcher = RuleMatcher::new(&net_config);
 
         // Open log file.
-        let log_file = open_log_file();
+        let log_file = open_log_file(raw.log_path.as_deref());
 
         Ok(Self {
             listen_port: raw.listen_port,
@@ -88,10 +89,13 @@ impl AgentProxyConfig {
     }
 }
 
-fn open_log_file() -> Option<std::fs::File> {
-    let log_dir = "/tmp/.cella";
-    let _ = std::fs::create_dir_all(log_dir);
-    let path = format!("{log_dir}/proxy.log");
+fn open_log_file(log_path: Option<&str>) -> Option<std::fs::File> {
+    let path = log_path.map_or_else(|| PathBuf::from("/tmp/.cella/proxy.log"), PathBuf::from);
+    if let Some(parent) = path.parent()
+        && parent != Path::new("")
+    {
+        let _ = std::fs::create_dir_all(parent);
+    }
     std::fs::OpenOptions::new()
         .create(true)
         .append(true)
@@ -108,6 +112,7 @@ struct ProxyConfigJson {
     upstream_proxy: Option<String>,
     ca_cert_pem: Option<String>,
     ca_key_pem: Option<String>,
+    log_path: Option<String>,
 }
 
 /// A rule in the JSON config.

--- a/crates/cella-cli/src/commands/config.rs
+++ b/crates/cella-cli/src/commands/config.rs
@@ -94,3 +94,68 @@ fn validate(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_config(contents: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "cella-config-test-{}-{}.json",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::write(&path, contents).unwrap();
+        path
+    }
+
+    #[test]
+    fn validate_accepts_minimal_devcontainer_file() {
+        let path = temp_config(
+            r#"{
+                "image": "mcr.microsoft.com/devcontainers/base:ubuntu"
+            }"#,
+        );
+
+        let result = validate(Some(path.clone()), false);
+
+        let _ = std::fs::remove_file(path);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_reports_missing_file_path() {
+        let path = std::env::temp_dir().join("cella-config-test-missing-devcontainer.json");
+
+        let err = validate(Some(path.clone()), false).expect_err("missing file should fail");
+
+        assert!(err.to_string().contains(&path.display().to_string()));
+    }
+
+    #[test]
+    fn validate_rejects_invalid_json() {
+        let path = temp_config("{ invalid json");
+
+        let err = validate(Some(path.clone()), false).expect_err("invalid json should fail");
+
+        let _ = std::fs::remove_file(path);
+        assert!(err.to_string().contains("validation failed"));
+    }
+
+    #[test]
+    fn unimplemented_config_commands_return_error() {
+        for command in [
+            ConfigCommand::Show,
+            ConfigCommand::Global,
+            ConfigCommand::Dotfiles,
+            ConfigCommand::Agent,
+        ] {
+            let result = ConfigArgs { command }.execute();
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().to_string(), "not yet implemented");
+        }
+    }
+}

--- a/crates/cella-cli/src/commands/ports.rs
+++ b/crates/cella-cli/src/commands/ports.rs
@@ -72,7 +72,10 @@ fn is_remote_docker_host(host: &str) -> bool {
     }
     if let Some(rest) = host.strip_prefix("tcp://") {
         let authority = rest.split('/').next().unwrap_or(rest);
-        let hostname = authority.split(':').next().unwrap_or(authority);
+        let hostname = authority
+            .strip_prefix('[')
+            .and_then(|h| h.split_once(']').map(|(host, _)| host))
+            .unwrap_or_else(|| authority.split(':').next().unwrap_or(authority));
         return !matches!(hostname, "localhost" | "127.0.0.1" | "::1" | "[::1]");
     }
     // Unknown scheme — assume remote to be safe
@@ -308,4 +311,119 @@ fn print_container_ports(containers: &[ContainerInfo], is_orbstack: bool) {
     }
 
     table.eprint();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cella_backend::{BackendKind, ContainerState, PortBinding};
+    use std::collections::HashMap;
+
+    fn container(
+        name: &str,
+        workspace_path: Option<&str>,
+        ports: Vec<PortBinding>,
+    ) -> ContainerInfo {
+        let mut labels = HashMap::new();
+        if let Some(path) = workspace_path {
+            labels.insert("dev.cella.workspace_path".to_string(), path.to_string());
+        }
+        ContainerInfo {
+            id: format!("{name}-id"),
+            name: name.to_string(),
+            state: ContainerState::Running,
+            exit_code: None,
+            labels,
+            config_hash: None,
+            ports,
+            created_at: None,
+            container_user: None,
+            image: None,
+            mounts: Vec::new(),
+            backend: BackendKind::Docker,
+        }
+    }
+
+    fn port(container_port: u16, host_port: Option<u16>, protocol: &str) -> PortBinding {
+        PortBinding {
+            container_port,
+            host_port,
+            protocol: protocol.to_string(),
+        }
+    }
+
+    #[test]
+    fn remote_docker_host_detects_local_aliases() {
+        assert!(!is_remote_docker_host("unix:///var/run/docker.sock"));
+        assert!(!is_remote_docker_host("npipe:////./pipe/docker_engine"));
+        assert!(!is_remote_docker_host("tcp://localhost:2375"));
+        assert!(!is_remote_docker_host("tcp://127.0.0.1:2375"));
+        assert!(!is_remote_docker_host("tcp://[::1]:2375"));
+    }
+
+    #[test]
+    fn remote_docker_host_detects_remote_or_unknown_hosts() {
+        assert!(is_remote_docker_host("tcp://docker.example.com:2375"));
+        assert!(is_remote_docker_host("ssh://docker.example.com"));
+        assert!(is_remote_docker_host("http://localhost:2375"));
+    }
+
+    #[test]
+    fn print_daemon_ports_handles_multiple_rows() {
+        let ports = vec![
+            cella_protocol::ForwardedPortDetail {
+                container_name: "app".to_string(),
+                container_port: 3000,
+                host_port: 49152,
+                protocol: cella_protocol::PortProtocol::Tcp,
+                process: Some("node".to_string()),
+                url: "localhost:49152".to_string(),
+            },
+            cella_protocol::ForwardedPortDetail {
+                container_name: "api".to_string(),
+                container_port: 8080,
+                host_port: 49153,
+                protocol: cella_protocol::PortProtocol::Tcp,
+                process: None,
+                url: "localhost:49153".to_string(),
+            },
+        ];
+
+        print_daemon_ports(&ports);
+    }
+
+    #[test]
+    fn print_backend_ports_non_orbstack_handles_hostless_and_bound_ports() {
+        let containers = vec![container(
+            "cella-project",
+            Some("/workspaces/project"),
+            vec![port(3000, Some(49152), "tcp"), port(9229, None, "tcp")],
+        )];
+
+        print_all_container_ports(&containers, false);
+        print_container_ports(&containers, false);
+    }
+
+    #[test]
+    fn print_backend_ports_orbstack_uses_container_local_urls() {
+        let containers = vec![container(
+            "cella-project",
+            Some("/workspaces/project"),
+            vec![port(3000, Some(49152), "tcp")],
+        )];
+
+        print_all_container_ports(&containers, true);
+        print_container_ports(&containers, true);
+    }
+
+    #[test]
+    fn print_all_container_ports_falls_back_to_container_name_without_workspace_label() {
+        let containers = vec![container(
+            "unnamed-workspace",
+            None,
+            vec![port(8080, Some(49153), "tcp")],
+        )];
+
+        print_all_container_ports(&containers, false);
+    }
 }

--- a/crates/cella-cli/src/commands/template.rs
+++ b/crates/cella-cli/src/commands/template.rs
@@ -33,3 +33,27 @@ impl TemplateArgs {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn template_commands_return_not_implemented() {
+        let commands = [
+            TemplateCommand::New {
+                name: "rust".to_string(),
+            },
+            TemplateCommand::List,
+            TemplateCommand::Edit {
+                name: "node".to_string(),
+            },
+        ];
+
+        for command in commands {
+            let result = TemplateArgs { command }.execute();
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().to_string(), "not yet implemented");
+        }
+    }
+}

--- a/crates/cella-orchestrator/src/compose_up.rs
+++ b/crates/cella-orchestrator/src/compose_up.rs
@@ -1238,6 +1238,103 @@ mod tests {
     }
 
     #[test]
+    fn build_compose_labels_include_runtime_project_and_spec_identity() {
+        let config = serde_json::json!({});
+        let config_dir = tempfile::tempdir().unwrap();
+        let workspace_dir = tempfile::tempdir().unwrap();
+        let config_path = config_dir.path().join("devcontainer.json");
+        std::fs::write(&config_path, "{}").unwrap();
+        let cfg = ComposeUpConfig {
+            config: &config,
+            config_path: &config_path,
+            workspace_root: workspace_dir.path(),
+            container_name: "test-container",
+            remote_env: &[],
+            remove_container: false,
+            build_no_cache: false,
+            skip_checksum: false,
+            profiles: vec![],
+            env_files: vec![],
+            pull_policy: None,
+        };
+        let project = ComposeProject {
+            project_name: "cella-test-project".to_string(),
+            compose_files: vec![config_dir.path().join("docker-compose.yml")],
+            override_file: config_dir.path().join("docker-compose.cella.yml"),
+            primary_service: "web".to_string(),
+            run_services: Some(vec!["web".to_string(), "worker".to_string()]),
+            shutdown_action: cella_compose::ShutdownAction::StopCompose,
+            override_command: false,
+            workspace_folder: "/workspace/project".to_string(),
+            config_dir: config_dir.path().to_path_buf(),
+            workspace_root: workspace_dir.path().to_path_buf(),
+            config_hash: "hash456".to_string(),
+            profiles: vec!["dev".to_string()],
+            env_files: vec![config_dir.path().join(".env")],
+            pull_policy: Some("missing".to_string()),
+        };
+
+        let labels = build_compose_labels(&cfg, &project, "node");
+
+        assert_eq!(
+            labels.get("dev.cella.compose_project").map(String::as_str),
+            Some("cella-test-project")
+        );
+        assert_eq!(
+            labels.get("dev.cella.primary_service").map(String::as_str),
+            Some("web")
+        );
+        assert_eq!(
+            labels.get("dev.cella.workspace_folder").map(String::as_str),
+            Some("/workspace/project")
+        );
+        assert_eq!(
+            labels.get("dev.cella.remote_user").map(String::as_str),
+            Some("node")
+        );
+        assert_eq!(
+            labels.get("devcontainer.local_folder"),
+            labels.get("dev.cella.workspace_path")
+        );
+        assert_eq!(
+            labels.get("devcontainer.config_file"),
+            labels.get("dev.cella.config_path")
+        );
+        assert!(labels.contains_key("dev.cella.docker_runtime"));
+    }
+
+    #[test]
+    fn insert_mount_input_fingerprint_label_changes_with_forwarded_mounts() {
+        let workspace = tempfile::tempdir().unwrap();
+        let settings = cella_config::CellaConfig::default();
+        let mut labels = BTreeMap::new();
+        let env_fwd = cella_env::EnvForwarding::default();
+
+        insert_mount_input_fingerprint_label(&mut labels, &settings, &env_fwd, workspace.path());
+        let base = labels
+            .get("dev.cella.mount_input_fingerprint")
+            .cloned()
+            .expect("fingerprint label");
+
+        let mut changed_env_fwd = cella_env::EnvForwarding::default();
+        changed_env_fwd.mounts.push(cella_env::ForwardMount {
+            source: workspace.path().join("sock").to_string_lossy().into_owned(),
+            target: "/tmp/socket".to_string(),
+        });
+        insert_mount_input_fingerprint_label(
+            &mut labels,
+            &settings,
+            &changed_env_fwd,
+            workspace.path(),
+        );
+        let changed = labels
+            .get("dev.cella.mount_input_fingerprint")
+            .expect("updated fingerprint label");
+
+        assert_ne!(&base, changed);
+    }
+
+    #[test]
     fn build_extra_env_preserves_precedence_order() {
         // daemon_env first, then env_fwd, then remote_env, then agent vars.
         let env_fwd = cella_env::EnvForwarding {

--- a/crates/cella-orchestrator/src/tool_install.rs
+++ b/crates/cella-orchestrator/src/tool_install.rs
@@ -1185,13 +1185,27 @@ mod tests {
     /// Minimal mock that replays pre-configured `exec_command` responses in order.
     struct MockBackend {
         responses: Mutex<VecDeque<Result<ExecResult, BackendError>>>,
+        calls: Mutex<Vec<RecordedExec>>,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct RecordedExec {
+        cmd: Vec<String>,
+        user: Option<String>,
+        env: Option<Vec<String>>,
+        working_dir: Option<String>,
     }
 
     impl MockBackend {
         fn new(responses: Vec<Result<ExecResult, BackendError>>) -> Self {
             Self {
                 responses: Mutex::new(VecDeque::from(responses)),
+                calls: Mutex::new(Vec::new()),
             }
+        }
+
+        fn calls(&self) -> Vec<RecordedExec> {
+            self.calls.lock().unwrap().clone()
         }
     }
 
@@ -1274,8 +1288,14 @@ mod tests {
         fn exec_command<'a>(
             &'a self,
             _container_id: &'a str,
-            _opts: &'a ExecOptions,
+            opts: &'a ExecOptions,
         ) -> BoxFuture<'a, Result<ExecResult, BackendError>> {
+            self.calls.lock().unwrap().push(RecordedExec {
+                cmd: opts.cmd.clone(),
+                user: opts.user.clone(),
+                env: opts.env.clone(),
+                working_dir: opts.working_dir.clone(),
+            });
             let response = self
                 .responses
                 .lock()
@@ -1491,6 +1511,373 @@ mod tests {
         ]);
         let result = ensure_codex_sandbox_deps(&backend, "test-container").await;
         assert!(!result);
+    }
+
+    #[tokio::test]
+    async fn ensure_node_available_uses_existing_npm_on_probed_path() {
+        let mut env = ProbedEnv::new();
+        env.insert(
+            "PATH".to_string(),
+            "/home/vscode/.npm/bin:/usr/bin".to_string(),
+        );
+        let backend = MockBackend::new(vec![Ok(ok_exit(0))]);
+
+        assert!(ensure_node_available(&backend, "test-container", Some(&env)).await);
+
+        let calls = backend.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].cmd, vec!["sh", "-c", "command -v npm"]);
+        assert_eq!(
+            calls[0].env,
+            Some(vec!["PATH=/home/vscode/.npm/bin:/usr/bin".to_string()])
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_node_available_installs_with_apt_on_non_alpine() {
+        let backend = MockBackend::new(vec![
+            Ok(ok_exit(1)), // npm not found
+            Ok(ok_exit(1)), // not Alpine
+            Ok(ok_exit(0)), // apt-get install succeeds
+        ]);
+
+        assert!(ensure_node_available(&backend, "test-container", None).await);
+
+        let calls = backend.calls();
+        assert_eq!(calls[0].cmd, vec!["sh", "-l", "-c", "command -v npm"]);
+        assert_eq!(
+            calls[2].cmd,
+            vec![
+                "sh",
+                "-c",
+                "apt-get update -qq && apt-get install -y -qq nodejs npm"
+            ]
+        );
+        assert_eq!(calls[2].user.as_deref(), Some("root"));
+    }
+
+    #[tokio::test]
+    async fn ensure_node_available_installs_with_apk_on_alpine() {
+        let backend = MockBackend::new(vec![
+            Ok(ok_exit(1)), // npm not found
+            Ok(ok_exit(0)), // Alpine
+            Ok(ok_exit(0)), // apk install succeeds
+        ]);
+
+        assert!(ensure_node_available(&backend, "test-container", None).await);
+
+        let calls = backend.calls();
+        assert_eq!(
+            calls[2].cmd,
+            vec!["sh", "-c", "apk add --no-cache nodejs npm"]
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_node_available_returns_false_when_install_fails() {
+        let backend = MockBackend::new(vec![
+            Ok(ok_exit(1)),                        // npm not found
+            Ok(ok_exit(1)),                        // not Alpine
+            Ok(fail_exit(100, "apt unavailable")), // install fails
+        ]);
+
+        assert!(!ensure_node_available(&backend, "test-container", None).await);
+    }
+
+    #[tokio::test]
+    async fn claude_code_install_probe_accepts_latest_and_pinned_versions() {
+        let latest_backend = MockBackend::new(vec![Ok(ok_stdout(0, "Claude Code 9.9.9\n"))]);
+        assert!(
+            is_claude_code_installed(&latest_backend, "test-container", "vscode", "latest", None)
+                .await
+        );
+
+        let pinned_backend = MockBackend::new(vec![Ok(ok_stdout(0, "Claude Code 1.2.3\n"))]);
+        assert!(
+            is_claude_code_installed(&pinned_backend, "test-container", "vscode", "1.2.3", None)
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn claude_code_install_probe_rejects_mismatched_version() {
+        let backend = MockBackend::new(vec![Ok(ok_stdout(0, "Claude Code 1.2.3\n"))]);
+        assert!(
+            !is_claude_code_installed(&backend, "test-container", "vscode", "2.0.0", None).await
+        );
+    }
+
+    #[tokio::test]
+    async fn install_claude_code_short_circuits_when_requested_version_exists() {
+        let backend = MockBackend::new(vec![Ok(ok_stdout(0, "Claude Code 1.2.3\n"))]);
+        let settings = cella_config::settings::ClaudeCode {
+            enabled: true,
+            version: "1.2.3".to_string(),
+            forward_config: false,
+        };
+
+        let result =
+            install_claude_code(&backend, "test-container", "vscode", &settings, None).await;
+
+        assert!(result.is_none());
+        assert_eq!(backend.calls().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn install_claude_code_installs_alpine_deps_then_native_installer() {
+        let backend = MockBackend::new(vec![
+            Ok(ok_exit(1)), // claude --version not installed
+            Ok(ok_exit(0)), // Alpine detected
+            Ok(ok_exit(0)), // apk deps install
+            Ok(ok_exit(0)), // native installer
+        ]);
+        let settings = cella_config::settings::ClaudeCode {
+            enabled: true,
+            version: "stable".to_string(),
+            forward_config: false,
+        };
+
+        let result = install_claude_code(&backend, "test-container", "vscode", &settings, None)
+            .await
+            .expect("installer should run");
+
+        assert_eq!(result.exit_code, 0);
+        let calls = backend.calls();
+        assert_eq!(
+            calls[2].cmd,
+            vec!["sh", "-c", "apk add --no-cache libgcc libstdc++ ripgrep"]
+        );
+        assert_eq!(
+            calls[3].cmd,
+            vec![
+                "sh",
+                "-c",
+                "curl -fsSL https://claude.ai/install.sh | bash -s stable"
+            ]
+        );
+        assert_eq!(
+            calls[3].env,
+            Some(vec!["USE_BUILTIN_RIPGREP=0".to_string()])
+        );
+    }
+
+    #[tokio::test]
+    async fn run_claude_install_preserves_probed_path_and_alpine_flag() {
+        let mut env = ProbedEnv::new();
+        env.insert("PATH".to_string(), "/opt/tools/bin:/usr/bin".to_string());
+        let backend = MockBackend::new(vec![Ok(ok_exit(0))]);
+
+        let result = run_claude_install(
+            &backend,
+            "test-container",
+            "vscode",
+            "1.0.0",
+            true,
+            Some(&env),
+        )
+        .await;
+
+        assert_eq!(result.exit_code, 0);
+        let calls = backend.calls();
+        assert_eq!(
+            calls[0].env,
+            Some(vec![
+                "PATH=/opt/tools/bin:/usr/bin".to_string(),
+                "USE_BUILTIN_RIPGREP=0".to_string()
+            ])
+        );
+        assert_eq!(calls[0].user.as_deref(), Some("vscode"));
+    }
+
+    #[tokio::test]
+    async fn npm_tool_probe_accepts_latest_and_pinned_versions() {
+        let latest_backend = MockBackend::new(vec![Ok(ok_stdout(0, "0.99.0\n"))]);
+        assert!(
+            is_npm_tool_installed(
+                &latest_backend,
+                "test-container",
+                "vscode",
+                "codex",
+                "latest",
+                None
+            )
+            .await
+        );
+
+        let pinned_backend = MockBackend::new(vec![Ok(ok_stdout(0, "codex 0.42.0\n"))]);
+        assert!(
+            is_npm_tool_installed(
+                &pinned_backend,
+                "test-container",
+                "vscode",
+                "codex",
+                "0.42.0",
+                None
+            )
+            .await
+        );
+    }
+
+    #[tokio::test]
+    async fn npm_tool_probe_rejects_nonzero_and_mismatched_versions() {
+        let nonzero_backend = MockBackend::new(vec![Ok(ok_exit(127))]);
+        assert!(
+            !is_npm_tool_installed(
+                &nonzero_backend,
+                "test-container",
+                "vscode",
+                "gemini",
+                "latest",
+                None,
+            )
+            .await
+        );
+
+        let mismatch_backend = MockBackend::new(vec![Ok(ok_stdout(0, "0.1.0\n"))]);
+        assert!(
+            !is_npm_tool_installed(
+                &mismatch_backend,
+                "test-container",
+                "vscode",
+                "gemini",
+                "0.2.0",
+                None,
+            )
+            .await
+        );
+    }
+
+    #[tokio::test]
+    async fn npm_install_global_omits_latest_suffix_and_pins_specific_version() {
+        let latest_backend = MockBackend::new(vec![Ok(ok_exit(0))]);
+        npm_install_global(
+            &latest_backend,
+            "test-container",
+            "vscode",
+            "@openai/codex",
+            "latest",
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            latest_backend.calls()[0].cmd,
+            vec!["sh", "-l", "-c", "npm install -g @openai/codex"]
+        );
+
+        let pinned_backend = MockBackend::new(vec![Ok(ok_exit(0))]);
+        npm_install_global(
+            &pinned_backend,
+            "test-container",
+            "vscode",
+            "@google/gemini-cli",
+            "1.2.3",
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            pinned_backend.calls()[0].cmd,
+            vec!["sh", "-l", "-c", "npm install -g @google/gemini-cli@1.2.3"]
+        );
+    }
+
+    #[tokio::test]
+    async fn install_codex_installs_deps_then_npm_package_when_missing() {
+        let backend = MockBackend::new(vec![
+            Ok(ok_exit(1)), // bwrap not found
+            Ok(ok_exit(1)), // not Alpine
+            Ok(ok_exit(0)), // apt bubblewrap install succeeds
+            Ok(ok_exit(1)), // codex --version missing
+            Ok(ok_exit(0)), // npm install succeeds
+        ]);
+        let settings = cella_config::settings::Codex {
+            enabled: true,
+            version: "0.42.0".to_string(),
+            forward_config: false,
+        };
+
+        let result = install_codex(&backend, "test-container", "vscode", &settings, None)
+            .await
+            .expect("npm should run");
+
+        assert_eq!(result.exit_code, 0);
+        let calls = backend.calls();
+        assert_eq!(
+            calls[2].cmd,
+            vec![
+                "sh",
+                "-c",
+                "apt-get update -qq && apt-get install -y -qq bubblewrap"
+            ]
+        );
+        assert_eq!(
+            calls[4].cmd,
+            vec!["sh", "-l", "-c", "npm install -g @openai/codex@0.42.0"]
+        );
+    }
+
+    #[tokio::test]
+    async fn install_codex_short_circuits_when_requested_version_exists() {
+        let backend = MockBackend::new(vec![
+            Ok(ok_exit(0)), // bwrap already installed
+            Ok(ok_stdout(0, "codex 0.42.0\n")),
+        ]);
+        let settings = cella_config::settings::Codex {
+            enabled: true,
+            version: "0.42.0".to_string(),
+            forward_config: false,
+        };
+
+        let result = install_codex(&backend, "test-container", "vscode", &settings, None).await;
+
+        assert!(result.is_none());
+        assert_eq!(backend.calls().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn install_gemini_installs_when_missing() {
+        let backend = MockBackend::new(vec![
+            Ok(ok_exit(1)), // gemini --version missing
+            Ok(ok_exit(0)), // npm install succeeds
+        ]);
+        let settings = cella_config::settings::Gemini {
+            enabled: true,
+            version: "latest".to_string(),
+            forward_config: false,
+        };
+
+        let result = install_gemini(&backend, "test-container", "vscode", &settings, None)
+            .await
+            .expect("npm should run");
+
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(
+            backend.calls()[1].cmd,
+            vec!["sh", "-l", "-c", "npm install -g @google/gemini-cli"]
+        );
+    }
+
+    #[tokio::test]
+    async fn install_gemini_flattens_backend_error_into_exec_result() {
+        let backend = MockBackend::new(vec![
+            Ok(ok_exit(1)), // gemini --version missing
+            Err(BackendError::ContainerNotFound {
+                identifier: "gone".into(),
+            }),
+        ]);
+        let settings = cella_config::settings::Gemini {
+            enabled: true,
+            version: "latest".to_string(),
+            forward_config: false,
+        };
+
+        let result = install_gemini(&backend, "test-container", "vscode", &settings, None)
+            .await
+            .expect("error should be flattened");
+
+        assert_eq!(result.exit_code, -1);
+        assert!(result.stderr.contains("gone"));
     }
 
     #[test]

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -1599,5 +1599,46 @@ mod tests {
             .await;
         hooks.on_container_stopping("test-container").await;
         assert!(hooks.daemon_env("test", "host").await.is_empty());
+        assert!(hooks.update_container_ip("container-123", None).await);
+    }
+
+    #[tokio::test]
+    async fn run_step_result_emits_completed_event_on_success() {
+        use crate::progress::{ProgressEvent, ProgressSender};
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<ProgressEvent>(8);
+        let progress = ProgressSender::new(tx, false);
+
+        let value = run_step_result(&progress, "Doing work...", async {
+            Ok::<_, std::convert::Infallible>("done")
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(value, "done");
+        let first = rx.try_recv().expect("phase started");
+        let second = rx.try_recv().expect("phase completed");
+        assert!(matches!(first, ProgressEvent::StepStarted { .. }));
+        assert!(matches!(second, ProgressEvent::StepCompleted { .. }));
+    }
+
+    #[tokio::test]
+    async fn run_step_result_emits_failed_event_on_error() {
+        use crate::progress::{ProgressEvent, ProgressSender};
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<ProgressEvent>(8);
+        let progress = ProgressSender::new(tx, false);
+
+        let result =
+            run_step_result(&progress, "Doing work...", async { Err::<(), _>("boom") }).await;
+
+        assert_eq!(result, Err("boom"));
+        let first = rx.try_recv().expect("phase started");
+        let second = rx.try_recv().expect("phase failed");
+        assert!(matches!(first, ProgressEvent::StepStarted { .. }));
+        assert!(matches!(
+            second,
+            ProgressEvent::StepFailed { message, .. } if message == "boom"
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- add feature-gated cella-agent integration tests for proxy-mediated network policy
- expose the proxy bound address so tests can use ephemeral ports safely
- isolate blocked-request logs during tests
- include cella-agent in the CI integration-test coverage job

## Notes
These tests verify Cella's current proxy-rule contract for HTTP(S) clients that use the injected proxy path. They do not claim hard raw-socket egress isolation.

## Validation
- cargo test -p cella-agent --features integration-tests
- cargo clippy -p cella-agent --all-features --all-targets -- -D warnings -D clippy::all