### PR TITLE
fix: network path blocking for Docker Compose devcontainers

### DIFF
--- a/crates/cella-agent/src/forward_proxy.rs
+++ b/crates/cella-agent/src/forward_proxy.rs
@@ -141,16 +141,19 @@ async fn handle_connect(mut client: BufReader<TcpStream>, target: &str, config: 
         return;
     }
 
-    if needs_path_inspection && config.warn_no_mitm_once(&host) {
-        warn!(
-            "CONNECT to {host}: path-level rules exist but MITM is unavailable; \
-             path blocking disabled (requires TLS interception)"
-        );
-    }
-
-    // Evaluate domain-level rules. The "/" path won't trigger path-specific
-    // rules, so domain blocks still apply even without MITM.
-    let verdict = config.matcher.evaluate(&host, "/");
+    // When MITM is unavailable, evaluate domain-level rules only — path
+    // rules are skipped entirely rather than matched against a fake path.
+    let verdict = if needs_path_inspection {
+        if config.warn_no_mitm_once(&host) {
+            warn!(
+                "CONNECT to {host}: path-level rules exist but MITM is unavailable; \
+                 path blocking disabled (requires TLS interception)"
+            );
+        }
+        config.matcher.evaluate_domain_only(&host)
+    } else {
+        config.matcher.evaluate(&host, "/")
+    };
     if !verdict.allowed {
         info!("BLOCKED CONNECT to {host}:{port} - {}", verdict.reason);
         config.log_blocked(&host, "/", &verdict.reason);

--- a/crates/cella-agent/src/forward_proxy.rs
+++ b/crates/cella-agent/src/forward_proxy.rs
@@ -141,19 +141,30 @@ async fn handle_connect(mut client: BufReader<TcpStream>, target: &str, config: 
         return;
     }
 
-    // No MITM available or no path-level rules — evaluate domain-level only.
-    let verdict = config.matcher.evaluate(&host, "/");
-    if !verdict.allowed {
-        info!("BLOCKED CONNECT to {host}:{port} - {}", verdict.reason);
-        config.log_blocked(&host, "/", &verdict.reason);
-        let _ = client
-            .get_mut()
-            .write_all(b"HTTP/1.1 403 Forbidden\r\n\r\n")
-            .await;
-        return;
+    if needs_path_inspection {
+        // Path-level rules but MITM unavailable — can't inspect paths without
+        // TLS interception. Warn once per domain and allow through.
+        if config.warn_no_mitm_once(&host) {
+            warn!(
+                "CONNECT to {host}: path-level rules exist but MITM is unavailable; \
+                 allowing connection (path blocking requires TLS interception)"
+            );
+        }
+    } else {
+        // Domain-only rules — evaluate without path inspection.
+        let verdict = config.matcher.evaluate(&host, "/");
+        if !verdict.allowed {
+            info!("BLOCKED CONNECT to {host}:{port} - {}", verdict.reason);
+            config.log_blocked(&host, "/", &verdict.reason);
+            let _ = client
+                .get_mut()
+                .write_all(b"HTTP/1.1 403 Forbidden\r\n\r\n")
+                .await;
+            return;
+        }
     }
 
-    // No path-level rules — just tunnel without MITM.
+    // Tunnel without MITM.
     let upstream = match connect_upstream(&host, port, config).await {
         Ok(s) => s,
         Err(e) => {

--- a/crates/cella-agent/src/forward_proxy.rs
+++ b/crates/cella-agent/src/forward_proxy.rs
@@ -141,27 +141,24 @@ async fn handle_connect(mut client: BufReader<TcpStream>, target: &str, config: 
         return;
     }
 
-    if needs_path_inspection {
-        // Path-level rules but MITM unavailable — can't inspect paths without
-        // TLS interception. Warn once per domain and allow through.
-        if config.warn_no_mitm_once(&host) {
-            warn!(
-                "CONNECT to {host}: path-level rules exist but MITM is unavailable; \
-                 allowing connection (path blocking requires TLS interception)"
-            );
-        }
-    } else {
-        // Domain-only rules — evaluate without path inspection.
-        let verdict = config.matcher.evaluate(&host, "/");
-        if !verdict.allowed {
-            info!("BLOCKED CONNECT to {host}:{port} - {}", verdict.reason);
-            config.log_blocked(&host, "/", &verdict.reason);
-            let _ = client
-                .get_mut()
-                .write_all(b"HTTP/1.1 403 Forbidden\r\n\r\n")
-                .await;
-            return;
-        }
+    if needs_path_inspection && config.warn_no_mitm_once(&host) {
+        warn!(
+            "CONNECT to {host}: path-level rules exist but MITM is unavailable; \
+             path blocking disabled (requires TLS interception)"
+        );
+    }
+
+    // Evaluate domain-level rules. The "/" path won't trigger path-specific
+    // rules, so domain blocks still apply even without MITM.
+    let verdict = config.matcher.evaluate(&host, "/");
+    if !verdict.allowed {
+        info!("BLOCKED CONNECT to {host}:{port} - {}", verdict.reason);
+        config.log_blocked(&host, "/", &verdict.reason);
+        let _ = client
+            .get_mut()
+            .write_all(b"HTTP/1.1 403 Forbidden\r\n\r\n")
+            .await;
+        return;
     }
 
     // Tunnel without MITM.

--- a/crates/cella-agent/src/integration_tests.rs
+++ b/crates/cella-agent/src/integration_tests.rs
@@ -288,3 +288,28 @@ async fn connect_with_path_rules_but_no_mitm_allows_through() {
     proxy.task.abort();
     upstream.task.abort();
 }
+
+#[tokio::test]
+async fn connect_domain_block_still_enforced_without_mitm() {
+    let log_dir = TempDir::new().expect("temp log dir");
+    let log_path = log_dir.path().join("proxy.log");
+    // Domain has both a domain-level block AND a path-level rule.
+    // Without MITM, path rules can't fire but the domain block must.
+    let config_json = proxy_config_json(
+        "denylist",
+        &[
+            rule("127.0.0.1", &[], "block"),
+            rule("127.0.0.1", &["/secret/**"], "block"),
+        ],
+        &log_path,
+    );
+    let proxy = start_proxy(&config_json).await;
+
+    let blocked = proxy_connect_request(proxy.local_addr, 9).await;
+    assert!(
+        blocked.starts_with("HTTP/1.1 403 Forbidden"),
+        "domain block should still apply without MITM, got {blocked:?}"
+    );
+
+    proxy.task.abort();
+}

--- a/crates/cella-agent/src/integration_tests.rs
+++ b/crates/cella-agent/src/integration_tests.rs
@@ -132,6 +132,59 @@ async fn proxy_connect_request(proxy_addr: SocketAddr, port: u16) -> String {
     String::from_utf8(response).expect("utf8 CONNECT response")
 }
 
+/// Send CONNECT, then tunnel an HTTP GET through the established connection.
+/// Returns the CONNECT status line if it fails (e.g. 403), or the tunneled
+/// HTTP response body if the tunnel is established.
+async fn proxy_connect_and_tunnel(
+    proxy_addr: SocketAddr,
+    upstream_addr: SocketAddr,
+    path: &str,
+) -> String {
+    let mut stream = TcpStream::connect(proxy_addr)
+        .await
+        .expect("connect to proxy");
+    let connect_req = format!(
+        "CONNECT 127.0.0.1:{} HTTP/1.1\r\nHost: 127.0.0.1:{}\r\n\r\n",
+        upstream_addr.port(),
+        upstream_addr.port(),
+    );
+    stream
+        .write_all(connect_req.as_bytes())
+        .await
+        .expect("write CONNECT");
+
+    // Read CONNECT response headers.
+    let mut headers = Vec::new();
+    let mut byte = [0_u8; 1];
+    while stream.read_exact(&mut byte).await.is_ok() {
+        headers.push(byte[0]);
+        if headers.ends_with(b"\r\n\r\n") {
+            break;
+        }
+    }
+    let connect_response = String::from_utf8_lossy(&headers).to_string();
+    if !connect_response.starts_with("HTTP/1.1 200") {
+        return connect_response;
+    }
+
+    // Tunnel is open — send plain HTTP through it.
+    let http_req = format!(
+        "GET {path} HTTP/1.1\r\nHost: 127.0.0.1:{}\r\nConnection: close\r\n\r\n",
+        upstream_addr.port(),
+    );
+    stream
+        .write_all(http_req.as_bytes())
+        .await
+        .expect("write HTTP through tunnel");
+
+    let mut response = Vec::new();
+    stream
+        .read_to_end(&mut response)
+        .await
+        .expect("read tunneled response");
+    String::from_utf8(response).expect("utf8 tunneled response")
+}
+
 #[tokio::test]
 async fn denylist_path_rule_blocks_matching_http_request() {
     let log_dir = TempDir::new().expect("temp log dir");
@@ -209,4 +262,29 @@ async fn connect_domain_rule_is_blocked_before_upstream_connection() {
     assert!(log.contains("BLOCKED\t127.0.0.1\t/"));
 
     proxy.task.abort();
+}
+
+#[tokio::test]
+async fn connect_with_path_rules_but_no_mitm_allows_through() {
+    let log_dir = TempDir::new().expect("temp log dir");
+    let log_path = log_dir.path().join("proxy.log");
+    let upstream = start_upstream_server().await;
+    // Path-level rule but no ca_cert_pem/ca_key_pem → no MITM available.
+    let config_json = proxy_config_json(
+        "denylist",
+        &[rule("127.0.0.1", &["/blocked/**"], "block")],
+        &log_path,
+    );
+    let proxy = start_proxy(&config_json).await;
+
+    // CONNECT should succeed (200) and tunnel to upstream, not 403.
+    let response =
+        proxy_connect_and_tunnel(proxy.local_addr, upstream.addr, "/blocked/secret").await;
+    assert!(
+        response.contains("upstream ok"),
+        "expected tunnel passthrough, got {response:?}"
+    );
+
+    proxy.task.abort();
+    upstream.task.abort();
 }

--- a/crates/cella-agent/src/proxy_config.rs
+++ b/crates/cella-agent/src/proxy_config.rs
@@ -3,6 +3,7 @@
 //! Deserializes the proxy config passed via `--proxy-config` JSON argument
 //! and builds the rule matcher for request evaluation.
 
+use std::collections::HashSet;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
@@ -29,6 +30,9 @@ pub struct AgentProxyConfig {
 
     /// Log file for blocked requests.
     log_file: Mutex<Option<std::fs::File>>,
+
+    /// Domains already warned about missing MITM (prevents log spam).
+    warned_no_mitm: Mutex<HashSet<String>>,
 }
 
 impl AgentProxyConfig {
@@ -70,6 +74,7 @@ impl AgentProxyConfig {
             ca_cert_pem: raw.ca_cert_pem,
             ca_key_pem: raw.ca_key_pem,
             log_file: Mutex::new(log_file),
+            warned_no_mitm: Mutex::new(HashSet::new()),
         })
     }
 
@@ -86,6 +91,14 @@ impl AgentProxyConfig {
             .map(|d| d.as_secs())
             .unwrap_or(0);
         let _ = writeln!(file, "{timestamp}\tBLOCKED\t{domain}\t{path}\t{reason}");
+    }
+
+    /// Returns `true` the first time a domain is seen (caller should log the warning).
+    pub fn warn_no_mitm_once(&self, domain: &str) -> bool {
+        let Ok(mut set) = self.warned_no_mitm.lock() else {
+            return false;
+        };
+        set.insert(domain.to_string())
     }
 }
 
@@ -272,5 +285,14 @@ mod tests {
         assert!(log.starts_with("existing\n"));
         assert!(log.contains("\tBLOCKED\tone.example\t/\tfirst"));
         assert!(log.contains("\tBLOCKED\ttwo.example\t/two\tsecond"));
+    }
+
+    #[test]
+    fn warn_no_mitm_once_deduplicates() {
+        let json = make_json("denylist", "", "");
+        let config = AgentProxyConfig::from_json(&json).unwrap();
+        assert!(config.warn_no_mitm_once("example.com"));
+        assert!(!config.warn_no_mitm_once("example.com"));
+        assert!(config.warn_no_mitm_once("other.com"));
     }
 }

--- a/crates/cella-cli/src/commands/compose_up.rs
+++ b/crates/cella-cli/src/commands/compose_up.rs
@@ -127,7 +127,7 @@ impl ComposeUpHooks for CliComposeUpHooks<'_> {
 
     fn post_create_setup<'a>(
         &'a self,
-        _client: &'a dyn ContainerBackend,
+        client: &'a dyn ContainerBackend,
         container_id: &'a str,
         remote_user: &'a str,
         config: &'a serde_json::Value,
@@ -135,7 +135,14 @@ impl ComposeUpHooks for CliComposeUpHooks<'_> {
         remote_env: &'a [String],
     ) -> Pin<Box<dyn Future<Output = Vec<String>> + Send + 'a>> {
         Box::pin(async move {
-            let env_fwd = cella_env::prepare_env_forwarding(config, remote_user, None);
+            let managed_agent = client.capabilities().managed_agent;
+            let proxy_fwd = cella_orchestrator::compose_up::build_proxy_forwarding_config(
+                config,
+                workspace_root,
+                managed_agent,
+            );
+            let env_fwd =
+                cella_env::prepare_env_forwarding(config, remote_user, proxy_fwd.as_ref());
             // Trait method can't return Result; fall back to defaults on config error.
             let settings =
                 cella_config::CellaConfig::load(workspace_root, Some(&self.ctx.resolved))

--- a/crates/cella-cli/src/commands/compose_up.rs
+++ b/crates/cella-cli/src/commands/compose_up.rs
@@ -34,6 +34,7 @@ pub async fn compose_ensure_up(
         profiles: ctx.compose_profiles.clone(),
         env_files: ctx.compose_env_files.clone(),
         pull_policy: ctx.compose_pull_policy.clone(),
+        network_rule_policy: ctx.network_rules,
     };
 
     let (sender, renderer) = crate::progress::bridge(&ctx.progress);
@@ -136,10 +137,12 @@ impl ComposeUpHooks for CliComposeUpHooks<'_> {
     ) -> Pin<Box<dyn Future<Output = Vec<String>> + Send + 'a>> {
         Box::pin(async move {
             let managed_agent = client.capabilities().managed_agent;
+            let skip_rules = self.ctx.network_rules == cella_orchestrator::NetworkRulePolicy::Skip;
             let proxy_fwd = cella_orchestrator::compose_up::build_proxy_forwarding_config(
                 config,
                 workspace_root,
                 managed_agent,
+                skip_rules,
             );
             let env_fwd =
                 cella_env::prepare_env_forwarding(config, remote_user, proxy_fwd.as_ref());

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -117,7 +117,7 @@ pub struct UpContext {
     /// Extra Docker labels to merge into the container (e.g., worktree labels).
     extra_labels: std::collections::HashMap<String, String>,
     /// Network rule enforcement policy.
-    network_rules: NetworkRulePolicy,
+    pub(crate) network_rules: NetworkRulePolicy,
     /// Docker host override (forwarded to daemon registration).
     docker_host: Option<String>,
     /// Docker Compose profiles to activate.

--- a/crates/cella-network/src/rules.rs
+++ b/crates/cella-network/src/rules.rs
@@ -119,6 +119,50 @@ impl RuleMatcher {
         }
     }
 
+    /// Evaluate only domain-level rules (rules without path patterns).
+    ///
+    /// Used for CONNECT requests when MITM is unavailable — path-level rules
+    /// are skipped entirely rather than evaluated against a fake path.
+    pub fn evaluate_domain_only(&self, domain: &str) -> RuleVerdict {
+        let domain_lower = domain.to_ascii_lowercase();
+
+        for rule in &self.rules {
+            if !rule.path_patterns.is_empty() {
+                continue;
+            }
+            if !match_domain(&rule.domain_parts, &domain_lower) {
+                continue;
+            }
+
+            let allowed = rule.action == RuleAction::Allow;
+            return RuleVerdict {
+                allowed,
+                reason: format!(
+                    "{} by rule: {}",
+                    if allowed { "allowed" } else { "blocked" },
+                    rule.pattern_display,
+                ),
+                matched_rule: Some(rule.pattern_display.clone()),
+                source: Some(rule.source.clone()),
+            };
+        }
+
+        match self.mode {
+            NetworkMode::Denylist => RuleVerdict {
+                allowed: true,
+                reason: "allowed (no matching deny rule)".to_string(),
+                matched_rule: None,
+                source: None,
+            },
+            NetworkMode::Allowlist => RuleVerdict {
+                allowed: false,
+                reason: "blocked (no matching allow rule)".to_string(),
+                matched_rule: None,
+                source: None,
+            },
+        }
+    }
+
     /// Check whether any rule for the given domain requires path inspection.
     ///
     /// If `true`, MITM TLS interception is needed for this domain.
@@ -533,5 +577,54 @@ mod tests {
 
         let v = matcher.evaluate("example.com", "");
         assert!(!v.allowed);
+    }
+
+    #[test]
+    fn evaluate_domain_only_skips_path_rules() {
+        let config = NetworkConfig {
+            mode: NetworkMode::Denylist,
+            rules: vec![NetworkRule {
+                domain: "example.com".to_string(),
+                paths: vec!["/**".to_string()],
+                action: RuleAction::Block,
+            }],
+            ..Default::default()
+        };
+        let matcher = RuleMatcher::new(&config);
+
+        // Full evaluate with "/" matches the "/**" path rule → blocked.
+        assert!(!matcher.evaluate("example.com", "/").allowed);
+        // Domain-only skips the path rule → allowed (denylist default).
+        assert!(matcher.evaluate_domain_only("example.com").allowed);
+    }
+
+    #[test]
+    fn evaluate_domain_only_still_blocks_domain_rules() {
+        let config = NetworkConfig {
+            mode: NetworkMode::Denylist,
+            rules: vec![
+                NetworkRule {
+                    domain: "evil.com".to_string(),
+                    paths: vec![],
+                    action: RuleAction::Block,
+                },
+                NetworkRule {
+                    domain: "mixed.com".to_string(),
+                    paths: vec!["/secret/**".to_string()],
+                    action: RuleAction::Block,
+                },
+                NetworkRule {
+                    domain: "mixed.com".to_string(),
+                    paths: vec![],
+                    action: RuleAction::Block,
+                },
+            ],
+            ..Default::default()
+        };
+        let matcher = RuleMatcher::new(&config);
+
+        assert!(!matcher.evaluate_domain_only("evil.com").allowed);
+        assert!(!matcher.evaluate_domain_only("mixed.com").allowed);
+        assert!(matcher.evaluate_domain_only("good.com").allowed);
     }
 }

--- a/crates/cella-orchestrator/src/compose_up.rs
+++ b/crates/cella-orchestrator/src/compose_up.rs
@@ -298,7 +298,10 @@ async fn resolve_user_and_env(
     let (image_user, image_meta_user) =
         resolve_compose_image_info(client, project, features_build, progress).await;
     let remote_user = resolve_remote_user(cfg.config, image_meta_user.as_ref(), &image_user);
-    let mut env_fwd = cella_env::prepare_env_forwarding(cfg.config, &remote_user, None);
+    let managed_agent = client.capabilities().managed_agent;
+    let proxy_fwd = build_proxy_forwarding_config(cfg.config, cfg.workspace_root, managed_agent);
+    let mut env_fwd =
+        cella_env::prepare_env_forwarding(cfg.config, &remote_user, proxy_fwd.as_ref());
     let ssh_agent_proxy = resolve_ssh_agent_proxy_for_compose(
         &mut env_fwd,
         cfg.workspace_root,
@@ -1157,6 +1160,44 @@ where
             Err(error)
         }
     }
+}
+
+/// Build proxy forwarding config from devcontainer.json and cella.toml network settings.
+///
+/// Mirrors the network config resolution in `Up::resolve_image_config` (up.rs).
+/// Used by both the orchestrator's `resolve_user_and_env` and the CLI's `post_create_setup`.
+pub fn build_proxy_forwarding_config(
+    config: &serde_json::Value,
+    workspace_root: &Path,
+    managed_agent: bool,
+) -> Option<cella_env::ProxyForwardingConfig> {
+    let settings = cella_config::CellaConfig::load(workspace_root, None).unwrap_or_default();
+    let toml_net = settings.network.to_network_config();
+    let toml_mode_override = settings.network.mode_override();
+    let dc_net = config
+        .get("customizations")
+        .and_then(|c| c.get("cella"))
+        .and_then(|c| c.get("network"))
+        .and_then(|n| serde_json::from_value::<cella_network::NetworkConfig>(n.clone()).ok());
+    let merged =
+        cella_network::merge_network_configs(dc_net.as_ref(), Some(&toml_net), toml_mode_override);
+    let net_config = cella_network::NetworkConfig {
+        mode: merged.mode,
+        proxy: merged.proxy,
+        rules: merged.rules.into_iter().map(|lr| lr.rule).collect(),
+    };
+    let has_rules = net_config.has_rules();
+
+    Some(cella_env::ProxyForwardingConfig {
+        proxy: net_config.proxy.clone(),
+        has_blocking_rules: has_rules && managed_agent,
+        full_config: if has_rules && managed_agent {
+            Some(net_config)
+        } else {
+            None
+        },
+        container_distro: cella_env::ca_bundle::ContainerDistro::Unknown,
+    })
 }
 
 #[cfg(test)]

--- a/crates/cella-orchestrator/src/compose_up.rs
+++ b/crates/cella-orchestrator/src/compose_up.rs
@@ -49,6 +49,8 @@ pub struct ComposeUpConfig<'a> {
     pub env_files: Vec<PathBuf>,
     /// Pull policy for docker compose up/build (`--pull` flag).
     pub pull_policy: Option<String>,
+    /// Network rule enforcement policy.
+    pub network_rule_policy: crate::NetworkRulePolicy,
 }
 
 // ---------------------------------------------------------------------------
@@ -299,7 +301,9 @@ async fn resolve_user_and_env(
         resolve_compose_image_info(client, project, features_build, progress).await;
     let remote_user = resolve_remote_user(cfg.config, image_meta_user.as_ref(), &image_user);
     let managed_agent = client.capabilities().managed_agent;
-    let proxy_fwd = build_proxy_forwarding_config(cfg.config, cfg.workspace_root, managed_agent);
+    let skip_rules = cfg.network_rule_policy == crate::NetworkRulePolicy::Skip;
+    let proxy_fwd =
+        build_proxy_forwarding_config(cfg.config, cfg.workspace_root, managed_agent, skip_rules);
     let mut env_fwd =
         cella_env::prepare_env_forwarding(cfg.config, &remote_user, proxy_fwd.as_ref());
     let ssh_agent_proxy = resolve_ssh_agent_proxy_for_compose(
@@ -1170,6 +1174,7 @@ pub fn build_proxy_forwarding_config(
     config: &serde_json::Value,
     workspace_root: &Path,
     managed_agent: bool,
+    skip_rules: bool,
 ) -> Option<cella_env::ProxyForwardingConfig> {
     let settings = cella_config::CellaConfig::load(workspace_root, None).unwrap_or_default();
     let toml_net = settings.network.to_network_config();
@@ -1186,7 +1191,7 @@ pub fn build_proxy_forwarding_config(
         proxy: merged.proxy,
         rules: merged.rules.into_iter().map(|lr| lr.rule).collect(),
     };
-    let has_rules = net_config.has_rules();
+    let has_rules = net_config.has_rules() && !skip_rules;
 
     Some(cella_env::ProxyForwardingConfig {
         proxy: net_config.proxy.clone(),
@@ -1253,6 +1258,7 @@ mod tests {
             profiles: vec![],
             env_files: vec![],
             pull_policy: None,
+            network_rule_policy: crate::NetworkRulePolicy::Enforce,
         };
         let project = ComposeProject {
             project_name: "cella-test".to_string(),
@@ -1297,6 +1303,7 @@ mod tests {
             profiles: vec![],
             env_files: vec![],
             pull_policy: None,
+            network_rule_policy: crate::NetworkRulePolicy::Enforce,
         };
         let project = ComposeProject {
             project_name: "cella-test-project".to_string(),


### PR DESCRIPTION
## Summary

- Compose flows passed `None` for the proxy config, so `HTTP_PROXY`, `proxy-config.json`, and the MITM CA were never injected into containers. Added a shared helper and wired it into both `resolve_user_and_env` and the CLI `post_create_setup` hook.
- Fixed the CONNECT handler's fallback when MITM is unavailable — it was evaluating path rules with a misleading `"/"` path. Now warns once per domain and allows the connection through.
- Threaded `NetworkRulePolicy` into `ComposeUpConfig` so `--no-network-rules` is honored.

## Test plan

- [x] Unit test: `warn_no_mitm_once_deduplicates` verifies per-domain dedup
- [x] Integration test: `connect_with_path_rules_but_no_mitm_allows_through` verifies CONNECT tunnels through instead of blocking
- [x] `cargo clippy --workspace --all-features --all-targets` clean
- [x] `cargo test --workspace` all passing
- [x] E2E: verify in a Compose devcontainer that `$HTTPS_PROXY` is set, `/tmp/.cella/proxy-config.json` exists, and proxy listens on 18080

🤖 Generated with [Claude Code](https://claude.com/claude-code)