### PR TITLE
feat: forward host global gitignore into containers

### DIFF
--- a/crates/cella-env/Cargo.toml
+++ b/crates/cella-env/Cargo.toml
@@ -11,6 +11,9 @@ serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
+[features]
+integration-tests = []
+
 [dev-dependencies]
 tempfile.workspace = true
 

--- a/crates/cella-env/src/git_ignore.rs
+++ b/crates/cella-env/src/git_ignore.rs
@@ -261,4 +261,10 @@ mod tests {
         let content = fs::read_to_string(&cella_ignore).unwrap();
         assert_eq!(content, "# --- forwarded from host ---\n*.log\n");
     }
+
+    #[cfg(feature = "integration-tests")]
+    #[test]
+    fn resolve_from_real_git_config() {
+        let _ = resolve_host_gitignore_path();
+    }
 }

--- a/crates/cella-env/src/git_ignore.rs
+++ b/crates/cella-env/src/git_ignore.rs
@@ -11,7 +11,7 @@ const HOST_UPLOAD_PATH: &str = "/tmp/.cella/host-gitignore";
 ///
 /// Checks `core.excludesFile` via git first, then falls back to the
 /// XDG default location.
-pub fn resolve_host_gitignore_path() -> Option<PathBuf> {
+fn resolve_host_gitignore_path() -> Option<PathBuf> {
     if let Some(path) = resolve_from_git_config() {
         return Some(path);
     }
@@ -55,15 +55,19 @@ fn read_gitignore_file(path: &Path) -> Option<String> {
     }
 }
 
+/// Read the host's global gitignore content, returning `None` if
+/// unset, missing, or empty.
 pub fn read_host_gitignore() -> Option<String> {
     let path = resolve_host_gitignore_path()?;
     read_gitignore_file(&path)
 }
 
+/// Container-side path for the cella-managed merged gitignore file.
 pub fn cella_ignore_path(remote_user: &str) -> String {
     format!("{}/.config/git/cella-ignore", container_home(remote_user))
 }
 
+/// Container-side staging path for the raw host gitignore upload.
 pub const fn host_upload_path() -> &'static str {
     HOST_UPLOAD_PATH
 }
@@ -87,6 +91,8 @@ cat {upload_path}
     )
 }
 
+/// Build `sh -c` commands to merge uploaded host gitignore with the
+/// container's existing `~/.config/git/ignore`.
 pub fn build_merge_commands(remote_user: &str, upload_path: &str) -> Vec<Vec<String>> {
     let home = container_home(remote_user);
     let git_config_dir = format!("{home}/.config/git");
@@ -260,6 +266,9 @@ mod tests {
     #[cfg(feature = "integration-tests")]
     #[test]
     fn resolve_from_real_git_config() {
-        let _ = resolve_host_gitignore_path();
+        // If git reports an excludesFile, the resolved path must exist.
+        if let Some(path) = resolve_host_gitignore_path() {
+            assert!(path.is_file(), "resolved gitignore path must be a file");
+        }
     }
 }

--- a/crates/cella-env/src/git_ignore.rs
+++ b/crates/cella-env/src/git_ignore.rs
@@ -1,0 +1,264 @@
+//! Host global gitignore resolution and container forwarding.
+
+use std::path::{Path, PathBuf};
+
+use crate::claude_code::container_home;
+
+const HOST_MARKER: &str = "# --- forwarded from host ---";
+const HOST_UPLOAD_PATH: &str = "/tmp/.cella/host-gitignore";
+
+/// Resolve the host's global gitignore file path.
+///
+/// Checks `core.excludesFile` via git first, then falls back to the
+/// XDG default location.
+pub fn resolve_host_gitignore_path() -> Option<PathBuf> {
+    if let Some(path) = resolve_from_git_config() {
+        return Some(path);
+    }
+
+    let xdg = std::env::var("XDG_CONFIG_HOME").ok();
+    let home = std::env::var("HOME").ok().unwrap_or_default();
+    resolve_gitignore_from_xdg(xdg.as_deref(), &home)
+}
+
+fn resolve_from_git_config() -> Option<PathBuf> {
+    let output = std::process::Command::new("git")
+        .args(["config", "--global", "--path", "core.excludesFile"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let path_str = String::from_utf8_lossy(&output.stdout);
+    let path = PathBuf::from(path_str.trim());
+    if path.is_file() { Some(path) } else { None }
+}
+
+fn resolve_gitignore_from_xdg(xdg_config_home: Option<&str>, home: &str) -> Option<PathBuf> {
+    let config_base = xdg_config_home
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(home).join(".config"));
+
+    let path = config_base.join("git/ignore");
+    if path.is_file() { Some(path) } else { None }
+}
+
+fn read_gitignore_file(path: &Path) -> Option<String> {
+    match std::fs::read_to_string(path) {
+        Ok(content) if !content.is_empty() => Some(content),
+        Ok(_) => None,
+        Err(e) => {
+            tracing::warn!("Failed to read global gitignore at {}: {e}", path.display());
+            None
+        }
+    }
+}
+
+pub fn read_host_gitignore() -> Option<String> {
+    let path = resolve_host_gitignore_path()?;
+    read_gitignore_file(&path)
+}
+
+pub fn cella_ignore_path(remote_user: &str) -> String {
+    format!("{}/.config/git/cella-ignore", container_home(remote_user))
+}
+
+pub fn host_upload_path() -> &'static str {
+    HOST_UPLOAD_PATH
+}
+
+fn build_merge_script(
+    git_config_dir: &str,
+    container_ignore: &str,
+    cella_ignore: &str,
+    upload_path: &str,
+) -> String {
+    format!(
+        r#"mkdir -p {git_config_dir}
+{{
+if [ -f {container_ignore} ]; then
+sed '/{marker}/,$d' {container_ignore}
+fi
+printf '%s\n' '{marker}'
+cat {upload_path}
+}} > {cella_ignore}"#,
+        git_config_dir = git_config_dir,
+        container_ignore = container_ignore,
+        cella_ignore = cella_ignore,
+        marker = HOST_MARKER,
+        upload_path = upload_path,
+    )
+}
+
+pub fn build_merge_commands(remote_user: &str, upload_path: &str) -> Vec<Vec<String>> {
+    let home = container_home(remote_user);
+    let git_config_dir = format!("{home}/.config/git");
+    let container_ignore = format!("{git_config_dir}/ignore");
+    let cella_ignore = format!("{git_config_dir}/cella-ignore");
+
+    let script = build_merge_script(
+        &git_config_dir,
+        &container_ignore,
+        &cella_ignore,
+        upload_path,
+    );
+
+    vec![vec!["sh".to_string(), "-c".to_string(), script]]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn resolve_xdg_default() {
+        let tmp = TempDir::new().unwrap();
+        let git_dir = tmp.path().join("git");
+        fs::create_dir_all(&git_dir).unwrap();
+        fs::write(git_dir.join("ignore"), "*.log\n").unwrap();
+
+        let path = resolve_gitignore_from_xdg(Some(tmp.path().to_str().unwrap()), "/nonexistent");
+        assert_eq!(path.unwrap(), git_dir.join("ignore"));
+    }
+
+    #[test]
+    fn resolve_home_default() {
+        let tmp = TempDir::new().unwrap();
+        let config_dir = tmp.path().join(".config/git");
+        fs::create_dir_all(&config_dir).unwrap();
+        fs::write(config_dir.join("ignore"), "*.log\n").unwrap();
+
+        let path = resolve_gitignore_from_xdg(None, tmp.path().to_str().unwrap());
+        assert_eq!(path.unwrap(), config_dir.join("ignore"));
+    }
+
+    #[test]
+    fn resolve_missing_returns_none() {
+        let path = resolve_gitignore_from_xdg(None, "/nonexistent/path");
+        assert!(path.is_none());
+    }
+
+    #[test]
+    fn read_returns_content() {
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("ignore");
+        fs::write(&file, "*.log\n.DS_Store\n").unwrap();
+
+        let content = read_gitignore_file(&file);
+        assert_eq!(content.unwrap(), "*.log\n.DS_Store\n");
+    }
+
+    #[test]
+    fn read_empty_file_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("ignore");
+        fs::write(&file, "").unwrap();
+
+        let content = read_gitignore_file(&file);
+        assert!(content.is_none());
+    }
+
+    #[test]
+    fn cella_ignore_path_root() {
+        assert_eq!(cella_ignore_path("root"), "/root/.config/git/cella-ignore");
+    }
+
+    #[test]
+    fn cella_ignore_path_regular_user() {
+        assert_eq!(
+            cella_ignore_path("vscode"),
+            "/home/vscode/.config/git/cella-ignore"
+        );
+    }
+
+    #[test]
+    fn merge_commands_produces_single_command() {
+        let cmds = build_merge_commands("vscode", "/tmp/.cella/host-gitignore");
+        assert_eq!(cmds.len(), 1);
+        let script = &cmds[0][2]; // sh -c <script>
+        assert!(script.contains("/home/vscode/.config/git"));
+        assert!(script.contains("# --- forwarded from host ---"));
+    }
+
+    #[test]
+    fn merge_commands_root_user() {
+        let cmds = build_merge_commands("root", "/tmp/.cella/host-gitignore");
+        assert_eq!(cmds.len(), 1);
+        let script = &cmds[0][2];
+        assert!(script.contains("/root/.config/git"));
+    }
+
+    #[test]
+    fn merge_script_is_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        let git_dir = tmp.path().join(".config/git");
+        fs::create_dir_all(&git_dir).unwrap();
+
+        let container_ignore = git_dir.join("ignore");
+        fs::write(&container_ignore, "local-pattern\n").unwrap();
+
+        let upload = tmp.path().join("host-gitignore");
+        fs::write(&upload, "*.log\n.DS_Store\n").unwrap();
+
+        let cella_ignore = git_dir.join("cella-ignore");
+
+        let script = build_merge_script(
+            git_dir.to_str().unwrap(),
+            container_ignore.to_str().unwrap(),
+            cella_ignore.to_str().unwrap(),
+            upload.to_str().unwrap(),
+        );
+
+        // Run twice
+        for _ in 0..2 {
+            let status = std::process::Command::new("sh")
+                .arg("-c")
+                .arg(&script)
+                .status()
+                .unwrap();
+            assert!(status.success());
+        }
+
+        let content = fs::read_to_string(&cella_ignore).unwrap();
+        assert_eq!(
+            content,
+            "local-pattern\n# --- forwarded from host ---\n*.log\n.DS_Store\n"
+        );
+    }
+
+    #[test]
+    fn merge_script_no_container_ignore() {
+        let tmp = TempDir::new().unwrap();
+        let git_dir = tmp.path().join(".config/git");
+
+        let container_ignore = git_dir.join("ignore");
+        let cella_ignore = git_dir.join("cella-ignore");
+
+        let upload = tmp.path().join("host-gitignore");
+        fs::write(&upload, "*.log\n").unwrap();
+
+        let script = build_merge_script(
+            git_dir.to_str().unwrap(),
+            container_ignore.to_str().unwrap(),
+            cella_ignore.to_str().unwrap(),
+            upload.to_str().unwrap(),
+        );
+
+        // Run twice — must be idempotent even without container ignore
+        for _ in 0..2 {
+            let status = std::process::Command::new("sh")
+                .arg("-c")
+                .arg(&script)
+                .status()
+                .unwrap();
+            assert!(status.success());
+        }
+
+        let content = fs::read_to_string(&cella_ignore).unwrap();
+        assert_eq!(content, "# --- forwarded from host ---\n*.log\n");
+    }
+}

--- a/crates/cella-env/src/git_ignore.rs
+++ b/crates/cella-env/src/git_ignore.rs
@@ -37,9 +37,8 @@ fn resolve_from_git_config() -> Option<PathBuf> {
 }
 
 fn resolve_gitignore_from_xdg(xdg_config_home: Option<&str>, home: &str) -> Option<PathBuf> {
-    let config_base = xdg_config_home
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from(home).join(".config"));
+    let config_base =
+        xdg_config_home.map_or_else(|| PathBuf::from(home).join(".config"), PathBuf::from);
 
     let path = config_base.join("git/ignore");
     if path.is_file() { Some(path) } else { None }
@@ -65,7 +64,7 @@ pub fn cella_ignore_path(remote_user: &str) -> String {
     format!("{}/.config/git/cella-ignore", container_home(remote_user))
 }
 
-pub fn host_upload_path() -> &'static str {
+pub const fn host_upload_path() -> &'static str {
     HOST_UPLOAD_PATH
 }
 
@@ -75,20 +74,16 @@ fn build_merge_script(
     cella_ignore: &str,
     upload_path: &str,
 ) -> String {
+    let marker = HOST_MARKER;
     format!(
-        r#"mkdir -p {git_config_dir}
+        r"mkdir -p {git_config_dir}
 {{
 if [ -f {container_ignore} ]; then
 sed '/{marker}/,$d' {container_ignore}
 fi
 printf '%s\n' '{marker}'
 cat {upload_path}
-}} > {cella_ignore}"#,
-        git_config_dir = git_config_dir,
-        container_ignore = container_ignore,
-        cella_ignore = cella_ignore,
-        marker = HOST_MARKER,
-        upload_path = upload_path,
+}} > {cella_ignore}"
     )
 }
 

--- a/crates/cella-env/src/lib.rs
+++ b/crates/cella-env/src/lib.rs
@@ -106,6 +106,9 @@ pub struct PostStartInjection {
     /// Git config commands to execute inside the container as `remote_user`.
     /// Each entry is a full command (e.g., `["git", "config", "--global", "user.name", "John"]`).
     pub git_config_commands: Vec<Vec<String>>,
+    /// Shell commands to execute as `remote_user` after file uploads,
+    /// before git config commands (e.g., gitignore merge scripts).
+    pub user_commands: Vec<Vec<String>>,
     /// Commands that require root privileges (e.g., CA trust store updates).
     /// Executed as root after file uploads.
     pub root_commands: Vec<Vec<String>>,
@@ -218,6 +221,33 @@ fn apply_credential_forwarding(fwd: &mut EnvForwarding) {
     ]);
 }
 
+fn apply_global_gitignore(fwd: &mut EnvForwarding, remote_user: &str) {
+    let Some(content) = git_ignore::read_host_gitignore() else {
+        return;
+    };
+
+    let upload_path = git_ignore::host_upload_path();
+    fwd.post_start.file_uploads.push(FileUpload {
+        container_path: upload_path.to_string(),
+        content: content.into_bytes(),
+        mode: 0o644,
+    });
+
+    fwd.post_start
+        .user_commands
+        .extend(git_ignore::build_merge_commands(remote_user, upload_path));
+
+    let cella_path = git_ignore::cella_ignore_path(remote_user);
+    tracing::info!("Forwarding host global gitignore to {cella_path}");
+    fwd.post_start.git_config_commands.push(vec![
+        "git".to_string(),
+        "config".to_string(),
+        "--global".to_string(),
+        "core.excludesFile".to_string(),
+        cella_path,
+    ]);
+}
+
 /// Network configuration for proxy forwarding.
 pub struct ProxyForwardingConfig {
     /// Proxy configuration from cella settings.
@@ -253,6 +283,7 @@ pub fn prepare_env_forwarding(
     apply_git_config(&mut fwd);
     apply_safe_directory(&mut fwd);
     apply_credential_forwarding(&mut fwd);
+    apply_global_gitignore(&mut fwd, remote_user);
 
     if let Some(net_config) = network {
         proxy::apply_proxy_env(&mut fwd, &net_config.proxy, net_config.has_blocking_rules);
@@ -356,6 +387,10 @@ mod tests {
         assert!(
             fwd.post_start.git_config_commands.is_empty(),
             "default git_config_commands should be empty"
+        );
+        assert!(
+            fwd.post_start.user_commands.is_empty(),
+            "default user_commands should be empty"
         );
         assert!(
             fwd.post_start.root_commands.is_empty(),

--- a/crates/cella-env/src/lib.rs
+++ b/crates/cella-env/src/lib.rs
@@ -12,6 +12,7 @@ mod error;
 pub mod gemini;
 pub mod gh_credential;
 pub mod git_config;
+pub mod git_ignore;
 pub mod nvim;
 pub mod paths;
 pub mod platform;

--- a/crates/cella-env/src/lib.rs
+++ b/crates/cella-env/src/lib.rs
@@ -221,6 +221,7 @@ fn apply_credential_forwarding(fwd: &mut EnvForwarding) {
     ]);
 }
 
+/// Forward the host's global gitignore into the container.
 fn apply_global_gitignore(fwd: &mut EnvForwarding, remote_user: &str) {
     let Some(content) = git_ignore::read_host_gitignore() else {
         return;

--- a/crates/cella-orchestrator/src/container_setup.rs
+++ b/crates/cella-orchestrator/src/container_setup.rs
@@ -274,6 +274,34 @@ pub async fn inject_post_start(
     remote_user: &str,
 ) {
     upload_ssh_files(client, container_id, &post_start.file_uploads, remote_user).await;
+
+    for cmd in &post_start.user_commands {
+        let result = client
+            .exec_command(
+                container_id,
+                &ExecOptions {
+                    cmd: cmd.clone(),
+                    user: Some(remote_user.to_string()),
+                    env: None,
+                    working_dir: None,
+                },
+            )
+            .await;
+        match result {
+            Ok(r) if r.exit_code != 0 => {
+                warn!(
+                    "Post-start command failed (exit {}): {}",
+                    r.exit_code,
+                    r.stderr.trim()
+                );
+            }
+            Err(e) => {
+                warn!("Failed to exec post-start command: {e}");
+            }
+            _ => {}
+        }
+    }
+
     apply_git_config(
         client,
         container_id,

--- a/crates/cella-orchestrator/src/container_setup.rs
+++ b/crates/cella-orchestrator/src/container_setup.rs
@@ -264,9 +264,9 @@ pub async fn config_exists_in_container(
 
 /// Inject post-start environment forwarding into a running container.
 ///
-/// Uploads SSH config files, sets git config, and runs privileged root
-/// commands. Never fails -- individual steps log warnings and are skipped
-/// on error.
+/// Uploads files, runs user commands (e.g., gitignore merge), sets git
+/// config, and runs privileged root commands. Never fails -- individual
+/// steps log warnings and are skipped on error.
 pub async fn inject_post_start(
     client: &dyn ContainerBackend,
     container_id: &str,


### PR DESCRIPTION
## Summary

- Detect and forward the host's global gitignore (`core.excludesFile` or XDG default) into devcontainers post-start
- Merge host patterns with any existing container gitignore into `~/.config/git/cella-ignore`, then point `core.excludesFile` at it
- Add `user_commands` field to `PostStartInjection` for shell scripts that run between file uploads and git config (log-and-continue, won't break credential forwarding)

Closes a known gap in both cella and the official devcontainer tools (VS Code, devcontainers CLI — see vscode-remote-release#10549, #4481).

## Test plan

- [x] 11 unit tests covering path resolution, file reading, merge command generation
- [x] 2 idempotency tests that execute the merge script via `sh -c` twice and assert stable output
- [x] Integration test gate (`--features integration-tests`) for real git config resolution
- [x] Full workspace: `cargo fmt --check`, `cargo clippy --all-features -D warnings`, `cargo test --workspace` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)