### PR TITLE
fix: connect compose containers to cella network for port forwarding

### DIFF
--- a/crates/cella-daemon/src/proxy.rs
+++ b/crates/cella-daemon/src/proxy.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::io;
 
-use tokio::io::copy_bidirectional;
+use tokio::io::{AsyncWriteExt, copy_bidirectional};
 use tokio::net::{TcpListener, TcpStream};
 use tracing::{debug, warn};
 
@@ -73,6 +73,7 @@ pub async fn start_proxy(host_port: u16, target: ProxyTarget) -> Result<ProxyHan
                             }
                             Err(e) => {
                                 warn!("Proxy connect to {ip}:{port} failed: {e}");
+                                let _ = inbound.shutdown().await;
                             }
                         }
                     }

--- a/crates/cella-orchestrator/src/compose_up.rs
+++ b/crates/cella-orchestrator/src/compose_up.rs
@@ -20,6 +20,7 @@ use cella_compose::{ComposeCommand, ComposeProject, OverrideConfig, ServiceBuild
 use crate::container_setup::{resolve_remote_user, run_host_command, verify_container_running};
 use crate::lifecycle::{lifecycle_entries_for_phase, run_lifecycle_entries};
 use crate::progress::ProgressSender;
+use crate::up::restart_agent_in_container;
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -482,6 +483,14 @@ async fn finalize_compose(
     // 15. Verify primary container is running
     verify_container_running(client, &primary.id).await?;
 
+    // 15b. Connect to cella network for daemon port-forwarding reachability
+    if let Err(e) = client
+        .ensure_container_network(&primary.id, cfg.workspace_root)
+        .await
+    {
+        warn!("Failed to connect container to cella network: {e}");
+    }
+
     // 16. Register with daemon (primary container only)
     hooks
         .register_container(client, &primary.id, config, cfg.container_name)
@@ -601,6 +610,14 @@ async fn handle_compose_running(
         progress.hint("Run `cella up --rebuild` to recreate with the updated mounts.");
     }
 
+    // Ensure container is on cella network (may have been created before this was added)
+    if let Err(e) = client
+        .ensure_container_network(&container.id, cfg.workspace_root)
+        .await
+    {
+        warn!("Failed to connect container to cella network: {e}");
+    }
+
     // Re-register with daemon in case it restarted
     hooks
         .register_container(client, &container.id, config, cfg.container_name)
@@ -610,6 +627,10 @@ async fn handle_compose_running(
     // running inside the already-up container can follow a daemon port
     // change since the last `cella up` (e.g., daemon binary update).
     hooks.sync_agent_runtime(client).await;
+
+    // Restart the agent so it reconnects and re-reports ports with the
+    // (potentially updated) cella network IP.
+    restart_agent_in_container(client, &container.id).await;
 
     if let Some(cmd) = config.get("postAttachCommand")
         && !cmd.is_null()


### PR DESCRIPTION
## Summary

- Connect compose containers to the `cella` bridge network before daemon registration so the proxy can actually reach them (mirrors what single-container `up` already does)
- Restart the agent on re-attach so it reconnects and re-reports ports with the updated cella network IP instead of the stale compose network IP
- Gracefully shut down inbound sockets on proxy connect failure (FIN instead of RST)

Fixes the `Connection reset by peer` / `Operation timed out` errors when port-forwarding in compose devcontainers.

## Test plan

- [x] `cargo clippy` / `cargo test` pass (verified locally)
- [x] Compose devcontainer with a service on port 3000 → `cella up` → `curl localhost:3000` responds
- [x] Compose container visible in `docker network inspect cella` after `cella up`
- [x] Compose service-to-service DNS (e.g. app → db) still works
- [x] Re-running `cella up` on an existing compose container also connects to cella network and restarts agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)