### PR TITLE
fix: SSH agent forwarding fallback & retry on mount failure

### DIFF
--- a/crates/cella-doctor/src/checks/git.rs
+++ b/crates/cella-doctor/src/checks/git.rs
@@ -124,10 +124,12 @@ fn classify_ssh_socket(path: &str) -> &'static str {
     let lower = path.to_lowercase();
     if lower.contains("orbstack") {
         "OrbStack"
-    } else if lower.contains("docker-desktop") || lower.contains("com.apple.launchd") {
+    } else if lower.contains("docker-desktop") {
         "Docker Desktop VM"
     } else if lower.contains("colima") {
         "Colima"
+    } else if lower.contains("com.apple.launchd") {
+        "macOS system"
     } else {
         "host-native"
     }
@@ -157,7 +159,7 @@ mod tests {
         );
         assert_eq!(
             classify_ssh_socket("/private/tmp/com.apple.launchd.xxx/Listeners"),
-            "Docker Desktop VM"
+            "macOS system"
         );
     }
 
@@ -215,7 +217,7 @@ mod tests {
         );
         assert_eq!(
             classify_ssh_socket("/private/tmp/com.apple.launchd.xyz/Listeners"),
-            "Docker Desktop VM"
+            "macOS system"
         );
     }
 

--- a/crates/cella-env/src/lib.rs
+++ b/crates/cella-env/src/lib.rs
@@ -96,6 +96,13 @@ pub struct EnvForwarding {
     /// where the SSH agent is forwarded directly via host bind-mount or
     /// the magic VM socket (already pushed into `mounts` and `env`).
     pub ssh_agent_proxy_request: Option<SshAgentProxyRequest>,
+    /// Source path of the currently-applied SSH agent mount, if any.
+    /// Used by retry logic to identify SSH-specific mount failures.
+    pub ssh_agent_mount_source: Option<String>,
+    /// Remaining SSH agent strategies to try if the primary fails.
+    pub ssh_agent_fallbacks: Vec<ssh_agent::SshAgentRequest>,
+    /// Detected runtime, passed through for warning messages on fallback.
+    pub ssh_agent_runtime: Option<DockerRuntime>,
 }
 
 /// Post-start injection commands and files.
@@ -116,21 +123,32 @@ pub struct PostStartInjection {
 
 /// Apply SSH agent forwarding to the environment.
 ///
-/// For most runtimes this synchronously appends the mount and env entries.
-/// For colima, the daemon must materialize a proxy socket first — we set
-/// `ssh_agent_proxy_request` and let the orchestrator resolve it.
+/// Takes the first strategy from the ordered list and applies it
+/// immediately. Remaining strategies are stored as fallbacks for the
+/// orchestrator's retry logic. For colima, the daemon must materialize
+/// a proxy socket first — we set `ssh_agent_proxy_request`.
 fn apply_ssh_agent_forwarding(
     fwd: &mut EnvForwarding,
     runtime: &DockerRuntime,
     config: &serde_json::Value,
 ) {
-    match ssh_agent::ssh_agent_request(runtime, config) {
-        Some(ssh_agent::SshAgentRequest::Direct(ssh)) => {
+    let mut strategies = ssh_agent::ssh_agent_request(runtime, config);
+    if strategies.is_empty() {
+        return;
+    }
+    fwd.ssh_agent_runtime = Some(runtime.clone());
+
+    let primary = strategies.remove(0);
+    fwd.ssh_agent_fallbacks = strategies;
+
+    match primary {
+        ssh_agent::SshAgentRequest::Direct(ssh) => {
             tracing::info!(
                 "SSH agent forwarding: {} -> {}",
                 ssh.mount_source,
                 ssh.mount_target
             );
+            fwd.ssh_agent_mount_source = Some(ssh.mount_source.clone());
             fwd.mounts.push(ForwardMount {
                 source: ssh.mount_source,
                 target: ssh.mount_target,
@@ -140,11 +158,11 @@ fn apply_ssh_agent_forwarding(
                 value: ssh.env_value,
             });
         }
-        Some(ssh_agent::SshAgentRequest::ProxyOnColima {
+        ssh_agent::SshAgentRequest::ProxyOnColima {
             upstream_socket,
             mount_target,
             env_value,
-        }) => {
+        } => {
             tracing::info!(
                 "SSH agent forwarding (colima proxy): bridging {} via daemon",
                 upstream_socket.display()
@@ -155,7 +173,6 @@ fn apply_ssh_agent_forwarding(
                 env_value,
             });
         }
-        None => {}
     }
 }
 

--- a/crates/cella-env/src/platform.rs
+++ b/crates/cella-env/src/platform.rs
@@ -10,13 +10,14 @@ pub enum DockerRuntime {
     OrbStack,
     /// Native Docker on Linux — direct socket bind-mount works.
     LinuxNative,
-    /// Colima (macOS) — direct socket bind-mount works.
+    /// Colima (macOS) — uses daemon-managed SSH proxy.
     Colima,
     /// Podman — VM-based on macOS (Podman Machine), native on Linux.
     Podman,
-    /// Rancher Desktop — VM-based (Lima) on macOS/Linux.
+    /// Rancher Desktop — VM-based (Lima) on macOS/Linux. Uses
+    /// `/run/host-services/ssh-auth.sock` when Lima `ssh.forwardAgent` is enabled.
     RancherDesktop,
-    /// Unknown runtime — try direct bind-mount with warning.
+    /// Unknown runtime — tries VM magic socket, then direct bind-mount.
     Unknown,
 }
 

--- a/crates/cella-env/src/ssh_agent.rs
+++ b/crates/cella-env/src/ssh_agent.rs
@@ -7,6 +7,7 @@ use tracing::warn;
 use crate::platform::DockerRuntime;
 
 /// SSH agent forwarding configuration.
+#[derive(Debug, Clone)]
 pub struct SshAgentForwarding {
     /// Host-side socket path or Docker-internal path to mount from.
     pub mount_source: String,
@@ -19,6 +20,7 @@ pub struct SshAgentForwarding {
 /// What `cella-env` can determine about SSH agent forwarding without
 /// daemon access. The orchestrator (Tier 2) translates `ProxyOnColima`
 /// into a real mount by calling into the daemon.
+#[derive(Debug, Clone)]
 pub enum SshAgentRequest {
     /// Direct mount of an existing socket — used for Docker Desktop and
     /// `OrbStack` (magic VM socket) and for Linux/Podman direct host
@@ -103,38 +105,63 @@ fn direct_ssh_forwarding(
     })
 }
 
-/// Detect the host SSH agent socket and decide how to forward it.
+/// Build the ordered list of SSH agent strategies for a given runtime.
 ///
-/// Returns `None` if:
-/// - `SSH_AUTH_SOCK` is unset or empty
+/// Separated from env/config concerns for testability. Each runtime gets
+/// strategies in preference order — the orchestrator tries them in sequence,
+/// falling back on bind-mount failures.
+fn ssh_agent_strategies_for_runtime(
+    runtime: &DockerRuntime,
+    host_socket: Option<String>,
+) -> Vec<SshAgentRequest> {
+    match runtime {
+        DockerRuntime::DockerDesktop | DockerRuntime::OrbStack => {
+            vec![SshAgentRequest::Direct(vm_host_services_ssh_forwarding(
+                runtime,
+                host_socket.as_ref(),
+            ))]
+        }
+        DockerRuntime::Colima => colima_proxy_request(host_socket.as_deref())
+            .into_iter()
+            .collect(),
+        DockerRuntime::LinuxNative => direct_ssh_forwarding(runtime, host_socket)
+            .map(SshAgentRequest::Direct)
+            .into_iter()
+            .collect(),
+        // VM-based or unknown: try magic socket first, then direct mount
+        DockerRuntime::RancherDesktop | DockerRuntime::Podman | DockerRuntime::Unknown => {
+            let mut strategies = vec![SshAgentRequest::Direct(vm_host_services_ssh_forwarding(
+                runtime,
+                host_socket.as_ref(),
+            ))];
+            if let Some(direct) = direct_ssh_forwarding(runtime, host_socket) {
+                strategies.push(SshAgentRequest::Direct(direct));
+            }
+            strategies
+        }
+    }
+}
+
+/// Detect the host SSH agent socket and return ordered strategies to try.
+///
+/// Returns an empty vec if:
 /// - The user has already configured `SSH_AUTH_SOCK` in `containerEnv`/`remoteEnv`
 /// - The user has a mount targeting the SSH socket path
-/// - The detected runtime is colima but `SSH_AUTH_SOCK` is unset on the host
-///   (proxy can't bridge to nothing — orchestrator skips forwarding)
-///
-/// Renamed from `ssh_agent_forwarding` to make the colima divergence
-/// explicit: the result on colima is a *request* the orchestrator must
-/// translate via the daemon, not a final mount.
+/// - No strategies are available for this runtime
 pub fn ssh_agent_request(
     runtime: &DockerRuntime,
     config: &serde_json::Value,
-) -> Option<SshAgentRequest> {
+) -> Vec<SshAgentRequest> {
     if has_user_ssh_override(config) {
         tracing::debug!("User has SSH_AUTH_SOCK override in config, skipping auto-forward");
-        return None;
+        return Vec::new();
     }
 
     let host_socket = std::env::var("SSH_AUTH_SOCK")
         .ok()
         .filter(|s| !s.is_empty());
 
-    match runtime {
-        DockerRuntime::DockerDesktop | DockerRuntime::OrbStack => Some(SshAgentRequest::Direct(
-            vm_host_services_ssh_forwarding(runtime, host_socket.as_ref()),
-        )),
-        DockerRuntime::Colima => colima_proxy_request(host_socket.as_deref()),
-        _ => direct_ssh_forwarding(runtime, host_socket).map(SshAgentRequest::Direct),
-    }
+    ssh_agent_strategies_for_runtime(runtime, host_socket)
 }
 
 /// On colima, defer SSH-agent forwarding to a daemon-managed host-side
@@ -340,30 +367,33 @@ mod tests {
     #[test]
     fn ssh_agent_request_user_override_skips_forward() {
         let config = json!({"containerEnv": {"SSH_AUTH_SOCK": "/custom/socket"}});
-        // Even on colima, an explicit user override wins.
-        assert!(ssh_agent_request(&DockerRuntime::Colima, &config).is_none());
-        assert!(ssh_agent_request(&DockerRuntime::DockerDesktop, &config).is_none());
-        assert!(ssh_agent_request(&DockerRuntime::OrbStack, &config).is_none());
+        assert!(ssh_agent_request(&DockerRuntime::Colima, &config).is_empty());
+        assert!(ssh_agent_request(&DockerRuntime::DockerDesktop, &config).is_empty());
+        assert!(ssh_agent_request(&DockerRuntime::OrbStack, &config).is_empty());
     }
 
     #[test]
     fn ssh_agent_request_orbstack_returns_direct_magic_socket() {
         let config = json!({});
-        let req = ssh_agent_request(&DockerRuntime::OrbStack, &config);
-        match req {
-            Some(SshAgentRequest::Direct(fwd)) => {
+        let strategies = ssh_agent_request(&DockerRuntime::OrbStack, &config);
+        assert!(!strategies.is_empty());
+        match &strategies[0] {
+            SshAgentRequest::Direct(fwd) => {
                 assert_eq!(fwd.mount_source, "/run/host-services/ssh-auth.sock");
                 assert_eq!(fwd.env_value, "/run/host-services/ssh-auth.sock");
             }
-            _ => panic!("expected Direct on OrbStack"),
+            SshAgentRequest::ProxyOnColima { .. } => {
+                panic!("expected Direct on OrbStack, got ProxyOnColima")
+            }
         }
     }
 
     #[test]
     fn ssh_agent_request_docker_desktop_returns_direct_magic_socket() {
         let config = json!({});
-        let req = ssh_agent_request(&DockerRuntime::DockerDesktop, &config);
-        assert!(matches!(req, Some(SshAgentRequest::Direct(_))));
+        let strategies = ssh_agent_request(&DockerRuntime::DockerDesktop, &config);
+        assert!(!strategies.is_empty());
+        assert!(matches!(&strategies[0], SshAgentRequest::Direct(_)));
     }
 
     #[test]
@@ -417,5 +447,137 @@ mod tests {
         assert_eq!(fwd.mount_source, sock.to_string_lossy());
         assert_eq!(fwd.mount_target, CONTAINER_SSH_SOCK);
         assert_eq!(fwd.env_value, CONTAINER_SSH_SOCK);
+    }
+
+    // -----------------------------------------------------------------
+    // ssh_agent_strategies_for_runtime: ordered strategy tests
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn strategies_rancher_desktop_returns_vm_then_direct() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock = tmp.path().join("ssh.sock");
+        std::fs::File::create(&sock).unwrap();
+        let host_socket = Some(sock.to_string_lossy().into_owned());
+
+        let strategies =
+            ssh_agent_strategies_for_runtime(&DockerRuntime::RancherDesktop, host_socket);
+        assert_eq!(strategies.len(), 2);
+        match &strategies[0] {
+            SshAgentRequest::Direct(fwd) => {
+                assert_eq!(fwd.mount_source, VM_HOST_SERVICES_SSH_SOCK);
+            }
+            SshAgentRequest::ProxyOnColima { .. } => {
+                panic!("first strategy should be vm_host_services, got ProxyOnColima")
+            }
+        }
+        match &strategies[1] {
+            SshAgentRequest::Direct(fwd) => {
+                assert_eq!(fwd.mount_source, sock.to_string_lossy());
+            }
+            SshAgentRequest::ProxyOnColima { .. } => {
+                panic!("second strategy should be direct mount, got ProxyOnColima")
+            }
+        }
+    }
+
+    #[test]
+    fn strategies_podman_returns_vm_then_direct() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock = tmp.path().join("ssh.sock");
+        std::fs::File::create(&sock).unwrap();
+        let host_socket = Some(sock.to_string_lossy().into_owned());
+
+        let strategies = ssh_agent_strategies_for_runtime(&DockerRuntime::Podman, host_socket);
+        assert_eq!(strategies.len(), 2);
+    }
+
+    #[test]
+    fn strategies_unknown_returns_vm_then_direct() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock = tmp.path().join("ssh.sock");
+        std::fs::File::create(&sock).unwrap();
+        let host_socket = Some(sock.to_string_lossy().into_owned());
+
+        let strategies = ssh_agent_strategies_for_runtime(&DockerRuntime::Unknown, host_socket);
+        assert_eq!(strategies.len(), 2);
+    }
+
+    #[test]
+    fn strategies_linux_native_returns_direct_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock = tmp.path().join("ssh.sock");
+        std::fs::File::create(&sock).unwrap();
+        let host_socket = Some(sock.to_string_lossy().into_owned());
+
+        let strategies = ssh_agent_strategies_for_runtime(&DockerRuntime::LinuxNative, host_socket);
+        assert_eq!(strategies.len(), 1);
+        match &strategies[0] {
+            SshAgentRequest::Direct(fwd) => {
+                assert_eq!(fwd.mount_source, sock.to_string_lossy());
+            }
+            SshAgentRequest::ProxyOnColima { .. } => {
+                panic!("should be direct mount, got ProxyOnColima")
+            }
+        }
+    }
+
+    #[test]
+    fn strategies_docker_desktop_returns_vm_only() {
+        let strategies = ssh_agent_strategies_for_runtime(&DockerRuntime::DockerDesktop, None);
+        assert_eq!(strategies.len(), 1);
+        match &strategies[0] {
+            SshAgentRequest::Direct(fwd) => {
+                assert_eq!(fwd.mount_source, VM_HOST_SERVICES_SSH_SOCK);
+            }
+            SshAgentRequest::ProxyOnColima { .. } => {
+                panic!("should be vm_host_services, got ProxyOnColima")
+            }
+        }
+    }
+
+    #[test]
+    fn strategies_orbstack_returns_vm_only() {
+        let strategies = ssh_agent_strategies_for_runtime(&DockerRuntime::OrbStack, None);
+        assert_eq!(strategies.len(), 1);
+        assert!(matches!(&strategies[0], SshAgentRequest::Direct(_)));
+    }
+
+    #[test]
+    fn strategies_colima_returns_proxy() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock = tmp.path().join("ssh.sock");
+        std::fs::File::create(&sock).unwrap();
+        let host_socket = Some(sock.to_string_lossy().into_owned());
+
+        let strategies = ssh_agent_strategies_for_runtime(&DockerRuntime::Colima, host_socket);
+        assert_eq!(strategies.len(), 1);
+        assert!(
+            matches!(&strategies[0], SshAgentRequest::ProxyOnColima { .. }),
+            "expected ProxyOnColima, got {:?}",
+            strategies[0]
+        );
+    }
+
+    #[test]
+    fn strategies_no_host_socket_vm_runtimes_still_return_magic() {
+        for runtime in [
+            DockerRuntime::RancherDesktop,
+            DockerRuntime::Podman,
+            DockerRuntime::Unknown,
+        ] {
+            let strategies = ssh_agent_strategies_for_runtime(&runtime, None);
+            assert_eq!(
+                strategies.len(),
+                1,
+                "{runtime:?}: should have magic socket only (no direct without host socket)"
+            );
+        }
+    }
+
+    #[test]
+    fn strategies_no_host_socket_linux_native_returns_empty() {
+        let strategies = ssh_agent_strategies_for_runtime(&DockerRuntime::LinuxNative, None);
+        assert!(strategies.is_empty());
     }
 }

--- a/crates/cella-env/src/ssh_agent.rs
+++ b/crates/cella-env/src/ssh_agent.rs
@@ -201,6 +201,36 @@ fn colima_proxy_request(host_socket: Option<&str>) -> Option<SshAgentRequest> {
     })
 }
 
+/// Check if a Docker error is a bind-mount failure for the SSH agent socket.
+pub fn is_ssh_mount_error(error_msg: &str, ssh_mount_source: Option<&str>) -> bool {
+    let Some(source) = ssh_mount_source else {
+        return false;
+    };
+    error_msg.contains("bind source path does not exist") && error_msg.contains(source)
+}
+
+/// Actionable warning message when SSH agent forwarding is skipped after
+/// all strategies fail.
+pub fn ssh_skip_warning(runtime: &DockerRuntime) -> String {
+    let base = "SSH agent forwarding skipped — git operations requiring SSH keys may not work inside the container.";
+    let hint = match runtime {
+        DockerRuntime::RancherDesktop => {
+            " To enable, create ~/Library/Application Support/rancher-desktop/lima/_config/override.yaml with:\n  ssh:\n    forwardAgent: true\n  Then restart Rancher Desktop."
+        }
+        DockerRuntime::Colima => {
+            " Try `colima start --ssh-agent` or add `forwardAgent: true` to ~/.colima/default/colima.yaml."
+        }
+        DockerRuntime::Podman => {
+            " Podman Machine may not forward the SSH agent by default. Check podman-machine configuration."
+        }
+        DockerRuntime::Unknown => {
+            " If using a VM-based Docker runtime, ensure SSH agent forwarding is enabled in the VM configuration."
+        }
+        DockerRuntime::DockerDesktop | DockerRuntime::OrbStack | DockerRuntime::LinuxNative => "",
+    };
+    format!("{base}{hint}")
+}
+
 /// Check if the user has already configured SSH agent forwarding in their config.
 fn has_user_ssh_override(config: &serde_json::Value) -> bool {
     // Check containerEnv for SSH_AUTH_SOCK
@@ -579,5 +609,75 @@ mod tests {
     fn strategies_no_host_socket_linux_native_returns_empty() {
         let strategies = ssh_agent_strategies_for_runtime(&DockerRuntime::LinuxNative, None);
         assert!(strategies.is_empty());
+    }
+
+    // -----------------------------------------------------------------
+    // Error detection and warning helpers
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn is_ssh_mount_error_matches_bind_source() {
+        let msg = r#"Docker responded with status code 400: invalid mount config for type "bind": bind source path does not exist: /run/host-services/ssh-auth.sock"#;
+        assert!(is_ssh_mount_error(
+            msg,
+            Some("/run/host-services/ssh-auth.sock")
+        ));
+    }
+
+    #[test]
+    fn is_ssh_mount_error_no_match_different_path() {
+        let msg = r#"bind source path does not exist: /some/other/path"#;
+        assert!(!is_ssh_mount_error(
+            msg,
+            Some("/run/host-services/ssh-auth.sock")
+        ));
+    }
+
+    #[test]
+    fn is_ssh_mount_error_no_match_different_error() {
+        let msg = "container name already in use";
+        assert!(!is_ssh_mount_error(
+            msg,
+            Some("/run/host-services/ssh-auth.sock")
+        ));
+    }
+
+    #[test]
+    fn is_ssh_mount_error_none_source() {
+        let msg = "bind source path does not exist: /foo";
+        assert!(!is_ssh_mount_error(msg, None));
+    }
+
+    #[test]
+    fn ssh_skip_warning_rancher_desktop_has_lima_hint() {
+        let msg = ssh_skip_warning(&DockerRuntime::RancherDesktop);
+        assert!(msg.contains("forwardAgent: true"));
+        assert!(msg.contains("Rancher Desktop"));
+    }
+
+    #[test]
+    fn ssh_skip_warning_linux_native_no_hint() {
+        let msg = ssh_skip_warning(&DockerRuntime::LinuxNative);
+        assert!(msg.contains("SSH agent forwarding skipped"));
+        assert!(!msg.contains("forwardAgent"));
+    }
+
+    #[test]
+    fn ssh_skip_warning_all_runtimes_have_base_message() {
+        for runtime in [
+            DockerRuntime::DockerDesktop,
+            DockerRuntime::OrbStack,
+            DockerRuntime::LinuxNative,
+            DockerRuntime::Colima,
+            DockerRuntime::Podman,
+            DockerRuntime::RancherDesktop,
+            DockerRuntime::Unknown,
+        ] {
+            let warning = ssh_skip_warning(&runtime);
+            assert!(
+                warning.contains("SSH agent forwarding skipped"),
+                "{runtime:?} missing base warning"
+            );
+        }
     }
 }

--- a/crates/cella-env/src/ssh_agent.rs
+++ b/crates/cella-env/src/ssh_agent.rs
@@ -23,8 +23,8 @@ pub struct SshAgentForwarding {
 #[derive(Debug, Clone)]
 pub enum SshAgentRequest {
     /// Direct mount of an existing socket — used for Docker Desktop and
-    /// `OrbStack` (magic VM socket) and for Linux/Podman direct host
-    /// bind-mount. Ready to be mounted as-is.
+    /// `OrbStack` (magic VM socket), Linux native (host bind-mount), and
+    /// as a fallback for VM-based runtimes. Ready to be mounted as-is.
     Direct(SshAgentForwarding),
     /// **Known broken on colima — see `cella_daemon::ssh_proxy` module
     /// docs.** Lima's OpenSSH-protocol `forwardAgent` degenerates with
@@ -77,14 +77,10 @@ fn vm_host_services_ssh_forwarding(
 
 /// SSH agent forwarding via direct bind-mount of the host socket.
 ///
-/// Used as the fallback in `ssh_agent_request` for runtimes that aren't
-/// `DockerDesktop` / `OrbStack` / `Colima` — typically `LinuxNative`
-/// Docker, Podman, or Rancher Desktop. macOS sandbox-dir concerns
-/// don't apply on these runtimes (no Lima virtiofs in the path), so
-/// the host socket is reachable from the docker daemon as-is. (For
-/// `Colima` direct mount fails — Docker's mkdir-source-if-missing
-/// returns EOPNOTSUPP under macOS sandbox dirs — which is why colima
-/// takes the daemon-managed proxy path instead.)
+/// Used for `LinuxNative` Docker where the docker daemon runs on the
+/// same host, so the host socket is reachable as-is. Also used as a
+/// fallback strategy for VM-based runtimes (Rancher Desktop, Podman,
+/// Unknown) when the magic VM socket is not available.
 fn direct_ssh_forwarding(
     _runtime: &DockerRuntime,
     host_socket: Option<String>,

--- a/crates/cella-env/src/ssh_agent.rs
+++ b/crates/cella-env/src/ssh_agent.rs
@@ -626,7 +626,7 @@ mod tests {
 
     #[test]
     fn is_ssh_mount_error_no_match_different_path() {
-        let msg = r#"bind source path does not exist: /some/other/path"#;
+        let msg = r"bind source path does not exist: /some/other/path";
         assert!(!is_ssh_mount_error(
             msg,
             Some("/run/host-services/ssh-auth.sock")

--- a/crates/cella-env/src/ssh_agent.rs
+++ b/crates/cella-env/src/ssh_agent.rs
@@ -64,7 +64,7 @@ fn vm_host_services_ssh_forwarding(
     host_socket: Option<&String>,
 ) -> SshAgentForwarding {
     if host_socket.is_none() {
-        warn!(
+        tracing::debug!(
             "SSH_AUTH_SOCK not set on host, but {runtime} may still provide the SSH agent via /run/host-services/ssh-auth.sock"
         );
     }

--- a/crates/cella-env/tests/ssh_agent_retry.rs
+++ b/crates/cella-env/tests/ssh_agent_retry.rs
@@ -1,0 +1,48 @@
+#![cfg(feature = "integration-tests")]
+
+use cella_env::platform::DockerRuntime;
+use cella_env::ssh_agent::{is_ssh_mount_error, ssh_skip_warning};
+
+#[test]
+fn realistic_docker_400_error_detected() {
+    let docker_error = r#"Docker responded with status code 400: {"message":"invalid mount config for type \"bind\": bind source path does not exist: /run/host-services/ssh-auth.sock"}"#;
+    assert!(is_ssh_mount_error(
+        docker_error,
+        Some("/run/host-services/ssh-auth.sock")
+    ));
+}
+
+#[test]
+fn realistic_docker_error_launchd_path() {
+    let docker_error = r#"Docker responded with status code 400: {"message":"invalid mount config for type \"bind\": bind source path does not exist: /var/run/com.apple.launchd.hxQo6EKt4v/Listeners"}"#;
+    assert!(is_ssh_mount_error(
+        docker_error,
+        Some("/var/run/com.apple.launchd.hxQo6EKt4v/Listeners")
+    ));
+}
+
+#[test]
+fn all_runtimes_have_warnings() {
+    for runtime in [
+        DockerRuntime::DockerDesktop,
+        DockerRuntime::OrbStack,
+        DockerRuntime::LinuxNative,
+        DockerRuntime::Colima,
+        DockerRuntime::Podman,
+        DockerRuntime::RancherDesktop,
+        DockerRuntime::Unknown,
+    ] {
+        let warning = ssh_skip_warning(&runtime);
+        assert!(
+            warning.contains("SSH agent forwarding skipped"),
+            "runtime {runtime:?} missing base warning"
+        );
+    }
+}
+
+#[test]
+fn rancher_desktop_warning_is_actionable() {
+    let warning = ssh_skip_warning(&DockerRuntime::RancherDesktop);
+    assert!(warning.contains("forwardAgent"));
+    assert!(warning.contains("override.yaml"));
+}

--- a/crates/cella-orchestrator/src/compose_up.rs
+++ b/crates/cella-orchestrator/src/compose_up.rs
@@ -935,10 +935,12 @@ async fn compose_up_with_ssh_fallback(
 
                 if let Some(ref source) = env_fwd.ssh_agent_mount_source {
                     ov_ctx.extra_volumes.retain(|m| m.source != *source);
+                    env_fwd.mounts.retain(|m| m.source != *source);
                 }
                 ov_ctx
                     .extra_env
                     .retain(|e| !e.starts_with("SSH_AUTH_SOCK="));
+                env_fwd.env.retain(|e| e.key != "SSH_AUTH_SOCK");
                 env_fwd.ssh_agent_mount_source = None;
 
                 if let Some(next) = env_fwd.ssh_agent_fallbacks.first().cloned() {

--- a/crates/cella-orchestrator/src/compose_up.rs
+++ b/crates/cella-orchestrator/src/compose_up.rs
@@ -399,56 +399,24 @@ async fn prepare_and_start(
     .await?;
 
     // 10. Resolve remote user, env forwarding, and ssh-agent proxy.
-    let (remote_user, image_user, env_fwd, ssh_agent_proxy) =
+    let (remote_user, image_user, mut env_fwd, ssh_agent_proxy) =
         resolve_user_and_env(client, ctx, project, features_build.as_ref()).await;
     info!("Resolved remote user: {remote_user} (image user: {image_user})");
 
-    // 11-12. Build extra env vars and labels for the primary service.
-    let managed = client.capabilities().managed_agent;
-    let extra_env = build_extra_env(daemon_env, &env_fwd, cfg.remote_env, managed);
-    let mut labels = build_compose_labels(cfg, project, &remote_user);
-
-    let settings = cella_config::CellaConfig::load(cfg.workspace_root, Some(cfg.resolved))?;
-    insert_mount_input_fingerprint_label(&mut labels, &settings, &env_fwd, cfg.workspace_root);
-
-    let mount_specs = build_compose_mount_specs(ComposeMountParams {
-        workspace_root: cfg.workspace_root,
-        settings: &settings,
-        remote_user: &remote_user,
-        env_fwd: &env_fwd,
-        project,
-        config,
-        resolved_features: features_build.as_ref().map(|fb| &fb.resolved_features),
-        agent_vol_target: &agent_vol_target,
-        agent_vol_name: &agent_vol_name,
-    })
-    .await?;
-
-    let ov_ctx = OverrideContext {
-        agent_vol_name,
-        agent_vol_target,
-        extra_env,
-        labels,
-        extra_volumes: mount_specs,
-    };
-
-    // 13. Build-time UID remap: build a thin image layer with correct UID/GID.
-    let uid_image = build_uid_remap_image_compose(
+    // 11-15. Build override context, UID remap, write override, and start.
+    build_override_and_start(
         ctx,
+        &compose_cmd,
         project,
         features_build.as_ref(),
+        config,
+        daemon_env,
+        &mut env_fwd,
         &remote_user,
         &image_user,
+        agent_vol_name,
+        agent_vol_target,
     )
-    .await?;
-
-    // 14. Write final override with labels, env, and UID remap image.
-    write_final_override(project, features_build.as_ref(), &ov_ctx, uid_image)?;
-
-    // 15. docker compose up -d (idempotent)
-    run_step_result(progress, "Starting compose services...", async {
-        compose_cmd.up(project.run_services.as_deref(), false).await
-    })
     .await?;
 
     let resolved_features = features_build.map(|b| b.resolved_features);
@@ -864,6 +832,148 @@ fn write_final_override(
         project.override_file.display()
     );
     Ok(())
+}
+
+/// Build the override context (env, labels, mounts), UID remap image,
+/// and start compose services with SSH fallback retry.
+#[expect(clippy::too_many_arguments)]
+async fn build_override_and_start(
+    ctx: &Ctx<'_>,
+    compose_cmd: &ComposeCommand,
+    project: &ComposeProject,
+    features_build: Option<&crate::compose_features::ComposeFeaturesBuild>,
+    config: &serde_json::Value,
+    daemon_env: Vec<String>,
+    env_fwd: &mut cella_env::EnvForwarding,
+    remote_user: &str,
+    image_user: &str,
+    agent_vol_name: String,
+    agent_vol_target: String,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let cfg = ctx.cfg;
+    let progress = ctx.progress;
+
+    let managed = ctx.client.capabilities().managed_agent;
+    let extra_env = build_extra_env(daemon_env, env_fwd, cfg.remote_env, managed);
+    let mut labels = build_compose_labels(cfg, project, remote_user);
+
+    let settings = cella_config::CellaConfig::load(cfg.workspace_root, Some(cfg.resolved))?;
+    insert_mount_input_fingerprint_label(&mut labels, &settings, env_fwd, cfg.workspace_root);
+
+    let mount_specs = build_compose_mount_specs(ComposeMountParams {
+        workspace_root: cfg.workspace_root,
+        settings: &settings,
+        remote_user,
+        env_fwd,
+        project,
+        config,
+        resolved_features: features_build.map(|fb| &fb.resolved_features),
+        agent_vol_target: &agent_vol_target,
+        agent_vol_name: &agent_vol_name,
+    })
+    .await?;
+
+    let mut ov_ctx = OverrideContext {
+        agent_vol_name,
+        agent_vol_target,
+        extra_env,
+        labels,
+        extra_volumes: mount_specs,
+    };
+
+    let uid_image =
+        build_uid_remap_image_compose(ctx, project, features_build, remote_user, image_user)
+            .await?;
+
+    compose_up_with_ssh_fallback(
+        compose_cmd,
+        project,
+        features_build,
+        &mut ov_ctx,
+        uid_image,
+        env_fwd,
+        progress,
+    )
+    .await
+}
+
+/// Write override and run `compose up`, retrying on SSH agent mount failures.
+///
+/// On failure, removes the SSH mount from `ov_ctx.extra_volumes` and
+/// `ov_ctx.extra_env`, tries the next fallback strategy, rewrites the
+/// override, and retries. If all strategies are exhausted, skips SSH
+/// forwarding with a warning.
+async fn compose_up_with_ssh_fallback(
+    compose_cmd: &ComposeCommand,
+    project: &ComposeProject,
+    features_build: Option<&crate::compose_features::ComposeFeaturesBuild>,
+    ov_ctx: &mut OverrideContext,
+    uid_image: Option<String>,
+    env_fwd: &mut cella_env::EnvForwarding,
+    progress: &ProgressSender,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    loop {
+        write_final_override(project, features_build, ov_ctx, uid_image.clone())?;
+
+        let result: Result<(), Box<dyn std::error::Error + Send + Sync>> =
+            run_step_result(progress, "Starting compose services...", async {
+                compose_cmd.up(project.run_services.as_deref(), false).await
+            })
+            .await
+            .map_err(Into::into);
+
+        match result {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                let err_msg = e.to_string();
+                if !cella_env::ssh_agent::is_ssh_mount_error(
+                    &err_msg,
+                    env_fwd.ssh_agent_mount_source.as_deref(),
+                ) {
+                    return Err(e);
+                }
+
+                if let Some(ref source) = env_fwd.ssh_agent_mount_source {
+                    ov_ctx.extra_volumes.retain(|m| m.source != *source);
+                }
+                ov_ctx
+                    .extra_env
+                    .retain(|e| !e.starts_with("SSH_AUTH_SOCK="));
+                env_fwd.ssh_agent_mount_source = None;
+
+                if let Some(next) = env_fwd.ssh_agent_fallbacks.first().cloned() {
+                    env_fwd.ssh_agent_fallbacks.remove(0);
+                    if let cella_env::ssh_agent::SshAgentRequest::Direct(ssh) = next {
+                        info!(
+                            "Compose SSH mount failed, trying fallback: {}",
+                            ssh.mount_source
+                        );
+                        env_fwd.ssh_agent_mount_source = Some(ssh.mount_source.clone());
+                        ov_ctx
+                            .extra_volumes
+                            .push(MountSpec::bind(ssh.mount_source, ssh.mount_target));
+                        ov_ctx
+                            .extra_env
+                            .push(format!("SSH_AUTH_SOCK={}", ssh.env_value));
+                        continue;
+                    }
+                }
+
+                let runtime = env_fwd
+                    .ssh_agent_runtime
+                    .as_ref()
+                    .unwrap_or(&cella_env::DockerRuntime::Unknown);
+                progress.warn(&cella_env::ssh_agent::ssh_skip_warning(runtime));
+
+                write_final_override(project, features_build, ov_ctx, uid_image)?;
+                return run_step_result(progress, "Starting compose services...", async {
+                    compose_cmd.up(project.run_services.as_deref(), false).await
+                })
+                .await
+                .map_err(Into::into);
+            }
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/cella-orchestrator/src/compose_up.rs
+++ b/crates/cella-orchestrator/src/compose_up.rs
@@ -943,19 +943,24 @@ async fn compose_up_with_ssh_fallback(
 
                 if let Some(next) = env_fwd.ssh_agent_fallbacks.first().cloned() {
                     env_fwd.ssh_agent_fallbacks.remove(0);
-                    if let cella_env::ssh_agent::SshAgentRequest::Direct(ssh) = next {
-                        info!(
-                            "Compose SSH mount failed, trying fallback: {}",
-                            ssh.mount_source
-                        );
-                        env_fwd.ssh_agent_mount_source = Some(ssh.mount_source.clone());
-                        ov_ctx
-                            .extra_volumes
-                            .push(MountSpec::bind(ssh.mount_source, ssh.mount_target));
-                        ov_ctx
-                            .extra_env
-                            .push(format!("SSH_AUTH_SOCK={}", ssh.env_value));
-                        continue;
+                    match next {
+                        cella_env::ssh_agent::SshAgentRequest::Direct(ssh) => {
+                            info!(
+                                "Compose SSH mount failed, trying fallback: {}",
+                                ssh.mount_source
+                            );
+                            env_fwd.ssh_agent_mount_source = Some(ssh.mount_source.clone());
+                            ov_ctx
+                                .extra_volumes
+                                .push(MountSpec::bind(ssh.mount_source, ssh.mount_target));
+                            ov_ctx
+                                .extra_env
+                                .push(format!("SSH_AUTH_SOCK={}", ssh.env_value));
+                            continue;
+                        }
+                        cella_env::ssh_agent::SshAgentRequest::ProxyOnColima { .. } => {
+                            debug!("Skipping ProxyOnColima fallback in retry loop");
+                        }
                     }
                 }
 

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -1319,23 +1319,28 @@ impl EnsureUpContext<'_> {
 
                     if let Some(next) = env_fwd.ssh_agent_fallbacks.first().cloned() {
                         env_fwd.ssh_agent_fallbacks.remove(0);
-                        if let cella_env::ssh_agent::SshAgentRequest::Direct(ssh) = next {
-                            info!(
-                                "SSH agent mount failed, trying fallback: {} -> {}",
-                                ssh.mount_source, ssh.mount_target
-                            );
-                            env_fwd.ssh_agent_mount_source = Some(ssh.mount_source.clone());
-                            create_opts.mounts.push(MountConfig {
-                                mount_type: "bind".to_string(),
-                                source: ssh.mount_source,
-                                target: ssh.mount_target.clone(),
-                                consistency: None,
-                                read_only: false,
-                            });
-                            create_opts
-                                .env
-                                .push(format!("SSH_AUTH_SOCK={}", ssh.env_value));
-                            continue;
+                        match next {
+                            cella_env::ssh_agent::SshAgentRequest::Direct(ssh) => {
+                                info!(
+                                    "SSH agent mount failed, trying fallback: {} -> {}",
+                                    ssh.mount_source, ssh.mount_target
+                                );
+                                env_fwd.ssh_agent_mount_source = Some(ssh.mount_source.clone());
+                                create_opts.mounts.push(MountConfig {
+                                    mount_type: "bind".to_string(),
+                                    source: ssh.mount_source,
+                                    target: ssh.mount_target.clone(),
+                                    consistency: None,
+                                    read_only: false,
+                                });
+                                create_opts
+                                    .env
+                                    .push(format!("SSH_AUTH_SOCK={}", ssh.env_value));
+                                continue;
+                            }
+                            cella_env::ssh_agent::SshAgentRequest::ProxyOnColima { .. } => {
+                                debug!("Skipping ProxyOnColima fallback in retry loop");
+                            }
                         }
                     }
 

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -124,6 +124,18 @@ struct CreateResult {
     ssh_agent_proxy: Option<crate::result::SshAgentProxyStatus>,
 }
 
+/// Remove the current SSH agent mount and env var from container create options.
+fn remove_ssh_from_create_opts(
+    create_opts: &mut cella_backend::CreateContainerOptions,
+    env_fwd: &mut cella_env::EnvForwarding,
+) {
+    if let Some(ref source) = env_fwd.ssh_agent_mount_source {
+        create_opts.mounts.retain(|m| m.source != *source);
+    }
+    create_opts.env.retain(|e| !e.starts_with("SSH_AUTH_SOCK="));
+    env_fwd.ssh_agent_mount_source = None;
+}
+
 async fn run_step_result<F, T, E>(progress: &ProgressSender, label: &str, future: F) -> Result<T, E>
 where
     F: Future<Output = Result<T, E>>,
@@ -1284,6 +1296,61 @@ impl EnsureUpContext<'_> {
         }
     }
 
+    /// Try creating the container. If it fails with an SSH agent bind-mount
+    /// error, try fallback strategies, then skip SSH forwarding entirely.
+    async fn create_container_with_ssh_fallback(
+        &self,
+        create_opts: &mut cella_backend::CreateContainerOptions,
+        env_fwd: &mut cella_env::EnvForwarding,
+    ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+        loop {
+            match self.create_container(create_opts).await {
+                Ok(id) => return Ok(id),
+                Err(e) => {
+                    let err_msg = e.to_string();
+                    if !cella_env::ssh_agent::is_ssh_mount_error(
+                        &err_msg,
+                        env_fwd.ssh_agent_mount_source.as_deref(),
+                    ) {
+                        return Err(e);
+                    }
+
+                    remove_ssh_from_create_opts(create_opts, env_fwd);
+
+                    if let Some(next) = env_fwd.ssh_agent_fallbacks.first().cloned() {
+                        env_fwd.ssh_agent_fallbacks.remove(0);
+                        if let cella_env::ssh_agent::SshAgentRequest::Direct(ssh) = next {
+                            info!(
+                                "SSH agent mount failed, trying fallback: {} -> {}",
+                                ssh.mount_source, ssh.mount_target
+                            );
+                            env_fwd.ssh_agent_mount_source = Some(ssh.mount_source.clone());
+                            create_opts.mounts.push(MountConfig {
+                                mount_type: "bind".to_string(),
+                                source: ssh.mount_source,
+                                target: ssh.mount_target.clone(),
+                                consistency: None,
+                                read_only: false,
+                            });
+                            create_opts
+                                .env
+                                .push(format!("SSH_AUTH_SOCK={}", ssh.env_value));
+                            continue;
+                        }
+                    }
+
+                    let runtime = env_fwd
+                        .ssh_agent_runtime
+                        .as_ref()
+                        .unwrap_or(&cella_env::DockerRuntime::Unknown);
+                    self.progress
+                        .warn(&cella_env::ssh_agent::ssh_skip_warning(runtime));
+                    return self.create_container(create_opts).await;
+                }
+            }
+        }
+    }
+
     /// Build a UID-remapped image and update `create_opts.image` if needed.
     async fn maybe_remap_uid(
         &self,
@@ -1382,7 +1449,9 @@ impl EnsureUpContext<'_> {
         )
         .await?;
 
-        let container_id = self.create_container(&create_opts).await?;
+        let container_id = self
+            .create_container_with_ssh_fallback(&mut create_opts, &mut env_fwd)
+            .await?;
 
         self.start_and_notify(&container_id).await?;
 

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -124,15 +124,27 @@ struct CreateResult {
     ssh_agent_proxy: Option<crate::result::SshAgentProxyStatus>,
 }
 
-/// Remove the current SSH agent mount and env var from container create options.
+/// Remove the current SSH agent mount, env var, and label entry from
+/// container create options. Also clears `env_fwd` so downstream label
+/// readers (`cella exec`, `cella shell`) don't inject a stale socket path.
 fn remove_ssh_from_create_opts(
     create_opts: &mut cella_backend::CreateContainerOptions,
     env_fwd: &mut cella_env::EnvForwarding,
 ) {
     if let Some(ref source) = env_fwd.ssh_agent_mount_source {
         create_opts.mounts.retain(|m| m.source != *source);
+        env_fwd.mounts.retain(|m| m.source != *source);
     }
     create_opts.env.retain(|e| !e.starts_with("SSH_AUTH_SOCK="));
+    env_fwd.env.retain(|e| e.key != "SSH_AUTH_SOCK");
+
+    if let Some(label) = create_opts.labels.get_mut("dev.cella.remote_env")
+        && let Ok(mut entries) = serde_json::from_str::<Vec<String>>(label)
+    {
+        entries.retain(|e| !e.starts_with("SSH_AUTH_SOCK="));
+        *label = serde_json::to_string(&entries).unwrap_or_default();
+    }
+
     env_fwd.ssh_agent_mount_source = None;
 }
 


### PR DESCRIPTION
## Summary

- `ssh_agent_request()` now returns an ordered list of strategies per runtime instead of a single option — VM-based runtimes (Rancher Desktop, Podman, Unknown) try the magic `/run/host-services/ssh-auth.sock` first, then fall back to direct host socket mount
- Both `up.rs` and `compose_up.rs` retry container creation when the SSH agent bind-mount fails, trying each fallback strategy before skipping SSH forwarding with an actionable runtime-specific warning
- `cella doctor` no longer misclassifies macOS `com.apple.launchd` SSH socket paths as "Docker Desktop VM"

Fixes #67

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings -D clippy::all`
- [x] `cargo test --workspace` — all pass
- [x] Integration tests for error detection and warning messages
- [ ] Manual: `cella up` on Rancher Desktop macOS with Lima `ssh.forwardAgent` enabled
- [ ] Manual: `SSH_AUTH_SOCK=/nonexistent/path cella up` warns but doesn't crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)