### PR TITLE
fix: Fix feature mount object parsing

### DIFF
--- a/crates/cella-backend/src/mount.rs
+++ b/crates/cella-backend/src/mount.rs
@@ -87,11 +87,6 @@ impl MountSpec {
     }
 
     /// Adapter: Docker API `MountConfig`.
-    ///
-    /// `read_only` is preserved in `MountConfig` but note that `cella-docker`
-    /// does not yet forward it to bollard's `Mount` struct — wiring
-    /// read-only into the single-container path is deferred to a follow-up
-    /// phase.
     pub fn to_mount_config(&self) -> MountConfig {
         MountConfig {
             mount_type: self.kind.as_str().to_owned(),

--- a/crates/cella-features/src/metadata.rs
+++ b/crates/cella-features/src/metadata.rs
@@ -29,6 +29,18 @@ pub fn parse_feature_metadata(json: &str) -> Result<FeatureMetadata, FeatureErro
     dto.into_metadata()
 }
 
+/// Mount object from `devcontainer-feature.json`.
+///
+/// Per the feature schema (`additionalProperties: false`), only object format
+/// is valid — string-format mounts are a `devcontainer.json`-only construct.
+#[derive(Deserialize)]
+struct FeatureMountDto {
+    #[serde(rename = "type")]
+    mount_type: String,
+    source: Option<String>,
+    target: String,
+}
+
 /// Internal DTO that maps camelCase JSON field names to Rust fields.
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -44,7 +56,7 @@ struct FeatureMetadataDto {
     container_user: Option<String>,
     entrypoint: Option<String>,
     #[serde(default)]
-    mounts: Vec<String>,
+    mounts: Vec<FeatureMountDto>,
     #[serde(default)]
     cap_add: Vec<String>,
     #[serde(default)]
@@ -103,6 +115,19 @@ impl FeatureMetadataDto {
             );
         }
 
+        let mounts = self
+            .mounts
+            .into_iter()
+            .map(|m| {
+                format!(
+                    "type={},source={},target={}",
+                    m.mount_type,
+                    m.source.as_deref().unwrap_or(""),
+                    m.target,
+                )
+            })
+            .collect();
+
         Ok(FeatureMetadata {
             id: self.id,
             version: self.version,
@@ -112,7 +137,7 @@ impl FeatureMetadataDto {
             installs_after: self.installs_after,
             container_user: self.container_user,
             entrypoint: self.entrypoint,
-            mounts: self.mounts,
+            mounts,
             cap_add: self.cap_add,
             security_opt: self.security_opt,
             privileged: self.privileged,
@@ -185,7 +210,7 @@ mod tests {
             "installsAfter": ["ghcr.io/devcontainers/features/common-utils"],
             "containerUser": "node",
             "entrypoint": "/usr/local/share/nvm-entrypoint.sh",
-            "mounts": ["source=node-modules,target=/usr/local/lib/node_modules,type=volume"],
+            "mounts": [{"source": "node-modules", "target": "/usr/local/lib/node_modules", "type": "volume"}],
             "capAdd": ["SYS_PTRACE"],
             "securityOpt": ["seccomp=unconfined"],
             "privileged": false,
@@ -241,7 +266,7 @@ mod tests {
         );
         assert_eq!(
             meta.mounts,
-            vec!["source=node-modules,target=/usr/local/lib/node_modules,type=volume"]
+            vec!["type=volume,source=node-modules,target=/usr/local/lib/node_modules"]
         );
         assert_eq!(meta.cap_add, vec!["SYS_PTRACE"]);
         assert_eq!(meta.security_opt, vec!["seccomp=unconfined"]);
@@ -403,5 +428,62 @@ mod tests {
         }"#;
         let meta = parse_feature_metadata(json).unwrap();
         assert_eq!(meta.id, "test");
+    }
+
+    #[test]
+    fn object_format_mounts_parsed() {
+        let json = r#"{
+            "id": "docker-in-docker",
+            "version": "2.16.1",
+            "mounts": [
+                {
+                    "source": "dind-var-lib-docker-${devcontainerId}",
+                    "target": "/var/lib/docker",
+                    "type": "volume"
+                }
+            ]
+        }"#;
+        let meta = parse_feature_metadata(json).expect("should parse object mounts");
+        assert_eq!(meta.mounts.len(), 1);
+        assert_eq!(
+            meta.mounts[0],
+            "type=volume,source=dind-var-lib-docker-${devcontainerId},target=/var/lib/docker"
+        );
+    }
+
+    #[test]
+    fn string_format_mounts_rejected_in_feature() {
+        let json = r#"{
+            "id": "test",
+            "version": "1.0.0",
+            "mounts": ["type=volume,src=v,dst=/v"]
+        }"#;
+        let result = parse_feature_metadata(json);
+        assert!(
+            result.is_err(),
+            "string-format mounts should be rejected in feature metadata"
+        );
+    }
+
+    #[test]
+    fn mount_object_without_source() {
+        let json = r#"{
+            "id": "test",
+            "version": "1.0.0",
+            "mounts": [{"type": "volume", "target": "/data"}]
+        }"#;
+        let meta = parse_feature_metadata(json).expect("mount without source should parse");
+        assert_eq!(meta.mounts[0], "type=volume,source=,target=/data");
+    }
+
+    #[test]
+    fn docker_in_docker_real_manifest() {
+        let json = include_str!("../tests/fixtures/docker-in-docker.json");
+        let meta = parse_feature_metadata(json).expect("docker-in-docker manifest should parse");
+        assert_eq!(meta.id, "docker-in-docker");
+        assert_eq!(meta.mounts.len(), 1);
+        assert!(meta.mounts[0].contains("target=/var/lib/docker"));
+        assert!(meta.mounts[0].contains("type=volume"));
+        assert_eq!(meta.privileged, Some(true));
     }
 }

--- a/crates/cella-features/tests/fixtures/docker-in-docker.json
+++ b/crates/cella-features/tests/fixtures/docker-in-docker.json
@@ -1,0 +1,82 @@
+{
+  "id": "docker-in-docker",
+  "version": "2.16.1",
+  "name": "Docker (Docker-in-Docker)",
+  "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-in-docker",
+  "description": "Create child containers *inside* a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.",
+  "options": {
+    "version": {
+      "type": "string",
+      "proposals": ["latest", "none", "20.10"],
+      "default": "latest",
+      "description": "Select or enter a Docker/Moby Engine version. (Availability can vary by OS version.)"
+    },
+    "moby": {
+      "type": "boolean",
+      "default": true,
+      "description": "Install OSS Moby build instead of Docker CE"
+    },
+    "mobyBuildxVersion": {
+      "type": "string",
+      "default": "latest",
+      "description": "Install a specific version of moby-buildx when using Moby"
+    },
+    "dockerDashComposeVersion": {
+      "type": "string",
+      "enum": ["none", "v1", "v2"],
+      "default": "v2",
+      "description": "Default version of Docker Compose (v1, v2 or none)"
+    },
+    "azureDnsAutoDetection": {
+      "type": "boolean",
+      "default": true,
+      "description": "Allow automatically setting the dockerd DNS server when the installation script detects it is running in Azure"
+    },
+    "dockerDefaultAddressPool": {
+      "type": "string",
+      "default": "",
+      "proposals": [],
+      "description": "Define default address pools for Docker networks. e.g. base=192.168.0.0/16,size=24"
+    },
+    "installDockerBuildx": {
+      "type": "boolean",
+      "default": true,
+      "description": "Install Docker Buildx"
+    },
+    "installDockerComposeSwitch": {
+      "type": "boolean",
+      "default": false,
+      "description": "Install Compose Switch (provided docker compose is available) which is a replacement to the Compose V1 docker-compose (python) executable. It translates the command line into Compose V2 docker compose then runs the latter."
+    },
+    "disableIp6tables": {
+      "type": "boolean",
+      "default": false,
+      "description": "Disable ip6tables (this option is only applicable for Docker versions 27 and greater)"
+    }
+  },
+  "entrypoint": "/usr/local/share/docker-init.sh",
+  "privileged": true,
+  "containerEnv": {
+    "DOCKER_BUILDKIT": "1"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["ms-azuretools.vscode-containers"],
+      "settings": {
+        "github.copilot.chat.codeGeneration.instructions": [
+          {
+            "text": "This dev container includes the Docker CLI (`docker`) pre-installed and available on the `PATH` for running and managing containers using a dedicated Docker daemon running inside the dev container."
+          }
+        ]
+      }
+    }
+  },
+  "mounts": [
+    {
+      "source": "dind-var-lib-docker-${devcontainerId}",
+      "target": "/var/lib/docker",
+      "type": "volume"
+    }
+  ],
+  "installsAfter": ["ghcr.io/devcontainers/features/common-utils"]
+}

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -216,6 +216,11 @@ These flags are cella-only. They do not conflict with any spec flag name and can
 - **Cella**: Runs on container creation, rebuild, and when the container is already running (`handle_running` fast path)
 - **Status**: PASS
 
+### 3.15 Feature Mount Format
+- **Spec**: Feature `mounts` is `Mount[]` (objects with `type`, `source?`, `target`); `devcontainer.json` mounts accept both objects and strings
+- **Cella**: Feature mounts parsed as objects, normalized to CSV strings (`type=X,source=Y,target=Z`) during metadata parsing
+- **Status**: PASS
+
 ---
 
 ## 4. Missing Features
@@ -235,6 +240,7 @@ These flags are cella-only. They do not conflict with any spec flag name and can
 | Feature authoring | test/package/publish/info/resolve-deps/generate-docs | Low |
 | Template commands | apply/publish/metadata/generate-docs | Low |
 | Git root mount | `--mount-workspace-git-root` | Medium |
+| Variable substitution | `${devcontainerId}`, `${localEnv:...}`, `${localWorkspaceFolder}`, etc. | High |
 
 ---
 


### PR DESCRIPTION
## Summary

- Parse object-format mounts in `devcontainer-feature.json` metadata (fix #66)
- The feature schema defines `mounts` as `Mount[]` (objects only), but the parser expected `Vec<String>` — features like `docker-in-docker` failed with "invalid type: map, expected a string"
- Remove stale readOnly comment (already wired in cella-docker)
- Update spec compliance doc

## Follow-up issues

- #71 — variable substitution (`${devcontainerId}`, etc.)
- #72 — `--mount` CLI flag
- #73 — `--workspace-mount-consistency` CLI flag
- #74 — `--mount-workspace-git-root` CLI flag
- #75 — `--mount-git-worktree-common-dir` CLI flag

## Test plan

- [x] Object-format mounts parse correctly
- [x] String-format mounts rejected in feature metadata (per spec)
- [x] Mount without source field works
- [x] Real docker-in-docker manifest fixture parses
- [x] Existing tests unchanged
- [x] Full workspace passes (`cargo test --workspace`)
- [x] Clippy + fmt clean