### PR TITLE
docs: sync documentation with current codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ curl -fsSL https://raw.githubusercontent.com/eve0415/cella/main/install.sh | sh
 
 ### From source
 
-Requires a [Rust toolchain](https://rustup.rs/) (1.94+).
+Requires a [Rust toolchain](https://rustup.rs/) (1.95+).
 
 ```sh
 cargo install --git https://github.com/eve0415/cella cella-cli
@@ -81,13 +81,14 @@ The [Dev Container specification](https://containers.dev/) ([spec repo](https://
 | SSH agent forwarding | Platform-aware (Docker Desktop, OrbStack, Colima, Linux) | No — [VS Code extension only](https://github.com/devcontainers/cli/issues/441) |
 | Git credential forwarding | gh CLI via socket + TCP, auto-on | No — [VS Code extension only](https://github.com/microsoft/vscode-remote-release/issues/4202) |
 | BROWSER interception | Host browser opens for OAuth | No — [VS Code extension only](https://github.com/microsoft/vscode-remote-release/issues/9935) |
+| Clipboard forwarding | Bidirectional (xsel/xclip) | No — VS Code extension only |
 | Container listing | `cella list` | No ([cli#843](https://github.com/devcontainers/cli/issues/843)) |
 | `runArgs` | 30+ docker create flags parsed | Yes |
 | `hostRequirements` | CPU/memory/storage/GPU validation | Partial (informational only) |
 | `waitFor` | Return after specified lifecycle phase | No |
 | Config validation | Source-positioned diagnostics | Basic |
 | Docker Compose | Yes | Yes |
-| Container backends | Docker, Apple Container (experimental) | Docker, Podman |
+| Container backends | Docker, Apple Container (experimental), Colima (experimental) | Docker, Podman |
 | Podman | Not yet | Yes |
 | Editor requirement | None (any terminal) | VS Code for full feature set |
 
@@ -122,6 +123,7 @@ The [Dev Container specification](https://containers.dev/) ([spec repo](https://
 - [x] AI provider API key forwarding (read live from the host on every exec/shell — never baked into the container)
 - [x] Environment variable forwarding (remoteEnv, containerEnv)
 - [x] User environment probing
+- [x] Bidirectional clipboard forwarding (xsel/xclip)
 - [x] Bubblewrap installed for Codex sandbox support
 
 ### Spec Compliance
@@ -139,6 +141,7 @@ The [Dev Container specification](https://containers.dev/) ([spec repo](https://
 - [x] Automatic port detection via /proc/net/tcp
 - [x] Host daemon + in-container agent
 - [x] BROWSER interception (OAuth callbacks)
+- [x] Reverse tunnel port forwarding (Colima, Docker Desktop for Mac)
 - [x] OrbStack-aware port handling
 
 ### Network Proxy
@@ -160,8 +163,8 @@ The [Dev Container specification](https://containers.dev/) ([spec repo](https://
 
 - [x] Docker Engine
 - [x] OrbStack
+- [x] Colima / Lima (experimental — reverse tunnel port forwarding)
 - [ ] Podman
-- [ ] Colima / Lima
 
 ### Experimental Backends
 
@@ -172,7 +175,6 @@ The [Dev Container specification](https://containers.dev/) ([spec repo](https://
 - [ ] `cella template new/list/edit` — template authoring (subcommands exist as stubs, not yet implemented)
 - [ ] `cella config show/global/dotfiles/agent` — global/dotfiles/agent config management (subcommands exist as stubs, not yet implemented; only `cella config validate` is live)
 - [ ] Podman backend
-- [ ] Colima / Lima support
 
 ## Commands
 
@@ -261,7 +263,7 @@ graph TD
 
     subgraph "Tier 3 — Foundation"
         backend[cella-backend<br><i>backend trait</i>]
-        port[cella-port<br><i>IPC protocol</i>]
+        port[cella-port<br><i>port allocation</i>]
         codegen[cella-codegen<br><i>schema codegen</i>]
         network[cella-network<br><i>network proxy</i>]
         protocol[cella-protocol<br><i>wire format</i>]
@@ -269,7 +271,7 @@ graph TD
     end
 
     cli --> docker & container & compose & git & env & daemon & doctor & orchestrator & config & features & templates
-    docker & container --> backend
+    docker & container & compose --> backend
     agent & daemon --> port
     config --> codegen
     config & templates --> jsonc

--- a/crates/cella-agent/README.md
+++ b/crates/cella-agent/README.md
@@ -14,8 +14,11 @@ cella-agent is a binary that runs inside dev containers started by cella. It is 
 4. **MITM proxy** — HTTPS interception proxy for path-level blocking rules (works alongside the forward proxy via `mitm`)
 5. **Browser interception** — handles `BROWSER` environment variable calls, forwarding URL open requests to the host (enables OAuth callbacks)
 6. **Credential forwarding** — forwards git credential requests to the host daemon for transparent authentication
-7. **Plugin synchronization** — synchronizes editor plugin/extension manifests between host and container
-8. **CLI mode** — when invoked as `cella` (via symlink, `cella` -> `cella-agent`), provides in-container CLI commands that delegate to the host daemon
+7. **Clipboard forwarding** — bidirectional clipboard sync (xsel/xclip) between container and host
+8. **Plugin synchronization** — synchronizes editor plugin/extension manifests between host and container
+9. **Reverse tunnels** — handles daemon tunnel requests by connecting back and relaying to local services
+10. **SSH agent bridge** — bridges a container-local Unix socket to the host's SSH agent over TCP, enabling transparent SSH signing (e.g. via 1Password)
+11. **CLI mode** — when invoked as `cella` (via symlink, `cella` -> `cella-agent`), provides in-container CLI commands that delegate to the host daemon
 
 The agent communicates with the host-side cella-daemon over a TCP control connection. When a daemon address is configured, the agent retries the initial connection indefinitely and transparently reconnects after daemon restarts or binary upgrades — it never gives up. A lightweight standalone mode (port watching and localhost→all-interfaces proxying only, no host-side forwarding) is used only when no daemon address is configured at all.
 
@@ -50,11 +53,15 @@ cella-agent credential <operation>           # Handle git credential request (ge
 | `mitm` | MITM proxy for HTTPS interception and path-level blocking |
 | `plugin_sync` | Plugin/extension synchronization for editors |
 | `proxy_config` | Network proxy configuration parsing and rule matching |
+| `clipboard` | Bidirectional clipboard forwarding — intercepts xsel/xclip calls and relays copy/paste/clear to the host daemon |
+| `tunnel` | Reverse tunnel handler — responds to daemon `TunnelRequest` messages by connecting back and relaying to local services |
+| `ssh_agent_bridge` | Unix-socket-to-TCP bridge for SSH agent forwarding — lets in-container SSH clients use the host's real agent (e.g. 1Password) |
+| `state` | Agent state snapshot file for the in-container doctor — writes PID, transport state, and heartbeat to a JSON file |
 | `reconnecting_client` | Resilient connection management with retry logic and automatic reconnection |
 
 ## Crate Dependencies
 
-**Depends on:** [cella-network](../cella-network), [cella-port](../cella-port)
+**Depends on:** [cella-network](../cella-network), [cella-port](../cella-port), [cella-protocol](../cella-protocol)
 
 **Depended on by:** none (standalone binary uploaded into containers)
 

--- a/crates/cella-agent/docs/agent-architecture.md
+++ b/crates/cella-agent/docs/agent-architecture.md
@@ -3,8 +3,9 @@
 ## Overview
 
 The cella agent runs inside each devcontainer, providing port detection,
-credential forwarding, and browser integration by communicating with the
-host daemon.
+credential forwarding, browser integration, bidirectional clipboard
+forwarding, reverse tunnel port forwarding, and SSH agent bridging by
+communicating with the host daemon.
 
 ## Modes
 
@@ -23,7 +24,20 @@ from `/cella/.daemon_addr`), the agent retries the connection
    host browser (for OAuth callbacks, etc.)
 4. **Health reporter** — sends periodic heartbeats with uptime and
    port count
-5. **Worktree/task proxy** — in CLI mode (see below) forwards
+5. **Clipboard forwarder** — intercepts `xsel`/`xclip` invocations
+   (agent binary is symlinked as both) and forwards clipboard
+   copy/paste operations to the daemon via `ClipboardCopy`/`ClipboardPaste`
+   messages
+6. **Reverse tunnel handler** — responds to `TunnelRequest` messages
+   from the daemon by opening a TCP connection back to the daemon and
+   relaying to the local service, enabling port forwarding on runtimes
+   without direct container-IP routing (Colima, Docker Desktop for Mac)
+7. **SSH agent bridge** — listens on a Unix socket inside the container
+   (`/run/host-services/ssh-auth.sock`) and bridges each connection
+   over TCP to the daemon, which connects to the host's real
+   `SSH_AUTH_SOCK`. Required for Colima where bind-mounting host Unix
+   sockets fails due to virtiofs limitations
+8. **Worktree/task proxy** — in CLI mode (see below) forwards
    `branch`, `exec`, `prune`, `down`, `up`, `switch`, and `task run/list/
    logs/wait/stop` commands to the daemon for host-side execution
 
@@ -132,6 +146,58 @@ Configuration sources, in priority order:
 2. **`/cella/.daemon_addr`** file, refreshed by the CLI on every
    `cella up` so agents that were running before a daemon restart pick
    up the new address without intervention.
+
+## Clipboard Forwarding (`clipboard.rs`)
+
+The agent binary is symlinked as `/cella/bin/xsel` and `/cella/bin/xclip`
+inside the container. When invoked under either name, it parses the
+command-line arguments to determine the clipboard operation:
+
+- **Copy** (`xsel -i` / `xclip -i`): reads stdin (up to 10 MiB),
+  base64-encodes it, and sends `AgentMessage::ClipboardCopy` to the daemon
+- **Paste** (`xsel -o` / `xclip -o`): sends `AgentMessage::ClipboardPaste`
+  to the daemon, receives `DaemonMessage::ClipboardContent`, base64-decodes,
+  and writes to stdout
+- **Clear** (`xsel -c`): sends a zero-length copy
+
+The daemon handles the actual clipboard access on the host using
+platform-specific backends (pbcopy/pbpaste on macOS, wl-copy/wl-paste
+on Wayland, xsel on X11).
+
+## Reverse Tunnel (`tunnel.rs`)
+
+For runtimes where the host cannot directly reach container IPs (Colima,
+Docker Desktop for Mac), the daemon sends `DaemonMessage::TunnelRequest`
+messages to the agent instead of opening a direct TCP proxy. The agent
+handles each request by:
+
+1. Opening a new TCP connection back to the daemon's control port
+2. Sending a `TunnelHandshake` with the auth token and connection ID
+3. Connecting to `127.0.0.1:<target_port>` inside the container
+4. Bidirectionally copying bytes between the daemon tunnel and the local
+   service
+
+This reverses the connection direction: instead of the daemon connecting
+to the container, the container connects back to the daemon, working
+around the lack of direct IP routing.
+
+## SSH Agent Bridge (`ssh_agent_bridge.rs`)
+
+Bridges the host's SSH agent into the container over TCP. Needed for
+Colima where bind-mounting host Unix sockets fails (`mkdir` on virtiofs
+rejects socket paths).
+
+The bridge:
+1. Creates a Unix socket at `/run/host-services/ssh-auth.sock` (or the
+   configured path) with mode 0666
+2. Accepts connections from `ssh-add`, `git`, etc.
+3. For each connection, opens a TCP connection to
+   `host.docker.internal:<bridge_port>`, sends the auth token, then
+   bidirectionally copies SSH agent protocol bytes
+
+The daemon side (`ssh_proxy.rs`) accepts these TCP connections and
+forwards each to the host's real `SSH_AUTH_SOCK` via a Unix socket
+connection.
 
 ## CLI Mode
 

--- a/crates/cella-backend/README.md
+++ b/crates/cella-backend/README.md
@@ -46,6 +46,8 @@ Container and image naming conventions live here so that all backends use consis
 | `agent` | Agent environment variable generation for in-container agent |
 | `lifecycle` | Lifecycle command parsing and execution (`LifecycleContext`, `OutputCallback`, `ParsedLifecycle`) |
 | `resolve` | Container target resolution (`ContainerTarget`) |
+| `mount` | Mount specification types and helpers |
+| `network` | Network configuration types |
 
 ## Crate Dependencies
 

--- a/crates/cella-cli/README.md
+++ b/crates/cella-cli/README.md
@@ -8,7 +8,7 @@ Part of the [cella](../../README.md) workspace.
 
 cella-cli is the binary frontend for cella. It defines the `cella` binary, parses CLI arguments via clap, and dispatches each subcommand to the appropriate library crate. No business logic lives here — every command handler delegates to library crates for the actual work.
 
-Error reporting uses miette's graphical handler for source-positioned diagnostics. Tracing is configured via the `RUST_LOG` environment variable.
+Error reporting uses miette's graphical handler for source-positioned diagnostics. Tracing is configured via the `RUST_LOG` environment variable. Terminal window titles are updated via OSC escape sequences for the duration of long-running commands and restored on exit.
 
 ## Commands
 
@@ -58,7 +58,7 @@ Hidden internal commands: `daemon`.
 | Module | Purpose |
 |--------|---------|
 | `commands/mod.rs` | `Command` enum and dispatch logic |
-| `commands/up.rs` | Container startup orchestration (largest command — handles single-container and compose paths) |
+| `commands/up/` | Container startup orchestration (largest command — handles single-container and compose paths) |
 | `commands/compose_up.rs` | Docker Compose orchestration (called by `up` when `dockerComposeFile` is present) |
 | `commands/down.rs` | Container teardown |
 | `commands/shell.rs` | Interactive shell attach |
@@ -73,7 +73,7 @@ Hidden internal commands: `daemon`.
 | `commands/config.rs` | Configuration management |
 | `commands/read_configuration.rs` | Resolved devcontainer config output (JSON, compatible with devcontainer CLI) |
 | `commands/template.rs` | Template management |
-| `commands/init.rs` | Repository initialization |
+| `commands/init/` | Interactive project initialization wizard (mod.rs, wizard.rs, noninteractive.rs, summary.rs) |
 | `commands/code.rs` | VS Code container connection (attached-container URI, auto-up, fork support) |
 | `commands/nvim.rs` | Neovim container connection |
 | `commands/tmux.rs` | tmux session management (attach-or-create, config forwarding) |
@@ -81,8 +81,6 @@ Hidden internal commands: `daemon`.
 | `commands/credential.rs` | Credential forwarding management |
 | `commands/daemon.rs` | Daemon lifecycle management (hidden) |
 | `commands/network.rs` | Network proxy management |
-| `commands/env_cache.rs` | Environment cache management (internal helper) |
-| `commands/image.rs` | Image inspection (internal helper) |
 | `commands/completions.rs` | Shell completion generation |
 | `commands/features/` | Feature management (mod.rs, edit.rs, jsonc_edit.rs, list.rs, prompts.rs, resolve.rs, update.rs) |
 | `backend.rs` | Backend selection and auto-detection (`--backend` flag resolution) |
@@ -90,6 +88,7 @@ Hidden internal commands: `daemon`.
 | `progress.rs` | Progress reporting (indicatif spinners, verbosity) |
 | `style.rs` | Output styling and colors |
 | `table.rs` | Table formatting for list output |
+| `title.rs` | Terminal title integration (sets/restores window title via OSC escape sequences, tmux-aware) |
 
 Each command file defines an args struct and an `execute()` method.
 

--- a/crates/cella-compose/README.md
+++ b/crates/cella-compose/README.md
@@ -48,7 +48,7 @@ Implements the Docker Compose portions of the [Dev Container specification](http
 
 ## Crate Dependencies
 
-**Depends on:** none
+**Depends on:** [cella-backend](../cella-backend)
 
 **Depended on by:** [cella-cli](../cella-cli), [cella-orchestrator](../cella-orchestrator)
 

--- a/crates/cella-config/README.md
+++ b/crates/cella-config/README.md
@@ -10,7 +10,7 @@ cella-config handles everything related to devcontainer.json: discovering config
 
 The crate uses build-time code generation via cella-codegen to produce typed Rust structs directly from the [devcontainer JSON Schema](https://containers.dev/implementors/json_reference/). This ensures that schema changes are automatically reflected in the Rust API without manual synchronization.
 
-Devcontainer configuration is discovered and parsed from the workspace. cella-specific settings live in TOML files: global (`~/.cella/config.toml`) and project (`.devcontainer/cella.toml`). Project settings override global settings per-key.
+Devcontainer configuration is discovered and parsed from the workspace. cella-specific settings (`CellaConfig`) are loaded from up to three layers — global (`~/.cella/config.toml`), `customizations.cella` in devcontainer.json, and project (`.devcontainer/cella.toml`) — merged with deep-merge semantics where later layers override scalars, extend arrays, and recursively merge objects.
 
 ### Spec Coverage
 
@@ -31,14 +31,27 @@ Parses all devcontainer.json properties defined in the [Dev Container specificat
 
 | Module | Purpose |
 |--------|---------|
+| `cella_config/cli` | CLI-related config types (`OutputFormat`, `PullPolicy`, `CliBuild`) |
+| `cella_config/error` | `CellaConfigError` diagnostics (miette + thiserror) |
+| `cella_config/format` | TOML/JSON/JSONC config file loader |
+| `cella_config/merge` | Deep-merge logic for config layers (scalars override, arrays extend, maps recurse) |
+| `cella_config/security` | `Security` and `SecurityMode` (disabled/logged/enforced) |
 | `devcontainer/discover` | Locates devcontainer.json files in workspace directories |
 | `devcontainer/parse` | Parses preprocessed JSON (via [cella-jsonc](../cella-jsonc)) into typed config structs |
-| `devcontainer/merge` | Merges config layers (global -> workspace -> local) |
+| `devcontainer/merge` | Merges devcontainer config layers (global -> workspace -> local) |
 | `devcontainer/resolve` | Resolves variable references and paths |
 | `devcontainer/subst` | Variable substitution (`${localWorkspaceFolder}`, etc.) |
 | `devcontainer/diagnostic` | Source-positioned error diagnostics via miette |
 | `devcontainer/span` | Byte offset tracking for mapping errors back to source locations |
-| `settings/` | CellaSettings parsing and credential forwarding configuration |
+| `settings/ai_credentials` | AI provider credential forwarding toggles |
+| `settings/claude_code` | Claude Code agent configuration |
+| `settings/codex` | Codex agent configuration |
+| `settings/credentials` | Top-level credential forwarding options (gh, gpg, ssh, ai) |
+| `settings/gemini` | Gemini agent configuration |
+| `settings/network` | Network settings (proxy, DNS) |
+| `settings/nvim` | Neovim forwarding configuration |
+| `settings/tmux` | Tmux forwarding configuration |
+| `settings/tools` | Tool detection and forwarding configuration |
 | `schema` | Auto-generated types from devcontainer JSON Schema (via `build.rs`) |
 
 ### Build System
@@ -47,7 +60,7 @@ Parses all devcontainer.json properties defined in the [Dev Container specificat
 
 ## Crate Dependencies
 
-**Depends on:** [cella-codegen](../cella-codegen) (build-time), [cella-jsonc](../cella-jsonc), [cella-network](../cella-network)
+**Depends on:** [cella-codegen](../cella-codegen) (build-time), [cella-env](../cella-env), [cella-jsonc](../cella-jsonc), [cella-network](../cella-network)
 
 **Depended on by:** [cella-cli](../cella-cli), [cella-doctor](../cella-doctor), [cella-orchestrator](../cella-orchestrator)
 

--- a/crates/cella-daemon/README.md
+++ b/crates/cella-daemon/README.md
@@ -1,16 +1,19 @@
 # cella-daemon
 
-> Unified host-side daemon for port forwarding, credential proxying, and browser handling.
+> Unified host-side daemon for port forwarding, credential proxying, clipboard forwarding, SSH agent bridging, reverse tunnelling, and browser handling.
 
 Part of the [cella](../../README.md) workspace.
 
 ## Overview
 
-cella-daemon is the host-side counterpart to the in-container cella-agent. It runs as a background process on the host and provides three services:
+cella-daemon is the host-side counterpart to the in-container cella-agent. It runs as a background process on the host and provides six services:
 
 1. **Port management** — receives port detection events from in-container agents and sets up host-side port forwarding
 2. **Credential proxying** — forwards git credential requests from containers to the host's credential store
 3. **Browser handling** — receives browser-open requests from containers and opens URLs in the host's default browser (enabling OAuth callbacks and similar flows)
+4. **Clipboard forwarding** — bidirectional clipboard sync between host and containers (copy/paste via platform-native backends)
+5. **SSH agent bridging** — TCP bridge from the host's `$SSH_AUTH_SOCK` into containers, avoiding virtiofs bind-mount issues
+6. **Reverse tunnelling** — broker that matches pending tunnel requests with incoming agent tunnel connections
 
 The daemon consolidates what was previously a standalone credential proxy into a single process. It manages PID files for lifecycle tracking, generates authentication tokens for agent connections, and includes health monitoring to detect stale connections.
 
@@ -38,13 +41,16 @@ The daemon has special handling for OrbStack, which provides its own port forwar
 | `shared` | Shared daemon primitives — PID management, process checks, socket helpers |
 | `stream_bridge` | Per-exec TCP stream bridge for TTY forwarding (interactive shell sessions through the daemon) |
 | `task_manager` | Background task manager for in-container worktree operations (tracks exec handles, output, lifecycle state) |
+| `clipboard` | Bidirectional clipboard forwarding — platform-native backends (pbcopy/xsel/xclip/wl-clipboard) for copy and paste |
+| `ssh_proxy` | Per-workspace SSH-agent TCP bridge — forwards the host's `$SSH_AUTH_SOCK` over TCP so containers get a working `SSH_AUTH_SOCK` without bind mounts |
+| `tunnel` | Reverse-tunnel broker — matches pending tunnel requests with incoming agent tunnel connections |
 | `logging` | File-based tracing to `~/.cella/daemon.log` with size rotation |
 
 ## Crate Dependencies
 
-**Depends on:** [cella-port](../cella-port) (for protocol message types)
+**Depends on:** [cella-port](../cella-port), [cella-protocol](../cella-protocol)
 
-**Depended on by:** [cella-cli](../cella-cli), [cella-doctor](../cella-doctor)
+**Depended on by:** [cella-cli](../cella-cli), [cella-doctor](../cella-doctor), [cella-orchestrator](../cella-orchestrator)
 
 ## Testing
 

--- a/crates/cella-daemon/docs/daemon-architecture.md
+++ b/crates/cella-daemon/docs/daemon-architecture.md
@@ -3,8 +3,9 @@
 ## Lifecycle
 
 The cella daemon is a long-running host process that manages port
-forwarding, credential forwarding, and browser integration for all active
-devcontainers.
+forwarding, credential forwarding, browser integration, clipboard
+forwarding, reverse tunnel port forwarding, and SSH agent bridging for
+all active devcontainers.
 
 ### Startup
 
@@ -103,6 +104,50 @@ bidirectionally proxies bytes between the accepted TCP stream and a
 PTY master. Used by `cella switch` so in-container users get a full
 PTY-backed shell in the target container via the agent → daemon →
 docker-exec path.
+
+### Clipboard Handler (`clipboard.rs`)
+
+Handles `ClipboardCopy` and `ClipboardPaste` messages from agents.
+Auto-detects the host clipboard backend at startup:
+
+- **macOS**: `pbcopy`/`pbpaste`
+- **Wayland**: `wl-copy`/`wl-paste`
+- **X11**: `xsel`
+
+Copy operations receive base64-encoded data from the agent, decode it,
+and write to the host clipboard. Paste operations read from the host
+clipboard and return the content as a `ClipboardContent` message with
+base64-encoded data.
+
+### Tunnel Broker (`tunnel.rs`)
+
+Manages reverse tunnel connections for runtimes without direct
+container-IP routing (Colima, Docker Desktop for Mac). Instead of the
+daemon connecting directly to `CONTAINER_IP:PORT`, the daemon:
+
+1. Allocates a connection ID via the `TunnelBroker`
+2. Sends `DaemonMessage::TunnelRequest { connection_id, port }` to the
+   agent over the control connection
+3. The agent opens a new TCP connection back to the daemon with a
+   `TunnelHandshake`
+4. The broker matches the connection by ID and returns the TCP stream
+   to the proxy coordinator
+
+This reverses the connection direction, working around the lack of
+direct container-IP routing on non-Linux Docker hosts.
+
+### SSH Proxy (`ssh_proxy.rs`)
+
+Per-workspace TCP listener that bridges the host's `SSH_AUTH_SOCK` to
+in-container agents. Each accepted TCP connection:
+
+1. Reads the auth token line
+2. Opens a `UnixStream` to the host's `$SSH_AUTH_SOCK`
+3. Bidirectionally copies SSH agent protocol bytes
+
+The bridge port is communicated to the agent at registration time.
+Required for Colima where bind-mounting host Unix sockets fails due to
+virtiofs limitations.
 
 ## OrbStack Detection
 

--- a/crates/cella-docker/README.md
+++ b/crates/cella-docker/README.md
@@ -45,7 +45,6 @@ Implements the container lifecycle portions of the [Dev Container specification]
 | `image` | Image building via Docker build API |
 | `network` | Network creation and configuration |
 | `volume` | Volume and mount management |
-| `uid` | UID remapping for `updateRemoteUserUID` |
 | `upload` | File upload to running containers via tar streaming |
 
 ## Crate Dependencies

--- a/crates/cella-orchestrator/README.md
+++ b/crates/cella-orchestrator/README.md
@@ -58,10 +58,11 @@ cella-orchestrator extracts the shared container management logic so that both t
 | `branch` | Worktree-backed branch creation and container delegation |
 | `prune` | Detect and remove merged worktrees with their containers |
 | `docker_helpers` | Container lookup and exec helpers via `ContainerBackend` trait |
+| `ssh_proxy_client` | SSH proxy client for tunneled connections |
 
 ## Crate Dependencies
 
-**Depends on:** [cella-backend](../cella-backend), [cella-compose](../cella-compose), [cella-config](../cella-config), [cella-env](../cella-env), [cella-features](../cella-features), [cella-git](../cella-git), [cella-network](../cella-network), [cella-port](../cella-port)
+**Depends on:** [cella-backend](../cella-backend), [cella-compose](../cella-compose), [cella-config](../cella-config), [cella-daemon](../cella-daemon), [cella-env](../cella-env), [cella-features](../cella-features), [cella-git](../cella-git), [cella-network](../cella-network), [cella-protocol](../cella-protocol)
 
 **Depended on by:** [cella-cli](../cella-cli), [cella-doctor](../cella-doctor)
 

--- a/crates/cella-port/README.md
+++ b/crates/cella-port/README.md
@@ -1,14 +1,14 @@
 # cella-port
 
-> Port allocation, detection, and IPC protocol for dev container port forwarding.
+> Port allocation and detection for dev container port forwarding.
 
 Part of the [cella](../../README.md) workspace.
 
 ## Overview
 
-cella-port handles three aspects of port management: detecting listening ports inside containers, allocating host ports to avoid conflicts across concurrent containers, and defining the IPC protocol used between the host daemon and the in-container agent.
+cella-port handles two aspects of port management: detecting listening ports inside containers and allocating host ports to avoid conflicts across concurrent containers.
 
-Port detection works by parsing `/proc/net/tcp` and `/proc/net/tcp6` inside the container to discover processes in the LISTEN state. The allocation table tracks which host ports are in use across all active containers to prevent collisions when multiple dev containers run simultaneously. The protocol module defines the message format for the daemon-agent communication channel.
+Port detection works by parsing `/proc/net/tcp` and `/proc/net/tcp6` inside the container to discover processes in the LISTEN state. The allocation table tracks which host ports are in use across all active containers to prevent collisions when multiple dev containers run simultaneously.
 
 ### Spec Coverage
 

--- a/crates/cella-port/docs/port-forwarding.md
+++ b/crates/cella-port/docs/port-forwarding.md
@@ -96,6 +96,24 @@ for supported runtimes (Docker Desktop, OrbStack).
 On OrbStack, `container.orb.local:PORT` also works as an alternative via
 OrbStack's built-in DNS.
 
+### Reverse Tunnel (Colima, Docker Desktop for Mac)
+
+On runtimes where the host cannot directly reach container IPs, the daemon
+uses reverse tunnels instead of direct TCP proxies. The flow:
+
+1. Host-side proxy accepts a connection on `127.0.0.1:HOST_PORT`
+2. Daemon sends `TunnelRequest { connection_id, port }` to the agent
+   via the control connection
+3. Agent opens a new TCP connection back to the daemon with a
+   `TunnelHandshake { auth_token, connection_id }`
+4. Daemon's tunnel broker matches the connection by ID
+5. Bytes flow bidirectionally: host client ↔ daemon ↔ agent ↔ container
+   service
+
+This reverses the connection direction so the container connects to the
+host rather than the other way around, working around the lack of direct
+IP routing.
+
 ### Browser URL rewriting
 
 When the agent requests `BrowserOpen`, the daemon rewrites the URL if the

--- a/crates/cella-protocol/README.md
+++ b/crates/cella-protocol/README.md
@@ -8,7 +8,7 @@ Part of the [cella](../../README.md) workspace.
 
 cella-protocol defines the message types and serialization format shared across cella's IPC boundaries. Three communication layers use this crate:
 
-1. **Agent ↔ Daemon** (TCP) — the in-container agent reports port changes, credential requests, and browser opens to the host daemon; the daemon sends configuration, credential responses, and port mappings back. Worktree operations (branch, exec, prune, etc.) and background tasks are also routed through this channel.
+1. **Agent ↔ Daemon** (TCP) — the in-container agent reports port changes, credential requests, clipboard operations, and browser opens to the host daemon; the daemon sends configuration, credential responses, clipboard content, port mappings, and reverse tunnel requests back. Worktree operations (branch, exec, prune, etc.) and background tasks are also routed through this channel.
 2. **CLI ↔ Daemon** (Unix socket) — the CLI registers/deregisters containers, queries port status, and manages daemon lifecycle.
 3. **Git credential helper** — key=value field parsing/formatting compatible with the git credential helper protocol.
 

--- a/crates/cella-templates/README.md
+++ b/crates/cella-templates/README.md
@@ -35,6 +35,7 @@ Templates are fetched from OCI registries (default: `ghcr.io/devcontainers/templ
 | `index` | Aggregated devcontainer index from containers.dev with offline fallback |
 | `apply` | Template application: option substitution, feature merging, JSONC/JSON generation |
 | `options` | Option validation and resolution (boolean, string, enum, proposals) |
+| `tags` | Image tag fetching, filtering, and sorting from OCI registries for version pinning |
 | `error` | `TemplateError` enum with thiserror |
 
 ## Crate Dependencies

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,7 +25,7 @@ graph TD
 
     subgraph "Tier 3 — Foundation"
         backend[cella-backend<br><i>backend trait</i>]
-        port[cella-port<br><i>IPC protocol</i>]
+        port[cella-port<br><i>port allocation</i>]
         codegen[cella-codegen<br><i>schema codegen</i>]
         network[cella-network<br><i>network proxy</i>]
         protocol[cella-protocol<br><i>wire format</i>]
@@ -33,7 +33,7 @@ graph TD
     end
 
     cli --> docker & container & compose & git & env & daemon & doctor & orchestrator & config & features & templates
-    docker & container --> backend
+    docker & container & compose --> backend
     templates --> features
     agent & daemon --> port
     port --> protocol
@@ -76,11 +76,11 @@ Environment forwarding orchestration. Detects the host environment (SSH agent, g
 
 ### cella-daemon
 
-Unified host-side daemon for credential forwarding, port management, browser handling, worktree operations, and background tasks. Runs as a background process, accepting TCP connections from in-container agents and Unix-socket connections from the CLI. Includes OrbStack-specific port coordination, health monitoring, auth token management, file-based logging, a per-exec TCP stream bridge for TTY forwarding (used by `cella switch`), and a task manager that tracks `cella task run` background processes with live output broadcast.
+Unified host-side daemon for credential forwarding, port management, browser handling, clipboard forwarding, reverse tunnel port forwarding, SSH proxying, worktree operations, and background tasks. Runs as a background process, accepting TCP connections from in-container agents and Unix-socket connections from the CLI. Includes OrbStack-specific port coordination, health monitoring, auth token management, file-based logging, a per-exec TCP stream bridge for TTY forwarding (used by `cella switch`), a bidirectional clipboard bridge (xsel/xclip), reverse tunnel server for Colima and Docker Desktop for Mac, an SSH proxy for Colima SSH-agent forwarding via TCP bridge, and a task manager that tracks `cella task run` background processes with live output broadcast.
 
 ### cella-agent
 
-In-container binary uploaded during `cella up`. Polls `/proc/net/tcp` for new listeners and reports them to the host daemon for automatic port forwarding. Proxies localhost-bound applications to `0.0.0.0`, handles `BROWSER` environment variable interception for OAuth callbacks, and forwards git credential requests to the host. The initial daemon connect retries indefinitely (so containers that start before the daemon is ready eventually reconnect), and the agent transparently reconnects after daemon restarts (including binary upgrades). When the binary is invoked as `cella` via an in-container symlink, it enters CLI mode instead of daemon mode — worktree and task commands inside the container delegate to the host daemon over the existing TCP control connection. Uses manual argument parsing (no clap) to minimize binary size.
+In-container binary uploaded during `cella up`. Polls `/proc/net/tcp` for new listeners and reports them to the host daemon for automatic port forwarding. Proxies localhost-bound applications to `0.0.0.0`, handles `BROWSER` environment variable interception for OAuth callbacks, forwards git credential requests to the host, provides bidirectional clipboard forwarding (xsel/xclip shims), bridges SSH-agent connections for Colima via TCP, and opens reverse tunnels for port forwarding through environments without direct container-IP routing. The initial daemon connect retries indefinitely (so containers that start before the daemon is ready eventually reconnect), and the agent transparently reconnects after daemon restarts (including binary upgrades). When the binary is invoked as `cella` via an in-container symlink, it enters CLI mode instead of daemon mode — worktree and task commands inside the container delegate to the host daemon over the existing TCP control connection. Uses manual argument parsing (no clap) to minimize binary size.
 
 ### cella-doctor
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -170,11 +170,12 @@ version = "latest"
 
 #### `[tools.nvim]`
 
-Neovim does not have an `enabled` toggle — it is installed on-demand when first used. This section controls config forwarding.
+Neovim does not have an `enabled` toggle — it is installed on-demand when first used. This section controls config forwarding and the install version.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `forward_config` | bool | `true` | Bind-mount host nvim config into the container |
+| `version` | string | `"stable"` | `"stable"`, `"nightly"`, or a pinned version like `"0.10.3"` |
 | `config_path` | string | *unset* | Override host config source directory (default: `~/.config/nvim`) |
 
 Host paths mounted when `forward_config = true`:
@@ -185,6 +186,7 @@ The `config_path` option changes where cella reads config on the host — the co
 ```toml
 [tools.nvim]
 forward_config = true
+version = "stable"
 config_path = "~/dotfiles/nvim"
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,8 +25,8 @@ Settings in `devcontainer.json` go under `customizations.cella`:
   "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
   "customizations": {
     "cella": {
-      "security": { "mode": "enforced" },
-      "credentials": { "gh": true }
+      "credentials": { "gh": true },
+      "tools": { "claude-code": { "version": "stable" } }
     }
   }
 }
@@ -79,19 +79,6 @@ anthropic = false        # added by project
 ## Settings reference
 
 All enum values are lowercase strings in config files.
-
-### `[security]`
-
-Security mode for the container.
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `mode` | string | `"disabled"` | `"disabled"`, `"logged"`, or `"enforced"` |
-
-```toml
-[security]
-mode = "enforced"
-```
 
 ### `[credentials]`
 
@@ -183,12 +170,11 @@ version = "latest"
 
 #### `[tools.nvim]`
 
-Neovim does not have an `enabled` toggle — it is installed on-demand when first used. This section controls config forwarding and the install version.
+Neovim does not have an `enabled` toggle — it is installed on-demand when first used. This section controls config forwarding.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `forward_config` | bool | `true` | Bind-mount host nvim config into the container |
-| `version` | string | `"stable"` | `"stable"`, `"nightly"`, or a pinned version like `"0.10.3"` |
 | `config_path` | string | *unset* | Override host config source directory (default: `~/.config/nvim`) |
 
 Host paths mounted when `forward_config = true`:
@@ -199,7 +185,6 @@ The `config_path` option changes where cella reads config on the host — the co
 ```toml
 [tools.nvim]
 forward_config = true
-version = "stable"
 config_path = "~/dotfiles/nvim"
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -255,21 +255,17 @@ Network proxy and blocking settings. See [Network Proxy](network-proxy.md) for f
 
 ### `[cli]`
 
-Controls CLI behavior defaults. These are equivalent to command-line flags but persisted in config.
+Persisted defaults for CLI flags.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `verbose` | bool | `false` | Enable verbose output |
-| `output` | string | `"text"` | Output format: `"text"` or `"json"` |
-| `pull` | string | `"missing"` | Image pull policy: `"always"`, `"missing"`, `"never"`, or `"build"` |
 | `skip_checksum` | bool | `false` | Skip agent binary checksum verification |
 | `no_network_rules` | bool | `false` | Disable all network blocking rules |
 
 ```toml
 [cli]
-verbose = false
-output = "text"
-pull = "missing"
+skip_checksum = false
+no_network_rules = false
 ```
 
 #### `[cli.build]`
@@ -279,15 +275,10 @@ Build-specific CLI defaults.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `no_cache` | bool | `false` | Disable Docker build cache |
-| `profiles` | array of strings | `[]` | Compose profiles to activate |
-| `env_files` | array of strings | `[]` | Additional env files to load |
-| `pull_policy` | string | `"missing"` | Build-time pull policy: `"always"`, `"missing"`, `"never"`, or `"build"` |
 
 ```toml
 [cli.build]
 no_cache = false
-profiles = ["debug"]
-env_files = [".env.local"]
 ```
 
 ## Validation

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,295 @@
+# Configuration
+
+Cella uses a layered configuration system that lets you set defaults globally, override per-project, and embed settings in `devcontainer.json`. Config files use TOML (preferred) or JSON with JSONC comments.
+
+## Config file locations
+
+Cella loads configuration from three locations, merged in order:
+
+| Priority | Path | Scope |
+|----------|------|-------|
+| 1 (lowest) | `~/.cella/config.toml` | Global defaults for all projects |
+| 2 | `customizations.cella` in `devcontainer.json` | Shared with version control |
+| 3 (highest) | `.devcontainer/cella.toml` | Project-level overrides |
+
+Each location is optional. When no config files exist, all settings use their defaults.
+
+The global and project-level configs can use either `.toml` or `.json` extension. When both exist in the same directory, the TOML file takes precedence and the JSON file is ignored. JSON files support JSONC comments (`//` and `/* */`).
+
+### devcontainer.json
+
+Settings in `devcontainer.json` go under `customizations.cella`:
+
+```jsonc
+{
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "customizations": {
+    "cella": {
+      "security": { "mode": "enforced" },
+      "credentials": { "gh": true }
+    }
+  }
+}
+```
+
+## Resolution order and merge semantics
+
+Layers are merged from lowest to highest priority. The merge algorithm handles different value types differently:
+
+| Value type | Behavior | Example |
+|------------|----------|---------|
+| Scalar (string, number, bool) | Higher-priority layer wins | `mode = "logged"` overrides `mode = "disabled"` |
+| Object | Recursive merge — sibling fields are preserved | Setting `[credentials.ai] enabled = false` in project config doesn't remove `gh = true` from global |
+| Array | Concatenated — all layers' entries are combined | `network.rules` from global + project are joined, not replaced |
+
+Array concatenation is notable: if the global config defines two network rules and the project config defines one, the result has all three. This is intentional — it lets teams layer organizational rules with project-specific ones.
+
+### Example
+
+Global config (`~/.cella/config.toml`):
+
+```toml
+[credentials]
+gh = true
+
+[credentials.ai]
+enabled = true
+openai = false
+```
+
+Project config (`.devcontainer/cella.toml`):
+
+```toml
+[credentials.ai]
+anthropic = false
+```
+
+Result after merge:
+
+```toml
+[credentials]
+gh = true                # preserved from global
+
+[credentials.ai]
+enabled = true           # preserved from global
+openai = false           # preserved from global
+anthropic = false        # added by project
+```
+
+## Settings reference
+
+All enum values are lowercase strings in config files.
+
+### `[security]`
+
+Security mode for the container.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `mode` | string | `"disabled"` | `"disabled"`, `"logged"`, or `"enforced"` |
+
+```toml
+[security]
+mode = "enforced"
+```
+
+### `[credentials]`
+
+Controls credential forwarding into containers.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `gh` | bool | `true` | Forward GitHub CLI credentials |
+
+```toml
+[credentials]
+gh = true
+```
+
+#### `[credentials.ai]`
+
+Controls which AI provider API keys are forwarded from the host environment into containers. Unknown provider names default to enabled.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `true` | Global toggle — when `false`, no AI keys are forwarded |
+| *`<provider>`* | bool | `true` | Per-provider override — known providers: `anthropic`, `openai`, `gemini`, `groq`, `mistral`, `deepseek`, `xai`, `fireworks`, `together`, `perplexity`, `cohere` |
+
+```toml
+[credentials.ai]
+enabled = true
+openai = false         # disable OpenAI key forwarding
+anthropic = true       # explicitly enable (also the default)
+```
+
+When `enabled = false`, all per-provider toggles are ignored and no keys are forwarded.
+
+### `[tools]`
+
+Controls automatic installation and host config forwarding for dev tools. Each tool section can enable/disable the tool and control whether host configuration is bind-mounted into the container.
+
+#### `[tools.claude-code]`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `true` | Install Claude Code in the container |
+| `forward_config` | bool | `true` | Bind-mount host config into the container |
+| `version` | string | `"latest"` | `"latest"`, `"stable"`, or a pinned version like `"1.0.58"` |
+
+Host paths mounted when `forward_config = true`:
+- `~/.claude/` → `$HOME/.claude/`
+- `~/.claude.json` → `$HOME/.claude.json`
+
+```toml
+[tools.claude-code]
+enabled = true
+forward_config = true
+version = "latest"
+```
+
+#### `[tools.codex]`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `true` | Install Codex CLI in the container |
+| `forward_config` | bool | `true` | Bind-mount host config into the container |
+| `version` | string | `"latest"` | `"latest"` or a pinned version like `"0.1.2"` |
+
+Host paths mounted when `forward_config = true`:
+- `~/.codex/` → `$HOME/.codex/`
+
+```toml
+[tools.codex]
+enabled = true
+version = "latest"
+```
+
+#### `[tools.gemini]`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `true` | Install Gemini CLI in the container |
+| `forward_config` | bool | `true` | Bind-mount host config into the container |
+| `version` | string | `"latest"` | `"latest"` or a pinned version like `"0.1.2"` |
+
+Host paths mounted when `forward_config = true`:
+- `~/.gemini/` → `$HOME/.gemini/`
+
+```toml
+[tools.gemini]
+enabled = true
+version = "latest"
+```
+
+#### `[tools.nvim]`
+
+Neovim does not have an `enabled` toggle — it is installed on-demand when first used. This section controls config forwarding and the install version.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `forward_config` | bool | `true` | Bind-mount host nvim config into the container |
+| `version` | string | `"stable"` | `"stable"`, `"nightly"`, or a pinned version like `"0.10.3"` |
+| `config_path` | string | *unset* | Override host config source directory (default: `~/.config/nvim`) |
+
+Host paths mounted when `forward_config = true`:
+- `~/.config/nvim/` (or custom `config_path`) → `$HOME/.config/nvim/`
+
+The `config_path` option changes where cella reads config on the host — the container destination is always `$HOME/.config/nvim/`.
+
+```toml
+[tools.nvim]
+forward_config = true
+version = "stable"
+config_path = "~/dotfiles/nvim"
+```
+
+#### `[tools.tmux]`
+
+Tmux does not have an `enabled` toggle or a `version` field. This section controls config forwarding only.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `forward_config` | bool | `true` | Bind-mount host tmux config into the container |
+| `config_path` | string | *unset* | Override host config source path (default: `~/.tmux.conf` or `~/.config/tmux/`) |
+
+Host paths mounted when `forward_config = true`:
+- `~/.tmux.conf` → `$HOME/.tmux.conf`
+- `~/.config/tmux/` → `$HOME/.config/tmux/`
+
+The `config_path` option changes where cella reads config on the host — the container destinations are always `$HOME/.tmux.conf` and `$HOME/.config/tmux/`.
+
+```toml
+[tools.tmux]
+forward_config = true
+config_path = "~/dotfiles/tmux"
+```
+
+### `[network]`
+
+Network proxy and blocking settings. See [Network Proxy](network-proxy.md) for full details on modes, rules, path patterns, CA certificates, and CLI commands.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `mode` | string | *unset* | `"denylist"` or `"allowlist"` — when unset, does not override `devcontainer.json` |
+| `proxy` | object | *(see below)* | Proxy configuration |
+| `rules` | array | `[]` | Network blocking rules |
+
+#### `[network.proxy]`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `true` | Enable proxy forwarding |
+| `http` | string | *unset* | HTTP proxy URL override |
+| `https` | string | *unset* | HTTPS proxy URL override |
+| `no_proxy` | string | *unset* | `NO_PROXY` override |
+| `ca_cert` | string | *unset* | Path to additional CA certificate |
+| `proxy_port` | integer | `18080` | In-container proxy listen port |
+
+#### `[[network.rules]]`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `domain` | string | *(required)* | Domain glob pattern |
+| `paths` | array of strings | `[]` | Path glob patterns |
+| `action` | string | *(required)* | `"block"` or `"allow"` |
+
+### `[cli]`
+
+Controls CLI behavior defaults. These are equivalent to command-line flags but persisted in config.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `verbose` | bool | `false` | Enable verbose output |
+| `output` | string | `"text"` | Output format: `"text"` or `"json"` |
+| `pull` | string | `"missing"` | Image pull policy: `"always"`, `"missing"`, `"never"`, or `"build"` |
+| `skip_checksum` | bool | `false` | Skip agent binary checksum verification |
+| `no_network_rules` | bool | `false` | Disable all network blocking rules |
+
+```toml
+[cli]
+verbose = false
+output = "text"
+pull = "missing"
+```
+
+#### `[cli.build]`
+
+Build-specific CLI defaults.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `no_cache` | bool | `false` | Disable Docker build cache |
+| `profiles` | array of strings | `[]` | Compose profiles to activate |
+| `env_files` | array of strings | `[]` | Additional env files to load |
+| `pull_policy` | string | `"missing"` | Build-time pull policy: `"always"`, `"missing"`, `"never"`, or `"build"` |
+
+```toml
+[cli.build]
+no_cache = false
+profiles = ["debug"]
+env_files = [".env.local"]
+```
+
+## Validation
+
+All config sections use strict validation — unknown fields are rejected. A typo like `[securityy]` or `enbled = true` produces an error at load time rather than being silently ignored.

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -2,7 +2,7 @@
 
 Audit of cella against the official devcontainer specification (containers.dev) and reference CLI (devcontainers/cli).
 
-Date: 2026-04-19
+Date: 2026-04-29
 
 ## Legend
 

--- a/docs/specs/ipc-protocol.md
+++ b/docs/specs/ipc-protocol.md
@@ -62,6 +62,19 @@ Sent by the daemon in response to `AgentHello`. Not internally tagged.
 {"protocol_version":1,"daemon_version":"0.1.0","workspace_path":"/home/user/project","parent_repo":null,"is_worktree":false}
 ```
 
+#### TunnelHandshake
+
+Sent by the agent as the first message on a **reverse tunnel** TCP connection (separate from the control connection). Discriminated from `AgentHello` by the `connection_id` field. Not internally tagged.
+
+| Field | Type | Description |
+|---|---|---|
+| `auth_token` | `string` | Auth token for validating the connection |
+| `connection_id` | `u64` | Connection ID assigned by the daemon's tunnel broker (matches the `TunnelRequest.connection_id` that triggered this connection) |
+
+```json
+{"auth_token":"abc123","connection_id":42}
+```
+
 ### Agent -> Daemon Messages (`AgentMessage`)
 
 All variants are tagged with `"type"` in snake_case.
@@ -103,6 +116,29 @@ All variants are tagged with `"type"` in snake_case.
 
 ```json
 {"type":"browser_open","url":"https://github.com/login"}
+```
+
+#### Clipboard
+
+**`clipboard_copy`** -- Copy data to the host clipboard.
+
+| Field | Type | Description |
+|---|---|---|
+| `data` | `string` | Base64-encoded clipboard content |
+| `mime_type` | `string` | MIME type of the content (e.g. `"text/plain"`, `"image/png"`) |
+
+```json
+{"type":"clipboard_copy","data":"aGVsbG8gd29ybGQ=","mime_type":"text/plain"}
+```
+
+**`clipboard_paste`** -- Request clipboard content from the host.
+
+| Field | Type | Description |
+|---|---|---|
+| `mime_type` | `string?` | Requested MIME type (omitted for default `text/plain`) |
+
+```json
+{"type":"clipboard_paste","mime_type":"text/plain"}
 ```
 
 #### Git Credentials
@@ -307,6 +343,19 @@ All variants are tagged with `"type"` in snake_case.
 {"type":"config","poll_interval_ms":2000,"proxy_localhost":true}
 ```
 
+#### Clipboard
+
+**`clipboard_content`** -- Clipboard content response (reply to `clipboard_paste`).
+
+| Field | Type | Description |
+|---|---|---|
+| `data` | `string` | Base64-encoded clipboard content |
+| `mime_type` | `string` | MIME type of the content |
+
+```json
+{"type":"clipboard_content","data":"aGVsbG8gd29ybGQ=","mime_type":"text/plain"}
+```
+
 #### Git Credentials
 
 **`credential_response`** -- Response to a credential request.
@@ -332,6 +381,21 @@ All variants are tagged with `"type"` in snake_case.
 ```json
 {"type":"port_mapping","container_port":3000,"host_port":3001}
 ```
+
+#### Reverse Tunnel
+
+**`tunnel_request`** -- Request the agent to open a reverse tunnel for a new forwarded connection. Used on runtimes without direct container-IP routing (Colima, Docker Desktop for Mac).
+
+| Field | Type | Description |
+|---|---|---|
+| `connection_id` | `u64` | Unique connection ID assigned by the daemon's tunnel broker |
+| `target_port` | `u16` | Port on the container to connect to |
+
+```json
+{"type":"tunnel_request","connection_id":42,"target_port":3000}
+```
+
+The agent responds by opening a **new** TCP connection to the daemon's control port and sending a `TunnelHandshake` with the matching `connection_id`. The daemon's tunnel broker matches the connection and uses it to relay bytes between the host client and the container service.
 
 #### Operation Results
 
@@ -699,6 +763,27 @@ All variants are tagged with `"type"` in snake_case.
 {"type":"update_container_ip","container_id":"abc123","container_ip":"172.20.0.5"}
 ```
 
+**`register_ssh_agent_proxy`** -- Register a per-workspace SSH-agent TCP bridge. The daemon binds a localhost TCP listener, bidirectionally forwards bytes to the host's `SSH_AUTH_SOCK`, and returns the bridge port. Refcounted by workspace: subsequent registrations bump the count and return the existing port.
+
+| Field | Type | Description |
+|---|---|---|
+| `workspace` | `string` | Workspace path (used as refcount key) |
+| `upstream_socket` | `string` | Host-side `SSH_AUTH_SOCK` path to forward to |
+
+```json
+{"type":"register_ssh_agent_proxy","workspace":"/Users/me/proj","upstream_socket":"/Users/me/.1password/agent.sock"}
+```
+
+**`release_ssh_agent_proxy`** -- Decrement the SSH-agent proxy refcount for a workspace. Tears down the listener when the count reaches zero. No-op for an unknown workspace.
+
+| Field | Type | Description |
+|---|---|---|
+| `workspace` | `string` | Workspace path |
+
+```json
+{"type":"release_ssh_agent_proxy","workspace":"/Users/me/proj"}
+```
+
 **`shutdown`** -- Request graceful shutdown of the daemon. No fields.
 
 ```json
@@ -782,6 +867,27 @@ All variants are tagged with `"type"` in snake_case.
 
 ```json
 {"type":"pong"}
+```
+
+**`ssh_agent_proxy_registered`** -- SSH-agent bridge registered (or refcount bumped).
+
+| Field | Type | Description |
+|---|---|---|
+| `bridge_port` | `u16` | Localhost TCP port the in-container agent should connect to (reachable via `host.docker.internal` or equivalent) |
+| `refcount` | `usize` | Post-register count; `1` means a fresh bridge was created, `>1` means an existing one was reused |
+
+```json
+{"type":"ssh_agent_proxy_registered","bridge_port":54321,"refcount":1}
+```
+
+**`ssh_agent_proxy_released`** -- SSH-agent proxy refcount decremented.
+
+| Field | Type | Description |
+|---|---|---|
+| `torn_down` | `bool` | `true` when the refcount reached zero and the listener was destroyed; `false` when still in use by another container |
+
+```json
+{"type":"ssh_agent_proxy_released","torn_down":true}
 ```
 
 **`error`** -- Error response.


### PR DESCRIPTION
## Summary

- Add end-user configuration reference (`docs/configuration.md`) covering config file locations, merge semantics, and all settings
- Sync IPC protocol spec with current message types (tunnel handshake, clipboard, notification dismiss)
- Update architecture docs for agent, daemon, and port forwarding to reflect current implementation
- Sync all crate READMEs with current module structure and dependencies
- Update root README with clipboard forwarding, Colima support, and MSRV
- Remove documentation for unimplemented CLI config fields

## Test plan

- [x] Verify docs render correctly on GitHub
- [x] Spot-check configuration field names against source code