### PR TITLE
fix: restore terminal title on exit and signal

### DIFF
--- a/crates/cella-cli/Cargo.toml
+++ b/crates/cella-cli/Cargo.toml
@@ -27,6 +27,7 @@ clap.workspace = true
 clap_complete.workspace = true
 inquire.workspace = true
 miette.workspace = true
+nix.workspace = true
 owo-colors.workspace = true
 serde_json.workspace = true
 terminal_size.workspace = true

--- a/crates/cella-cli/src/main.rs
+++ b/crates/cella-cli/src/main.rs
@@ -27,6 +27,8 @@ struct Cli {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    title::install_signal_handlers();
+
     // Install miette's graphical error handler for pretty diagnostics
     miette::set_hook(Box::new(|_| {
         Box::new(miette::GraphicalReportHandler::new_themed(

--- a/crates/cella-cli/src/title.rs
+++ b/crates/cella-cli/src/title.rs
@@ -157,7 +157,7 @@ impl Drop for TitleGuard {
     fn drop(&mut self) {
         let tmux = in_tmux();
         let mut stderr = io::stderr().lock();
-        let _ = emit_pop(&mut stderr, tmux);
+        let _ = emit_restore(&mut stderr, tmux);
         let _ = stderr.flush();
     }
 }
@@ -187,6 +187,11 @@ fn emit_set(w: &mut impl Write, title: &str, in_tmux: bool) -> io::Result<()> {
     } else {
         w.write_all(&bytes)
     }
+}
+
+fn emit_restore(w: &mut impl Write, in_tmux: bool) -> io::Result<()> {
+    emit_set(w, "", in_tmux)?;
+    emit_pop(w, in_tmux)
 }
 
 fn emit_pop(w: &mut impl Write, in_tmux: bool) -> io::Result<()> {
@@ -486,6 +491,24 @@ mod tests {
     fn no_branch_without_explicit_or_label() {
         // Plain `cella up` in a non-worktree with no existing container.
         assert_eq!(effective_branch(None, None), None);
+    }
+
+    // ── emit_restore ─────────────────────────────────────────────────
+
+    #[test]
+    fn emit_restore_plain_emits_reset_then_pop() {
+        let mut out = Vec::new();
+        emit_restore(&mut out, false).unwrap();
+        assert_eq!(out, b"\x1b]0;\x07\x1b[23;0t");
+    }
+
+    #[test]
+    fn emit_restore_tmux_emits_wrapped_reset_then_pop() {
+        let mut out = Vec::new();
+        emit_restore(&mut out, true).unwrap();
+        let mut expected = tmux_wrap(b"\x1b]0;\x07");
+        expected.extend_from_slice(&tmux_wrap(b"\x1b[23;0t"));
+        assert_eq!(out, expected);
     }
 
     // ── public API reachability ──────────────────────────────────────

--- a/crates/cella-cli/src/title.rs
+++ b/crates/cella-cli/src/title.rs
@@ -15,6 +15,13 @@
 //! actually updates.
 
 use std::io::{self, IsTerminal, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static TITLE_ACTIVE: AtomicBool = AtomicBool::new(false);
+static NEEDS_TMUX_WRAP: AtomicBool = AtomicBool::new(false);
+
+const RESTORE_PLAIN: &[u8] = b"\x1b]0;\x07\x1b[23;0t";
+const RESTORE_TMUX: &[u8] = b"\x1bPtmux;\x1b\x1b]0;\x07\x1b\\\x1bPtmux;\x1b\x1b[23;0t\x1b\\";
 
 /// Strip the `"cella-"` prefix so the title doesn't repeat the brand already
 /// present in the `" \u{2014} cella <subcommand>"` suffix. No-op if the prefix
@@ -88,6 +95,8 @@ impl TitleGuard {
         let _ = emit_push(&mut stderr, tmux);
         let _ = emit_set(&mut stderr, &content.format(), tmux);
         let _ = stderr.flush();
+        NEEDS_TMUX_WRAP.store(tmux, Ordering::Release);
+        TITLE_ACTIVE.store(true, Ordering::Release);
         Some(Self(()))
     }
 }
@@ -155,6 +164,7 @@ fn base_name(container: &cella_backend::ContainerInfo) -> &str {
 
 impl Drop for TitleGuard {
     fn drop(&mut self) {
+        TITLE_ACTIVE.store(false, Ordering::Release);
         let tmux = in_tmux();
         let mut stderr = io::stderr().lock();
         let _ = emit_restore(&mut stderr, tmux);
@@ -218,6 +228,44 @@ fn tmux_wrap(inner: &[u8]) -> Vec<u8> {
     }
     out.extend_from_slice(b"\x1b\\");
     out
+}
+
+pub fn install_signal_handlers() {
+    use nix::sys::signal::{SaFlags, SigAction, SigHandler, SigSet, Signal, sigaction};
+
+    let action = SigAction::new(
+        SigHandler::Handler(restore_title_on_signal),
+        SaFlags::SA_RESETHAND,
+        SigSet::empty(),
+    );
+    #[allow(unsafe_code)]
+    // SAFETY: sigaction is async-signal-safe; the handler only uses
+    // async-signal-safe operations (atomic loads + libc::write + libc::raise).
+    unsafe {
+        let _ = sigaction(Signal::SIGINT, &action);
+        let _ = sigaction(Signal::SIGTERM, &action);
+    }
+}
+
+extern "C" fn restore_title_on_signal(sig: nix::libc::c_int) {
+    if TITLE_ACTIVE.load(Ordering::Acquire) {
+        let bytes = if NEEDS_TMUX_WRAP.load(Ordering::Acquire) {
+            RESTORE_TMUX
+        } else {
+            RESTORE_PLAIN
+        };
+        #[allow(unsafe_code)]
+        // SAFETY: libc::write on STDERR_FILENO is async-signal-safe.
+        unsafe {
+            nix::libc::write(nix::libc::STDERR_FILENO, bytes.as_ptr().cast(), bytes.len());
+        }
+    }
+    #[allow(unsafe_code)]
+    // SAFETY: raise is async-signal-safe. SA_RESETHAND already restored the
+    // default disposition, so this re-delivers the signal with SIG_DFL.
+    unsafe {
+        nix::libc::raise(sig);
+    }
 }
 
 #[cfg(test)]
@@ -509,6 +557,22 @@ mod tests {
         let mut expected = tmux_wrap(b"\x1b]0;\x07");
         expected.extend_from_slice(&tmux_wrap(b"\x1b[23;0t"));
         assert_eq!(out, expected);
+    }
+
+    // ── signal handler constants ───────────────────────────────────────
+
+    #[test]
+    fn restore_plain_matches_emit_restore_output() {
+        let mut out = Vec::new();
+        emit_restore(&mut out, false).unwrap();
+        assert_eq!(out.as_slice(), RESTORE_PLAIN);
+    }
+
+    #[test]
+    fn restore_tmux_matches_emit_restore_output() {
+        let mut out = Vec::new();
+        emit_restore(&mut out, true).unwrap();
+        assert_eq!(out.as_slice(), RESTORE_TMUX);
     }
 
     // ── public API reachability ──────────────────────────────────────

--- a/crates/cella-cli/src/title.rs
+++ b/crates/cella-cli/src/title.rs
@@ -164,11 +164,13 @@ fn base_name(container: &cella_backend::ContainerInfo) -> &str {
 
 impl Drop for TitleGuard {
     fn drop(&mut self) {
-        TITLE_ACTIVE.store(false, Ordering::Release);
         let tmux = in_tmux();
         let mut stderr = io::stderr().lock();
         let _ = emit_restore(&mut stderr, tmux);
         let _ = stderr.flush();
+        // Clear after writing so a signal during Drop still triggers the handler.
+        // Worst case both paths emit — a harmless double-pop that the shell prompt resets.
+        TITLE_ACTIVE.store(false, Ordering::Release);
     }
 }
 
@@ -199,6 +201,8 @@ fn emit_set(w: &mut impl Write, title: &str, in_tmux: bool) -> io::Result<()> {
     }
 }
 
+// Empty title first so terminals without title-stack support (WezTerm, kitty)
+// still clear the title; the subsequent pop handles stack-supporting terminals.
 fn emit_restore(w: &mut impl Write, in_tmux: bool) -> io::Result<()> {
     emit_set(w, "", in_tmux)?;
     emit_pop(w, in_tmux)
@@ -230,6 +234,12 @@ fn tmux_wrap(inner: &[u8]) -> Vec<u8> {
     out
 }
 
+/// Install SIGINT/SIGTERM handlers that restore the terminal title before the
+/// process exits. Call once, early in `main`, before any `TitleGuard` is created.
+///
+/// Uses `SA_RESETHAND` so the handler fires at most once, then re-raises the
+/// signal with the default disposition — preserving exit status 128+signum for
+/// parent processes.
 pub fn install_signal_handlers() {
     use nix::sys::signal::{SaFlags, SigAction, SigHandler, SigSet, Signal, sigaction};
 
@@ -257,7 +267,7 @@ extern "C" fn restore_title_on_signal(sig: nix::libc::c_int) {
         #[allow(unsafe_code)]
         // SAFETY: libc::write on STDERR_FILENO is async-signal-safe.
         unsafe {
-            nix::libc::write(nix::libc::STDERR_FILENO, bytes.as_ptr().cast(), bytes.len());
+            let _ = nix::libc::write(nix::libc::STDERR_FILENO, bytes.as_ptr().cast(), bytes.len());
         }
     }
     #[allow(unsafe_code)]


### PR DESCRIPTION
## Summary

- Emit an empty title (OSC 0) before the xterm stack pop so terminals without title-stack support (WezTerm, kitty, Terminal.app) clear the title on exit
- Install SIGINT/SIGTERM handlers that restore the title via async-signal-safe `libc::write`, fixing Ctrl+C leaving the title stuck on non-interactive commands
- Pre-computed byte constants with sync tests to keep them in lockstep with `emit_restore`

## Test Plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings -D clippy::all` passes
- [x] `cargo test -p cella-cli` — 465 tests pass
- [x] Manual: run `cella up` in WezTerm, verify title clears after completion
- [x] Manual: run `cella up` in WezTerm, Ctrl+C, verify title clears