### PR TITLE
fix: WezTerm tab title disappearing on exit

### DIFF
--- a/crates/cella-cli/src/commands/switch.rs
+++ b/crates/cella-cli/src/commands/switch.rs
@@ -50,6 +50,7 @@ impl SwitchArgs {
         };
 
         let container = target.resolve(client.as_ref(), true).await?;
+        let title_guard = crate::title::push_for_container(&container, None, "switch");
 
         super::ensure_cella_daemon().await;
 
@@ -122,6 +123,7 @@ impl SwitchArgs {
             )
             .await?;
 
+        drop(title_guard);
         std::process::exit(i32::try_from(exit_code).unwrap_or(125));
     }
 }

--- a/crates/cella-cli/src/title.rs
+++ b/crates/cella-cli/src/title.rs
@@ -20,8 +20,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 static TITLE_ACTIVE: AtomicBool = AtomicBool::new(false);
 static NEEDS_TMUX_WRAP: AtomicBool = AtomicBool::new(false);
 
-const RESTORE_PLAIN: &[u8] = b"\x1b]0;\x07\x1b[23;0t";
-const RESTORE_TMUX: &[u8] = b"\x1bPtmux;\x1b\x1b]0;\x07\x1b\\\x1bPtmux;\x1b\x1b[23;0t\x1b\\";
+const RESTORE_PLAIN: &[u8] = b"\x1b[23;0t";
+const RESTORE_TMUX: &[u8] = b"\x1bPtmux;\x1b\x1b[23;0t\x1b\\";
 
 /// Strip the `"cella-"` prefix so the title doesn't repeat the brand already
 /// present in the `" \u{2014} cella <subcommand>"` suffix. No-op if the prefix
@@ -201,10 +201,10 @@ fn emit_set(w: &mut impl Write, title: &str, in_tmux: bool) -> io::Result<()> {
     }
 }
 
-// Empty title first so terminals without title-stack support (WezTerm, kitty)
-// still clear the title; the subsequent pop handles stack-supporting terminals.
+// Pop the title stack. Terminals with stack support (xterm, kitty, iTerm2)
+// restore the prior title; terminals without (WezTerm) silently ignore the
+// pop and leave the cella title until the shell prompt overwrites it.
 fn emit_restore(w: &mut impl Write, in_tmux: bool) -> io::Result<()> {
-    emit_set(w, "", in_tmux)?;
     emit_pop(w, in_tmux)
 }
 
@@ -554,19 +554,17 @@ mod tests {
     // ── emit_restore ─────────────────────────────────────────────────
 
     #[test]
-    fn emit_restore_plain_emits_reset_then_pop() {
+    fn emit_restore_plain_emits_pop_only() {
         let mut out = Vec::new();
         emit_restore(&mut out, false).unwrap();
-        assert_eq!(out, b"\x1b]0;\x07\x1b[23;0t");
+        assert_eq!(out, b"\x1b[23;0t");
     }
 
     #[test]
-    fn emit_restore_tmux_emits_wrapped_reset_then_pop() {
+    fn emit_restore_tmux_emits_wrapped_pop_only() {
         let mut out = Vec::new();
         emit_restore(&mut out, true).unwrap();
-        let mut expected = tmux_wrap(b"\x1b]0;\x07");
-        expected.extend_from_slice(&tmux_wrap(b"\x1b[23;0t"));
-        assert_eq!(out, expected);
+        assert_eq!(out, tmux_wrap(b"\x1b[23;0t"));
     }
 
     // ── signal handler constants ───────────────────────────────────────

--- a/crates/cella-cli/src/title.rs
+++ b/crates/cella-cli/src/title.rs
@@ -590,6 +590,40 @@ mod tests {
         assert_eq!(out.as_slice(), RESTORE_TMUX);
     }
 
+    // ── full push/set/restore lifecycle ─────────────────────────────
+
+    #[test]
+    fn full_push_set_restore_lifecycle_plain() {
+        let mut out = Vec::new();
+        emit_push(&mut out, false).unwrap();
+        emit_set(&mut out, "x \u{2014} cella exec", false).unwrap();
+        emit_restore(&mut out, false).unwrap();
+
+        let expected = [
+            b"\x1b[22;0t".as_slice(),
+            b"\x1b]0;x \xe2\x80\x94 cella exec\x07".as_slice(),
+            b"\x1b[23;0t".as_slice(),
+        ]
+        .concat();
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn full_push_set_restore_lifecycle_tmux() {
+        let mut out = Vec::new();
+        emit_push(&mut out, true).unwrap();
+        emit_set(&mut out, "x", true).unwrap();
+        emit_restore(&mut out, true).unwrap();
+
+        let expected = [
+            tmux_wrap(b"\x1b[22;0t").as_slice(),
+            tmux_wrap(b"\x1b]0;x\x07").as_slice(),
+            tmux_wrap(b"\x1b[23;0t").as_slice(),
+        ]
+        .concat();
+        assert_eq!(out, expected);
+    }
+
     // ── public API reachability ──────────────────────────────────────
 
     #[test]

--- a/crates/cella-cli/src/title.rs
+++ b/crates/cella-cli/src/title.rs
@@ -567,6 +567,13 @@ mod tests {
         assert_eq!(out, tmux_wrap(b"\x1b[23;0t"));
     }
 
+    #[test]
+    fn emit_restore_plain_does_not_contain_osc_set() {
+        let mut out = Vec::new();
+        emit_restore(&mut out, false).unwrap();
+        assert!(!out.windows(3).any(|w| w == b"\x1b]0"));
+    }
+
     // ── signal handler constants ───────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
## Summary

- Stop emitting an empty title (`OSC 0`) before the title-stack pop on restore — WezTerm ignores the pop (no xterm stack support) and the empty title sticks permanently
- Add missing title guard to `switch` command so it gets the same push/pop behavior as `shell`, `exec`, `tmux`, and `nvim`

## Context

WezTerm doesn't support the xterm title stack (`CSI 22;0t` push / `CSI 23;0t` pop). The previous restore logic sent an empty title first as a fallback, but that's worse than leaving the cella title — an empty tab is confusing, while "container — cella exec" is informative and gets overwritten by the shell prompt on the next `PROMPT_COMMAND`/`precmd` anyway.

The comment also incorrectly grouped kitty with WezTerm as non-stack terminals — kitty fully implements a 10-deep title stack.

## Test plan

- [x] Updated existing restore tests to expect pop-only output
- [x] Added regression guard asserting no `OSC 0` (title-set) bytes in restore output
- [x] Added full push/set/restore lifecycle byte-level tests (plain + tmux)
- [x] `cargo fmt`, `cargo clippy`, `cargo test --workspace` all pass
- [x] Manual: verify in WezTerm that tab title is not blank after `cella exec` exits
- [x] Manual: verify `cella switch` sets/restores title