### PR TITLE
fix: proxy MITM reliability and agent restart

### DIFF
--- a/crates/cella-agent/src/main.rs
+++ b/crates/cella-agent/src/main.rs
@@ -144,6 +144,20 @@ async fn main() {
         .compact()
         .init();
 
+    // rustls 0.23 refuses to pick a default crypto provider when both `ring`
+    // and `aws-lc-rs` end up in the dependency graph — it panics on first use
+    // (acceptor.accept, connector.connect) from inside a spawned task where
+    // the panic goes only to stderr, which the entrypoint redirects to
+    // /dev/null. Without this call, every MITM'd HTTPS request silently
+    // aborts. Install ring explicitly so the behaviour is deterministic
+    // regardless of what other workspace crates enable.
+    if rustls::crypto::ring::default_provider()
+        .install_default()
+        .is_err()
+    {
+        // Already installed by some earlier code path — harmless.
+    }
+
     let args = match parse_args() {
         Ok(a) => a,
         Err(e) => {

--- a/crates/cella-agent/src/mitm.rs
+++ b/crates/cella-agent/src/mitm.rs
@@ -430,14 +430,8 @@ fn load_ca_materials(config: &AgentProxyConfig) -> Result<CaIssuerMaterials, Str
 
     let ca_key_pair = KeyPair::from_pem(ca_key_pem).map_err(|e| format!("parse CA key: {e}"))?;
 
-    let mut ca_params = CertificateParams::default();
-    ca_params.is_ca = IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
-    ca_params
-        .distinguished_name
-        .push(DnType::CommonName, "Cella Dev Container CA");
-
     Ok(CaIssuerMaterials {
-        params: ca_params,
+        params: cella_network::ca::ca_certificate_params(),
         key_pair: ca_key_pair,
     })
 }

--- a/crates/cella-agent/src/mitm.rs
+++ b/crates/cella-agent/src/mitm.rs
@@ -30,6 +30,7 @@ pub async fn intercept_tls(client: TcpStream, host: &str, port: u16, config: &Ag
         Ok(cfg) => cfg,
         Err(e) => {
             warn!("Failed to generate MITM cert for {host}: {e}");
+            config.log_error(host, &format!("MITM cert generation failed: {e}"));
             return;
         }
     };
@@ -39,7 +40,8 @@ pub async fn intercept_tls(client: TcpStream, host: &str, port: u16, config: &Ag
     let tls_stream = match acceptor.accept(client).await {
         Ok(s) => s,
         Err(e) => {
-            debug!("TLS handshake failed for {host}: {e}");
+            warn!("TLS handshake failed for {host}: {e}");
+            config.log_error(host, &format!("TLS handshake failed: {e}"));
             return;
         }
     };

--- a/crates/cella-agent/src/proxy_config.rs
+++ b/crates/cella-agent/src/proxy_config.rs
@@ -93,6 +93,21 @@ impl AgentProxyConfig {
         let _ = writeln!(file, "{timestamp}\tBLOCKED\t{domain}\t{path}\t{reason}");
     }
 
+    /// Log an error (e.g. TLS handshake failure) to the proxy log file.
+    pub fn log_error(&self, domain: &str, error: &str) {
+        let Ok(mut guard) = self.log_file.lock() else {
+            return;
+        };
+        let Some(ref mut file) = *guard else {
+            return;
+        };
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let _ = writeln!(file, "{timestamp}\tERROR\t{domain}\t{error}");
+    }
+
     /// Returns `true` the first time a domain is seen (caller should log the warning).
     pub fn warn_no_mitm_once(&self, domain: &str) -> bool {
         let Ok(mut set) = self.warned_no_mitm.lock() else {
@@ -285,6 +300,23 @@ mod tests {
         assert!(log.starts_with("existing\n"));
         assert!(log.contains("\tBLOCKED\tone.example\t/\tfirst"));
         assert!(log.contains("\tBLOCKED\ttwo.example\t/two\tsecond"));
+    }
+
+    #[test]
+    fn log_error_writes_to_log_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("proxy.log");
+        let json = make_json(
+            "denylist",
+            "",
+            &format!(r#","log_path":"{}""#, path.display()),
+        );
+        let config = AgentProxyConfig::from_json(&json).unwrap();
+
+        config.log_error("example.com", "TLS handshake failed: test error");
+
+        let log = std::fs::read_to_string(path).unwrap();
+        assert!(log.contains("\tERROR\texample.com\tTLS handshake failed: test error"));
     }
 
     #[test]

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -382,6 +382,22 @@ impl UpContext {
             )
             .await;
 
+        // The agent daemon was launched at container start (or by launch_agent
+        // in the compose flow) before proxy-config.json existed on disk. If
+        // this run just uploaded it, restart the daemon so it re-reads
+        // CELLA_PROXY_CONFIG and actually binds the forward-proxy port —
+        // otherwise every request through HTTP_PROXY is ECONNREFUSED.
+        if env_fwd
+            .post_start
+            .file_uploads
+            .iter()
+            .any(|upload| upload.container_path == cella_env::PROXY_CONFIG_PATH)
+            && self.client.capabilities().managed_agent
+        {
+            cella_orchestrator::up::restart_agent_in_container(self.client.as_ref(), container_id)
+                .await;
+        }
+
         // Add /cella/bin to PATH in shell profiles so `cella` CLI is discoverable.
         inject_cella_path(self.client.as_ref(), container_id, remote_user).await;
 

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -382,22 +382,6 @@ impl UpContext {
             )
             .await;
 
-        // The agent daemon was launched at container start (or by launch_agent
-        // in the compose flow) before proxy-config.json existed on disk. If
-        // this run just uploaded it, restart the daemon so it re-reads
-        // CELLA_PROXY_CONFIG and actually binds the forward-proxy port —
-        // otherwise every request through HTTP_PROXY is ECONNREFUSED.
-        if env_fwd
-            .post_start
-            .file_uploads
-            .iter()
-            .any(|upload| upload.container_path == cella_env::PROXY_CONFIG_PATH)
-            && self.client.capabilities().managed_agent
-        {
-            cella_orchestrator::up::restart_agent_in_container(self.client.as_ref(), container_id)
-                .await;
-        }
-
         // Add /cella/bin to PATH in shell profiles so `cella` CLI is discoverable.
         inject_cella_path(self.client.as_ref(), container_id, remote_user).await;
 

--- a/crates/cella-env/src/lib.rs
+++ b/crates/cella-env/src/lib.rs
@@ -25,6 +25,13 @@ pub use error::CellaEnvError;
 pub use git_config::GitConfigEntry;
 pub use platform::DockerRuntime;
 
+/// In-container path of the cella-agent proxy config file.
+///
+/// Uploaded post-start by the orchestrator (contains the MITM CA private key,
+/// so it must not live in an image layer or env var) and read by `cella-agent`
+/// at daemon startup via the `CELLA_PROXY_CONFIG` env var.
+pub const PROXY_CONFIG_PATH: &str = "/tmp/.cella/proxy-config.json";
+
 /// A bind mount to add to the container at creation time.
 #[derive(Debug, Clone)]
 pub struct ForwardMount {
@@ -255,15 +262,14 @@ pub fn prepare_env_forwarding(
             && let Some(ref net_full) = net_config.full_config
         {
             let json = proxy::build_agent_proxy_config_json(net_full);
-            let config_path = "/tmp/.cella/proxy-config.json";
             fwd.post_start.file_uploads.push(FileUpload {
-                container_path: config_path.to_string(),
+                container_path: PROXY_CONFIG_PATH.to_string(),
                 content: json.into_bytes(),
                 mode: 0o600,
             });
             fwd.env.push(ForwardEnv {
                 key: "CELLA_PROXY_CONFIG".to_string(),
-                value: config_path.to_string(),
+                value: PROXY_CONFIG_PATH.to_string(),
             });
         }
 

--- a/crates/cella-network/src/ca.rs
+++ b/crates/cella-network/src/ca.rs
@@ -79,12 +79,16 @@ pub fn ensure_ca() -> Result<CaCertificate, CaError> {
     generate_ca(&ca_dir)
 }
 
-/// Generate a new CA certificate and save to disk.
-fn generate_ca(ca_dir: &Path) -> Result<CaCertificate, CaError> {
-    std::fs::create_dir_all(ca_dir)?;
-
-    let key_pair = KeyPair::generate().map_err(CaError::KeyGeneration)?;
-
+/// Build the `CertificateParams` used for the cella MITM CA.
+///
+/// Used both when first creating the CA on disk and when re-loading it inside
+/// `cella-agent` to sign per-domain leaf certificates. The two call sites
+/// MUST produce identical params — otherwise leaf certs end up with an
+/// `Issuer` DN that doesn't match the CA's `Subject` DN, and TLS chain
+/// validation in the container fails (every MITM'd request gets a
+/// connection reset).
+#[must_use]
+pub fn ca_certificate_params() -> CertificateParams {
     let mut params = CertificateParams::default();
     params.is_ca = IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
     params
@@ -93,6 +97,16 @@ fn generate_ca(ca_dir: &Path) -> Result<CaCertificate, CaError> {
     params
         .distinguished_name
         .push(DnType::OrganizationName, "Cella");
+    params
+}
+
+/// Generate a new CA certificate and save to disk.
+fn generate_ca(ca_dir: &Path) -> Result<CaCertificate, CaError> {
+    std::fs::create_dir_all(ca_dir)?;
+
+    let key_pair = KeyPair::generate().map_err(CaError::KeyGeneration)?;
+
+    let params = ca_certificate_params();
 
     let cert = params
         .self_signed(&key_pair)

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -981,6 +981,17 @@ impl EnsureUpContext<'_> {
         })
         .await;
 
+        // The container's entrypoint launches `cella-agent daemon` immediately,
+        // before this post-start step uploads `proxy-config.json`. The daemon
+        // therefore reads `CELLA_PROXY_CONFIG`, finds no file, and gives up
+        // without binding port 18080 — leaving every connection through
+        // `HTTP_PROXY` to ECONNREFUSED. Restart the daemon now that the file
+        // exists so the entrypoint's restart loop respawns it against a
+        // populated config.
+        if injected_proxy_config(&env_fwd.post_start) && self.client.capabilities().managed_agent {
+            restart_agent_in_container(self.client, container_id).await;
+        }
+
         crate::container_setup::inject_cella_path(self.client, container_id, remote_user).await;
 
         if settings.credentials.gh {
@@ -1537,6 +1548,16 @@ pub async fn ensure_up(
     })
 }
 
+/// Returns `true` if the post-start injection includes the cella-agent
+/// proxy config upload. Used by the create flow to decide whether to
+/// restart the agent so it picks up the now-present config file.
+fn injected_proxy_config(post_start: &cella_env::PostStartInjection) -> bool {
+    post_start
+        .file_uploads
+        .iter()
+        .any(|upload| upload.container_path == cella_env::PROXY_CONFIG_PATH)
+}
+
 /// Restart the in-container agent daemon.
 ///
 /// Kills only the `cella-agent daemon` process (not credential or browser
@@ -1589,6 +1610,34 @@ mod tests {
     #[test]
     fn network_rule_policy_skip_eq() {
         assert_eq!(NetworkRulePolicy::Skip, NetworkRulePolicy::Skip);
+    }
+
+    #[test]
+    fn injected_proxy_config_detects_upload() {
+        let mut post_start = cella_env::PostStartInjection::default();
+        post_start.file_uploads.push(cella_env::FileUpload {
+            container_path: cella_env::PROXY_CONFIG_PATH.to_string(),
+            content: b"{}".to_vec(),
+            mode: 0o600,
+        });
+        assert!(injected_proxy_config(&post_start));
+    }
+
+    #[test]
+    fn injected_proxy_config_false_when_only_other_uploads() {
+        let mut post_start = cella_env::PostStartInjection::default();
+        post_start.file_uploads.push(cella_env::FileUpload {
+            container_path: "/etc/some-other-file".to_string(),
+            content: b"x".to_vec(),
+            mode: 0o644,
+        });
+        assert!(!injected_proxy_config(&post_start));
+    }
+
+    #[test]
+    fn injected_proxy_config_false_when_empty() {
+        let post_start = cella_env::PostStartInjection::default();
+        assert!(!injected_proxy_config(&post_start));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Extract `ca_certificate_params()` so the agent and CA generation share identical cert params — fixes TLS chain validation failures from Issuer/Subject DN mismatches
- Install rustls ring crypto provider explicitly to prevent silent panics when both ring and aws-lc-rs are in the dep graph
- Restart the agent daemon after proxy-config.json is uploaded so it actually binds the forward-proxy port (was ECONNREFUSED)
- Add error logging to proxy log for MITM cert and TLS handshake failures
- Remove duplicate agent restart from the compose path that would have started two agent daemons

## Test plan
- [x] Verify MITM proxy intercepts HTTPS requests without connection resets
- [x] Confirm proxy log contains ERROR entries on TLS failures
- [x] Test compose flow starts exactly one agent daemon
- [x] Test non-compose flow restarts agent after proxy config upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)