### PR TITLE
Overhaul MITM proxy with hyper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,6 +313,7 @@ dependencies = [
  "rcgen",
  "rustls",
  "rustls-native-certs",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "tempfile",
@@ -2615,6 +2616,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,9 @@ dependencies = [
  "cella-network",
  "cella-port",
  "cella-protocol",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "miette",
  "nix 0.31.2",
  "notify",
@@ -1052,6 +1055,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,6 +1222,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1321,6 +1349,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,11 @@ rustls-native-certs = "=0.8.3"
 rustls-pemfile = "=2.2.0"
 tokio-rustls = "=0.26.4"
 
+# HTTP proxy (MITM relay)
+hyper = { version = "=1.9.0", features = ["server", "client", "http1", "http2"] }
+hyper-util = { version = "=0.1.20", features = ["tokio", "server-auto", "http1", "http2"] }
+http-body-util = "=0.1.3"
+
 # File watching
 notify = "=8.2.0"
 

--- a/crates/cella-agent/Cargo.toml
+++ b/crates/cella-agent/Cargo.toml
@@ -23,6 +23,9 @@ serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-rustls.workspace = true
+hyper.workspace = true
+hyper-util.workspace = true
+http-body-util.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 

--- a/crates/cella-agent/Cargo.toml
+++ b/crates/cella-agent/Cargo.toml
@@ -18,6 +18,7 @@ notify.workspace = true
 rcgen.workspace = true
 rustls.workspace = true
 rustls-native-certs.workspace = true
+rustls-pemfile.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/cella-agent/src/forward_proxy.rs
+++ b/crates/cella-agent/src/forward_proxy.rs
@@ -112,7 +112,11 @@ async fn handle_connection(stream: TcpStream, config: Arc<AgentProxyConfig>) {
 /// CONNECT requests look like: `CONNECT host:port HTTP/1.1`
 /// We evaluate domain blocking rules before establishing the tunnel.
 /// For domains with path-level rules, we defer to MITM TLS interception.
-async fn handle_connect(mut client: BufReader<TcpStream>, target: &str, config: &AgentProxyConfig) {
+async fn handle_connect(
+    mut client: BufReader<TcpStream>,
+    target: &str,
+    config: &Arc<AgentProxyConfig>,
+) {
     // Parse host:port from CONNECT target.
     let Some((host, port)) = parse_host_port(target) else {
         let _ = client
@@ -137,7 +141,7 @@ async fn handle_connect(mut client: BufReader<TcpStream>, target: &str, config: 
         {
             return;
         }
-        crate::mitm::intercept_tls(client_tcp, &host, port, config).await;
+        crate::mitm::intercept_tls(client_tcp, &host, port, config.clone()).await;
         return;
     }
 
@@ -189,7 +193,9 @@ async fn handle_connect(mut client: BufReader<TcpStream>, target: &str, config: 
 
     // Tunnel bidirectionally.
     let mut upstream = upstream;
-    let _ = copy_bidirectional(&mut client_tcp, &mut upstream).await;
+    if let Err(e) = copy_bidirectional(&mut client_tcp, &mut upstream).await {
+        debug!("Tunnel to {host}:{port} ended: {e}");
+    }
 }
 
 /// Handle direct HTTP proxy request (non-CONNECT).
@@ -244,7 +250,9 @@ async fn handle_direct_http(
 
     // Bidirectional copy for the rest (request body + response).
     let mut client_tcp = client.into_inner();
-    let _ = copy_bidirectional(&mut client_tcp, &mut upstream).await;
+    if let Err(e) = copy_bidirectional(&mut client_tcp, &mut upstream).await {
+        debug!("Direct HTTP tunnel to {host}:{port} ended: {e}");
+    }
 }
 
 /// Connect to the target, either directly or through an upstream proxy.

--- a/crates/cella-agent/src/integration_tests.rs
+++ b/crates/cella-agent/src/integration_tests.rs
@@ -566,6 +566,70 @@ async fn start_h2_tls_upstream(ca: &TestCa, domain: &str) -> TlsUpstreamServer {
     TlsUpstreamServer { addr, task }
 }
 
+async fn start_tls_upgrade_upstream(ca: &TestCa, domain: &str) -> TlsUpstreamServer {
+    let (certs, key) = generate_server_cert(ca, domain);
+    let mut tls_config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, key)
+        .unwrap();
+    tls_config.alpn_protocols = vec![b"http/1.1".to_vec()];
+    let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(tls_config));
+
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let task = tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                break;
+            };
+            let acceptor = acceptor.clone();
+            tokio::spawn(async move {
+                let Ok(mut tls) = acceptor.accept(stream).await else {
+                    return;
+                };
+                let mut headers = Vec::new();
+                let mut byte = [0u8; 1];
+                while tls.read_exact(&mut byte).await.is_ok() {
+                    headers.push(byte[0]);
+                    if headers.ends_with(b"\r\n\r\n") {
+                        break;
+                    }
+                }
+                let headers_str = String::from_utf8_lossy(&headers);
+                let has_upgrade = headers_str
+                    .lines()
+                    .any(|l| l.to_ascii_lowercase().starts_with("upgrade:"));
+                if has_upgrade {
+                    let resp = "HTTP/1.1 101 Switching Protocols\r\n\
+                        Upgrade: websocket\r\n\
+                        Connection: Upgrade\r\n\r\n";
+                    let _ = tls.write_all(resp.as_bytes()).await;
+                    let mut buf = [0u8; 1024];
+                    loop {
+                        match tls.read(&mut buf).await {
+                            Ok(0) | Err(_) => break,
+                            Ok(n) => {
+                                let _ = tls.write_all(&buf[..n]).await;
+                            }
+                        }
+                    }
+                } else {
+                    let body = b"no upgrade";
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                        body.len()
+                    );
+                    let _ = tls.write_all(resp.as_bytes()).await;
+                    let _ = tls.write_all(body).await;
+                }
+            });
+        }
+    });
+
+    TlsUpstreamServer { addr, task }
+}
+
 fn simple_200_handler() -> (u16, Vec<u8>) {
     (200, b"upstream ok".to_vec())
 }
@@ -791,6 +855,157 @@ async fn mitm_relays_through_h2_upstream() {
     assert!(
         resp.contains("h2 upstream ok"),
         "expected h2 body, got {resp:?}"
+    );
+
+    proxy.task.abort();
+    upstream.task.abort();
+}
+
+#[tokio::test]
+async fn mitm_relays_websocket_upgrade() {
+    let ca = test_ca();
+    let log_dir = TempDir::new().unwrap();
+    let log_path = log_dir.path().join("proxy.log");
+
+    let upstream = start_tls_upgrade_upstream(ca, "localhost").await;
+    let config_json = mitm_proxy_config_json(
+        "denylist",
+        &[rule("localhost", &["/blocked/**"], "block")],
+        &log_path,
+        ca,
+    );
+    let proxy = start_proxy(&config_json).await;
+
+    let mut stream = TcpStream::connect(proxy.local_addr).await.unwrap();
+    let connect_req = format!(
+        "CONNECT localhost:{} HTTP/1.1\r\nHost: localhost\r\n\r\n",
+        upstream.addr.port()
+    );
+    stream.write_all(connect_req.as_bytes()).await.unwrap();
+    let mut headers = Vec::new();
+    let mut byte = [0u8; 1];
+    while stream.read_exact(&mut byte).await.is_ok() {
+        headers.push(byte[0]);
+        if headers.ends_with(b"\r\n\r\n") {
+            break;
+        }
+    }
+
+    let cert_der = CertificateDer::from(
+        ca.params
+            .clone()
+            .self_signed(&ca.key)
+            .unwrap()
+            .der()
+            .to_vec(),
+    );
+    let mut root_store = rustls::RootCertStore::empty();
+    let _ = root_store.add(cert_der);
+    let mut tls_config = rustls::ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+    tls_config.alpn_protocols = vec![b"http/1.1".to_vec()];
+    let connector = tokio_rustls::TlsConnector::from(Arc::new(tls_config));
+    let server_name = rustls::pki_types::ServerName::try_from("localhost".to_string()).unwrap();
+    let mut tls = connector.connect(server_name, stream).await.unwrap();
+
+    let req = "GET /allowed HTTP/1.1\r\n\
+        Host: localhost\r\n\
+        Upgrade: websocket\r\n\
+        Connection: Upgrade\r\n\r\n";
+    tls.write_all(req.as_bytes()).await.unwrap();
+
+    let mut resp_headers = Vec::new();
+    while tls.read_exact(&mut byte).await.is_ok() {
+        resp_headers.push(byte[0]);
+        if resp_headers.ends_with(b"\r\n\r\n") {
+            break;
+        }
+    }
+    let resp_str = String::from_utf8_lossy(&resp_headers);
+    assert!(resp_str.contains("101"), "expected 101, got {resp_str:?}");
+
+    let test_data = b"hello websocket";
+    tls.write_all(test_data).await.unwrap();
+    let mut echoed = vec![0u8; test_data.len()];
+    tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        tls.read_exact(&mut echoed),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert_eq!(&echoed, test_data, "echoed data mismatch");
+
+    proxy.task.abort();
+    upstream.task.abort();
+}
+
+#[tokio::test]
+async fn mitm_blocks_upgrade_on_blocked_path() {
+    let ca = test_ca();
+    let log_dir = TempDir::new().unwrap();
+    let log_path = log_dir.path().join("proxy.log");
+
+    let upstream = start_tls_upgrade_upstream(ca, "localhost").await;
+    let config_json = mitm_proxy_config_json(
+        "denylist",
+        &[rule("localhost", &["/blocked/**"], "block")],
+        &log_path,
+        ca,
+    );
+    let proxy = start_proxy(&config_json).await;
+
+    let mut stream = TcpStream::connect(proxy.local_addr).await.unwrap();
+    let connect_req = format!(
+        "CONNECT localhost:{} HTTP/1.1\r\nHost: localhost\r\n\r\n",
+        upstream.addr.port()
+    );
+    stream.write_all(connect_req.as_bytes()).await.unwrap();
+    let mut headers = Vec::new();
+    let mut byte = [0u8; 1];
+    while stream.read_exact(&mut byte).await.is_ok() {
+        headers.push(byte[0]);
+        if headers.ends_with(b"\r\n\r\n") {
+            break;
+        }
+    }
+
+    let cert_der = CertificateDer::from(
+        ca.params
+            .clone()
+            .self_signed(&ca.key)
+            .unwrap()
+            .der()
+            .to_vec(),
+    );
+    let mut root_store = rustls::RootCertStore::empty();
+    let _ = root_store.add(cert_der);
+    let mut tls_config = rustls::ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+    tls_config.alpn_protocols = vec![b"http/1.1".to_vec()];
+    let connector = tokio_rustls::TlsConnector::from(Arc::new(tls_config));
+    let server_name = rustls::pki_types::ServerName::try_from("localhost".to_string()).unwrap();
+    let mut tls = connector.connect(server_name, stream).await.unwrap();
+
+    let req = "GET /blocked/ws HTTP/1.1\r\n\
+        Host: localhost\r\n\
+        Upgrade: websocket\r\n\
+        Connection: Upgrade\r\n\r\n";
+    tls.write_all(req.as_bytes()).await.unwrap();
+
+    let mut resp_headers = Vec::new();
+    while tls.read_exact(&mut byte).await.is_ok() {
+        resp_headers.push(byte[0]);
+        if resp_headers.ends_with(b"\r\n\r\n") {
+            break;
+        }
+    }
+    let resp_str = String::from_utf8_lossy(&resp_headers);
+    assert!(
+        resp_str.contains("403"),
+        "expected 403 for blocked path, got {resp_str:?}"
     );
 
     proxy.task.abort();

--- a/crates/cella-agent/src/integration_tests.rs
+++ b/crates/cella-agent/src/integration_tests.rs
@@ -890,6 +890,11 @@ async fn mitm_relays_websocket_upgrade() {
             break;
         }
     }
+    let connect_resp = String::from_utf8_lossy(&headers);
+    assert!(
+        connect_resp.starts_with("HTTP/1.1 200"),
+        "CONNECT failed: {connect_resp:?}"
+    );
 
     let cert_der = CertificateDer::from(
         ca.params
@@ -970,6 +975,11 @@ async fn mitm_blocks_upgrade_on_blocked_path() {
             break;
         }
     }
+    let connect_resp = String::from_utf8_lossy(&headers);
+    assert!(
+        connect_resp.starts_with("HTTP/1.1 200"),
+        "CONNECT failed: {connect_resp:?}"
+    );
 
     let cert_der = CertificateDer::from(
         ca.params

--- a/crates/cella-agent/src/integration_tests.rs
+++ b/crates/cella-agent/src/integration_tests.rs
@@ -526,6 +526,46 @@ async fn proxy_connect_tls_and_request(
     Ok(String::from_utf8_lossy(&full_response).to_string())
 }
 
+async fn start_h2_tls_upstream(ca: &TestCa, domain: &str) -> TlsUpstreamServer {
+    use http_body_util::Full as FullBody;
+    use hyper::body::Bytes;
+    use hyper_util::rt::{TokioExecutor, TokioIo};
+
+    let (certs, key) = generate_server_cert(ca, domain);
+    let mut tls_config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, key)
+        .unwrap();
+    tls_config.alpn_protocols = vec![b"h2".to_vec()];
+    let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(tls_config));
+
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let task = tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                break;
+            };
+            let acceptor = acceptor.clone();
+            tokio::spawn(async move {
+                let Ok(tls) = acceptor.accept(stream).await else {
+                    return;
+                };
+                let svc = hyper::service::service_fn(|_req| async {
+                    Ok::<_, std::convert::Infallible>(hyper::Response::new(FullBody::new(
+                        Bytes::from("h2 upstream ok"),
+                    )))
+                });
+                let builder = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new());
+                let _ = builder.serve_connection(TokioIo::new(tls), svc).await;
+            });
+        }
+    });
+
+    TlsUpstreamServer { addr, task }
+}
+
 fn simple_200_handler() -> (u16, Vec<u8>) {
     (200, b"upstream ok".to_vec())
 }
@@ -607,7 +647,12 @@ async fn mitm_relays_large_response() {
     let log_path = log_dir.path().join("proxy.log");
 
     let upstream = start_tls_upstream(ca, "localhost", large_body_handler).await;
-    let config_json = mitm_proxy_config_json("denylist", &[], &log_path, ca);
+    let config_json = mitm_proxy_config_json(
+        "denylist",
+        &[rule("localhost", &["/never-block-this/**"], "block")],
+        &log_path,
+        ca,
+    );
     let proxy = start_proxy(&config_json).await;
 
     let resp = proxy_connect_tls_and_request(
@@ -641,7 +686,12 @@ async fn mitm_handles_many_keepalive_cycles() {
     let log_path = log_dir.path().join("proxy.log");
 
     let upstream = start_tls_upstream(ca, "localhost", simple_200_handler).await;
-    let config_json = mitm_proxy_config_json("denylist", &[], &log_path, ca);
+    let config_json = mitm_proxy_config_json(
+        "denylist",
+        &[rule("localhost", &["/never-block-this/**"], "block")],
+        &log_path,
+        ca,
+    );
     let proxy = start_proxy(&config_json).await;
 
     let mut stream = TcpStream::connect(proxy.local_addr).await.unwrap();
@@ -706,6 +756,42 @@ async fn mitm_handles_many_keepalive_cycles() {
             tls.read_exact(&mut body).await.unwrap();
         }
     }
+
+    proxy.task.abort();
+    upstream.task.abort();
+}
+
+#[tokio::test]
+async fn mitm_relays_through_h2_upstream() {
+    let ca = test_ca();
+    let log_dir = TempDir::new().unwrap();
+    let log_path = log_dir.path().join("proxy.log");
+
+    let upstream = start_h2_tls_upstream(ca, "localhost").await;
+    // Path rule triggers MITM interception (domain-only rules skip MITM).
+    let config_json = mitm_proxy_config_json(
+        "denylist",
+        &[rule("localhost", &["/never-block-this/**"], "block")],
+        &log_path,
+        ca,
+    );
+    let proxy = start_proxy(&config_json).await;
+
+    let resp = proxy_connect_tls_and_request(
+        proxy.local_addr,
+        "localhost",
+        upstream.addr.port(),
+        "/api/test",
+        ca,
+    )
+    .await
+    .unwrap();
+
+    assert!(resp.contains("200"), "expected 200, got {resp:?}");
+    assert!(
+        resp.contains("h2 upstream ok"),
+        "expected h2 body, got {resp:?}"
+    );
 
     proxy.task.abort();
     upstream.task.abort();

--- a/crates/cella-agent/src/integration_tests.rs
+++ b/crates/cella-agent/src/integration_tests.rs
@@ -2,8 +2,10 @@
 
 use std::net::SocketAddr;
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
+use rcgen::{CertificateParams, DnType, DnValue, IsCa, Issuer, KeyPair, SanType};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 use serde_json::Value;
 use tempfile::TempDir;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -312,4 +314,399 @@ async fn connect_domain_block_still_enforced_without_mitm() {
     );
 
     proxy.task.abort();
+}
+
+// ---- MITM integration test infrastructure ----
+
+struct TestCa {
+    cert_pem: String,
+    key_pem: String,
+    key: KeyPair,
+    params: CertificateParams,
+}
+
+static TEST_CA: OnceLock<TestCa> = OnceLock::new();
+
+fn test_ca() -> &'static TestCa {
+    TEST_CA.get_or_init(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let key = KeyPair::generate().unwrap();
+        let params = cella_network::ca::ca_certificate_params();
+        let cert = params.self_signed(&key).unwrap();
+
+        TestCa {
+            cert_pem: cert.pem(),
+            key_pem: key.serialize_pem(),
+            key,
+            params,
+        }
+    })
+}
+
+fn generate_server_cert(
+    ca: &TestCa,
+    domain: &str,
+) -> (Vec<CertificateDer<'static>>, PrivateKeyDer<'static>) {
+    let issuer = Issuer::from_params(&ca.params, &ca.key);
+    let server_key = KeyPair::generate().unwrap();
+    let mut params = CertificateParams::default();
+    params.is_ca = IsCa::NoCa;
+    params
+        .distinguished_name
+        .push(DnType::CommonName, DnValue::Utf8String(domain.to_string()));
+    params
+        .subject_alt_names
+        .push(SanType::DnsName(domain.to_string().try_into().unwrap()));
+    let cert = params.signed_by(&server_key, &issuer).unwrap();
+    let cert_der = CertificateDer::from(cert.der().to_vec());
+    let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(server_key.serialize_der()));
+    (vec![cert_der], key_der)
+}
+
+struct TlsUpstreamServer {
+    addr: SocketAddr,
+    task: JoinHandle<()>,
+}
+
+async fn start_tls_upstream(
+    ca: &TestCa,
+    domain: &str,
+    handler: fn() -> (u16, Vec<u8>),
+) -> TlsUpstreamServer {
+    let (certs, key) = generate_server_cert(ca, domain);
+    let mut tls_config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, key)
+        .unwrap();
+    tls_config.alpn_protocols = vec![b"http/1.1".to_vec()];
+    let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(tls_config));
+
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let task = tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                break;
+            };
+            let acceptor = acceptor.clone();
+            tokio::spawn(async move {
+                let Ok(mut tls) = acceptor.accept(stream).await else {
+                    return;
+                };
+                loop {
+                    let mut headers = Vec::new();
+                    let mut byte = [0u8; 1];
+                    loop {
+                        if tls.read_exact(&mut byte).await.is_err() {
+                            return;
+                        }
+                        headers.push(byte[0]);
+                        if headers.ends_with(b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+                    let (status, body) = handler();
+                    let resp = format!(
+                        "HTTP/1.1 {status} OK\r\nContent-Length: {}\r\n\r\n",
+                        body.len()
+                    );
+                    if tls.write_all(resp.as_bytes()).await.is_err() {
+                        return;
+                    }
+                    if tls.write_all(&body).await.is_err() {
+                        return;
+                    }
+                }
+            });
+        }
+    });
+
+    TlsUpstreamServer { addr, task }
+}
+
+fn mitm_proxy_config_json(mode: &str, rules: &[Value], log_path: &Path, ca: &TestCa) -> String {
+    serde_json::json!({
+        "listen_port": 0,
+        "mode": mode,
+        "rules": rules,
+        "upstream_proxy": null,
+        "ca_cert_pem": ca.cert_pem,
+        "ca_key_pem": ca.key_pem,
+        "log_path": log_path.to_string_lossy().into_owned(),
+    })
+    .to_string()
+}
+
+async fn proxy_connect_tls_and_request(
+    proxy_addr: SocketAddr,
+    host: &str,
+    port: u16,
+    path: &str,
+    ca: &TestCa,
+) -> Result<String, String> {
+    let mut stream = TcpStream::connect(proxy_addr)
+        .await
+        .map_err(|e| format!("connect: {e}"))?;
+
+    let connect_req = format!("CONNECT {host}:{port} HTTP/1.1\r\nHost: {host}:{port}\r\n\r\n");
+    stream
+        .write_all(connect_req.as_bytes())
+        .await
+        .map_err(|e| format!("write CONNECT: {e}"))?;
+
+    let mut headers = Vec::new();
+    let mut byte = [0u8; 1];
+    while stream.read_exact(&mut byte).await.is_ok() {
+        headers.push(byte[0]);
+        if headers.ends_with(b"\r\n\r\n") {
+            break;
+        }
+    }
+    let connect_resp = String::from_utf8_lossy(&headers).to_string();
+    if !connect_resp.starts_with("HTTP/1.1 200") {
+        return Ok(connect_resp);
+    }
+
+    let cert_der = CertificateDer::from(
+        ca.params
+            .clone()
+            .self_signed(&ca.key)
+            .unwrap()
+            .der()
+            .to_vec(),
+    );
+    let mut root_store = rustls::RootCertStore::empty();
+    let _ = root_store.add(cert_der);
+
+    let mut tls_config = rustls::ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+    tls_config.alpn_protocols = vec![b"http/1.1".to_vec()];
+
+    let connector = tokio_rustls::TlsConnector::from(Arc::new(tls_config));
+    let server_name = rustls::pki_types::ServerName::try_from(host.to_string()).unwrap();
+    let mut tls = connector
+        .connect(server_name, stream)
+        .await
+        .map_err(|e| format!("client TLS: {e}"))?;
+
+    let req = format!("GET {path} HTTP/1.1\r\nHost: {host}\r\n\r\n");
+    tls.write_all(req.as_bytes())
+        .await
+        .map_err(|e| format!("write request: {e}"))?;
+
+    let mut headers = Vec::new();
+    let mut byte = [0u8; 1];
+    while tls.read_exact(&mut byte).await.is_ok() {
+        headers.push(byte[0]);
+        if headers.ends_with(b"\r\n\r\n") {
+            break;
+        }
+    }
+
+    let headers_str = String::from_utf8_lossy(&headers).to_string();
+    let cl = headers_str
+        .lines()
+        .find(|l| l.to_ascii_lowercase().starts_with("content-length:"))
+        .and_then(|l| l.split(':').nth(1))
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(0);
+
+    let mut body = vec![0u8; cl];
+    if cl > 0 {
+        tls.read_exact(&mut body)
+            .await
+            .map_err(|e| format!("read body: {e}"))?;
+    }
+
+    let mut full_response = headers;
+    full_response.extend_from_slice(&body);
+    Ok(String::from_utf8_lossy(&full_response).to_string())
+}
+
+fn simple_200_handler() -> (u16, Vec<u8>) {
+    (200, b"upstream ok".to_vec())
+}
+
+fn large_body_handler() -> (u16, Vec<u8>) {
+    (200, vec![0x42; 256 * 1024])
+}
+
+#[tokio::test]
+async fn mitm_allows_and_relays_response() {
+    let ca = test_ca();
+    let log_dir = TempDir::new().unwrap();
+    let log_path = log_dir.path().join("proxy.log");
+
+    let upstream = start_tls_upstream(ca, "localhost", simple_200_handler).await;
+    let config_json = mitm_proxy_config_json(
+        "denylist",
+        &[rule("localhost", &["/blocked/**"], "block")],
+        &log_path,
+        ca,
+    );
+    let proxy = start_proxy(&config_json).await;
+
+    let resp = proxy_connect_tls_and_request(
+        proxy.local_addr,
+        "localhost",
+        upstream.addr.port(),
+        "/allowed",
+        ca,
+    )
+    .await
+    .unwrap();
+
+    assert!(resp.contains("200"), "expected 200, got {resp:?}");
+    assert!(resp.contains("upstream ok"), "expected body, got {resp:?}");
+
+    proxy.task.abort();
+    upstream.task.abort();
+}
+
+#[tokio::test]
+async fn mitm_blocks_matching_path() {
+    let ca = test_ca();
+    let log_dir = TempDir::new().unwrap();
+    let log_path = log_dir.path().join("proxy.log");
+
+    let upstream = start_tls_upstream(ca, "localhost", simple_200_handler).await;
+    let config_json = mitm_proxy_config_json(
+        "denylist",
+        &[rule("localhost", &["/blocked/**"], "block")],
+        &log_path,
+        ca,
+    );
+    let proxy = start_proxy(&config_json).await;
+
+    let resp = proxy_connect_tls_and_request(
+        proxy.local_addr,
+        "localhost",
+        upstream.addr.port(),
+        "/blocked/secret",
+        ca,
+    )
+    .await
+    .unwrap();
+
+    assert!(resp.contains("403"), "expected 403, got {resp:?}");
+
+    let log = std::fs::read_to_string(&log_path).unwrap();
+    assert!(log.contains("BLOCKED\tlocalhost\t/blocked/secret"));
+
+    proxy.task.abort();
+    upstream.task.abort();
+}
+
+#[tokio::test]
+async fn mitm_relays_large_response() {
+    let ca = test_ca();
+    let log_dir = TempDir::new().unwrap();
+    let log_path = log_dir.path().join("proxy.log");
+
+    let upstream = start_tls_upstream(ca, "localhost", large_body_handler).await;
+    let config_json = mitm_proxy_config_json("denylist", &[], &log_path, ca);
+    let proxy = start_proxy(&config_json).await;
+
+    let resp = proxy_connect_tls_and_request(
+        proxy.local_addr,
+        "localhost",
+        upstream.addr.port(),
+        "/large",
+        ca,
+    )
+    .await
+    .unwrap();
+
+    assert!(resp.contains("200"), "expected 200, got {resp:?}");
+    let body_start = resp.find("\r\n\r\n").unwrap() + 4;
+    let body = &resp.as_bytes()[body_start..];
+    assert_eq!(
+        body.len(),
+        256 * 1024,
+        "expected 256KB body, got {} bytes",
+        body.len()
+    );
+
+    proxy.task.abort();
+    upstream.task.abort();
+}
+
+#[tokio::test]
+async fn mitm_handles_many_keepalive_cycles() {
+    let ca = test_ca();
+    let log_dir = TempDir::new().unwrap();
+    let log_path = log_dir.path().join("proxy.log");
+
+    let upstream = start_tls_upstream(ca, "localhost", simple_200_handler).await;
+    let config_json = mitm_proxy_config_json("denylist", &[], &log_path, ca);
+    let proxy = start_proxy(&config_json).await;
+
+    let mut stream = TcpStream::connect(proxy.local_addr).await.unwrap();
+    let connect_req = format!(
+        "CONNECT localhost:{} HTTP/1.1\r\nHost: localhost:{}\r\n\r\n",
+        upstream.addr.port(),
+        upstream.addr.port(),
+    );
+    stream.write_all(connect_req.as_bytes()).await.unwrap();
+
+    let mut headers = Vec::new();
+    let mut byte = [0u8; 1];
+    while stream.read_exact(&mut byte).await.is_ok() {
+        headers.push(byte[0]);
+        if headers.ends_with(b"\r\n\r\n") {
+            break;
+        }
+    }
+
+    let cert_der = CertificateDer::from(
+        ca.params
+            .clone()
+            .self_signed(&ca.key)
+            .unwrap()
+            .der()
+            .to_vec(),
+    );
+    let mut root_store = rustls::RootCertStore::empty();
+    let _ = root_store.add(cert_der);
+    let mut tls_config = rustls::ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+    tls_config.alpn_protocols = vec![b"http/1.1".to_vec()];
+
+    let connector = tokio_rustls::TlsConnector::from(Arc::new(tls_config));
+    let server_name = rustls::pki_types::ServerName::try_from("localhost".to_string()).unwrap();
+    let mut tls = connector.connect(server_name, stream).await.unwrap();
+
+    for i in 0..20 {
+        let req = format!("GET /req/{i} HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        tls.write_all(req.as_bytes()).await.unwrap();
+
+        let mut resp_headers = Vec::new();
+        let mut b = [0u8; 1];
+        while tls.read_exact(&mut b).await.is_ok() {
+            resp_headers.push(b[0]);
+            if resp_headers.ends_with(b"\r\n\r\n") {
+                break;
+            }
+        }
+        let resp_str = String::from_utf8_lossy(&resp_headers);
+        assert!(resp_str.contains("200"), "request {i} failed: {resp_str}");
+
+        let cl = resp_str
+            .lines()
+            .find(|l| l.to_ascii_lowercase().starts_with("content-length:"))
+            .and_then(|l| l.split(':').nth(1))
+            .and_then(|v| v.trim().parse::<usize>().ok())
+            .unwrap_or(0);
+        if cl > 0 {
+            let mut body = vec![0u8; cl];
+            tls.read_exact(&mut body).await.unwrap();
+        }
+    }
+
+    proxy.task.abort();
+    upstream.task.abort();
 }

--- a/crates/cella-agent/src/mitm.rs
+++ b/crates/cella-agent/src/mitm.rs
@@ -40,95 +40,15 @@ pub async fn intercept_tls(
     port: u16,
     config: Arc<AgentProxyConfig>,
 ) {
-    let tls_config = match generate_server_config(host, &config) {
-        Ok(cfg) => cfg,
-        Err(e) => {
-            warn!("Failed to generate MITM cert for {host}: {e}");
-            config.log_error(host, &format!("MITM cert generation failed: {e}"));
-            return;
-        }
+    let Some(client_tls) = accept_client_tls(client, host, &config).await else {
+        return;
     };
-
-    let acceptor = TlsAcceptor::from(Arc::new(tls_config));
-    let client_tls = match acceptor.accept(client).await {
-        Ok(s) => s,
-        Err(e) => {
-            warn!("TLS handshake failed for {host}: {e}");
-            config.log_error(host, &format!("TLS handshake failed: {e}"));
-            return;
-        }
-    };
-
-    let upstream_tcp =
-        match super::forward_proxy::connect_upstream_for_mitm(host, port, &config).await {
-            Ok(s) => s,
-            Err(e) => {
-                warn!("Failed to connect to {host}:{port}: {e}");
-                config.log_error(host, &format!("upstream connect failed: {e}"));
-                return;
-            }
-        };
-
-    let extra = config.ca_cert_der.as_ref().map(std::slice::from_ref);
-    let connector = tokio_rustls::TlsConnector::from(Arc::new(upstream_tls_config(extra)));
-    let server_name = match rustls::pki_types::ServerName::try_from(host.to_string()) {
-        Ok(sn) => sn,
-        Err(e) => {
-            warn!("Invalid server name {host}: {e}");
-            return;
-        }
-    };
-
-    let upstream_tls = match connector.connect(server_name, upstream_tcp).await {
-        Ok(s) => s,
-        Err(e) => {
-            warn!("Upstream TLS handshake failed for {host}: {e}");
-            config.log_error(host, &format!("upstream TLS failed: {e}"));
-            return;
-        }
-    };
-
-    let is_h2 = upstream_tls
-        .get_ref()
-        .1
-        .alpn_protocol()
-        .is_some_and(|p| p == b"h2");
-
-    let upstream_io = TokioIo::new(upstream_tls);
-    let sender = if is_h2 {
-        let (sender, conn) =
-            match hyper::client::conn::http2::handshake(TokioExecutor::new(), upstream_io).await {
-                Ok(pair) => pair,
-                Err(e) => {
-                    warn!("Upstream HTTP/2 handshake failed for {host}: {e}");
-                    return;
-                }
-            };
-        tokio::spawn(async move {
-            if let Err(e) = conn.await {
-                debug!("Upstream h2 connection ended: {e}");
-            }
-        });
-        UpstreamSender::Http2(sender)
-    } else {
-        let (sender, conn) = match hyper::client::conn::http1::handshake(upstream_io).await {
-            Ok(pair) => pair,
-            Err(e) => {
-                warn!("Upstream HTTP/1.1 handshake failed for {host}: {e}");
-                return;
-            }
-        };
-        tokio::spawn(async move {
-            if let Err(e) = conn.await {
-                debug!("Upstream h1 connection ended: {e}");
-            }
-        });
-        UpstreamSender::Http1(sender)
+    let Some(sender) = connect_upstream_tls(host, port, &config).await else {
+        return;
     };
 
     let sender = Arc::new(Mutex::new(sender));
     let host_owned: Arc<str> = host.into();
-
     let client_io = TokioIo::new(client_tls);
 
     let svc = service_fn(move |req: Request<Incoming>| {
@@ -141,6 +61,103 @@ pub async fn intercept_tls(
     let builder = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new());
     if let Err(e) = builder.serve_connection(client_io, svc).await {
         debug!("MITM server for {host} ended: {e}");
+    }
+}
+
+async fn accept_client_tls(
+    client: TcpStream,
+    host: &str,
+    config: &AgentProxyConfig,
+) -> Option<tokio_rustls::server::TlsStream<TcpStream>> {
+    let tls_config = match generate_server_config(host, config) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            warn!("Failed to generate MITM cert for {host}: {e}");
+            config.log_error(host, &format!("MITM cert generation failed: {e}"));
+            return None;
+        }
+    };
+    let acceptor = TlsAcceptor::from(Arc::new(tls_config));
+    match acceptor.accept(client).await {
+        Ok(s) => Some(s),
+        Err(e) => {
+            warn!("TLS handshake failed for {host}: {e}");
+            config.log_error(host, &format!("TLS handshake failed: {e}"));
+            None
+        }
+    }
+}
+
+async fn connect_upstream_tls(
+    host: &str,
+    port: u16,
+    config: &AgentProxyConfig,
+) -> Option<UpstreamSender> {
+    let upstream_tcp =
+        match super::forward_proxy::connect_upstream_for_mitm(host, port, config).await {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("Failed to connect to {host}:{port}: {e}");
+                config.log_error(host, &format!("upstream connect failed: {e}"));
+                return None;
+            }
+        };
+
+    let extra = config.ca_cert_der.as_ref().map(std::slice::from_ref);
+    let connector = tokio_rustls::TlsConnector::from(Arc::new(upstream_tls_config(extra)));
+    let server_name = match rustls::pki_types::ServerName::try_from(host.to_string()) {
+        Ok(sn) => sn,
+        Err(e) => {
+            warn!("Invalid server name {host}: {e}");
+            return None;
+        }
+    };
+
+    let upstream_tls = match connector.connect(server_name, upstream_tcp).await {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("Upstream TLS handshake failed for {host}: {e}");
+            config.log_error(host, &format!("upstream TLS failed: {e}"));
+            return None;
+        }
+    };
+
+    let is_h2 = upstream_tls
+        .get_ref()
+        .1
+        .alpn_protocol()
+        .is_some_and(|p| p == b"h2");
+    let upstream_io = TokioIo::new(upstream_tls);
+
+    if is_h2 {
+        let (sender, conn) =
+            match hyper::client::conn::http2::handshake(TokioExecutor::new(), upstream_io).await {
+                Ok(pair) => pair,
+                Err(e) => {
+                    warn!("Upstream HTTP/2 handshake failed for {host}: {e}");
+                    return None;
+                }
+            };
+        tokio::spawn(async move {
+            if let Err(e) = conn.await {
+                debug!("Upstream h2 connection ended: {e}");
+            }
+        });
+        Some(UpstreamSender::Http2(sender))
+    } else {
+        let (sender, conn) = match hyper::client::conn::http1::handshake(upstream_io).await {
+            Ok(pair) => pair,
+            Err(e) => {
+                warn!("Upstream HTTP/1.1 handshake failed for {host}: {e}");
+                return None;
+            }
+        };
+        tokio::spawn(async move {
+            if let Err(e) = conn.await {
+                debug!("Upstream h1 connection ended: {e}");
+            }
+        });
+        Some(UpstreamSender::Http1(sender))
     }
 }
 

--- a/crates/cella-agent/src/mitm.rs
+++ b/crates/cella-agent/src/mitm.rs
@@ -59,7 +59,7 @@ pub async fn intercept_tls(
     });
 
     let builder = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new());
-    if let Err(e) = builder.serve_connection(client_io, svc).await {
+    if let Err(e) = builder.serve_connection_with_upgrades(client_io, svc).await {
         debug!("MITM server for {host} ended: {e}");
     }
 }
@@ -161,6 +161,18 @@ async fn connect_upstream_tls(
     }
 }
 
+fn is_upgrade_request<B>(req: &Request<B>) -> bool {
+    req.headers().get("upgrade").is_some()
+        && req
+            .headers()
+            .get("connection")
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|v| {
+                v.split(',')
+                    .any(|t| t.trim().eq_ignore_ascii_case("upgrade"))
+            })
+}
+
 async fn handle_request(
     req: Request<Incoming>,
     host: &str,
@@ -181,7 +193,11 @@ async fn handle_request(
         return Ok(resp);
     }
 
-    let req = prepare_forwarded_request(req, host);
+    if is_upgrade_request(&req) {
+        debug!("Upgrade request for {host}{path}");
+    }
+
+    let req = prepare_forwarded_request(req, host, false);
     let mut upstream = sender.lock().await;
     match upstream.send_request(req).await {
         Ok(resp) => Ok(resp.map(|body| body.map_err(Into::into).boxed())),
@@ -196,10 +212,13 @@ async fn handle_request(
     }
 }
 
-fn prepare_forwarded_request(req: Request<Incoming>, host: &str) -> Request<Incoming> {
+fn prepare_forwarded_request(
+    req: Request<Incoming>,
+    host: &str,
+    preserve_upgrade: bool,
+) -> Request<Incoming> {
     let (mut parts, body) = req.into_parts();
 
-    // Set URI authority+scheme when missing (h1 origin-form → h2 needs these).
     if parts.uri.authority().is_none() {
         let pq = parts
             .uri
@@ -215,18 +234,27 @@ fn prepare_forwarded_request(req: Request<Incoming>, host: &str) -> Request<Inco
         }
     }
 
-    // Strip hop-by-hop headers (RFC 7230 §6.1) — these are per-connection,
-    // not end-to-end, and invalid in HTTP/2.
-    for name in &[
-        "connection",
-        "keep-alive",
-        "proxy-authenticate",
-        "proxy-authorization",
-        "te",
-        "trailer",
-        "transfer-encoding",
-        "upgrade",
-    ] {
+    let hop_by_hop: &[&str] = if preserve_upgrade {
+        &[
+            "keep-alive",
+            "proxy-authenticate",
+            "proxy-authorization",
+            "te",
+            "trailer",
+        ]
+    } else {
+        &[
+            "connection",
+            "keep-alive",
+            "proxy-authenticate",
+            "proxy-authorization",
+            "te",
+            "trailer",
+            "transfer-encoding",
+            "upgrade",
+        ]
+    };
+    for name in hop_by_hop {
         parts.headers.remove(*name);
     }
 
@@ -375,5 +403,44 @@ mod tests {
             config.alpn_protocols,
             vec![b"h2".to_vec(), b"http/1.1".to_vec()]
         );
+    }
+
+    #[test]
+    fn detects_websocket_upgrade_request() {
+        let req = Request::builder()
+            .header("upgrade", "websocket")
+            .header("connection", "Upgrade")
+            .body(())
+            .unwrap();
+        assert!(is_upgrade_request(&req));
+    }
+
+    #[test]
+    fn detects_upgrade_in_multi_value_connection() {
+        let req = Request::builder()
+            .header("upgrade", "websocket")
+            .header("connection", "keep-alive, Upgrade")
+            .body(())
+            .unwrap();
+        assert!(is_upgrade_request(&req));
+    }
+
+    #[test]
+    fn rejects_request_without_upgrade_header() {
+        let req = Request::builder()
+            .header("connection", "keep-alive")
+            .body(())
+            .unwrap();
+        assert!(!is_upgrade_request(&req));
+    }
+
+    #[test]
+    fn rejects_upgrade_without_connection_token() {
+        let req = Request::builder()
+            .header("upgrade", "websocket")
+            .header("connection", "keep-alive")
+            .body(())
+            .unwrap();
+        assert!(!is_upgrade_request(&req));
     }
 }

--- a/crates/cella-agent/src/mitm.rs
+++ b/crates/cella-agent/src/mitm.rs
@@ -280,6 +280,8 @@ async fn handle_request(
         return Ok(resp);
     }
 
+    // HTTP/2 clients use Extended CONNECT (RFC 8441) instead of Upgrade headers,
+    // so this only triggers for HTTP/1.1 clients.
     if is_upgrade_request(&req) {
         return handle_upgrade_request(req, host, port, config).await;
     }

--- a/crates/cella-agent/src/mitm.rs
+++ b/crates/cella-agent/src/mitm.rs
@@ -330,6 +330,7 @@ fn prepare_forwarded_request(
             "proxy-authorization",
             "te",
             "trailer",
+            "transfer-encoding",
         ]
     } else {
         &[

--- a/crates/cella-agent/src/mitm.rs
+++ b/crates/cella-agent/src/mitm.rs
@@ -1,4 +1,3 @@
-use std::convert::Infallible;
 use std::sync::{Arc, OnceLock};
 
 use http_body_util::{BodyExt, Full};
@@ -16,7 +15,8 @@ use tracing::{debug, warn};
 
 use crate::proxy_config::AgentProxyConfig;
 
-type BoxBody = http_body_util::combinators::BoxBody<Bytes, Infallible>;
+type BoxBody =
+    http_body_util::combinators::BoxBody<Bytes, Box<dyn std::error::Error + Send + Sync>>;
 
 static NATIVE_ROOTS: OnceLock<Arc<rustls::RootCertStore>> = OnceLock::new();
 
@@ -69,7 +69,8 @@ pub async fn intercept_tls(
             }
         };
 
-    let connector = tokio_rustls::TlsConnector::from(Arc::new(upstream_tls_config(None)));
+    let extra = config.ca_cert_der.as_ref().map(std::slice::from_ref);
+    let connector = tokio_rustls::TlsConnector::from(Arc::new(upstream_tls_config(extra)));
     let server_name = match rustls::pki_types::ServerName::try_from(host.to_string()) {
         Ok(sn) => sn,
         Err(e) => {
@@ -148,7 +149,7 @@ async fn handle_request(
     host: &str,
     config: &AgentProxyConfig,
     sender: &Mutex<UpstreamSender>,
-) -> Result<Response<BoxBody>, Infallible> {
+) -> Result<Response<BoxBody>, std::convert::Infallible> {
     let path = super::forward_proxy::strip_query(req.uri().path());
     let verdict = config.matcher.evaluate(host, path);
 
@@ -165,7 +166,7 @@ async fn handle_request(
 
     let mut upstream = sender.lock().await;
     match upstream.send_request(req).await {
-        Ok(resp) => Ok(resp.map(|body| body.map_err(|_: hyper::Error| unreachable!()).boxed())),
+        Ok(resp) => Ok(resp.map(|body| body.map_err(Into::into).boxed())),
         Err(e) => {
             warn!("Upstream request to {host} failed: {e}");
             let resp = Response::builder()
@@ -178,7 +179,9 @@ async fn handle_request(
 }
 
 fn full(data: &'static str) -> BoxBody {
-    Full::new(Bytes::from(data)).boxed()
+    Full::new(Bytes::from(data))
+        .map_err(|never| match never {})
+        .boxed()
 }
 
 fn generate_server_config(domain: &str, config: &AgentProxyConfig) -> Result<ServerConfig, String> {
@@ -246,17 +249,18 @@ fn cached_native_roots() -> Arc<rustls::RootCertStore> {
         .clone()
 }
 
-pub fn upstream_tls_config(custom_roots: Option<&[CertificateDer<'_>]>) -> rustls::ClientConfig {
-    let root_store = custom_roots.map_or_else(cached_native_roots, |roots| {
-        let mut store = rustls::RootCertStore::empty();
+pub fn upstream_tls_config(
+    additional_roots: Option<&[CertificateDer<'_>]>,
+) -> rustls::ClientConfig {
+    let mut root_store = (*cached_native_roots()).clone();
+    if let Some(roots) = additional_roots {
         for cert in roots {
-            let _ = store.add(cert.clone());
+            let _ = root_store.add(cert.clone());
         }
-        Arc::new(store)
-    });
+    }
 
     let mut config = rustls::ClientConfig::builder()
-        .with_root_certificates((*root_store).clone())
+        .with_root_certificates(root_store)
         .with_no_client_auth();
     config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
     config

--- a/crates/cella-agent/src/mitm.rs
+++ b/crates/cella-agent/src/mitm.rs
@@ -55,7 +55,7 @@ pub async fn intercept_tls(
         let sender = sender.clone();
         let host = host_owned.clone();
         let config = config.clone();
-        async move { handle_request(req, &host, &config, &sender).await }
+        async move { handle_request(req, &host, port, &config, &sender).await }
     });
 
     let builder = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new());
@@ -173,9 +173,96 @@ fn is_upgrade_request<B>(req: &Request<B>) -> bool {
             })
 }
 
+async fn connect_h1_upstream(
+    host: &str,
+    port: u16,
+    config: &AgentProxyConfig,
+) -> Result<hyper::client::conn::http1::SendRequest<Incoming>, String> {
+    let upstream_tcp = super::forward_proxy::connect_upstream_for_mitm(host, port, config)
+        .await
+        .map_err(|e| format!("upstream connect: {e}"))?;
+
+    let extra = config.ca_cert_der.as_ref().map(std::slice::from_ref);
+    let mut tls_config = upstream_tls_config(extra);
+    tls_config.alpn_protocols = vec![b"http/1.1".to_vec()];
+    let connector = tokio_rustls::TlsConnector::from(Arc::new(tls_config));
+    let server_name = rustls::pki_types::ServerName::try_from(host.to_string())
+        .map_err(|e| format!("invalid server name: {e}"))?;
+    let upstream_tls = connector
+        .connect(server_name, upstream_tcp)
+        .await
+        .map_err(|e| format!("upstream TLS: {e}"))?;
+
+    let (sender, conn) = hyper::client::conn::http1::handshake(TokioIo::new(upstream_tls))
+        .await
+        .map_err(|e| format!("upstream h1 handshake: {e}"))?;
+    tokio::spawn(async move {
+        if let Err(e) = conn.with_upgrades().await {
+            debug!("Upgrade upstream connection ended: {e}");
+        }
+    });
+    Ok(sender)
+}
+
+async fn handle_upgrade_request(
+    mut req: Request<Incoming>,
+    host: &str,
+    port: u16,
+    config: &AgentProxyConfig,
+) -> Result<Response<BoxBody>, std::convert::Infallible> {
+    let client_upgrade = hyper::upgrade::on(&mut req);
+    let req = prepare_forwarded_request(req, host, true);
+
+    let mut sender = match connect_h1_upstream(host, port, config).await {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("Upgrade upstream connection to {host} failed: {e}");
+            return Ok(Response::builder()
+                .status(hyper::StatusCode::BAD_GATEWAY)
+                .body(full("Bad Gateway"))
+                .expect("building 502"));
+        }
+    };
+
+    let mut resp = match sender.send_request(req).await {
+        Ok(r) => r,
+        Err(e) => {
+            warn!("Upgrade request to {host} failed: {e}");
+            return Ok(Response::builder()
+                .status(hyper::StatusCode::BAD_GATEWAY)
+                .body(full("Bad Gateway"))
+                .expect("building 502"));
+        }
+    };
+
+    if resp.status() != hyper::StatusCode::SWITCHING_PROTOCOLS {
+        return Ok(resp.map(|body| body.map_err(Into::into).boxed()));
+    }
+
+    let upstream_upgrade = hyper::upgrade::on(&mut resp);
+    let host_owned = host.to_string();
+    tokio::spawn(async move {
+        let (client_io, upstream_io) = match tokio::join!(client_upgrade, upstream_upgrade) {
+            (Ok(c), Ok(u)) => (c, u),
+            (Err(e), _) | (_, Err(e)) => {
+                debug!("Upgrade for {host_owned} failed: {e}");
+                return;
+            }
+        };
+        let mut client_io = TokioIo::new(client_io);
+        let mut upstream_io = TokioIo::new(upstream_io);
+        if let Err(e) = tokio::io::copy_bidirectional(&mut client_io, &mut upstream_io).await {
+            debug!("Upgraded connection to {host_owned} ended: {e}");
+        }
+    });
+
+    Ok(resp.map(|body| body.map_err(Into::into).boxed()))
+}
+
 async fn handle_request(
     req: Request<Incoming>,
     host: &str,
+    port: u16,
     config: &AgentProxyConfig,
     sender: &Mutex<UpstreamSender>,
 ) -> Result<Response<BoxBody>, std::convert::Infallible> {
@@ -194,7 +281,7 @@ async fn handle_request(
     }
 
     if is_upgrade_request(&req) {
-        debug!("Upgrade request for {host}{path}");
+        return handle_upgrade_request(req, host, port, config).await;
     }
 
     let req = prepare_forwarded_request(req, host, false);

--- a/crates/cella-agent/src/mitm.rs
+++ b/crates/cella-agent/src/mitm.rs
@@ -1,34 +1,46 @@
-//! TLS MITM interception for HTTPS path-level blocking.
-//!
-//! When a domain has path-level blocking rules, the proxy intercepts the
-//! TLS connection:
-//! 1. Generate a per-domain certificate signed by the cella CA
-//! 2. Accept TLS from the client using that certificate
-//! 3. Parse decrypted HTTP requests to inspect URL paths
-//! 4. Evaluate blocking rules against domain + path for every request
-//! 5. If allowed, relay to upstream; if blocked, send 403
-
+use std::convert::Infallible;
 use std::sync::{Arc, OnceLock};
 
+use http_body_util::{BodyExt, Full};
+use hyper::body::{Bytes, Incoming};
+use hyper::service::service_fn;
+use hyper::{Request, Response};
+use hyper_util::rt::{TokioExecutor, TokioIo};
 use rcgen::{CertificateParams, DnType, DnValue, IsCa, Issuer, KeyPair, SanType};
 use rustls::ServerConfig;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
-use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
+use tokio::sync::Mutex;
 use tokio_rustls::TlsAcceptor;
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 
 use crate::proxy_config::AgentProxyConfig;
 
+type BoxBody = http_body_util::combinators::BoxBody<Bytes, Infallible>;
+
 static NATIVE_ROOTS: OnceLock<Arc<rustls::RootCertStore>> = OnceLock::new();
 
-/// Perform MITM interception on a CONNECT tunnel.
-///
-/// The client has already received "200 Connection Established" and expects
-/// to start a TLS handshake. We accept TLS with a generated cert, then
-/// inspect every HTTP/1.1 request on the connection for rule evaluation.
-pub async fn intercept_tls(client: TcpStream, host: &str, port: u16, config: &AgentProxyConfig) {
-    let tls_config = match generate_server_config(host, config) {
+enum UpstreamSender {
+    Http1(hyper::client::conn::http1::SendRequest<Incoming>),
+    Http2(hyper::client::conn::http2::SendRequest<Incoming>),
+}
+
+impl UpstreamSender {
+    async fn send_request(&mut self, req: Request<Incoming>) -> hyper::Result<Response<Incoming>> {
+        match self {
+            Self::Http1(s) => s.send_request(req).await,
+            Self::Http2(s) => s.send_request(req).await,
+        }
+    }
+}
+
+pub async fn intercept_tls(
+    client: TcpStream,
+    host: &str,
+    port: u16,
+    config: Arc<AgentProxyConfig>,
+) {
+    let tls_config = match generate_server_config(host, &config) {
         Ok(cfg) => cfg,
         Err(e) => {
             warn!("Failed to generate MITM cert for {host}: {e}");
@@ -38,8 +50,7 @@ pub async fn intercept_tls(client: TcpStream, host: &str, port: u16, config: &Ag
     };
 
     let acceptor = TlsAcceptor::from(Arc::new(tls_config));
-
-    let tls_stream = match acceptor.accept(client).await {
+    let client_tls = match acceptor.accept(client).await {
         Ok(s) => s,
         Err(e) => {
             warn!("TLS handshake failed for {host}: {e}");
@@ -48,43 +59,16 @@ pub async fn intercept_tls(client: TcpStream, host: &str, port: u16, config: &Ag
         }
     };
 
-    let (reader, mut writer) = tokio::io::split(tls_stream);
-    let mut reader = BufReader::new(reader);
-
-    // Read first request headers.
-    let mut header_bytes = Vec::new();
-    if read_request_headers(&mut reader, &mut header_bytes)
-        .await
-        .is_err()
-    {
-        return;
-    }
-
-    let (method, path) = parse_method_and_path(&header_bytes);
-    let path = super::forward_proxy::strip_query(path);
-
-    let verdict = config.matcher.evaluate(host, path);
-    if !verdict.allowed {
-        info!("BLOCKED HTTPS {host}{path} - {}", verdict.reason);
-        config.log_blocked(host, path, &verdict.reason);
-        let _ = writer
-            .write_all(b"HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n")
-            .await;
-        return;
-    }
-
-    // Connect to upstream server.
     let upstream_tcp =
-        match super::forward_proxy::connect_upstream_for_mitm(host, port, config).await {
+        match super::forward_proxy::connect_upstream_for_mitm(host, port, &config).await {
             Ok(s) => s,
             Err(e) => {
-                warn!("Failed to connect to {host}:{port} for MITM relay: {e}");
-                let _ = writer.write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n").await;
+                warn!("Failed to connect to {host}:{port}: {e}");
+                config.log_error(host, &format!("upstream connect failed: {e}"));
                 return;
             }
         };
 
-    // Establish TLS to upstream.
     let connector = tokio_rustls::TlsConnector::from(Arc::new(upstream_tls_config(None)));
     let server_name = match rustls::pki_types::ServerName::try_from(host.to_string()) {
         Ok(sn) => sn,
@@ -98,298 +82,105 @@ pub async fn intercept_tls(client: TcpStream, host: &str, port: u16, config: &Ag
         Ok(s) => s,
         Err(e) => {
             warn!("Upstream TLS handshake failed for {host}: {e}");
-            let _ = writer.write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n").await;
+            config.log_error(host, &format!("upstream TLS failed: {e}"));
             return;
         }
     };
 
-    let (upstream_reader, mut upstream_writer) = tokio::io::split(upstream_tls);
-    let mut upstream_reader = BufReader::new(upstream_reader);
+    let is_h2 = upstream_tls
+        .get_ref()
+        .1
+        .alpn_protocol()
+        .is_some_and(|p| p == b"h2");
 
-    // Request loop: evaluate rules on every request, relay if allowed.
-    let has_body = method_has_body(&method);
-    let content_length = parse_content_length(&header_bytes);
-    let is_chunked = is_chunked_transfer(&header_bytes);
+    let upstream_io = TokioIo::new(upstream_tls);
+    let sender = if is_h2 {
+        let (sender, conn) =
+            match hyper::client::conn::http2::handshake(TokioExecutor::new(), upstream_io).await {
+                Ok(pair) => pair,
+                Err(e) => {
+                    warn!("Upstream HTTP/2 handshake failed for {host}: {e}");
+                    return;
+                }
+            };
+        tokio::spawn(async move {
+            if let Err(e) = conn.await {
+                debug!("Upstream h2 connection ended: {e}");
+            }
+        });
+        UpstreamSender::Http2(sender)
+    } else {
+        let (sender, conn) = match hyper::client::conn::http1::handshake(upstream_io).await {
+            Ok(pair) => pair,
+            Err(e) => {
+                warn!("Upstream HTTP/1.1 handshake failed for {host}: {e}");
+                return;
+            }
+        };
+        tokio::spawn(async move {
+            if let Err(e) = conn.await {
+                debug!("Upstream h1 connection ended: {e}");
+            }
+        });
+        UpstreamSender::Http1(sender)
+    };
 
-    // Forward first request headers to upstream.
-    if upstream_writer.write_all(&header_bytes).await.is_err() {
-        return;
+    let sender = Arc::new(Mutex::new(sender));
+    let host_owned: Arc<str> = host.into();
+
+    let client_io = TokioIo::new(client_tls);
+
+    let svc = service_fn(move |req: Request<Incoming>| {
+        let sender = sender.clone();
+        let host = host_owned.clone();
+        let config = config.clone();
+        async move { handle_request(req, &host, &config, &sender).await }
+    });
+
+    let builder = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new());
+    if let Err(e) = builder.serve_connection(client_io, svc).await {
+        debug!("MITM server for {host} ended: {e}");
     }
-
-    // Relay first request body.
-    if has_body
-        && let Err(e) = relay_body(
-            &mut reader,
-            &mut upstream_writer,
-            content_length,
-            is_chunked,
-        )
-        .await
-    {
-        debug!("Error relaying request body: {e}");
-        return;
-    }
-
-    request_loop(
-        host,
-        config,
-        &mut reader,
-        &mut writer,
-        &mut upstream_reader,
-        &mut upstream_writer,
-        &mut header_bytes,
-    )
-    .await;
 }
 
-/// Process subsequent HTTP/1.1 requests on a keep-alive MITM connection.
-async fn request_loop<CR, CW, UR, UW>(
+async fn handle_request(
+    req: Request<Incoming>,
     host: &str,
     config: &AgentProxyConfig,
-    reader: &mut CR,
-    writer: &mut CW,
-    upstream_reader: &mut UR,
-    upstream_writer: &mut UW,
-    header_bytes: &mut Vec<u8>,
-) where
-    CR: AsyncBufRead + Unpin,
-    CW: AsyncWriteExt + Unpin,
-    UR: AsyncBufRead + Unpin,
-    UW: AsyncWriteExt + Unpin,
-{
-    loop {
-        // Read response from upstream and relay to client.
-        let mut resp_headers = Vec::new();
-        if read_request_headers(upstream_reader, &mut resp_headers)
-            .await
-            .is_err()
-        {
-            break;
-        }
-        if writer.write_all(&resp_headers).await.is_err() {
-            break;
-        }
+    sender: &Mutex<UpstreamSender>,
+) -> Result<Response<BoxBody>, Infallible> {
+    let path = super::forward_proxy::strip_query(req.uri().path());
+    let verdict = config.matcher.evaluate(host, path);
 
-        let resp_content_length = parse_content_length(&resp_headers);
-        let resp_chunked = is_chunked_transfer(&resp_headers);
-        let keep_alive = !has_connection_close(&resp_headers);
+    if !verdict.allowed {
+        tracing::info!("BLOCKED HTTPS {host}{path} - {}", verdict.reason);
+        config.log_blocked(host, path, &verdict.reason);
+        let resp = Response::builder()
+            .status(hyper::StatusCode::FORBIDDEN)
+            .header("connection", "close")
+            .body(full("Forbidden"))
+            .expect("building 403 response");
+        return Ok(resp);
+    }
 
-        // Relay response body.
-        if let Err(e) = relay_body(upstream_reader, writer, resp_content_length, resp_chunked).await
-        {
-            debug!("Error relaying response body: {e}");
-            break;
-        }
-
-        if !keep_alive {
-            break;
-        }
-
-        // Read next request from client.
-        header_bytes.clear();
-        if read_request_headers(reader, header_bytes).await.is_err() {
-            break;
-        }
-
-        let (next_method, next_path) = parse_method_and_path(header_bytes);
-        let next_path = super::forward_proxy::strip_query(next_path);
-
-        // Evaluate rules on this request.
-        let verdict = config.matcher.evaluate(host, next_path);
-        if !verdict.allowed {
-            info!(
-                "BLOCKED HTTPS {host}{next_path} (keep-alive) - {}",
-                verdict.reason
-            );
-            config.log_blocked(host, next_path, &verdict.reason);
-            let _ = writer
-                .write_all(b"HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n")
-                .await;
-            break;
-        }
-
-        // Forward allowed request to upstream.
-        if upstream_writer.write_all(header_bytes).await.is_err() {
-            break;
-        }
-
-        let has_body = method_has_body(&next_method);
-        let content_length = parse_content_length(header_bytes);
-        let is_chunked = is_chunked_transfer(header_bytes);
-
-        if has_body
-            && let Err(e) = relay_body(reader, upstream_writer, content_length, is_chunked).await
-        {
-            debug!("Error relaying request body: {e}");
-            break;
+    let mut upstream = sender.lock().await;
+    match upstream.send_request(req).await {
+        Ok(resp) => Ok(resp.map(|body| body.map_err(|_: hyper::Error| unreachable!()).boxed())),
+        Err(e) => {
+            warn!("Upstream request to {host} failed: {e}");
+            let resp = Response::builder()
+                .status(hyper::StatusCode::BAD_GATEWAY)
+                .body(full("Bad Gateway"))
+                .expect("building 502 response");
+            Ok(resp)
         }
     }
 }
 
-/// Read HTTP headers (request or response) into `buf` until `\r\n\r\n`.
-async fn read_request_headers<R: AsyncBufRead + Unpin>(
-    reader: &mut R,
-    buf: &mut Vec<u8>,
-) -> Result<(), ()> {
-    loop {
-        let mut line = String::new();
-        let n = reader.read_line(&mut line).await.map_err(|_| ())?;
-        if n == 0 {
-            return Err(());
-        }
-        let is_end = line == "\r\n" || line == "\n";
-        buf.extend_from_slice(line.as_bytes());
-        if is_end {
-            return Ok(());
-        }
-    }
+fn full(data: &'static str) -> BoxBody {
+    Full::new(Bytes::from(data)).boxed()
 }
 
-/// Parse method and path from request line bytes.
-fn parse_method_and_path(header_bytes: &[u8]) -> (String, &str) {
-    let header_str = std::str::from_utf8(header_bytes).unwrap_or("");
-    let first_line = header_str.lines().next().unwrap_or("");
-    let parts: Vec<&str> = first_line.split_whitespace().collect();
-    let method = parts.first().copied().unwrap_or("GET").to_string();
-    let path = if parts.len() >= 2 { parts[1] } else { "/" };
-    (method, path)
-}
-
-/// Check if the HTTP method typically has a request body.
-fn method_has_body(method: &str) -> bool {
-    matches!(
-        method.to_ascii_uppercase().as_str(),
-        "POST" | "PUT" | "PATCH"
-    )
-}
-
-/// Parse Content-Length from raw header bytes.
-fn parse_content_length(headers: &[u8]) -> Option<u64> {
-    let headers_str = std::str::from_utf8(headers).ok()?;
-    for line in headers_str.lines() {
-        if let Some(val) = line
-            .strip_prefix("Content-Length:")
-            .or_else(|| line.strip_prefix("content-length:"))
-        {
-            return val.trim().parse().ok();
-        }
-        // Case-insensitive check.
-        if line.len() > 16 && line[..16].eq_ignore_ascii_case("content-length: ") {
-            return line[16..].trim().parse().ok();
-        }
-    }
-    None
-}
-
-/// Check if Transfer-Encoding: chunked is set.
-fn is_chunked_transfer(headers: &[u8]) -> bool {
-    let Ok(headers_str) = std::str::from_utf8(headers) else {
-        return false;
-    };
-    for line in headers_str.lines() {
-        let lower = line.to_ascii_lowercase();
-        if lower.starts_with("transfer-encoding:") && lower.contains("chunked") {
-            return true;
-        }
-    }
-    false
-}
-
-/// Check if Connection: close is set.
-fn has_connection_close(headers: &[u8]) -> bool {
-    let Ok(headers_str) = std::str::from_utf8(headers) else {
-        return false;
-    };
-    for line in headers_str.lines() {
-        let lower = line.to_ascii_lowercase();
-        if lower.starts_with("connection:") && lower.contains("close") {
-            return true;
-        }
-    }
-    false
-}
-
-/// Relay an HTTP message body between reader and writer.
-///
-/// Handles Content-Length, chunked transfer encoding, and no-body cases.
-async fn relay_body<R: AsyncBufRead + Unpin, W: AsyncWriteExt + Unpin>(
-    reader: &mut R,
-    writer: &mut W,
-    content_length: Option<u64>,
-    chunked: bool,
-) -> Result<(), std::io::Error> {
-    if chunked {
-        relay_chunked(reader, writer).await
-    } else if let Some(len) = content_length {
-        relay_fixed(reader, writer, len).await
-    } else {
-        // No body (GET, HEAD, or 204/304 response).
-        Ok(())
-    }
-}
-
-/// Relay a fixed-length body.
-async fn relay_fixed<R: AsyncRead + Unpin, W: AsyncWriteExt + Unpin>(
-    reader: &mut R,
-    writer: &mut W,
-    length: u64,
-) -> Result<(), std::io::Error> {
-    let mut remaining = length;
-    let mut buf = [0u8; 8192];
-    while remaining > 0 {
-        let to_read = usize::try_from(remaining)
-            .unwrap_or(buf.len())
-            .min(buf.len());
-        let n = reader.read(&mut buf[..to_read]).await?;
-        if n == 0 {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::UnexpectedEof,
-                "connection closed mid-body",
-            ));
-        }
-        writer.write_all(&buf[..n]).await?;
-        remaining -= n as u64;
-    }
-    Ok(())
-}
-
-/// Relay a chunked transfer-encoded body.
-///
-/// Reads and forwards chunk headers + data + trailers verbatim.
-async fn relay_chunked<R: AsyncBufRead + Unpin, W: AsyncWriteExt + Unpin>(
-    reader: &mut R,
-    writer: &mut W,
-) -> Result<(), std::io::Error> {
-    loop {
-        // Read chunk size line.
-        let mut size_line = String::new();
-        reader.read_line(&mut size_line).await?;
-        writer.write_all(size_line.as_bytes()).await?;
-
-        let size_str = size_line.trim().split(';').next().unwrap_or("0");
-        let chunk_size = u64::from_str_radix(size_str, 16).unwrap_or(0);
-
-        if chunk_size == 0 {
-            // Terminal chunk. Read trailing \r\n (end of chunked body).
-            let mut trailer = String::new();
-            reader.read_line(&mut trailer).await?;
-            writer.write_all(trailer.as_bytes()).await?;
-            break;
-        }
-
-        // Relay chunk data.
-        relay_fixed(reader, writer, chunk_size).await?;
-
-        // Read and relay trailing \r\n after chunk data.
-        let mut crlf = String::new();
-        reader.read_line(&mut crlf).await?;
-        writer.write_all(crlf.as_bytes()).await?;
-    }
-    Ok(())
-}
-
-/// Generate a rustls `ServerConfig` with a certificate for the given domain,
-/// signed by the cella CA.
 fn generate_server_config(domain: &str, config: &AgentProxyConfig) -> Result<ServerConfig, String> {
     let ca = load_ca_materials(config)?;
     let ca_issuer = Issuer::from_params(&ca.params, &ca.key_pair);
@@ -475,448 +266,55 @@ pub fn upstream_tls_config(custom_roots: Option<&[CertificateDer<'_>]>) -> rustl
 mod tests {
     use super::*;
 
-    #[test]
-    fn parse_content_length_header() {
-        let headers = b"GET / HTTP/1.1\r\nContent-Length: 42\r\n\r\n";
-        assert_eq!(parse_content_length(headers), Some(42));
+    fn install_crypto_provider() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
     }
 
     #[test]
-    fn parse_content_length_case_insensitive() {
-        let headers = b"POST / HTTP/1.1\r\ncontent-length: 100\r\n\r\n";
-        assert_eq!(parse_content_length(headers), Some(100));
+    fn server_config_offers_h2_and_http11_alpn() {
+        install_crypto_provider();
+        let ca_key = KeyPair::generate().unwrap();
+        let ca_params = cella_network::ca::ca_certificate_params();
+        let ca_cert = ca_params.self_signed(&ca_key).unwrap();
+
+        let json = serde_json::json!({
+            "listen_port": 0,
+            "mode": "denylist",
+            "rules": [],
+            "ca_cert_pem": ca_cert.pem(),
+            "ca_key_pem": ca_key.serialize_pem(),
+        })
+        .to_string();
+        let config = AgentProxyConfig::from_json(&json).unwrap();
+        let server_config = generate_server_config("example.com", &config).unwrap();
+        assert_eq!(
+            server_config.alpn_protocols,
+            vec![b"h2".to_vec(), b"http/1.1".to_vec()]
+        );
     }
 
     #[test]
-    fn parse_content_length_absent() {
-        let headers = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
-        assert_eq!(parse_content_length(headers), None);
+    fn upstream_config_offers_h2_and_http11_alpn() {
+        install_crypto_provider();
+        let config = upstream_tls_config(None);
+        assert_eq!(
+            config.alpn_protocols,
+            vec![b"h2".to_vec(), b"http/1.1".to_vec()]
+        );
     }
 
     #[test]
-    fn detect_chunked_transfer() {
-        let headers = b"POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n";
-        assert!(is_chunked_transfer(headers));
-    }
+    fn upstream_tls_config_with_custom_roots() {
+        install_crypto_provider();
+        let key = KeyPair::generate().unwrap();
+        let params = cella_network::ca::ca_certificate_params();
+        let cert = params.self_signed(&key).unwrap();
+        let der = CertificateDer::from(cert.der().to_vec());
 
-    #[test]
-    fn detect_connection_close() {
-        let headers = b"HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n";
-        assert!(has_connection_close(headers));
-
-        let headers = b"HTTP/1.1 200 OK\r\nConnection: keep-alive\r\n\r\n";
-        assert!(!has_connection_close(headers));
-    }
-
-    #[test]
-    fn parse_method_and_path_basic() {
-        let headers = b"GET /api/v1 HTTP/1.1\r\nHost: example.com\r\n\r\n";
-        let (method, path) = parse_method_and_path(headers);
-        assert_eq!(method, "GET");
-        assert_eq!(path, "/api/v1");
-    }
-
-    #[test]
-    fn parse_method_and_path_with_query() {
-        let headers = b"GET /api/v1?foo=bar HTTP/1.1\r\nHost: example.com\r\n\r\n";
-        let (method, path) = parse_method_and_path(headers);
-        assert_eq!(method, "GET");
-        assert_eq!(path, "/api/v1?foo=bar");
-        // strip_query is applied by the caller
-        assert_eq!(super::super::forward_proxy::strip_query(path), "/api/v1");
-    }
-
-    #[test]
-    fn method_body_detection() {
-        assert!(method_has_body("POST"));
-        assert!(method_has_body("PUT"));
-        assert!(method_has_body("PATCH"));
-        assert!(!method_has_body("GET"));
-        assert!(!method_has_body("HEAD"));
-        assert!(!method_has_body("DELETE"));
-    }
-
-    // --- Additional header parsing edge cases ---
-
-    #[test]
-    fn parse_method_and_path_post() {
-        let headers = b"POST /submit HTTP/1.1\r\nHost: example.com\r\n\r\n";
-        let (method, path) = parse_method_and_path(headers);
-        assert_eq!(method, "POST");
-        assert_eq!(path, "/submit");
-    }
-
-    #[test]
-    fn parse_method_and_path_empty_bytes() {
-        let headers = b"";
-        let (method, path) = parse_method_and_path(headers);
-        assert_eq!(method, "GET");
-        assert_eq!(path, "/");
-    }
-
-    #[test]
-    fn parse_method_and_path_single_word() {
-        let headers = b"CONNECT\r\n\r\n";
-        let (method, path) = parse_method_and_path(headers);
-        assert_eq!(method, "CONNECT");
-        assert_eq!(path, "/");
-    }
-
-    #[test]
-    fn parse_content_length_mixed_case() {
-        // Test the case-insensitive branch with "Content-length:" (not exact prefix match).
-        let headers = b"GET / HTTP/1.1\r\nContent-length: 77\r\n\r\n";
-        assert_eq!(parse_content_length(headers), Some(77));
-    }
-
-    #[test]
-    fn parse_content_length_uppercase() {
-        let headers = b"GET / HTTP/1.1\r\nCONTENT-LENGTH: 55\r\n\r\n";
-        assert_eq!(parse_content_length(headers), Some(55));
-    }
-
-    #[test]
-    fn parse_content_length_invalid_value() {
-        let headers = b"GET / HTTP/1.1\r\nContent-Length: not-a-number\r\n\r\n";
-        assert_eq!(parse_content_length(headers), None);
-    }
-
-    #[test]
-    fn chunked_transfer_mixed_case() {
-        let headers = b"POST / HTTP/1.1\r\nTRANSFER-ENCODING: chunked\r\n\r\n";
-        assert!(is_chunked_transfer(headers));
-    }
-
-    #[test]
-    fn chunked_transfer_not_set() {
-        let headers = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
-        assert!(!is_chunked_transfer(headers));
-    }
-
-    #[test]
-    fn chunked_transfer_invalid_utf8() {
-        let headers = &[0xFF, 0xFE, 0xFD];
-        assert!(!is_chunked_transfer(headers));
-    }
-
-    #[test]
-    fn connection_close_mixed_case() {
-        let headers = b"HTTP/1.1 200 OK\r\nCONNECTION: close\r\n\r\n";
-        assert!(has_connection_close(headers));
-    }
-
-    #[test]
-    fn connection_close_not_present() {
-        let headers = b"HTTP/1.1 200 OK\r\n\r\n";
-        assert!(!has_connection_close(headers));
-    }
-
-    #[test]
-    fn connection_close_invalid_utf8() {
-        let headers = &[0xFF, 0xFE];
-        assert!(!has_connection_close(headers));
-    }
-
-    #[test]
-    fn method_has_body_case_insensitive() {
-        assert!(method_has_body("post"));
-        assert!(method_has_body("Put"));
-        assert!(method_has_body("PATCH"));
-        assert!(!method_has_body("get"));
-        assert!(!method_has_body("head"));
-        assert!(!method_has_body("OPTIONS"));
-        assert!(!method_has_body("TRACE"));
-    }
-
-    // --- Async relay tests ---
-
-    #[tokio::test]
-    async fn read_request_headers_basic() {
-        let data = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
-        let mut reader = BufReader::new(&data[..]);
-        let mut buf = Vec::new();
-        let result = read_request_headers(&mut reader, &mut buf).await;
-        assert!(result.is_ok());
-        assert_eq!(buf, data);
-    }
-
-    #[tokio::test]
-    async fn read_request_headers_empty_stream() {
-        let data = b"";
-        let mut reader = BufReader::new(&data[..]);
-        let mut buf = Vec::new();
-        let result = read_request_headers(&mut reader, &mut buf).await;
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn read_request_headers_multiple_headers() {
-        let data = b"POST /api HTTP/1.1\r\nHost: api.example.com\r\nContent-Length: 5\r\n\r\n";
-        let mut reader = BufReader::new(&data[..]);
-        let mut buf = Vec::new();
-        let result = read_request_headers(&mut reader, &mut buf).await;
-        assert!(result.is_ok());
-        assert_eq!(buf, data);
-    }
-
-    #[tokio::test]
-    async fn relay_fixed_body() {
-        let body = b"hello world";
-        let mut reader = BufReader::new(&body[..]);
-        let mut writer = Vec::new();
-        let result = relay_fixed(&mut reader, &mut writer, body.len() as u64).await;
-        assert!(result.is_ok());
-        assert_eq!(writer, body);
-    }
-
-    #[tokio::test]
-    async fn relay_fixed_body_empty() {
-        let body = b"";
-        let mut reader = BufReader::new(&body[..]);
-        let mut writer = Vec::new();
-        let result = relay_fixed(&mut reader, &mut writer, 0).await;
-        assert!(result.is_ok());
-        assert!(writer.is_empty());
-    }
-
-    #[tokio::test]
-    async fn relay_fixed_body_premature_eof() {
-        let body = b"short";
-        let mut reader = BufReader::new(&body[..]);
-        let mut writer = Vec::new();
-        let result = relay_fixed(&mut reader, &mut writer, 100).await;
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn relay_body_no_body() {
-        let data = b"";
-        let mut reader = BufReader::new(&data[..]);
-        let mut writer = Vec::new();
-        // No content-length, not chunked: should be a no-op.
-        let result = relay_body(&mut reader, &mut writer, None, false).await;
-        assert!(result.is_ok());
-        assert!(writer.is_empty());
-    }
-
-    #[tokio::test]
-    async fn relay_body_with_content_length() {
-        let body = b"abcde";
-        let mut reader = BufReader::new(&body[..]);
-        let mut writer = Vec::new();
-        let result = relay_body(&mut reader, &mut writer, Some(5), false).await;
-        assert!(result.is_ok());
-        assert_eq!(writer, b"abcde");
-    }
-
-    #[tokio::test]
-    async fn relay_chunked_body() {
-        // A valid chunked body: one chunk of "hello" (5 bytes) then terminal chunk.
-        let chunked = b"5\r\nhello\r\n0\r\n\r\n";
-        let mut reader = BufReader::new(&chunked[..]);
-        let mut writer = Vec::new();
-        let result = relay_chunked(&mut reader, &mut writer).await;
-        assert!(result.is_ok());
-        assert_eq!(writer, chunked);
-    }
-
-    #[tokio::test]
-    async fn relay_body_chunked_mode() {
-        let chunked = b"3\r\nabc\r\n0\r\n\r\n";
-        let mut reader = BufReader::new(&chunked[..]);
-        let mut writer = Vec::new();
-        let result = relay_body(&mut reader, &mut writer, None, true).await;
-        assert!(result.is_ok());
-        assert_eq!(writer, chunked);
-    }
-
-    // --- Additional edge cases for parse_method_and_path ---
-
-    #[test]
-    fn parse_method_and_path_delete() {
-        let headers = b"DELETE /api/resource/42 HTTP/1.1\r\n\r\n";
-        let (method, path) = parse_method_and_path(headers);
-        assert_eq!(method, "DELETE");
-        assert_eq!(path, "/api/resource/42");
-    }
-
-    #[test]
-    fn parse_method_and_path_options() {
-        let headers = b"OPTIONS * HTTP/1.1\r\n\r\n";
-        let (method, path) = parse_method_and_path(headers);
-        assert_eq!(method, "OPTIONS");
-        assert_eq!(path, "*");
-    }
-
-    #[test]
-    fn parse_method_and_path_connect() {
-        let headers = b"CONNECT example.com:443 HTTP/1.1\r\n\r\n";
-        let (method, path) = parse_method_and_path(headers);
-        assert_eq!(method, "CONNECT");
-        assert_eq!(path, "example.com:443");
-    }
-
-    #[test]
-    fn parse_method_and_path_put_with_long_path() {
-        let headers = b"PUT /api/v2/users/12345/settings/preferences HTTP/1.1\r\nHost: api.example.com\r\n\r\n";
-        let (method, path) = parse_method_and_path(headers);
-        assert_eq!(method, "PUT");
-        assert_eq!(path, "/api/v2/users/12345/settings/preferences");
-    }
-
-    #[test]
-    fn parse_method_and_path_patch() {
-        let headers = b"PATCH /resource HTTP/1.1\r\n\r\n";
-        let (method, path) = parse_method_and_path(headers);
-        assert_eq!(method, "PATCH");
-        assert_eq!(path, "/resource");
-    }
-
-    #[test]
-    fn parse_method_and_path_head() {
-        let headers = b"HEAD / HTTP/1.1\r\n\r\n";
-        let (method, path) = parse_method_and_path(headers);
-        assert_eq!(method, "HEAD");
-        assert_eq!(path, "/");
-    }
-
-    // --- Content-Length edge cases ---
-
-    #[test]
-    fn parse_content_length_with_extra_whitespace() {
-        let headers = b"POST / HTTP/1.1\r\nContent-Length:   99  \r\n\r\n";
-        assert_eq!(parse_content_length(headers), Some(99));
-    }
-
-    #[test]
-    fn parse_content_length_zero() {
-        let headers = b"POST / HTTP/1.1\r\nContent-Length: 0\r\n\r\n";
-        assert_eq!(parse_content_length(headers), Some(0));
-    }
-
-    #[test]
-    fn parse_content_length_large_value() {
-        let headers = b"POST / HTTP/1.1\r\nContent-Length: 4294967296\r\n\r\n";
-        assert_eq!(parse_content_length(headers), Some(4_294_967_296));
-    }
-
-    #[test]
-    fn parse_content_length_invalid_utf8() {
-        let headers = &[0xFF, 0xFE, 0xFD];
-        assert_eq!(parse_content_length(headers), None);
-    }
-
-    #[test]
-    fn parse_content_length_among_many_headers() {
-        let headers = b"POST /api HTTP/1.1\r\nHost: example.com\r\nAccept: */*\r\nContent-Length: 256\r\nContent-Type: application/json\r\n\r\n";
-        assert_eq!(parse_content_length(headers), Some(256));
-    }
-
-    // --- Transfer-Encoding edge cases ---
-
-    #[test]
-    fn chunked_transfer_with_extra_encoding() {
-        let headers = b"POST / HTTP/1.1\r\nTransfer-Encoding: gzip, chunked\r\n\r\n";
-        assert!(is_chunked_transfer(headers));
-    }
-
-    #[test]
-    fn chunked_transfer_not_chunked_encoding() {
-        let headers = b"POST / HTTP/1.1\r\nTransfer-Encoding: gzip\r\n\r\n";
-        assert!(!is_chunked_transfer(headers));
-    }
-
-    // --- Connection: close edge cases ---
-
-    #[test]
-    fn connection_keep_alive_is_not_close() {
-        let headers = b"HTTP/1.1 200 OK\r\nConnection: keep-alive\r\n\r\n";
-        assert!(!has_connection_close(headers));
-    }
-
-    #[test]
-    fn no_connection_header_is_not_close() {
-        let headers = b"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n";
-        assert!(!has_connection_close(headers));
-    }
-
-    // --- Async header reading edge cases ---
-
-    #[tokio::test]
-    async fn read_request_headers_lf_only() {
-        // Some servers use bare LF.
-        let data = b"GET / HTTP/1.1\nHost: example.com\n\n";
-        let mut reader = BufReader::new(&data[..]);
-        let mut buf = Vec::new();
-        let result = read_request_headers(&mut reader, &mut buf).await;
-        assert!(result.is_ok());
-        assert_eq!(buf, data);
-    }
-
-    #[tokio::test]
-    async fn read_request_headers_stops_at_separator() {
-        // Data after the header separator should not be consumed.
-        let data = b"GET / HTTP/1.1\r\n\r\nbody data here";
-        let mut reader = BufReader::new(&data[..]);
-        let mut buf = Vec::new();
-        let result = read_request_headers(&mut reader, &mut buf).await;
-        assert!(result.is_ok());
-        assert_eq!(buf, b"GET / HTTP/1.1\r\n\r\n");
-    }
-
-    // --- Relay body edge cases ---
-
-    #[tokio::test]
-    async fn relay_body_content_length_takes_precedence_over_no_body() {
-        let body = b"hello";
-        let mut reader = BufReader::new(&body[..]);
-        let mut writer = Vec::new();
-        // Content-Length is set but chunked is false.
-        let result = relay_body(&mut reader, &mut writer, Some(5), false).await;
-        assert!(result.is_ok());
-        assert_eq!(writer, b"hello");
-    }
-
-    #[tokio::test]
-    async fn relay_chunked_multiple_chunks() {
-        let chunked = b"5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n";
-        let mut reader = BufReader::new(&chunked[..]);
-        let mut writer = Vec::new();
-        let result = relay_chunked(&mut reader, &mut writer).await;
-        assert!(result.is_ok());
-        assert_eq!(writer, chunked);
-    }
-
-    #[tokio::test]
-    async fn relay_chunked_with_extension() {
-        // Chunk with extension (;ext=val) should still work.
-        let chunked = b"3;ext=val\r\nabc\r\n0\r\n\r\n";
-        let mut reader = BufReader::new(&chunked[..]);
-        let mut writer = Vec::new();
-        let result = relay_chunked(&mut reader, &mut writer).await;
-        assert!(result.is_ok());
-        assert_eq!(writer, chunked);
-    }
-
-    #[tokio::test]
-    async fn relay_fixed_exact_size() {
-        let body = b"exact";
-        let mut reader = BufReader::new(&body[..]);
-        let mut writer = Vec::new();
-        let result = relay_fixed(&mut reader, &mut writer, 5).await;
-        assert!(result.is_ok());
-        assert_eq!(writer, b"exact");
-    }
-
-    #[tokio::test]
-    async fn relay_fixed_large_body() {
-        // Body larger than internal buffer size (8192).
-        let body = vec![0x42u8; 16384];
-        let mut reader = BufReader::new(&body[..]);
-        let mut writer = Vec::new();
-        let result = relay_fixed(&mut reader, &mut writer, 16384).await;
-        assert!(result.is_ok());
-        assert_eq!(writer.len(), 16384);
-        assert!(writer.iter().all(|&b| b == 0x42));
+        let config = upstream_tls_config(Some(&[der]));
+        assert_eq!(
+            config.alpn_protocols,
+            vec![b"h2".to_vec(), b"http/1.1".to_vec()]
+        );
     }
 }

--- a/crates/cella-agent/src/mitm.rs
+++ b/crates/cella-agent/src/mitm.rs
@@ -8,7 +8,7 @@
 //! 4. Evaluate blocking rules against domain + path for every request
 //! 5. If allowed, relay to upstream; if blocked, send 403
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use rcgen::{CertificateParams, DnType, DnValue, IsCa, Issuer, KeyPair, SanType};
 use rustls::ServerConfig;
@@ -19,6 +19,8 @@ use tokio_rustls::TlsAcceptor;
 use tracing::{debug, info, warn};
 
 use crate::proxy_config::AgentProxyConfig;
+
+static NATIVE_ROOTS: OnceLock<Arc<rustls::RootCertStore>> = OnceLock::new();
 
 /// Perform MITM interception on a CONNECT tunnel.
 ///
@@ -83,7 +85,7 @@ pub async fn intercept_tls(client: TcpStream, host: &str, port: u16, config: &Ag
         };
 
     // Establish TLS to upstream.
-    let connector = tokio_rustls::TlsConnector::from(Arc::new(upstream_tls_config()));
+    let connector = tokio_rustls::TlsConnector::from(Arc::new(upstream_tls_config(None)));
     let server_name = match rustls::pki_types::ServerName::try_from(host.to_string()) {
         Ok(sn) => sn,
         Err(e) => {
@@ -413,10 +415,12 @@ fn generate_server_config(domain: &str, config: &AgentProxyConfig) -> Result<Ser
     let cert_der = CertificateDer::from(domain_cert.der().to_vec());
     let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(domain_key.serialize_der()));
 
-    ServerConfig::builder()
+    let mut config = ServerConfig::builder()
         .with_no_client_auth()
         .with_single_cert(vec![cert_der], key_der)
-        .map_err(|e| format!("server config: {e}"))
+        .map_err(|e| format!("server config: {e}"))?;
+    config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+    Ok(config)
 }
 
 struct CaIssuerMaterials {
@@ -438,17 +442,33 @@ fn load_ca_materials(config: &AgentProxyConfig) -> Result<CaIssuerMaterials, Str
     })
 }
 
-fn upstream_tls_config() -> rustls::ClientConfig {
-    let mut root_store = rustls::RootCertStore::empty();
+fn cached_native_roots() -> Arc<rustls::RootCertStore> {
+    NATIVE_ROOTS
+        .get_or_init(|| {
+            let mut root_store = rustls::RootCertStore::empty();
+            let native = rustls_native_certs::load_native_certs();
+            for cert in native.certs {
+                let _ = root_store.add(cert);
+            }
+            Arc::new(root_store)
+        })
+        .clone()
+}
 
-    let native = rustls_native_certs::load_native_certs();
-    for cert in native.certs {
-        let _ = root_store.add(cert);
-    }
+pub fn upstream_tls_config(custom_roots: Option<&[CertificateDer<'_>]>) -> rustls::ClientConfig {
+    let root_store = custom_roots.map_or_else(cached_native_roots, |roots| {
+        let mut store = rustls::RootCertStore::empty();
+        for cert in roots {
+            let _ = store.add(cert.clone());
+        }
+        Arc::new(store)
+    });
 
-    rustls::ClientConfig::builder()
-        .with_root_certificates(root_store)
-        .with_no_client_auth()
+    let mut config = rustls::ClientConfig::builder()
+        .with_root_certificates((*root_store).clone())
+        .with_no_client_auth();
+    config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+    config
 }
 
 #[cfg(test)]

--- a/crates/cella-agent/src/mitm.rs
+++ b/crates/cella-agent/src/mitm.rs
@@ -164,6 +164,7 @@ async fn handle_request(
         return Ok(resp);
     }
 
+    let req = prepare_forwarded_request(req, host);
     let mut upstream = sender.lock().await;
     match upstream.send_request(req).await {
         Ok(resp) => Ok(resp.map(|body| body.map_err(Into::into).boxed())),
@@ -176,6 +177,43 @@ async fn handle_request(
             Ok(resp)
         }
     }
+}
+
+fn prepare_forwarded_request(req: Request<Incoming>, host: &str) -> Request<Incoming> {
+    let (mut parts, body) = req.into_parts();
+
+    // Set URI authority+scheme when missing (h1 origin-form → h2 needs these).
+    if parts.uri.authority().is_none() {
+        let pq = parts
+            .uri
+            .path_and_query()
+            .map_or("/", hyper::http::uri::PathAndQuery::as_str);
+        if let Ok(uri) = hyper::Uri::builder()
+            .scheme("https")
+            .authority(host)
+            .path_and_query(pq)
+            .build()
+        {
+            parts.uri = uri;
+        }
+    }
+
+    // Strip hop-by-hop headers (RFC 7230 §6.1) — these are per-connection,
+    // not end-to-end, and invalid in HTTP/2.
+    for name in &[
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+    ] {
+        parts.headers.remove(*name);
+    }
+
+    Request::from_parts(parts, body)
 }
 
 fn full(data: &'static str) -> BoxBody {

--- a/crates/cella-agent/src/proxy_config.rs
+++ b/crates/cella-agent/src/proxy_config.rs
@@ -4,12 +4,13 @@
 //! and builds the rule matcher for request evaluation.
 
 use std::collections::HashSet;
-use std::io::Write;
+use std::io::{BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use cella_network::config::{NetworkConfig, NetworkMode, NetworkRule, RuleAction};
 use cella_network::rules::RuleMatcher;
+use rustls::pki_types::CertificateDer;
 
 /// Runtime configuration for the forward proxy.
 pub struct AgentProxyConfig {
@@ -27,6 +28,9 @@ pub struct AgentProxyConfig {
 
     /// PEM-encoded CA private key for MITM TLS interception.
     pub ca_key_pem: Option<String>,
+
+    /// Parsed CA certificate DER (for upstream TLS trust).
+    pub ca_cert_der: Option<CertificateDer<'static>>,
 
     /// Log file for blocked requests.
     log_file: Mutex<Option<std::fs::File>>,
@@ -67,12 +71,18 @@ impl AgentProxyConfig {
         // Open log file.
         let log_file = open_log_file(raw.log_path.as_deref());
 
+        let ca_cert_der = raw.ca_cert_pem.as_deref().and_then(|pem| {
+            let mut reader = BufReader::new(pem.as_bytes());
+            rustls_pemfile::certs(&mut reader).find_map(Result::ok)
+        });
+
         Ok(Self {
             listen_port: raw.listen_port,
             matcher,
             upstream_proxy: raw.upstream_proxy,
             ca_cert_pem: raw.ca_cert_pem,
             ca_key_pem: raw.ca_key_pem,
+            ca_cert_der,
             log_file: Mutex::new(log_file),
             warned_no_mitm: Mutex::new(HashSet::new()),
         })


### PR DESCRIPTION
Replace the hand-rolled HTTP parser in the MITM proxy with hyper's connection handlers, adding HTTP/2 and WebSocket upgrade support along the way.

## What changed

- Swapped the manual request/response parser for hyper server + client connections
- Added HTTP/2 upstream support with ALPN negotiation and h1↔h2 bridging
- Added WebSocket/HTTP upgrade passthrough with hop-by-hop header stripping
- Stripped `transfer-encoding` on the upgrade path to prevent request smuggling
- Cached native root certs and wired the CA cert into upstream TLS trust
- Extracted helpers to keep functions under the 100-LOC clippy limit
- Added integration tests covering TLS upstream, h2, keep-alive, streaming, and WebSocket upgrades

## Test plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] Integration tests with Docker (`cargo test -p cella-agent --features integration-tests`)