### PR TITLE
fix: unblock port watcher on unforwarded ports

### DIFF
--- a/crates/cella-agent/src/port_watcher.rs
+++ b/crates/cella-agent/src/port_watcher.rs
@@ -104,19 +104,26 @@ async fn record_port_mapping(port_map: &PortMap, container_port: u16, host_port:
 async fn process_port_open_response(
     response: Result<DaemonMessage, cella_port::CellaPortError>,
     port_map: &PortMap,
-) {
+) -> bool {
     match response {
         Ok(DaemonMessage::PortMapping {
             container_port,
             host_port,
         }) => {
             record_port_mapping(port_map, container_port, host_port).await;
+            true
+        }
+        Ok(DaemonMessage::Ack { .. }) => {
+            debug!("PortOpen acknowledged without host port mapping");
+            true
         }
         Ok(_) => {
             debug!("Unexpected response to PortOpen (no mapping allocated)");
+            false
         }
         Err(e) => {
             debug!("No response to PortOpen: {e}");
+            false
         }
     }
 }
@@ -159,8 +166,7 @@ async fn send_port_open_and_record(
 
     let response = ctrl.recv().await;
     drop(ctrl);
-    process_port_open_response(response, ctx.port_map).await;
-    true
+    process_port_open_response(response, ctx.port_map).await
 }
 
 /// Handle a single newly-detected listener: start proxy if needed, report to daemon,
@@ -438,5 +444,38 @@ mod tests {
         let closed = collect_closed_keys(&known, &current);
         assert_eq!(closed.len(), 1);
         assert_eq!(closed[0], (8080, PortProtocol::Udp));
+    }
+
+    #[tokio::test]
+    async fn process_port_open_response_ack_is_success_without_mapping() {
+        let port_map = Arc::new(Mutex::new(HashMap::new()));
+
+        let handled =
+            process_port_open_response(Ok(DaemonMessage::Ack { id: None }), &port_map).await;
+
+        assert!(handled, "Ack means the daemon handled the port report");
+        assert!(
+            port_map.lock().await.is_empty(),
+            "Ack does not publish a host port mapping"
+        );
+    }
+
+    #[tokio::test]
+    async fn process_port_open_response_unrelated_message_is_not_success() {
+        let port_map = Arc::new(Mutex::new(HashMap::new()));
+
+        let handled = process_port_open_response(
+            Ok(DaemonMessage::Config {
+                poll_interval_ms: 1000,
+                proxy_localhost: true,
+            }),
+            &port_map,
+        )
+        .await;
+
+        assert!(
+            !handled,
+            "unrelated daemon messages should not mark the listener as reported"
+        );
     }
 }

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -482,10 +482,13 @@ async fn handle_port_open(
         let mut pm = ctx.port_manager.lock().await;
         pm.handle_port_open(&cid, port, protocol, process)
     };
+    let Some(hp) = host_port else {
+        return Some(DaemonMessage::Ack { id: None });
+    };
 
     let target_port = proxy_port.unwrap_or(port);
 
-    if let (Some(hp), Some(tx)) = (host_port, ctx.proxy_cmd_tx) {
+    if let Some(tx) = ctx.proxy_cmd_tx {
         let use_direct_ip = cfg!(target_os = "linux") || ctx.is_orbstack;
         let target = if use_direct_ip {
             if let Some(ip) = ctx.container_ip {
@@ -495,7 +498,8 @@ async fn handle_port_open(
                 }
             } else {
                 warn!("No container IP for direct proxy, skipping port {port}");
-                return None;
+                ctx.port_manager.lock().await.handle_port_closed(&cid, port);
+                return Some(DaemonMessage::Ack { id: None });
             }
         } else if let Some(name) = ctx.container_name {
             ProxyStartTarget::AgentTunnel {
@@ -504,16 +508,17 @@ async fn handle_port_open(
             }
         } else {
             warn!("No container name for tunnel proxy, skipping port {port}");
-            return None;
+            ctx.port_manager.lock().await.handle_port_closed(&cid, port);
+            return Some(DaemonMessage::Ack { id: None });
         };
 
         if !start_port_proxy(hp, target, tx).await {
             ctx.port_manager.lock().await.handle_port_closed(&cid, port);
-            return None;
+            return Some(DaemonMessage::Ack { id: None });
         }
     }
 
-    host_port.map(|hp| DaemonMessage::PortMapping {
+    Some(DaemonMessage::PortMapping {
         container_port: port,
         host_port: hp,
     })
@@ -3193,6 +3198,85 @@ branch refs/heads/feat-b
             }
             other => panic!("Expected PortMapping, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn handle_port_open_acknowledges_ignored_port() {
+        let pm = Arc::new(Mutex::new(PortManager::new(false)));
+        {
+            let mut guard = pm.lock().await;
+            guard.register_container(
+                "c1",
+                "test",
+                Some("172.20.0.5".to_string()),
+                vec![cella_protocol::PortAttributes {
+                    port: cella_protocol::PortPattern::Single(9229),
+                    on_auto_forward: cella_protocol::OnAutoForward::Ignore,
+                    ..cella_protocol::PortAttributes::default()
+                }],
+                None,
+            );
+        }
+        let browser = Arc::new(BrowserHandler::new());
+        let state = Arc::new(AgentConnectionState::new());
+        let ctx = AgentHandlerContext {
+            port_manager: &pm,
+            browser_handler: &browser,
+            container_id: Some("c1"),
+            proxy_cmd_tx: None,
+            container_ip: Some("172.20.0.5"),
+            container_name: Some("test"),
+            is_orbstack: false,
+        };
+
+        let msg = AgentMessage::PortOpen {
+            port: 9229,
+            protocol: PortProtocol::Tcp,
+            process: None,
+            bind: cella_protocol::BindAddress::Localhost,
+            proxy_port: None,
+        };
+        let result = handle_agent_message(msg, &ctx, &state).await;
+
+        assert!(
+            matches!(result, Some(DaemonMessage::Ack { id: None })),
+            "ignored ports must be acknowledged so the agent watcher keeps scanning"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_port_open_acknowledges_missing_container_ip() {
+        let pm = Arc::new(Mutex::new(PortManager::new(false)));
+        {
+            let mut guard = pm.lock().await;
+            guard.register_container("c1", "test", None, vec![], None);
+        }
+        let browser = Arc::new(BrowserHandler::new());
+        let state = Arc::new(AgentConnectionState::new());
+        let (proxy_tx, _proxy_rx) = tokio::sync::mpsc::channel(1);
+        let ctx = AgentHandlerContext {
+            port_manager: &pm,
+            browser_handler: &browser,
+            container_id: Some("c1"),
+            proxy_cmd_tx: Some(&proxy_tx),
+            container_ip: None,
+            container_name: Some("test"),
+            is_orbstack: false,
+        };
+
+        let msg = AgentMessage::PortOpen {
+            port: 3000,
+            protocol: PortProtocol::Tcp,
+            process: None,
+            bind: cella_protocol::BindAddress::Localhost,
+            proxy_port: None,
+        };
+        let result = handle_agent_message(msg, &ctx, &state).await;
+
+        assert!(
+            matches!(result, Some(DaemonMessage::Ack { id: None })),
+            "unforwardable ports must be acknowledged so the agent watcher keeps scanning"
+        );
     }
 
     // ---------------------------------------------------------------

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -3286,11 +3286,14 @@ branch refs/heads/feat-b
     #[tokio::test]
     async fn handle_port_open_uses_updated_container_ip_after_handshake() {
         let pm = Arc::new(Mutex::new(PortManager::new(false)));
-        {
-            let mut guard = pm.lock().await;
-            guard.register_container("c1", "test", None, vec![], None);
-            assert!(guard.update_container_ip("c1", Some("172.20.0.9".to_string())));
-        }
+        pm.lock()
+            .await
+            .register_container("c1", "test", None, vec![], None);
+        assert!(
+            pm.lock()
+                .await
+                .update_container_ip("c1", Some("172.20.0.9".to_string()))
+        );
         let browser = Arc::new(BrowserHandler::new());
         let state = Arc::new(AgentConnectionState::new());
         let (proxy_tx, mut proxy_rx) = tokio::sync::mpsc::channel(1);

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -487,11 +487,15 @@ async fn handle_port_open(
     };
 
     let target_port = proxy_port.unwrap_or(port);
+    let current_container_ip = {
+        let pm = ctx.port_manager.lock().await;
+        pm.container_ip(&cid).map(str::to_string)
+    };
 
     if let Some(tx) = ctx.proxy_cmd_tx {
         let use_direct_ip = cfg!(target_os = "linux") || ctx.is_orbstack;
         let target = if use_direct_ip {
-            if let Some(ip) = ctx.container_ip {
+            if let Some(ip) = current_container_ip.as_deref().or(ctx.container_ip) {
                 ProxyStartTarget::DirectIp {
                     ip: ip.to_string(),
                     port: target_port,
@@ -3277,6 +3281,77 @@ branch refs/heads/feat-b
             matches!(result, Some(DaemonMessage::Ack { id: None })),
             "unforwardable ports must be acknowledged so the agent watcher keeps scanning"
         );
+    }
+
+    #[tokio::test]
+    async fn handle_port_open_uses_updated_container_ip_after_handshake() {
+        let pm = Arc::new(Mutex::new(PortManager::new(false)));
+        {
+            let mut guard = pm.lock().await;
+            guard.register_container("c1", "test", None, vec![], None);
+            assert!(guard.update_container_ip("c1", Some("172.20.0.9".to_string())));
+        }
+        let browser = Arc::new(BrowserHandler::new());
+        let state = Arc::new(AgentConnectionState::new());
+        let (proxy_tx, mut proxy_rx) = tokio::sync::mpsc::channel(1);
+        let proxy_assertion = tokio::spawn(async move {
+            let cmd = tokio::time::timeout(std::time::Duration::from_secs(1), proxy_rx.recv())
+                .await
+                .expect("proxy start command should be sent")
+                .expect("proxy channel should stay open");
+            match cmd {
+                ProxyCommand::Start {
+                    host_port,
+                    target,
+                    result_tx,
+                } => {
+                    assert_eq!(host_port, 3000);
+                    assert!(matches!(
+                        target,
+                        ProxyStartTarget::DirectIp { ref ip, port: 3000 } if ip == "172.20.0.9"
+                    ));
+                    result_tx
+                        .expect("proxy start should request bind result")
+                        .send(Ok(()))
+                        .expect("port handler should wait for proxy result");
+                }
+                ProxyCommand::Stop { .. } => panic!("expected proxy start command"),
+            }
+        });
+        let ctx = AgentHandlerContext {
+            port_manager: &pm,
+            browser_handler: &browser,
+            container_id: Some("c1"),
+            proxy_cmd_tx: Some(&proxy_tx),
+            // Simulates an agent connection that handshook before the CLI
+            // updated the daemon's container IP state.
+            container_ip: None,
+            container_name: Some("test"),
+            is_orbstack: false,
+        };
+
+        let msg = AgentMessage::PortOpen {
+            port: 3000,
+            protocol: PortProtocol::Tcp,
+            process: None,
+            bind: cella_protocol::BindAddress::Localhost,
+            proxy_port: None,
+        };
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            handle_agent_message(msg, &ctx, &state),
+        )
+        .await
+        .expect("port open handler should not hang");
+
+        assert!(matches!(
+            result,
+            Some(DaemonMessage::PortMapping {
+                container_port: 3000,
+                host_port: 3000
+            })
+        ));
+        proxy_assertion.await.unwrap();
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Return `Ack` instead of `None` when a port can't be forwarded (ignored, no container IP, proxy bind failure) so the agent's port watcher doesn't stall waiting for a response
- Handle `Ack` as a success in the agent's port open response processing so the scan loop keeps moving
- Resolve the latest container IP from `PortManager` state at proxy-start time instead of relying on the stale IP captured during the initial handshake

## Test plan

- [x] Unit tests for `Ack` handling in port open response
- [x] Unit tests for ignored port acknowledgment
- [x] Unit test for missing container IP acknowledgment
- [x] Unit test for updated container IP resolution after handshake

🤖 Generated with [Claude Code](https://claude.com/claude-code)