### PR TITLE
feat: reverse tunnel port forwarding for Colima/Docker Desktop

### DIFF
--- a/crates/cella-agent/src/control.rs
+++ b/crates/cella-agent/src/control.rs
@@ -7,8 +7,13 @@ use tokio::net::TcpStream;
 
 /// Client for sending messages to the host daemon via TCP.
 pub struct ControlClient {
-    reader: BufReader<tokio::io::ReadHalf<TcpStream>>,
     writer: tokio::io::WriteHalf<TcpStream>,
+    /// After `start_reader()`, messages arrive via this channel instead of the
+    /// raw TCP reader. `None` before `start_reader()` is called.
+    response_rx: Option<tokio::sync::mpsc::Receiver<DaemonMessage>>,
+    /// Direct reader, used only during handshake and before `start_reader()`.
+    reader: Option<BufReader<tokio::io::ReadHalf<TcpStream>>>,
+    reader_handle: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl ControlClient {
@@ -31,9 +36,12 @@ impl ControlClient {
             })?;
 
         let (reader, writer) = tokio::io::split(stream);
+        let mut reader = BufReader::new(reader);
         let mut client = Self {
-            reader: BufReader::new(reader),
             writer,
+            response_rx: None,
+            reader: None,
+            reader_handle: None,
         };
 
         // Perform Hello handshake
@@ -62,8 +70,7 @@ impl ControlClient {
 
         // Read DaemonHello response
         let mut line = String::new();
-        client
-            .reader
+        reader
             .read_line(&mut line)
             .await
             .map_err(|e| CellaPortError::ControlSocket {
@@ -81,7 +88,27 @@ impl ControlClient {
             });
         }
 
+        client.reader = Some(reader);
         Ok((client, daemon_hello))
+    }
+
+    /// Spawn a background reader task that dispatches `TunnelRequest` messages
+    /// to the tunnel handler and forwards everything else to the response channel.
+    pub fn start_reader(&mut self, tunnel_config: Option<crate::tunnel::TunnelConfig>) {
+        let Some(reader) = self.reader.take() else {
+            return;
+        };
+
+        if let Some(handle) = self.reader_handle.take() {
+            handle.abort();
+        }
+
+        let (tx, rx) = tokio::sync::mpsc::channel(32);
+        self.response_rx = Some(rx);
+
+        self.reader_handle = Some(tokio::spawn(async move {
+            run_reader_loop(reader, tx, tunnel_config).await;
+        }));
     }
 
     /// Send a message to the daemon (newline-delimited JSON).
@@ -112,22 +139,58 @@ impl ControlClient {
     ///
     /// Returns error on I/O or deserialization failure.
     pub async fn recv(&mut self) -> Result<DaemonMessage, CellaPortError> {
-        let mut line = String::new();
-        self.reader
-            .read_line(&mut line)
-            .await
-            .map_err(|e| CellaPortError::ControlSocket {
-                message: format!("read error: {e}"),
-            })?;
-
-        if line.is_empty() {
-            return Err(CellaPortError::ControlSocket {
-                message: "connection closed".to_string(),
-            });
+        if let Some(ref mut rx) = self.response_rx {
+            rx.recv()
+                .await
+                .ok_or_else(|| CellaPortError::ControlSocket {
+                    message: "connection closed".to_string(),
+                })
+        } else {
+            Err(CellaPortError::ControlSocket {
+                message: "reader not started".to_string(),
+            })
         }
+    }
+}
 
-        let msg: DaemonMessage = serde_json::from_str(&line)?;
-        Ok(msg)
+impl Drop for ControlClient {
+    fn drop(&mut self) {
+        if let Some(handle) = self.reader_handle.take() {
+            handle.abort();
+        }
+    }
+}
+
+async fn run_reader_loop(
+    mut reader: BufReader<tokio::io::ReadHalf<TcpStream>>,
+    response_tx: tokio::sync::mpsc::Sender<DaemonMessage>,
+    tunnel_config: Option<crate::tunnel::TunnelConfig>,
+) {
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line).await {
+            Ok(0) | Err(_) => break,
+            Ok(_) => {}
+        }
+        let Ok(msg) = serde_json::from_str::<DaemonMessage>(line.trim()) else {
+            tracing::warn!("Invalid daemon message, skipping");
+            continue;
+        };
+        if let DaemonMessage::TunnelRequest {
+            connection_id,
+            target_port,
+        } = msg
+        {
+            if let Some(ref config) = tunnel_config {
+                let config = config.clone();
+                tokio::spawn(async move {
+                    crate::tunnel::handle_tunnel_request(connection_id, target_port, &config).await;
+                });
+            }
+        } else if response_tx.send(msg).await.is_err() {
+            break;
+        }
     }
 }
 
@@ -325,6 +388,7 @@ mod tests {
             ControlClient::connect(&addr.to_string(), "test-container", "token")
                 .await
                 .unwrap();
+        client.start_reader(None);
 
         // Send a message.
         let msg = AgentMessage::Health {
@@ -368,6 +432,7 @@ mod tests {
             ControlClient::connect(&addr.to_string(), "test-container", "token")
                 .await
                 .unwrap();
+        client.start_reader(None);
 
         let result = client.recv().await;
         assert!(result.is_err());

--- a/crates/cella-agent/src/control.rs
+++ b/crates/cella-agent/src/control.rs
@@ -135,21 +135,42 @@ impl ControlClient {
 
     /// Read a response message from the daemon.
     ///
+    /// Uses the background reader channel if `start_reader()` was called,
+    /// otherwise reads directly from the TCP stream (for one-shot clients).
+    ///
     /// # Errors
     ///
     /// Returns error on I/O or deserialization failure.
     pub async fn recv(&mut self) -> Result<DaemonMessage, CellaPortError> {
         if let Some(ref mut rx) = self.response_rx {
-            rx.recv()
+            return rx
+                .recv()
                 .await
                 .ok_or_else(|| CellaPortError::ControlSocket {
                     message: "connection closed".to_string(),
-                })
-        } else {
-            Err(CellaPortError::ControlSocket {
-                message: "reader not started".to_string(),
-            })
+                });
         }
+
+        if let Some(ref mut reader) = self.reader {
+            let mut line = String::new();
+            reader
+                .read_line(&mut line)
+                .await
+                .map_err(|e| CellaPortError::ControlSocket {
+                    message: format!("read error: {e}"),
+                })?;
+            if line.is_empty() {
+                return Err(CellaPortError::ControlSocket {
+                    message: "connection closed".to_string(),
+                });
+            }
+            let msg: DaemonMessage = serde_json::from_str(&line)?;
+            return Ok(msg);
+        }
+
+        Err(CellaPortError::ControlSocket {
+            message: "not connected".to_string(),
+        })
     }
 }
 
@@ -438,5 +459,52 @@ mod tests {
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(msg.contains("connection closed"));
+    }
+
+    #[tokio::test]
+    async fn recv_works_without_start_reader_for_oneshot_clients() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 4096];
+            let _ = tokio::io::AsyncReadExt::read(&mut stream, &mut buf).await;
+            let hello = DaemonHello {
+                protocol_version: PROTOCOL_VERSION,
+                daemon_version: "0.1.0".to_string(),
+                error: None,
+                workspace_path: None,
+                parent_repo: None,
+                is_worktree: false,
+            };
+            let mut json = serde_json::to_string(&hello).unwrap();
+            json.push('\n');
+            stream.write_all(json.as_bytes()).await.unwrap();
+
+            let mut msg_buf = vec![0u8; 4096];
+            let _ = tokio::io::AsyncReadExt::read(&mut stream, &mut msg_buf).await;
+
+            let response = DaemonMessage::Ack {
+                id: Some("oneshot-1".to_string()),
+            };
+            let mut resp_json = serde_json::to_string(&response).unwrap();
+            resp_json.push('\n');
+            stream.write_all(resp_json.as_bytes()).await.unwrap();
+        });
+
+        let (mut client, _hello) =
+            ControlClient::connect(&addr.to_string(), "test-container", "token")
+                .await
+                .unwrap();
+
+        let msg = AgentMessage::Health {
+            uptime_secs: 1,
+            ports_detected: 0,
+        };
+        client.send(&msg).await.unwrap();
+
+        let resp = client.recv().await.unwrap();
+        assert!(matches!(resp, DaemonMessage::Ack { id } if id.as_deref() == Some("oneshot-1")));
     }
 }

--- a/crates/cella-agent/src/main.rs
+++ b/crates/cella-agent/src/main.rs
@@ -24,6 +24,7 @@ mod proxy_config;
 mod reconnecting_client;
 mod ssh_agent_bridge;
 mod state;
+mod tunnel;
 
 use std::time::Duration;
 

--- a/crates/cella-agent/src/reconnecting_client.rs
+++ b/crates/cella-agent/src/reconnecting_client.rs
@@ -47,6 +47,7 @@ pub struct ReconnectingClient {
     reconnected: bool,
     /// The `DaemonHello` received during the most recent handshake.
     daemon_hello: Option<DaemonHello>,
+    tunnel_config: Option<crate::tunnel::TunnelConfig>,
 }
 
 /// How often to surface a progress log while the initial connect retries.
@@ -70,8 +71,13 @@ impl ReconnectingClient {
 
         loop {
             match ControlClient::connect(&addr, container_name, &token).await {
-                Ok((client, hello)) => {
+                Ok((mut client, hello)) => {
                     info!("Connected to daemon at {addr}");
+                    let tunnel_config = Some(crate::tunnel::TunnelConfig {
+                        daemon_addr: addr.clone(),
+                        auth_token: token.clone(),
+                    });
+                    client.start_reader(tunnel_config.clone());
                     return Self {
                         addr,
                         container_name: container_name.to_string(),
@@ -79,6 +85,7 @@ impl ReconnectingClient {
                         inner: Some(client),
                         reconnected: false,
                         daemon_hello: Some(hello),
+                        tunnel_config,
                     };
                 }
                 Err(e) => {
@@ -140,16 +147,22 @@ impl ReconnectingClient {
     /// future inline reconnects use the new values.
     pub fn install_connection(
         &mut self,
-        client: ControlClient,
+        mut client: ControlClient,
         hello: DaemonHello,
         new_addr: String,
         new_token: String,
     ) {
+        let tunnel_config = Some(crate::tunnel::TunnelConfig {
+            daemon_addr: new_addr.clone(),
+            auth_token: new_token.clone(),
+        });
+        client.start_reader(tunnel_config.clone());
         self.inner = Some(client);
         self.daemon_hello = Some(hello);
         self.addr = new_addr;
         self.auth_token = new_token;
         self.reconnected = true;
+        self.tunnel_config = tunnel_config;
     }
 
     /// Send a message, attempting a single reconnect on failure.
@@ -206,11 +219,17 @@ impl ReconnectingClient {
     async fn try_reconnect(&mut self) -> Result<(), CellaPortError> {
         // 1. Try the current address
         match ControlClient::connect(&self.addr, &self.container_name, &self.auth_token).await {
-            Ok((client, hello)) => {
+            Ok((mut client, hello)) => {
                 info!("Reconnected to daemon at {}", self.addr);
+                let tunnel_config = Some(crate::tunnel::TunnelConfig {
+                    daemon_addr: self.addr.clone(),
+                    auth_token: self.auth_token.clone(),
+                });
+                client.start_reader(tunnel_config.clone());
                 self.inner = Some(client);
                 self.daemon_hello = Some(hello);
                 self.reconnected = true;
+                self.tunnel_config = tunnel_config;
                 return Ok(());
             }
             Err(e) => {
@@ -227,13 +246,19 @@ impl ReconnectingClient {
                 self.addr, info.addr
             );
             match ControlClient::connect(&info.addr, &self.container_name, &info.token).await {
-                Ok((client, hello)) => {
+                Ok((mut client, hello)) => {
                     info!("Reconnected to daemon at {} (from .daemon_addr)", info.addr);
+                    let tunnel_config = Some(crate::tunnel::TunnelConfig {
+                        daemon_addr: info.addr.clone(),
+                        auth_token: info.token.clone(),
+                    });
+                    client.start_reader(tunnel_config.clone());
                     self.addr = info.addr;
                     self.auth_token = info.token;
                     self.inner = Some(client);
                     self.daemon_hello = Some(hello);
                     self.reconnected = true;
+                    self.tunnel_config = tunnel_config;
                     return Ok(());
                 }
                 Err(e) => {
@@ -364,6 +389,7 @@ mod tests {
             inner: None,
             reconnected: true,
             daemon_hello: None,
+            tunnel_config: None,
         };
 
         assert!(client.take_reconnected());
@@ -379,6 +405,7 @@ mod tests {
             inner: None,
             reconnected: false,
             daemon_hello: None,
+            tunnel_config: None,
         };
 
         let msg = AgentMessage::Health {
@@ -398,6 +425,7 @@ mod tests {
             inner: None,
             reconnected: false,
             daemon_hello: None,
+            tunnel_config: None,
         };
 
         let result = client.recv().await;
@@ -415,6 +443,7 @@ mod tests {
             inner: None,
             reconnected: false,
             daemon_hello: None,
+            tunnel_config: None,
         };
         assert!(!client.take_reconnected());
     }
@@ -428,6 +457,7 @@ mod tests {
             inner: None,
             reconnected: false,
             daemon_hello: None,
+            tunnel_config: None,
         };
         let result = client.try_reconnect().await;
         assert!(result.is_err());
@@ -444,6 +474,7 @@ mod tests {
             inner: None,
             reconnected: false,
             daemon_hello: None,
+            tunnel_config: None,
         };
 
         let msg = AgentMessage::Health {
@@ -465,6 +496,7 @@ mod tests {
             inner: None,
             reconnected: false,
             daemon_hello: None,
+            tunnel_config: None,
         };
 
         let (addr, name, token) = client.connection_params();
@@ -482,6 +514,7 @@ mod tests {
             inner: None,
             reconnected: false,
             daemon_hello: None,
+            tunnel_config: None,
         };
 
         assert!(client.inner.is_none());

--- a/crates/cella-agent/src/tunnel.rs
+++ b/crates/cella-agent/src/tunnel.rs
@@ -1,4 +1,4 @@
-//! Reverse tunnel handler: responds to daemon TunnelRequest messages by opening
+//! Reverse tunnel handler: responds to daemon `TunnelRequest` messages by opening
 //! a TCP connection back to the daemon and relaying to a local service.
 
 use cella_protocol::TunnelHandshake;
@@ -13,7 +13,7 @@ pub struct TunnelConfig {
     pub auth_token: String,
 }
 
-/// Handle a single TunnelRequest by connecting back to the daemon and relaying
+/// Handle a single `TunnelRequest` by connecting back to the daemon and relaying
 /// to the local service.
 pub async fn handle_tunnel_request(connection_id: u64, target_port: u16, config: &TunnelConfig) {
     debug!("Tunnel request: connection_id={connection_id} target_port={target_port}");
@@ -65,13 +65,17 @@ pub async fn handle_tunnel_request(connection_id: u64, target_port: u16, config:
 mod tests {
     use super::*;
 
+    fn clone_config(c: &TunnelConfig) -> TunnelConfig {
+        c.clone()
+    }
+
     #[test]
     fn tunnel_config_clone() {
         let config = TunnelConfig {
             daemon_addr: "127.0.0.1:5000".to_string(),
             auth_token: "secret".to_string(),
         };
-        let cloned = config.clone();
+        let cloned = clone_config(&config);
         assert_eq!(cloned.daemon_addr, "127.0.0.1:5000");
         assert_eq!(cloned.auth_token, "secret");
     }

--- a/crates/cella-agent/src/tunnel.rs
+++ b/crates/cella-agent/src/tunnel.rs
@@ -1,0 +1,88 @@
+//! Reverse tunnel handler: responds to daemon TunnelRequest messages by opening
+//! a TCP connection back to the daemon and relaying to a local service.
+
+use cella_protocol::TunnelHandshake;
+use tokio::io::{AsyncWriteExt, copy_bidirectional};
+use tokio::net::TcpStream;
+use tracing::{debug, warn};
+
+/// Configuration for creating reverse tunnels back to the daemon.
+#[derive(Clone)]
+pub struct TunnelConfig {
+    pub daemon_addr: String,
+    pub auth_token: String,
+}
+
+/// Handle a single TunnelRequest by connecting back to the daemon and relaying
+/// to the local service.
+pub async fn handle_tunnel_request(connection_id: u64, target_port: u16, config: &TunnelConfig) {
+    debug!("Tunnel request: connection_id={connection_id} target_port={target_port}");
+
+    let tunnel_result = TcpStream::connect(&config.daemon_addr).await;
+    let mut tunnel = match tunnel_result {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("Tunnel connect to daemon failed: {e}");
+            return;
+        }
+    };
+
+    let hs = TunnelHandshake {
+        auth_token: config.auth_token.clone(),
+        connection_id,
+    };
+    let mut json = match serde_json::to_string(&hs) {
+        Ok(j) => j,
+        Err(e) => {
+            warn!("Tunnel handshake serialize failed: {e}");
+            return;
+        }
+    };
+    json.push('\n');
+    if let Err(e) = tunnel.write_all(json.as_bytes()).await {
+        warn!("Tunnel handshake write failed: {e}");
+        return;
+    }
+    if let Err(e) = tunnel.flush().await {
+        warn!("Tunnel handshake flush failed: {e}");
+        return;
+    }
+
+    let local_result = TcpStream::connect(("127.0.0.1", target_port)).await;
+    let mut local = match local_result {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("Tunnel local connect to 127.0.0.1:{target_port} failed: {e}");
+            return;
+        }
+    };
+
+    let _ = copy_bidirectional(&mut tunnel, &mut local).await;
+    debug!("Tunnel connection {connection_id} closed");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tunnel_config_clone() {
+        let config = TunnelConfig {
+            daemon_addr: "127.0.0.1:5000".to_string(),
+            auth_token: "secret".to_string(),
+        };
+        let cloned = config.clone();
+        assert_eq!(cloned.daemon_addr, "127.0.0.1:5000");
+        assert_eq!(cloned.auth_token, "secret");
+    }
+
+    #[tokio::test]
+    async fn handle_tunnel_request_fails_gracefully_on_unreachable_daemon() {
+        let config = TunnelConfig {
+            daemon_addr: "127.0.0.1:1".to_string(),
+            auth_token: "token".to_string(),
+        };
+        // Should not panic — just logs a warning.
+        handle_tunnel_request(1, 3000, &config).await;
+    }
+}

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -551,16 +551,15 @@ async fn re_register_containers(
     let containers = client.list_cella_containers(true).await?;
 
     for container in &containers {
-        if let Some(workspace_path) = container.labels.get("dev.cella.workspace_path") {
-            if let Err(e) = client
+        if let Some(workspace_path) = container.labels.get("dev.cella.workspace_path")
+            && let Err(e) = client
                 .ensure_container_network(&container.id, std::path::Path::new(workspace_path))
                 .await
-            {
-                tracing::debug!(
-                    "Failed to connect container {} to cella network: {e}",
-                    container.name
-                );
-            }
+        {
+            tracing::debug!(
+                "Failed to connect container {} to cella network: {e}",
+                container.name
+            );
         }
 
         let container_ip = client.get_container_ip(&container.id).await.unwrap_or(None);

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -551,6 +551,18 @@ async fn re_register_containers(
     let containers = client.list_cella_containers(true).await?;
 
     for container in &containers {
+        if let Some(workspace_path) = container.labels.get("dev.cella.workspace_path") {
+            if let Err(e) = client
+                .ensure_container_network(&container.id, std::path::Path::new(workspace_path))
+                .await
+            {
+                tracing::debug!(
+                    "Failed to connect container {} to cella network: {e}",
+                    container.name
+                );
+            }
+        }
+
         let container_ip = client.get_container_ip(&container.id).await.unwrap_or(None);
 
         // Read ports_attributes from container label

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -150,13 +150,13 @@ async fn handle_tunnel_connection(
     }
 
     let stream = reader.into_inner().unsplit(writer);
-    if !ctx.tunnel_broker.deliver(hs.connection_id, stream).await {
+    if ctx.tunnel_broker.deliver(hs.connection_id, stream).await {
+        debug!("Tunnel connection {} delivered", hs.connection_id);
+    } else {
         warn!(
             "Tunnel connection {}: no pending request (timed out or spurious)",
             hs.connection_id
         );
-    } else {
-        debug!("Tunnel connection {} delivered", hs.connection_id);
     }
 }
 
@@ -2406,6 +2406,7 @@ mod tests {
                     agent_state: agent_state.clone(),
                     backend_kind: Some("docker".to_string()),
                     docker_host: None,
+                    agent_tx: None,
                 },
             );
             Arc::new(Mutex::new(map))

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -10,6 +10,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use cella_protocol::{
     AgentHello, AgentMessage, DaemonHello, DaemonMessage, PROTOCOL_VERSION, PortProtocol,
+    TunnelHandshake,
 };
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpListener;
@@ -21,6 +22,7 @@ use crate::browser::BrowserHandler;
 use crate::credential::invoke_git_credential;
 use crate::port_manager::PortManager;
 use crate::proxy::ProxyCommand;
+use crate::tunnel::TunnelBroker;
 
 /// Shared context for the control server and its connection handlers.
 pub(crate) struct ControlContext {
@@ -33,6 +35,8 @@ pub(crate) struct ControlContext {
     /// Host-native cella binary, resolved and snapshotted at daemon startup so
     /// that in-container `cargo build` cannot clobber it via the bind mount.
     pub cella_bin: std::path::PathBuf,
+    pub tunnel_broker: Arc<TunnelBroker>,
+    pub is_orbstack: bool,
 }
 
 /// Tracks whether an agent has actually connected and sent messages.
@@ -71,11 +75,11 @@ pub struct ContainerHandle {
     pub agent_tx: Option<tokio::sync::mpsc::Sender<DaemonMessage>>,
 }
 
-/// Spawn a handler task for a new agent TCP connection.
-fn spawn_agent_handler(stream: tokio::net::TcpStream, ctx: Arc<ControlContext>) {
+/// Spawn a handler task for a new TCP connection (agent or tunnel).
+fn spawn_connection_handler(stream: tokio::net::TcpStream, ctx: Arc<ControlContext>) {
     tokio::spawn(async move {
-        if let Err(e) = handle_agent_connection(stream, &ctx).await {
-            warn!("Agent connection error: {e}");
+        if let Err(e) = handle_incoming_connection(stream, &ctx).await {
+            warn!("Connection handler error: {e}");
         }
     });
 }
@@ -89,12 +93,70 @@ fn handle_accept_result(
     match result {
         Ok((stream, peer)) => {
             last_activity.store(current_time_secs(), Ordering::Relaxed);
-            debug!("Agent TCP connection from {peer}");
-            spawn_agent_handler(stream, ctx.clone());
+            debug!("TCP connection from {peer}");
+            spawn_connection_handler(stream, ctx.clone());
         }
         Err(e) => {
             warn!("Control server accept error: {e}");
         }
+    }
+}
+
+/// Discriminate the first message to determine connection type.
+async fn handle_incoming_connection(
+    stream: tokio::net::TcpStream,
+    ctx: &ControlContext,
+) -> Result<(), CellaDaemonError> {
+    let (reader, mut writer) = tokio::io::split(stream);
+    let mut reader = BufReader::new(reader);
+    let mut line = String::new();
+
+    let n = reader
+        .read_line(&mut line)
+        .await
+        .map_err(|e| CellaDaemonError::Socket {
+            message: format!("first message read error: {e}"),
+        })?;
+    if n == 0 {
+        return Ok(());
+    }
+
+    let trimmed = line.trim();
+
+    if let Ok(tunnel_hs) = serde_json::from_str::<TunnelHandshake>(trimmed) {
+        handle_tunnel_connection(tunnel_hs, reader, writer, ctx).await;
+        return Ok(());
+    }
+
+    if let Ok(agent_hello) = serde_json::from_str::<AgentHello>(trimmed) {
+        return handle_agent_connection_after_hello(agent_hello, reader, writer, ctx).await;
+    }
+
+    warn!("Unrecognized first message, closing connection");
+    send_reject(&mut writer, "unrecognized first message".to_string()).await;
+    Ok(())
+}
+
+/// Handle a validated tunnel handshake: deliver the stream to the broker.
+async fn handle_tunnel_connection(
+    hs: TunnelHandshake,
+    reader: BufReader<tokio::io::ReadHalf<tokio::net::TcpStream>>,
+    writer: tokio::io::WriteHalf<tokio::net::TcpStream>,
+    ctx: &ControlContext,
+) {
+    if hs.auth_token != ctx.auth_token {
+        warn!("Tunnel connection rejected: invalid auth token");
+        return;
+    }
+
+    let stream = reader.into_inner().unsplit(writer);
+    if !ctx.tunnel_broker.deliver(hs.connection_id, stream).await {
+        warn!(
+            "Tunnel connection {}: no pending request (timed out or spurious)",
+            hs.connection_id
+        );
+    } else {
+        debug!("Tunnel connection {} delivered", hs.connection_id);
     }
 }
 
@@ -151,35 +213,15 @@ struct HandshakeResult {
     workspace_path: Option<String>,
 }
 
-/// Perform the hello handshake: read `AgentHello`, validate, look up container.
+/// Validate an already-parsed `AgentHello`, look up container, send `DaemonHello`.
 ///
 /// Returns `Ok(None)` if the connection should be cleanly closed (rejection sent).
 /// Returns `Ok(Some(..))` on success with validated handshake data.
-async fn perform_handshake<R, W>(
-    reader: &mut R,
+async fn validate_agent_hello<W: AsyncWriteExt + Unpin>(
+    agent_hello: AgentHello,
     writer: &mut W,
-    line: &mut String,
     ctx: &ControlContext,
-) -> Result<Option<HandshakeResult>, CellaDaemonError>
-where
-    R: AsyncBufReadExt + Unpin,
-    W: AsyncWriteExt + Unpin,
-{
-    let n = reader
-        .read_line(line)
-        .await
-        .map_err(|e| CellaDaemonError::Socket {
-            message: format!("hello read error: {e}"),
-        })?;
-    if n == 0 {
-        return Ok(None);
-    }
-
-    let Ok(agent_hello) = serde_json::from_str::<AgentHello>(line.trim()) else {
-        send_reject(writer, "Hello required as first message".to_string()).await;
-        return Ok(None);
-    };
-
+) -> Result<Option<HandshakeResult>, CellaDaemonError> {
     if agent_hello.protocol_version != PROTOCOL_VERSION {
         send_reject(
             writer,
@@ -213,7 +255,6 @@ where
         pm.container_ip(&container_id).map(String::from)
     };
 
-    // Store the live agent version for status queries.
     if let Ok(mut v) = agent_state.agent_version.lock() {
         *v = Some(agent_hello.agent_version.clone());
     }
@@ -226,7 +267,6 @@ where
         );
     }
 
-    // Send DaemonHello success with workspace metadata from container labels.
     let labels = lookup_container_labels(&container_id, &ctx.container_handles).await;
     let hello = DaemonHello {
         protocol_version: PROTOCOL_VERSION,
@@ -268,18 +308,17 @@ where
     }))
 }
 
-/// Handle a single agent TCP connection (newline-delimited JSON).
-async fn handle_agent_connection(
-    stream: tokio::net::TcpStream,
+/// Handle an agent TCP connection after the `AgentHello` has been parsed.
+async fn handle_agent_connection_after_hello(
+    agent_hello: AgentHello,
+    mut reader: BufReader<tokio::io::ReadHalf<tokio::net::TcpStream>>,
+    mut writer: tokio::io::WriteHalf<tokio::net::TcpStream>,
     ctx: &ControlContext,
 ) -> Result<(), CellaDaemonError> {
-    let (reader, mut writer) = tokio::io::split(stream);
-    let mut reader = BufReader::new(reader);
-    let mut line = String::new();
-
-    let Some(hs) = perform_handshake(&mut reader, &mut writer, &mut line, ctx).await? else {
+    let Some(hs) = validate_agent_hello(agent_hello, &mut writer, ctx).await? else {
         return Ok(());
     };
+    let mut line = String::new();
 
     info!("Agent connected for container {}", hs.container_name);
 
@@ -2268,13 +2307,13 @@ mod tests {
             proxy_cmd_tx: proxy_tx,
             task_manager: crate::task_manager::new_shared(),
             cella_bin: std::path::PathBuf::from("/nonexistent"),
+            tunnel_broker: Arc::new(TunnelBroker::new()),
+            is_orbstack: false,
         }
     }
 
     #[tokio::test]
-    async fn perform_handshake_marks_connected_without_follow_up_message() {
-        use tokio::io::AsyncWriteExt;
-
+    async fn validate_agent_hello_marks_connected() {
         let agent_state = Arc::new(AgentConnectionState::new());
         let handles = {
             let mut map = HashMap::new();
@@ -2292,28 +2331,22 @@ mod tests {
         };
         let ctx = test_control_context(handles, "test-token");
 
-        let (mut agent_side, daemon_side) = tokio::io::duplex(4096);
-        let (daemon_r, mut daemon_w) = tokio::io::split(daemon_side);
-        let mut daemon_reader = BufReader::new(daemon_r);
-
         let hello = AgentHello {
             protocol_version: PROTOCOL_VERSION,
             agent_version: "0.0.28".to_string(),
             container_name: "test-container".to_string(),
             auth_token: "test-token".to_string(),
         };
-        let mut json = serde_json::to_string(&hello).unwrap();
-        json.push('\n');
-        agent_side.write_all(json.as_bytes()).await.unwrap();
-        agent_side.flush().await.unwrap();
 
         assert!(
             !agent_state.connected.load(Ordering::Relaxed),
             "pre-condition: connected starts false"
         );
 
-        let mut line = String::new();
-        let result = perform_handshake(&mut daemon_reader, &mut daemon_w, &mut line, &ctx).await;
+        let (_daemon_side, agent_side) = tokio::io::duplex(4096);
+        let (_r, mut w) = tokio::io::split(agent_side);
+
+        let result = validate_agent_hello(hello, &mut w, &ctx).await;
 
         let hs = result
             .expect("handshake should not error")
@@ -2321,7 +2354,7 @@ mod tests {
         assert_eq!(hs.container_name, "test-container");
         assert!(
             agent_state.connected.load(Ordering::Relaxed),
-            "connected must be true immediately after handshake, before any message"
+            "connected must be true immediately after handshake"
         );
         assert_ne!(
             agent_state.last_seen_secs.load(Ordering::Relaxed),
@@ -2416,15 +2449,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn perform_handshake_unknown_container_does_not_mark_connected() {
-        use tokio::io::AsyncWriteExt;
-
+    async fn validate_agent_hello_unknown_container_rejects() {
         let handles = Arc::new(Mutex::new(HashMap::new()));
         let ctx = test_control_context(handles, "test-token");
-
-        let (mut agent_side, daemon_side) = tokio::io::duplex(4096);
-        let (daemon_r, mut daemon_w) = tokio::io::split(daemon_side);
-        let mut daemon_reader = BufReader::new(daemon_r);
 
         let hello = AgentHello {
             protocol_version: PROTOCOL_VERSION,
@@ -2432,13 +2459,11 @@ mod tests {
             container_name: "not-registered".to_string(),
             auth_token: "test-token".to_string(),
         };
-        let mut json = serde_json::to_string(&hello).unwrap();
-        json.push('\n');
-        agent_side.write_all(json.as_bytes()).await.unwrap();
-        agent_side.flush().await.unwrap();
 
-        let mut line = String::new();
-        let result = perform_handshake(&mut daemon_reader, &mut daemon_w, &mut line, &ctx).await;
+        let (_daemon_side, agent_side) = tokio::io::duplex(4096);
+        let (_r, mut w) = tokio::io::split(agent_side);
+
+        let result = validate_agent_hello(hello, &mut w, &ctx).await;
 
         assert!(
             matches!(result, Ok(None)),

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -67,6 +67,8 @@ pub struct ContainerHandle {
     pub backend_kind: Option<String>,
     /// Docker host override used when the container was created.
     pub docker_host: Option<String>,
+    /// Channel for sending daemon-initiated messages to the connected agent.
+    pub agent_tx: Option<tokio::sync::mpsc::Sender<DaemonMessage>>,
 }
 
 /// Spawn a handler task for a new agent TCP connection.
@@ -281,85 +283,103 @@ async fn handle_agent_connection(
 
     info!("Agent connected for container {}", hs.container_name);
 
-    // --- Message loop ---
-    loop {
-        line.clear();
-        let n = reader
-            .read_line(&mut line)
-            .await
-            .map_err(|e| CellaDaemonError::Socket {
-                message: format!("read error: {e}"),
-            })?;
+    let (daemon_tx, mut daemon_rx) = tokio::sync::mpsc::channel::<DaemonMessage>(32);
 
-        if n == 0 {
-            break; // Connection closed
-        }
-
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-
-        let msg: AgentMessage =
-            serde_json::from_str(trimmed).map_err(|e| CellaDaemonError::Protocol {
-                message: format!("invalid agent message: {e}"),
-            })?;
-
-        // Worktree/exec/task operations need writer access for multi-message responses.
-        // Handle them directly before falling through to the single-response handler.
-        if matches!(
-            &msg,
-            AgentMessage::BranchRequest { .. }
-                | AgentMessage::ListRequest { .. }
-                | AgentMessage::ExecRequest { .. }
-                | AgentMessage::PruneRequest { .. }
-                | AgentMessage::DownRequest { .. }
-                | AgentMessage::UpRequest { .. }
-                | AgentMessage::TaskRunRequest { .. }
-                | AgentMessage::TaskListRequest { .. }
-                | AgentMessage::TaskLogsRequest { .. }
-                | AgentMessage::TaskWaitRequest { .. }
-                | AgentMessage::TaskStopRequest { .. }
-                | AgentMessage::SwitchRequest { .. }
-        ) {
-            handle_worktree_message(
-                msg,
-                WorktreeHandlerCtx {
-                    workspace_path: hs.workspace_path.as_deref(),
-                    cella_bin: &ctx.cella_bin,
-                    task_mgr: &ctx.task_manager,
-                    container_handles: &ctx.container_handles,
-                    container_name: &hs.container_name,
-                },
-                &mut writer,
-            )
-            .await?;
-            continue;
-        }
-
-        let handler_ctx = AgentHandlerContext {
-            port_manager: &ctx.port_manager,
-            browser_handler: &ctx.browser_handler,
-            container_id: Some(&hs.container_id),
-            proxy_cmd_tx: Some(&ctx.proxy_cmd_tx),
-            container_ip: hs.container_ip.as_deref(),
-        };
-        let response = handle_agent_message(msg, &handler_ctx, &hs.agent_state).await;
-
-        if let Some(resp) = response {
-            send_message(&mut writer, &resp).await?;
+    {
+        let mut handles = ctx.container_handles.lock().await;
+        if let Some(handle) = handles.get_mut(&hs.container_name) {
+            handle.agent_tx = Some(daemon_tx);
         }
     }
 
+    // --- Message loop ---
+    let result: Result<(), CellaDaemonError> = loop {
+        tokio::select! {
+            result = reader.read_line(&mut line) => {
+                let n = result.map_err(|e| CellaDaemonError::Socket {
+                    message: format!("read error: {e}"),
+                })?;
+
+                if n == 0 {
+                    break Ok(());
+                }
+
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    line.clear();
+                    continue;
+                }
+
+                let msg: AgentMessage =
+                    serde_json::from_str(trimmed).map_err(|e| CellaDaemonError::Protocol {
+                        message: format!("invalid agent message: {e}"),
+                    })?;
+                line.clear();
+
+                if matches!(
+                    &msg,
+                    AgentMessage::BranchRequest { .. }
+                        | AgentMessage::ListRequest { .. }
+                        | AgentMessage::ExecRequest { .. }
+                        | AgentMessage::PruneRequest { .. }
+                        | AgentMessage::DownRequest { .. }
+                        | AgentMessage::UpRequest { .. }
+                        | AgentMessage::TaskRunRequest { .. }
+                        | AgentMessage::TaskListRequest { .. }
+                        | AgentMessage::TaskLogsRequest { .. }
+                        | AgentMessage::TaskWaitRequest { .. }
+                        | AgentMessage::TaskStopRequest { .. }
+                        | AgentMessage::SwitchRequest { .. }
+                ) {
+                    handle_worktree_message(
+                        msg,
+                        WorktreeHandlerCtx {
+                            workspace_path: hs.workspace_path.as_deref(),
+                            cella_bin: &ctx.cella_bin,
+                            task_mgr: &ctx.task_manager,
+                            container_handles: &ctx.container_handles,
+                            container_name: &hs.container_name,
+                        },
+                        &mut writer,
+                    )
+                    .await?;
+                    continue;
+                }
+
+                let handler_ctx = AgentHandlerContext {
+                    port_manager: &ctx.port_manager,
+                    browser_handler: &ctx.browser_handler,
+                    container_id: Some(&hs.container_id),
+                    proxy_cmd_tx: Some(&ctx.proxy_cmd_tx),
+                    container_ip: hs.container_ip.as_deref(),
+                };
+                let response = handle_agent_message(msg, &handler_ctx, &hs.agent_state).await;
+
+                if let Some(resp) = response {
+                    send_message(&mut writer, &resp).await?;
+                }
+            }
+            Some(msg) = daemon_rx.recv() => {
+                send_message(&mut writer, &msg).await?;
+            }
+        }
+    };
+
     // Connection closed — clear live state so status queries don't report
     // stale version/connectivity info for this container.
+    {
+        let mut handles = ctx.container_handles.lock().await;
+        if let Some(handle) = handles.get_mut(&hs.container_name) {
+            handle.agent_tx = None;
+        }
+    }
     hs.agent_state.connected.store(false, Ordering::Relaxed);
     if let Ok(mut v) = hs.agent_state.agent_version.lock() {
         *v = None;
     }
     info!("Agent disconnected for container {}", hs.container_name);
 
-    Ok(())
+    result
 }
 
 /// Per-connection context shared across agent message handlers.
@@ -2227,6 +2247,7 @@ mod tests {
             agent_state: Arc::new(AgentConnectionState::new()),
             backend_kind: Some("docker".into()),
             docker_host: None,
+            agent_tx: None,
         };
         assert_eq!(handle.container_id, "abc123");
         assert!(!handle.agent_state.connected.load(Ordering::Relaxed));
@@ -2264,6 +2285,7 @@ mod tests {
                     agent_state: agent_state.clone(),
                     backend_kind: Some("docker".to_string()),
                     docker_host: None,
+                    agent_tx: None,
                 },
             );
             Arc::new(Mutex::new(map))

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -391,6 +391,8 @@ async fn handle_agent_connection_after_hello(
                     container_id: Some(&hs.container_id),
                     proxy_cmd_tx: Some(&ctx.proxy_cmd_tx),
                     container_ip: hs.container_ip.as_deref(),
+                    container_name: Some(&hs.container_name),
+                    is_orbstack: ctx.is_orbstack,
                 };
                 let response = handle_agent_message(msg, &handler_ctx, &hs.agent_state).await;
 
@@ -428,23 +430,25 @@ pub(crate) struct AgentHandlerContext<'a> {
     pub container_id: Option<&'a str>,
     pub proxy_cmd_tx: Option<&'a tokio::sync::mpsc::Sender<ProxyCommand>>,
     pub container_ip: Option<&'a str>,
+    pub container_name: Option<&'a str>,
+    pub is_orbstack: bool,
 }
+
+use crate::proxy::ProxyStartTarget;
 
 /// Start a TCP proxy for a forwarded port and verify it bound successfully.
 ///
 /// Returns `false` if the proxy bind failed and the allocation should be rolled back.
 async fn start_port_proxy(
     host_port: u16,
-    container_ip: &str,
-    target_port: u16,
+    target: ProxyStartTarget,
     proxy_cmd_tx: &tokio::sync::mpsc::Sender<ProxyCommand>,
 ) -> bool {
     let (result_tx, result_rx) = tokio::sync::oneshot::channel();
     let _ = proxy_cmd_tx
         .send(ProxyCommand::Start {
             host_port,
-            container_ip: container_ip.to_string(),
-            container_port: target_port,
+            target,
             result_tx: Some(result_tx),
         })
         .await;
@@ -452,10 +456,7 @@ async fn start_port_proxy(
     match result_rx.await {
         Ok(Ok(())) => true,
         Ok(Err(e)) => {
-            warn!(
-                "Proxy bind failed for port {host_port} (container port {target_port}): {e}. \
-                 Rolling back allocation."
-            );
+            warn!("Proxy bind failed for port {host_port}: {e}. Rolling back allocation.");
             false
         }
         Err(_) => {
@@ -484,11 +485,32 @@ async fn handle_port_open(
 
     let target_port = proxy_port.unwrap_or(port);
 
-    if let (Some(hp), Some(tx), Some(ip)) = (host_port, ctx.proxy_cmd_tx, ctx.container_ip)
-        && !start_port_proxy(hp, ip, target_port, tx).await
-    {
-        ctx.port_manager.lock().await.handle_port_closed(&cid, port);
-        return None;
+    if let (Some(hp), Some(tx)) = (host_port, ctx.proxy_cmd_tx) {
+        let use_direct_ip = cfg!(target_os = "linux") || ctx.is_orbstack;
+        let target = if use_direct_ip {
+            if let Some(ip) = ctx.container_ip {
+                ProxyStartTarget::DirectIp {
+                    ip: ip.to_string(),
+                    port: target_port,
+                }
+            } else {
+                warn!("No container IP for direct proxy, skipping port {port}");
+                return None;
+            }
+        } else if let Some(name) = ctx.container_name {
+            ProxyStartTarget::AgentTunnel {
+                container_name: name.to_string(),
+                port: target_port,
+            }
+        } else {
+            warn!("No container name for tunnel proxy, skipping port {port}");
+            return None;
+        };
+
+        if !start_port_proxy(hp, target, tx).await {
+            ctx.port_manager.lock().await.handle_port_closed(&cid, port);
+            return None;
+        }
     }
 
     host_port.map(|hp| DaemonMessage::PortMapping {
@@ -2977,6 +2999,8 @@ branch refs/heads/feat-b
             container_id: Some("c1"),
             proxy_cmd_tx: None,
             container_ip: None,
+            container_name: None,
+            is_orbstack: false,
         };
 
         let msg = AgentMessage::Health {
@@ -3008,6 +3032,8 @@ branch refs/heads/feat-b
             container_id: Some("c1"),
             proxy_cmd_tx: None,
             container_ip: None,
+            container_name: None,
+            is_orbstack: false,
         };
 
         let msg = AgentMessage::PortClosed {
@@ -3033,6 +3059,8 @@ branch refs/heads/feat-b
             container_id: Some("c1"),
             proxy_cmd_tx: None,
             container_ip: None,
+            container_name: None,
+            is_orbstack: false,
         };
 
         // Use an unknown operation so it fails fast without needing real git
@@ -3072,6 +3100,8 @@ branch refs/heads/feat-b
             container_id: Some("c1"),
             proxy_cmd_tx: None,
             container_ip: None,
+            container_name: None,
+            is_orbstack: false,
         };
 
         let msg = AgentMessage::Health {
@@ -3139,6 +3169,8 @@ branch refs/heads/feat-b
             container_id: Some("c1"),
             proxy_cmd_tx: None,
             container_ip: None,
+            container_name: None,
+            is_orbstack: false,
         };
 
         let msg = AgentMessage::PortOpen {

--- a/crates/cella-daemon/src/daemon.rs
+++ b/crates/cella-daemon/src/daemon.rs
@@ -13,8 +13,9 @@ use crate::health::run_health_monitor;
 use crate::management::{ManagementContext, run_management_server};
 use crate::orbstack;
 use crate::port_manager::PortManager;
-use crate::proxy::run_proxy_coordinator;
+use crate::proxy::{ProxyCoordinatorContext, run_proxy_coordinator};
 use crate::shared::{cleanup_files, current_time_secs, read_pid_file, set_socket_permissions};
+use crate::tunnel::TunnelBroker;
 
 /// Write the PID file and ensure the parent directory exists.
 fn write_pid_and_ensure_dir(socket_path: &Path, pid_path: &Path) -> Result<u32, CellaDaemonError> {
@@ -114,11 +115,25 @@ pub async fn run_daemon(socket_path: &Path, pid_path: &Path) -> Result<(), Cella
         run_health_monitor(health_activity, &health_pid, &health_socket).await;
     });
 
-    // Spawn proxy coordinator
+    // Create shared tunnel broker and container handles at daemon level
+    let tunnel_broker = Arc::new(TunnelBroker::new());
+    let container_handles: Arc<
+        tokio::sync::Mutex<
+            std::collections::HashMap<String, crate::control_server::ContainerHandle>,
+        >,
+    > = Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new()));
+
+    // Spawn proxy coordinator with tunnel context
     let (proxy_cmd_tx, proxy_cmd_rx) = tokio::sync::mpsc::channel(64);
-    tokio::spawn(async move {
-        run_proxy_coordinator(proxy_cmd_rx).await;
-    });
+    {
+        let proxy_ctx = ProxyCoordinatorContext {
+            tunnel_broker: tunnel_broker.clone(),
+            container_handles: container_handles.clone(),
+        };
+        tokio::spawn(async move {
+            run_proxy_coordinator(proxy_cmd_rx, Some(proxy_ctx)).await;
+        });
+    }
 
     let start_time = std::time::Instant::now();
     let daemon_started_at = std::time::SystemTime::now()
@@ -140,6 +155,8 @@ pub async fn run_daemon(socket_path: &Path, pid_path: &Path) -> Result<(), Cella
         auth_token,
         control_port,
         ssh_proxy_manager,
+        container_handles,
+        tunnel_broker,
     };
 
     // Run the management server (CLI protocol) — blocks until shutdown

--- a/crates/cella-daemon/src/lib.rs
+++ b/crates/cella-daemon/src/lib.rs
@@ -18,5 +18,6 @@ pub mod shared;
 pub mod ssh_proxy;
 pub mod stream_bridge;
 pub mod task_manager;
+pub mod tunnel;
 
 pub use error::CellaDaemonError;

--- a/crates/cella-daemon/src/management.rs
+++ b/crates/cella-daemon/src/management.rs
@@ -92,6 +92,8 @@ pub(crate) async fn run_management_server(
             proxy_cmd_tx: ctx.proxy_cmd_tx.clone(),
             task_manager: crate::task_manager::new_shared(),
             cella_bin: crate::control_server::resolve_cella_binary(),
+            tunnel_broker: Arc::new(crate::tunnel::TunnelBroker::new()),
+            is_orbstack: ctx.is_orbstack,
         };
         tokio::spawn(async move {
             crate::control_server::run_control_server(

--- a/crates/cella-daemon/src/management.rs
+++ b/crates/cella-daemon/src/management.rs
@@ -369,6 +369,7 @@ async fn handle_register(
                 agent_state: Arc::new(AgentConnectionState::new()),
                 backend_kind: reg.backend_kind,
                 docker_host: reg.docker_host,
+                agent_tx: None,
             },
         );
     }

--- a/crates/cella-daemon/src/management.rs
+++ b/crates/cella-daemon/src/management.rs
@@ -35,6 +35,8 @@ pub(crate) struct ManagementContext {
     pub auth_token: String,
     pub control_port: u16,
     pub ssh_proxy_manager: crate::ssh_proxy::SharedSshProxyManager,
+    pub container_handles: Arc<Mutex<HashMap<String, ContainerHandle>>>,
+    pub tunnel_broker: Arc<crate::tunnel::TunnelBroker>,
 }
 
 /// Bind the management Unix socket, cleaning up stale sockets and setting permissions.
@@ -75,9 +77,7 @@ pub(crate) async fn run_management_server(
 ) -> Result<(), CellaDaemonError> {
     let listener = bind_management_socket(socket_path)?;
 
-    let container_handles: Arc<Mutex<HashMap<String, ContainerHandle>>> =
-        Arc::new(Mutex::new(HashMap::new()));
-
+    let container_handles = ctx.container_handles.clone();
     let ctx = Arc::new(ctx);
 
     // Spawn the unified TCP control server for agent connections
@@ -92,7 +92,7 @@ pub(crate) async fn run_management_server(
             proxy_cmd_tx: ctx.proxy_cmd_tx.clone(),
             task_manager: crate::task_manager::new_shared(),
             cella_bin: crate::control_server::resolve_cella_binary(),
-            tunnel_broker: Arc::new(crate::tunnel::TunnelBroker::new()),
+            tunnel_broker: ctx.tunnel_broker.clone(),
             is_orbstack: ctx.is_orbstack,
         };
         tokio::spawn(async move {
@@ -559,6 +559,8 @@ mod tests {
             auth_token: "test-token".to_string(),
             control_port: ctrl_port,
             ssh_proxy_manager: crate::ssh_proxy::new_shared(tmp.keep(), "test-token".to_string()),
+            container_handles: Arc::new(Mutex::new(HashMap::new())),
+            tunnel_broker: Arc::new(crate::tunnel::TunnelBroker::new()),
         };
         (ctx, srx)
     }

--- a/crates/cella-daemon/src/proxy.rs
+++ b/crates/cella-daemon/src/proxy.rs
@@ -2,23 +2,37 @@
 
 use std::collections::HashMap;
 use std::io;
+use std::sync::Arc;
 
+use cella_protocol::DaemonMessage;
 use tokio::io::{AsyncWriteExt, copy_bidirectional};
 use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::Mutex;
 use tracing::{debug, warn};
+
+use crate::control_server::ContainerHandle;
+use crate::tunnel::TunnelBroker;
 
 /// Commands for the proxy coordinator.
 pub enum ProxyCommand {
     /// Start a new TCP proxy.
     Start {
         host_port: u16,
-        container_ip: String,
-        container_port: u16,
+        target: ProxyStartTarget,
         /// Receives `Ok(())` if proxy bound successfully, or the bind error.
         result_tx: Option<tokio::sync::oneshot::Sender<Result<(), io::Error>>>,
     },
     /// Stop a running TCP proxy.
     Stop { host_port: u16 },
+}
+
+/// Target specification for starting a proxy.
+#[derive(Debug, Clone)]
+pub enum ProxyStartTarget {
+    /// Connect directly to an IP:port (OrbStack, Linux native).
+    DirectIp { ip: String, port: u16 },
+    /// Tunnel through the agent via a reverse TCP connection.
+    AgentTunnel { container_name: String, port: u16 },
 }
 
 /// Handle to a running TCP proxy task.
@@ -33,23 +47,20 @@ impl ProxyHandle {
     }
 }
 
-/// Target for a TCP proxy connection.
-#[derive(Debug, Clone)]
-pub enum ProxyTarget {
-    /// Connect directly to an IP:port (`OrbStack`, Linux native).
-    DirectIp { ip: String, port: u16 },
+/// Shared state needed by the proxy coordinator for tunnel mode.
+pub struct ProxyCoordinatorContext {
+    pub tunnel_broker: Arc<TunnelBroker>,
+    pub container_handles: Arc<Mutex<HashMap<String, ContainerHandle>>>,
 }
 
-/// Start a TCP proxy from `host_port` to the given target.
-///
-/// Returns a handle that can be used to stop the proxy.
-///
-/// # Errors
-///
-/// Returns error if binding to the host port fails.
-pub async fn start_proxy(host_port: u16, target: ProxyTarget) -> Result<ProxyHandle, io::Error> {
+/// Start a direct-IP TCP proxy from `host_port` to the given IP:port.
+async fn start_direct_proxy(
+    host_port: u16,
+    ip: String,
+    port: u16,
+) -> Result<ProxyHandle, io::Error> {
     let listener = TcpListener::bind(("127.0.0.1", host_port)).await?;
-    debug!("TCP proxy listening on 127.0.0.1:{host_port} -> {target:?}");
+    debug!("Direct proxy listening on 127.0.0.1:{host_port} -> {ip}:{port}");
 
     let handle = tokio::spawn(async move {
         loop {
@@ -61,21 +72,17 @@ pub async fn start_proxy(host_port: u16, target: ProxyTarget) -> Result<ProxyHan
                 }
             };
 
-            let target = target.clone();
+            let ip = ip.clone();
             debug!("Proxy connection from {peer} on port {host_port}");
 
             tokio::spawn(async move {
-                match &target {
-                    ProxyTarget::DirectIp { ip, port } => {
-                        match TcpStream::connect((ip.as_str(), *port)).await {
-                            Ok(mut outbound) => {
-                                let _ = copy_bidirectional(&mut inbound, &mut outbound).await;
-                            }
-                            Err(e) => {
-                                warn!("Proxy connect to {ip}:{port} failed: {e}");
-                                let _ = inbound.shutdown().await;
-                            }
-                        }
+                match TcpStream::connect((ip.as_str(), port)).await {
+                    Ok(mut outbound) => {
+                        let _ = copy_bidirectional(&mut inbound, &mut outbound).await;
+                    }
+                    Err(e) => {
+                        warn!("Proxy connect to {ip}:{port} failed: {e}");
+                        let _ = inbound.shutdown().await;
                     }
                 }
             });
@@ -85,57 +92,171 @@ pub async fn start_proxy(host_port: u16, target: ProxyTarget) -> Result<ProxyHan
     Ok(ProxyHandle { handle })
 }
 
-/// Handle a proxy start command: bind the proxy and report the result.
-async fn handle_proxy_start(
+/// Start an agent-tunnel TCP proxy from `host_port` through the agent.
+async fn start_tunnel_proxy(
     host_port: u16,
-    container_ip: String,
-    container_port: u16,
-    result_tx: Option<tokio::sync::oneshot::Sender<Result<(), io::Error>>>,
-    proxies: &mut HashMap<u16, ProxyHandle>,
-) {
-    let target = ProxyTarget::DirectIp {
-        ip: container_ip,
-        port: container_port,
+    container_name: String,
+    target_port: u16,
+    broker: Arc<TunnelBroker>,
+    container_handles: Arc<Mutex<HashMap<String, ContainerHandle>>>,
+) -> Result<ProxyHandle, io::Error> {
+    let listener = TcpListener::bind(("127.0.0.1", host_port)).await?;
+    debug!(
+        "Tunnel proxy listening on 127.0.0.1:{host_port} -> agent:{container_name}:{target_port}"
+    );
+
+    let handle = tokio::spawn(async move {
+        loop {
+            let (mut inbound, peer) = match listener.accept().await {
+                Ok(conn) => conn,
+                Err(e) => {
+                    warn!("Tunnel proxy accept error on port {host_port}: {e}");
+                    continue;
+                }
+            };
+
+            let broker = broker.clone();
+            let handles = container_handles.clone();
+            let name = container_name.clone();
+            debug!("Tunnel proxy connection from {peer} on port {host_port}");
+
+            tokio::spawn(async move {
+                if let Err(e) = handle_tunnel_proxy_connection(
+                    &mut inbound,
+                    &name,
+                    target_port,
+                    &broker,
+                    &handles,
+                )
+                .await
+                {
+                    debug!("Tunnel proxy connection failed: {e}");
+                    let _ = inbound.shutdown().await;
+                }
+            });
+        }
+    });
+
+    Ok(ProxyHandle { handle })
+}
+
+async fn handle_tunnel_proxy_connection(
+    inbound: &mut TcpStream,
+    container_name: &str,
+    target_port: u16,
+    broker: &TunnelBroker,
+    container_handles: &Arc<Mutex<HashMap<String, ContainerHandle>>>,
+) -> Result<(), io::Error> {
+    let (connection_id, rx) = broker.request_tunnel().await;
+
+    let agent_tx = {
+        let handles = container_handles.lock().await;
+        handles.get(container_name).and_then(|h| h.agent_tx.clone())
     };
-    match start_proxy(host_port, target).await {
-        Ok(handle) => {
-            debug!("Started proxy: localhost:{host_port} -> container:{container_port}");
-            proxies.insert(host_port, handle);
-            if let Some(tx) = result_tx {
-                let _ = tx.send(Ok(()));
-            }
-        }
-        Err(e) => {
-            warn!("Failed to start proxy on port {host_port}: {e}");
-            if let Some(tx) = result_tx {
-                let _ = tx.send(Err(e));
-            }
-        }
+
+    let Some(agent_tx) = agent_tx else {
+        broker.cancel(connection_id).await;
+        return Err(io::Error::new(
+            io::ErrorKind::NotConnected,
+            "agent not connected",
+        ));
+    };
+
+    if agent_tx
+        .send(DaemonMessage::TunnelRequest {
+            connection_id,
+            target_port,
+        })
+        .await
+        .is_err()
+    {
+        broker.cancel(connection_id).await;
+        return Err(io::Error::new(
+            io::ErrorKind::BrokenPipe,
+            "agent channel closed",
+        ));
     }
+
+    let tunnel_stream = tokio::time::timeout(std::time::Duration::from_secs(5), rx).await;
+
+    let mut tunnel = match tunnel_stream {
+        Ok(Ok(stream)) => stream,
+        Ok(Err(_)) => {
+            broker.cancel(connection_id).await;
+            return Err(io::Error::new(
+                io::ErrorKind::ConnectionRefused,
+                "tunnel delivery failed",
+            ));
+        }
+        Err(_) => {
+            broker.cancel(connection_id).await;
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "tunnel request timed out",
+            ));
+        }
+    };
+
+    let _ = copy_bidirectional(inbound, &mut tunnel).await;
+    Ok(())
 }
 
 /// Run the proxy coordinator that manages TCP proxy lifecycle.
 ///
 /// Receives `ProxyCommand` messages and starts/stops TCP proxies accordingly.
-pub async fn run_proxy_coordinator(mut rx: tokio::sync::mpsc::Receiver<ProxyCommand>) {
+pub async fn run_proxy_coordinator(
+    mut rx: tokio::sync::mpsc::Receiver<ProxyCommand>,
+    ctx: Option<ProxyCoordinatorContext>,
+) {
     let mut proxies: HashMap<u16, ProxyHandle> = HashMap::new();
 
     while let Some(cmd) = rx.recv().await {
         match cmd {
             ProxyCommand::Start {
                 host_port,
-                container_ip,
-                container_port,
+                target,
                 result_tx,
             } => {
-                handle_proxy_start(
-                    host_port,
-                    container_ip,
-                    container_port,
-                    result_tx,
-                    &mut proxies,
-                )
-                .await;
+                let result = match target {
+                    ProxyStartTarget::DirectIp { ip, port } => {
+                        start_direct_proxy(host_port, ip, port).await
+                    }
+                    ProxyStartTarget::AgentTunnel {
+                        container_name,
+                        port,
+                    } => {
+                        if let Some(ref ctx) = ctx {
+                            start_tunnel_proxy(
+                                host_port,
+                                container_name,
+                                port,
+                                ctx.tunnel_broker.clone(),
+                                ctx.container_handles.clone(),
+                            )
+                            .await
+                        } else {
+                            Err(io::Error::new(
+                                io::ErrorKind::Unsupported,
+                                "tunnel proxy not available",
+                            ))
+                        }
+                    }
+                };
+                match result {
+                    Ok(handle) => {
+                        debug!("Started proxy on localhost:{host_port}");
+                        proxies.insert(host_port, handle);
+                        if let Some(tx) = result_tx {
+                            let _ = tx.send(Ok(()));
+                        }
+                    }
+                    Err(e) => {
+                        warn!("Failed to start proxy on port {host_port}: {e}");
+                        if let Some(tx) = result_tx {
+                            let _ = tx.send(Err(e));
+                        }
+                    }
+                }
             }
             ProxyCommand::Stop { host_port } => {
                 if let Some(handle) = proxies.remove(&host_port) {
@@ -152,20 +273,18 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn proxy_starts_and_stops() {
-        let target = ProxyTarget::DirectIp {
-            ip: "127.0.0.1".to_string(),
-            port: 9999,
-        };
-        let handle = start_proxy(0, target).await.unwrap();
+    async fn direct_proxy_starts_and_stops() {
+        let handle = start_direct_proxy(0, "127.0.0.1".to_string(), 9999)
+            .await
+            .unwrap();
         handle.abort();
     }
 
-    // -- ProxyTarget --
+    // -- ProxyStartTarget --
 
     #[test]
-    fn proxy_target_debug_contains_ip_and_port() {
-        let target = ProxyTarget::DirectIp {
+    fn proxy_start_target_debug_contains_ip_and_port() {
+        let target = ProxyStartTarget::DirectIp {
             ip: "10.0.0.5".into(),
             port: 8080,
         };
@@ -175,20 +294,31 @@ mod tests {
     }
 
     #[test]
-    fn proxy_target_clone() {
-        let original = ProxyTarget::DirectIp {
+    fn proxy_start_target_clone() {
+        let original = ProxyStartTarget::DirectIp {
             ip: "1.2.3.4".into(),
             port: 443,
         };
-        // Use a function boundary to prevent clippy redundant_clone.
         let cloned = clone_target(&original);
-        let ProxyTarget::DirectIp { ip, port } = &cloned;
-        assert_eq!(ip, "1.2.3.4");
-        assert_eq!(*port, 443);
+        assert!(matches!(
+            cloned,
+            ProxyStartTarget::DirectIp { ref ip, port: 443 } if ip == "1.2.3.4"
+        ));
     }
 
-    fn clone_target(t: &ProxyTarget) -> ProxyTarget {
+    fn clone_target(t: &ProxyStartTarget) -> ProxyStartTarget {
         t.clone()
+    }
+
+    #[test]
+    fn proxy_start_target_agent_tunnel_debug() {
+        let target = ProxyStartTarget::AgentTunnel {
+            container_name: "cella-test".into(),
+            port: 3000,
+        };
+        let dbg = format!("{target:?}");
+        assert!(dbg.contains("cella-test"));
+        assert!(dbg.contains("3000"));
     }
 
     // -- ProxyCommand construction --
@@ -197,20 +327,21 @@ mod tests {
     fn proxy_command_start_fields() {
         let cmd = ProxyCommand::Start {
             host_port: 3000,
-            container_ip: "172.17.0.2".into(),
-            container_port: 8080,
+            target: ProxyStartTarget::DirectIp {
+                ip: "172.17.0.2".into(),
+                port: 8080,
+            },
             result_tx: None,
         };
         match cmd {
             ProxyCommand::Start {
-                host_port,
-                container_ip,
-                container_port,
-                ..
+                host_port, target, ..
             } => {
                 assert_eq!(host_port, 3000);
-                assert_eq!(container_ip, "172.17.0.2");
-                assert_eq!(container_port, 8080);
+                assert!(matches!(
+                    target,
+                    ProxyStartTarget::DirectIp { ref ip, port: 8080 } if ip == "172.17.0.2"
+                ));
             }
             ProxyCommand::Stop { .. } => panic!("expected Start"),
         }
@@ -229,24 +360,17 @@ mod tests {
 
     #[tokio::test]
     async fn proxy_handle_abort_is_idempotent() {
-        let target = ProxyTarget::DirectIp {
-            ip: "127.0.0.1".into(),
-            port: 1,
-        };
-        let handle = start_proxy(0, target).await.unwrap();
-        // Aborting should not panic.
+        let handle = start_direct_proxy(0, "127.0.0.1".into(), 1).await.unwrap();
         handle.abort();
     }
 
-    // -- start_proxy binding --
+    // -- start_direct_proxy binding --
 
     #[tokio::test]
-    async fn start_proxy_port_zero_binds_random() {
-        let target = ProxyTarget::DirectIp {
-            ip: "127.0.0.1".into(),
-            port: 1234,
-        };
-        let handle = start_proxy(0, target).await.unwrap();
+    async fn start_direct_proxy_port_zero_binds_random() {
+        let handle = start_direct_proxy(0, "127.0.0.1".into(), 1234)
+            .await
+            .unwrap();
         handle.abort();
     }
 
@@ -255,12 +379,11 @@ mod tests {
     #[tokio::test]
     async fn coordinator_stop_unknown_port_is_harmless() {
         let (tx, rx) = tokio::sync::mpsc::channel(8);
-        let coordinator = tokio::spawn(run_proxy_coordinator(rx));
+        let coordinator = tokio::spawn(run_proxy_coordinator(rx, None));
 
         tx.send(ProxyCommand::Stop { host_port: 9999 })
             .await
             .unwrap();
-        // Drop sender to shut down coordinator.
         drop(tx);
         coordinator.await.unwrap();
     }
@@ -268,19 +391,20 @@ mod tests {
     #[tokio::test]
     async fn coordinator_start_and_stop_lifecycle() {
         let (tx, rx) = tokio::sync::mpsc::channel(8);
-        let coordinator = tokio::spawn(run_proxy_coordinator(rx));
+        let coordinator = tokio::spawn(run_proxy_coordinator(rx, None));
 
         let (result_tx, result_rx) = tokio::sync::oneshot::channel();
         tx.send(ProxyCommand::Start {
-            host_port: 0, // random port
-            container_ip: "127.0.0.1".into(),
-            container_port: 1,
+            host_port: 0,
+            target: ProxyStartTarget::DirectIp {
+                ip: "127.0.0.1".into(),
+                port: 1,
+            },
             result_tx: Some(result_tx),
         })
         .await
         .unwrap();
 
-        // Should succeed.
         result_rx.await.unwrap().unwrap();
 
         drop(tx);

--- a/crates/cella-daemon/src/proxy.rs
+++ b/crates/cella-daemon/src/proxy.rs
@@ -29,7 +29,7 @@ pub enum ProxyCommand {
 /// Target specification for starting a proxy.
 #[derive(Debug, Clone)]
 pub enum ProxyStartTarget {
-    /// Connect directly to an IP:port (OrbStack, Linux native).
+    /// Connect directly to an `IP:port` (`OrbStack`, Linux native).
     DirectIp { ip: String, port: u16 },
     /// Tunnel through the agent via a reverse TCP connection.
     AgentTunnel { container_name: String, port: u16 },
@@ -53,7 +53,7 @@ pub struct ProxyCoordinatorContext {
     pub container_handles: Arc<Mutex<HashMap<String, ContainerHandle>>>,
 }
 
-/// Start a direct-IP TCP proxy from `host_port` to the given IP:port.
+/// Start a direct-IP TCP proxy from `host_port` to the given `IP:port`.
 async fn start_direct_proxy(
     host_port: u16,
     ip: String,

--- a/crates/cella-daemon/src/tunnel.rs
+++ b/crates/cella-daemon/src/tunnel.rs
@@ -1,0 +1,124 @@
+//! Reverse-tunnel broker: matches pending tunnel requests with incoming agent
+//! tunnel connections.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use tokio::net::TcpStream;
+use tokio::sync::{Mutex, oneshot};
+
+/// Manages pending reverse-tunnel requests and matches them with incoming
+/// tunnel connections from agents.
+pub struct TunnelBroker {
+    next_id: AtomicU64,
+    pending: Arc<Mutex<HashMap<u64, oneshot::Sender<TcpStream>>>>,
+}
+
+impl TunnelBroker {
+    pub fn new() -> Self {
+        Self {
+            next_id: AtomicU64::new(1),
+            pending: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Allocate a connection ID and register a waiter.
+    pub async fn request_tunnel(&self) -> (u64, oneshot::Receiver<TcpStream>) {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let (tx, rx) = oneshot::channel();
+        self.pending.lock().await.insert(id, tx);
+        (id, rx)
+    }
+
+    /// Deliver a reverse tunnel connection from an agent.
+    ///
+    /// Returns `false` if no pending request matches (timed out or spurious).
+    pub async fn deliver(&self, connection_id: u64, stream: TcpStream) -> bool {
+        let tx = self.pending.lock().await.remove(&connection_id);
+        if let Some(tx) = tx {
+            tx.send(stream).is_ok()
+        } else {
+            false
+        }
+    }
+
+    /// Remove a timed-out pending request.
+    pub async fn cancel(&self, connection_id: u64) {
+        self.pending.lock().await.remove(&connection_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn request_returns_incrementing_ids() {
+        let broker = TunnelBroker::new();
+        let (id1, _rx1) = broker.request_tunnel().await;
+        let (id2, _rx2) = broker.request_tunnel().await;
+        assert_eq!(id1 + 1, id2);
+    }
+
+    #[tokio::test]
+    async fn deliver_to_pending_request() {
+        let broker = TunnelBroker::new();
+        let (id, rx) = broker.request_tunnel().await;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let connect_handle = tokio::spawn(async move { TcpStream::connect(addr).await.unwrap() });
+        let (accepted, _) = listener.accept().await.unwrap();
+        let _ = connect_handle.await;
+
+        assert!(broker.deliver(id, accepted).await);
+        assert!(rx.await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn deliver_to_unknown_id_returns_false() {
+        let broker = TunnelBroker::new();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let connect_handle = tokio::spawn(async move { TcpStream::connect(addr).await.unwrap() });
+        let (accepted, _) = listener.accept().await.unwrap();
+        let _ = connect_handle.await;
+
+        assert!(!broker.deliver(999, accepted).await);
+    }
+
+    #[tokio::test]
+    async fn cancel_removes_pending_request() {
+        let broker = TunnelBroker::new();
+        let (id, rx) = broker.request_tunnel().await;
+        broker.cancel(id).await;
+
+        // Receiver should error since sender was dropped
+        assert!(rx.await.is_err());
+    }
+
+    #[tokio::test]
+    async fn cancel_unknown_id_is_harmless() {
+        let broker = TunnelBroker::new();
+        broker.cancel(12345).await;
+    }
+
+    #[tokio::test]
+    async fn deliver_after_receiver_dropped_returns_false() {
+        let broker = TunnelBroker::new();
+        let (id, rx) = broker.request_tunnel().await;
+        drop(rx);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let connect_handle = tokio::spawn(async move { TcpStream::connect(addr).await.unwrap() });
+        let (accepted, _) = listener.accept().await.unwrap();
+        let _ = connect_handle.await;
+
+        assert!(!broker.deliver(id, accepted).await);
+    }
+}

--- a/crates/cella-daemon/src/tunnel.rs
+++ b/crates/cella-daemon/src/tunnel.rs
@@ -15,6 +15,12 @@ pub struct TunnelBroker {
     pending: Arc<Mutex<HashMap<u64, oneshot::Sender<TcpStream>>>>,
 }
 
+impl Default for TunnelBroker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TunnelBroker {
     pub fn new() -> Self {
         Self {
@@ -35,12 +41,11 @@ impl TunnelBroker {
     ///
     /// Returns `false` if no pending request matches (timed out or spurious).
     pub async fn deliver(&self, connection_id: u64, stream: TcpStream) -> bool {
-        let tx = self.pending.lock().await.remove(&connection_id);
-        if let Some(tx) = tx {
-            tx.send(stream).is_ok()
-        } else {
-            false
-        }
+        self.pending
+            .lock()
+            .await
+            .remove(&connection_id)
+            .is_some_and(|tx| tx.send(stream).is_ok())
     }
 
     /// Remove a timed-out pending request.

--- a/crates/cella-doctor/src/checks/container.rs
+++ b/crates/cella-doctor/src/checks/container.rs
@@ -66,7 +66,7 @@ async fn check_all_containers(client: &dyn ContainerBackend) -> Vec<CategoryRepo
             let mut reports = Vec::new();
             for container in &containers {
                 let name = format!("Container: {}", container.name);
-                let checks = check_single_container(client, &container.id, &container.name).await;
+                let checks = check_single_container(client, &container.id).await;
                 reports.push(CategoryReport::new(name, checks));
             }
             reports
@@ -111,7 +111,7 @@ async fn check_workspace_container(
     match target.resolve(client, false).await {
         Ok(container) => {
             let name = format!("Container: {}", container.name);
-            let checks = check_single_container(client, &container.id, &container.name).await;
+            let checks = check_single_container(client, &container.id).await;
             vec![CategoryReport::new(name, checks)]
         }
         Err(_) => {
@@ -131,7 +131,6 @@ async fn check_workspace_container(
 async fn check_single_container(
     client: &dyn ContainerBackend,
     container_id: &str,
-    container_name: &str,
 ) -> Vec<CheckResult> {
     let mut checks = Vec::new();
 
@@ -144,7 +143,7 @@ async fn check_single_container(
     });
 
     // Version skew check
-    check_version_skew(client, container_id, &mut checks, container_name).await;
+    check_version_skew(client, container_id, &mut checks).await;
 
     // Agent/port checks only apply to backends with managed agents
     if client.capabilities().managed_agent {
@@ -165,7 +164,6 @@ async fn check_version_skew(
     client: &dyn ContainerBackend,
     container_id: &str,
     checks: &mut Vec<CheckResult>,
-    container_name: &str,
 ) {
     let cli_version = env!("CARGO_PKG_VERSION");
 

--- a/crates/cella-doctor/src/checks/container.rs
+++ b/crates/cella-doctor/src/checks/container.rs
@@ -149,13 +149,13 @@ async fn check_single_container(
     // Agent/port checks only apply to backends with managed agents
     if client.capabilities().managed_agent {
         // Agent connectivity via daemon
-        check_agent_connectivity(&mut checks, container_name).await;
+        check_agent_connectivity(&mut checks, container_id).await;
 
         // Credential forwarding
         check_credentials(client, container_id, &mut checks).await;
 
         // Port forwarding
-        check_ports(&mut checks, container_name).await;
+        check_ports(&mut checks, container_id).await;
     }
 
     checks
@@ -172,7 +172,7 @@ async fn check_version_skew(
     // Prefer the live agent version from the daemon handshake.
     // Fall back to the Docker label when the agent isn't connected
     // (unmanaged backend, agent crashed, etc.).
-    let agent_version = query_live_agent_version(container_name).await;
+    let agent_version = query_live_agent_version(container_id).await;
 
     match agent_version.as_deref() {
         Some(v) if v == cli_version => {
@@ -220,7 +220,7 @@ async fn check_version_skew(
 }
 
 /// Query the daemon for a container's live agent version.
-async fn query_live_agent_version(container_name: &str) -> Option<String> {
+async fn query_live_agent_version(container_id: &str) -> Option<String> {
     let data_dir = cella_env::paths::cella_data_dir()?;
     let mgmt_socket = data_dir.join("daemon.sock");
     if !mgmt_socket.exists() {
@@ -237,14 +237,14 @@ async fn query_live_agent_version(container_name: &str) -> Option<String> {
     if let ManagementResponse::Status { containers, .. } = resp {
         containers
             .into_iter()
-            .find(|c| c.container_name == container_name && c.agent_connected)
+            .find(|c| c.container_id == container_id && c.agent_connected)
             .and_then(|c| c.agent_version)
     } else {
         None
     }
 }
 
-async fn check_agent_connectivity(checks: &mut Vec<CheckResult>, container_name: &str) {
+async fn check_agent_connectivity(checks: &mut Vec<CheckResult>, container_id: &str) {
     let Some(data_dir) = cella_env::paths::cella_data_dir() else {
         return;
     };
@@ -259,7 +259,7 @@ async fn check_agent_connectivity(checks: &mut Vec<CheckResult>, container_name:
         Ok(ManagementResponse::Status { containers, .. }) => {
             let found = containers
                 .iter()
-                .any(|c| c.container_name == container_name && c.agent_connected);
+                .any(|c| c.container_id == container_id && c.agent_connected);
             if found {
                 checks.push(CheckResult {
                     name: "agent".into(),
@@ -335,7 +335,7 @@ async fn check_credentials(
     }
 }
 
-async fn check_ports(checks: &mut Vec<CheckResult>, container_name: &str) {
+async fn check_ports(checks: &mut Vec<CheckResult>, container_id: &str) {
     let Some(data_dir) = cella_env::paths::cella_data_dir() else {
         return;
     };
@@ -343,15 +343,15 @@ async fn check_ports(checks: &mut Vec<CheckResult>, container_name: &str) {
 
     match cella_daemon::management::send_management_request(
         &mgmt_socket,
-        &ManagementRequest::QueryPorts,
+        &ManagementRequest::QueryStatus,
     )
     .await
     {
-        Ok(ManagementResponse::Ports { ports }) => {
-            let port_count = ports
+        Ok(ManagementResponse::Status { containers, .. }) => {
+            let port_count = containers
                 .iter()
-                .filter(|p| p.container_name == container_name)
-                .count();
+                .find(|c| c.container_id == container_id)
+                .map_or(0, |c| c.forwarded_port_count);
             checks.push(CheckResult {
                 name: "forwarded ports".into(),
                 severity: Severity::Info,

--- a/crates/cella-protocol/src/lib.rs
+++ b/crates/cella-protocol/src/lib.rs
@@ -10,6 +10,15 @@ use serde::{Deserialize, Serialize};
 /// Current protocol version for the agent↔daemon handshake.
 pub const PROTOCOL_VERSION: u32 = 1;
 
+/// Sent by an agent on a new TCP connection to identify it as a reverse tunnel
+/// for an active port-forward. Discriminated from [`AgentHello`] by the
+/// `connection_id` field.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TunnelHandshake {
+    pub auth_token: String,
+    pub connection_id: u64,
+}
+
 /// Sent by the agent as the first message after connecting.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentHello {
@@ -313,6 +322,11 @@ pub enum DaemonMessage {
     },
     /// Port mapping notification: tells the agent which host port was allocated.
     PortMapping { container_port: u16, host_port: u16 },
+    /// Request the agent to open a reverse tunnel for a new forwarded connection.
+    TunnelRequest {
+        connection_id: u64,
+        target_port: u16,
+    },
 
     // -- Worktree operation responses (daemon → in-container agent) ---------
     /// Progress update for a long-running operation (branch creation, etc.).
@@ -686,6 +700,64 @@ mod tests {
                 host_port: 3001
             }
         ));
+    }
+
+    #[test]
+    fn roundtrip_tunnel_handshake() {
+        let hs = TunnelHandshake {
+            auth_token: "secret".to_string(),
+            connection_id: 42,
+        };
+        let json = serde_json::to_string(&hs).unwrap();
+        assert!(json.contains("\"connection_id\":42"));
+        assert!(json.contains("\"auth_token\":\"secret\""));
+        let decoded: TunnelHandshake = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.connection_id, 42);
+        assert_eq!(decoded.auth_token, "secret");
+    }
+
+    #[test]
+    fn roundtrip_tunnel_request() {
+        let msg = DaemonMessage::TunnelRequest {
+            connection_id: 99,
+            target_port: 3000,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("\"type\":\"tunnel_request\""));
+        assert!(json.contains("\"connection_id\":99"));
+        assert!(json.contains("\"target_port\":3000"));
+        let decoded: DaemonMessage = serde_json::from_str(&json).unwrap();
+        assert!(matches!(
+            decoded,
+            DaemonMessage::TunnelRequest {
+                connection_id: 99,
+                target_port: 3000
+            }
+        ));
+    }
+
+    #[test]
+    fn tunnel_handshake_not_parseable_as_agent_hello() {
+        let hs = TunnelHandshake {
+            auth_token: "token".to_string(),
+            connection_id: 1,
+        };
+        let json = serde_json::to_string(&hs).unwrap();
+        let result = serde_json::from_str::<AgentHello>(&json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn agent_hello_not_parseable_as_tunnel_handshake() {
+        let hello = AgentHello {
+            protocol_version: PROTOCOL_VERSION,
+            agent_version: "0.1.0".to_string(),
+            container_name: "test".to_string(),
+            auth_token: "token".to_string(),
+        };
+        let json = serde_json::to_string(&hello).unwrap();
+        let result = serde_json::from_str::<TunnelHandshake>(&json);
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add agent-based reverse tunneling for port forwarding on VM-based Docker runtimes (Colima, Docker Desktop) where direct bridge IP access isn't available
- Fix `cella doctor` showing "agent not connected" for compose containers by matching on container ID instead of name
- Connect compose containers to the cella network during daemon-restart re-registration

## How it works

When a host client connects to a forwarded port, the daemon asks the agent (inside the container) to open a reverse TCP connection back. The agent connects to `localhost:target_port` inside the container and relays bidirectionally through the tunnel. Detection: `DirectIp` on OrbStack/Linux, `AgentTunnel` everywhere else.

## Test plan

- [x] Unit tests pass (`cargo test --workspace` — 2,882 tests, 0 failures)
- [x] Clippy clean (`cargo clippy --workspace --all-features --all-targets`)
- [x] Format clean (`cargo fmt --all -- --check`)
- [x] Manual: Colima macOS — `cella up` with a web server, `curl localhost:3000` works
- [x] Manual: OrbStack — verify DirectIp path still works (regression)
- [x] Manual: `cella doctor` shows connected agent and forwarded ports for compose containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)