### PR TITLE
feat: mount CLI flags for up command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,6 +627,7 @@ dependencies = [
  "cella-tool-install",
  "miette",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/cella-backend/src/mount.rs
+++ b/crates/cella-backend/src/mount.rs
@@ -94,6 +94,7 @@ impl MountSpec {
             target: self.target.clone(),
             consistency: self.consistency.clone(),
             read_only: self.read_only,
+            external: false,
         }
     }
 
@@ -203,6 +204,7 @@ mod tests {
             target: "/b".into(),
             consistency: Some("cached".into()),
             read_only: false,
+            external: false,
         };
         let spec = MountSpec::from_mount_config(&mc).unwrap();
         assert_eq!(spec.kind, MountKind::Bind);
@@ -219,6 +221,7 @@ mod tests {
             target: "/data".into(),
             consistency: None,
             read_only: false,
+            external: false,
         };
         assert!(
             MountSpec::from_mount_config(&mc).is_none(),
@@ -234,6 +237,7 @@ mod tests {
             target: r"//./pipe/docker_engine".into(),
             consistency: None,
             read_only: false,
+            external: false,
         };
         let spec = MountSpec::from_mount_config(&mc).unwrap();
         assert_eq!(spec.kind, MountKind::NamedPipe);

--- a/crates/cella-backend/src/types.rs
+++ b/crates/cella-backend/src/types.rs
@@ -202,6 +202,8 @@ pub struct MountConfig {
     /// `Mount` struct — wiring read-only into the single-container path is
     /// deferred to a follow-up phase.
     pub read_only: bool,
+    /// Whether the volume already exists externally (don't auto-create).
+    pub external: bool,
 }
 
 /// Backend-agnostic port forward specification.

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -73,6 +73,24 @@ pub enum StrictnessLevel {
     All,
 }
 
+/// Mount consistency mode for workspace mounts.
+#[derive(Clone, Debug, ValueEnum)]
+pub enum MountConsistency {
+    Consistent,
+    Cached,
+    Delegated,
+}
+
+impl MountConsistency {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Consistent => "consistent",
+            Self::Cached => "cached",
+            Self::Delegated => "delegated",
+        }
+    }
+}
+
 /// Pull policy for Docker Compose services.
 #[derive(Clone, ValueEnum)]
 pub enum ComposePullPolicy {

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -38,6 +38,28 @@ pub struct UpBuildArgs {
     pub(crate) secrets: Vec<String>,
 }
 
+/// Mount-related flags for an `up` invocation.
+#[derive(Args)]
+pub struct UpMountArgs {
+    /// Additional mount point(s).
+    /// Format: type=<bind|volume>,source=<source>,target=<target>[,external=<true|false>]
+    #[arg(long = "mount")]
+    pub(crate) mount: Vec<String>,
+
+    /// Workspace mount consistency (ignored on Linux).
+    #[arg(long, value_enum, default_value = "cached")]
+    pub(crate) workspace_mount_consistency: MountConsistency,
+
+    /// Mount the workspace using its Git root (default: true).
+    #[arg(long, action = clap::ArgAction::Set, default_value_t = true)]
+    pub(crate) mount_workspace_git_root: bool,
+
+    /// Mount the Git worktree common dir for Git operations in the container.
+    /// Requires the worktree to be created with relative paths.
+    #[arg(long)]
+    pub(crate) mount_git_worktree_common_dir: bool,
+}
+
 /// Start a dev container for the current workspace.
 #[derive(Args)]
 pub struct UpArgs {
@@ -90,18 +112,8 @@ pub struct UpArgs {
     #[arg(long = "pull-policy", value_enum)]
     pub(crate) pull_policy: Option<ComposePullPolicy>,
 
-    /// Additional mount point(s).
-    /// Format: type=<bind|volume>,source=<source>,target=<target>[,external=<true|false>]
-    #[arg(long = "mount")]
-    pub(crate) mount: Vec<String>,
-
-    /// Workspace mount consistency (ignored on Linux).
-    #[arg(long, value_enum, default_value = "cached")]
-    pub(crate) workspace_mount_consistency: MountConsistency,
-
-    /// Mount the workspace using its Git root (default: true).
-    #[arg(long, action = clap::ArgAction::Set, default_value_t = true)]
-    pub(crate) mount_workspace_git_root: bool,
+    #[command(flatten)]
+    pub(crate) mounts: UpMountArgs,
 }
 
 impl UpArgs {
@@ -185,6 +197,14 @@ fn parse_cli_mount(s: &str) -> Result<MountConfig, String> {
 
 use cella_orchestrator::NetworkRulePolicy;
 
+/// Resolved mount configuration for an `up` invocation.
+struct ResolvedMountConfig {
+    additional_cli_mounts: Vec<MountConfig>,
+    workspace_mount_consistency: Option<String>,
+    mount_workspace_git_root: bool,
+    mount_git_worktree_common_dir: bool,
+}
+
 /// Holds resolved state for an `up` invocation, shared across all code paths.
 pub struct UpContext {
     pub(crate) resolved: ResolvedConfig,
@@ -216,12 +236,7 @@ pub struct UpContext {
     build_secrets: Vec<BuildSecret>,
     /// Extra Docker networks to connect after container start (before lifecycle hooks).
     pub(crate) extra_networks: Vec<String>,
-    /// Additional CLI-specified mounts (`--mount` flag).
-    additional_cli_mounts: Vec<MountConfig>,
-    /// Workspace mount consistency mode.
-    workspace_mount_consistency: Option<String>,
-    /// Whether to mount the git root instead of the workspace folder.
-    mount_workspace_git_root: bool,
+    mount_config: ResolvedMountConfig,
 }
 
 impl UpContext {
@@ -274,6 +289,7 @@ impl UpContext {
         let cella_cfg = cella_config::CellaConfig::load(&resolved.workspace_root, Some(&resolved))?;
 
         let additional_cli_mounts = args
+            .mounts
             .mount
             .iter()
             .map(|s| parse_cli_mount(s))
@@ -310,11 +326,14 @@ impl UpContext {
             compose_pull_policy: args.pull_policy.as_ref().map(|p| p.as_str().to_string()),
             build_secrets,
             extra_networks: Vec::new(),
-            additional_cli_mounts,
-            workspace_mount_consistency: Some(
-                args.workspace_mount_consistency.as_str().to_string(),
-            ),
-            mount_workspace_git_root: args.mount_workspace_git_root,
+            mount_config: ResolvedMountConfig {
+                additional_cli_mounts,
+                workspace_mount_consistency: Some(
+                    args.mounts.workspace_mount_consistency.as_str().to_string(),
+                ),
+                mount_workspace_git_root: args.mounts.mount_workspace_git_root,
+                mount_git_worktree_common_dir: args.mounts.mount_git_worktree_common_dir,
+            },
         })
     }
 
@@ -383,9 +402,12 @@ impl UpContext {
             compose_pull_policy: None,
             build_secrets: vec![],
             extra_networks: Vec::new(),
-            additional_cli_mounts: Vec::new(),
-            workspace_mount_consistency: None,
-            mount_workspace_git_root: true,
+            mount_config: ResolvedMountConfig {
+                additional_cli_mounts: Vec::new(),
+                workspace_mount_consistency: None,
+                mount_workspace_git_root: true,
+                mount_git_worktree_common_dir: false,
+            },
         })
     }
 
@@ -772,9 +794,15 @@ impl UpContext {
             pull_policy: self.pull_policy.as_deref(),
             build_secrets: self.build_secrets.clone(),
             extra_networks: self.extra_networks.clone(),
-            additional_cli_mounts: &self.additional_cli_mounts,
-            workspace_mount_consistency: self.workspace_mount_consistency.as_deref(),
-            mount_workspace_git_root: self.mount_workspace_git_root,
+            mount_flags: cella_orchestrator::MountFlags {
+                additional_cli_mounts: &self.mount_config.additional_cli_mounts,
+                workspace_mount_consistency: self
+                    .mount_config
+                    .workspace_mount_consistency
+                    .as_deref(),
+                mount_workspace_git_root: self.mount_config.mount_workspace_git_root,
+                mount_git_worktree_common_dir: self.mount_config.mount_git_worktree_common_dir,
+            },
         };
 
         let result =
@@ -1228,7 +1256,7 @@ mod tests {
         ])
         .unwrap();
         if let crate::commands::Command::Up(args) = &cli.command {
-            assert_eq!(args.mount.len(), 2);
+            assert_eq!(args.mounts.mount.len(), 2);
         }
     }
 

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -98,6 +98,10 @@ pub struct UpArgs {
     /// Workspace mount consistency (ignored on Linux).
     #[arg(long, value_enum, default_value = "cached")]
     pub(crate) workspace_mount_consistency: MountConsistency,
+
+    /// Mount the workspace using its Git root (default: true).
+    #[arg(long, action = clap::ArgAction::Set, default_value_t = true)]
+    pub(crate) mount_workspace_git_root: bool,
 }
 
 impl UpArgs {
@@ -216,6 +220,8 @@ pub struct UpContext {
     additional_cli_mounts: Vec<MountConfig>,
     /// Workspace mount consistency mode.
     workspace_mount_consistency: Option<String>,
+    /// Whether to mount the git root instead of the workspace folder.
+    mount_workspace_git_root: bool,
 }
 
 impl UpContext {
@@ -308,6 +314,7 @@ impl UpContext {
             workspace_mount_consistency: Some(
                 args.workspace_mount_consistency.as_str().to_string(),
             ),
+            mount_workspace_git_root: args.mount_workspace_git_root,
         })
     }
 
@@ -378,6 +385,7 @@ impl UpContext {
             extra_networks: Vec::new(),
             additional_cli_mounts: Vec::new(),
             workspace_mount_consistency: None,
+            mount_workspace_git_root: true,
         })
     }
 
@@ -766,6 +774,7 @@ impl UpContext {
             extra_networks: self.extra_networks.clone(),
             additional_cli_mounts: &self.additional_cli_mounts,
             workspace_mount_consistency: self.workspace_mount_consistency.as_deref(),
+            mount_workspace_git_root: self.mount_workspace_git_root,
         };
 
         let result =

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -195,6 +195,27 @@ fn parse_cli_mount(s: &str) -> Result<MountConfig, String> {
     })
 }
 
+fn compute_default_workspace_folder(
+    workspace_root: &std::path::Path,
+    host_mount_folder: &std::path::Path,
+) -> String {
+    let mount_basename = host_mount_folder.file_name().map_or_else(
+        || "workspace".to_string(),
+        |n| n.to_string_lossy().to_string(),
+    );
+    let container_mount_folder = format!("/workspaces/{mount_basename}");
+    if host_mount_folder == workspace_root {
+        return container_mount_folder;
+    }
+    if let Ok(rel) = workspace_root.strip_prefix(host_mount_folder) {
+        let rel_posix = rel.to_string_lossy().replace('\\', "/");
+        if !rel_posix.is_empty() {
+            return format!("{container_mount_folder}/{rel_posix}");
+        }
+    }
+    container_mount_folder
+}
+
 use cella_orchestrator::NetworkRulePolicy;
 
 /// Resolved mount configuration for an `up` invocation.
@@ -272,11 +293,12 @@ impl UpContext {
             .get("workspaceFolder")
             .and_then(|v| v.as_str())
             .map(String::from);
-        let workspace_basename = resolved.workspace_root.file_name().map_or_else(
-            || "workspace".to_string(),
-            |n| n.to_string_lossy().to_string(),
+        let host_mount_folder = cella_git::find_git_root_folder(
+            &resolved.workspace_root,
+            args.mounts.mount_workspace_git_root,
         );
-        let default_workspace_folder = format!("/workspaces/{workspace_basename}");
+        let default_workspace_folder =
+            compute_default_workspace_folder(&resolved.workspace_root, &host_mount_folder);
 
         let build_secrets = args
             .build
@@ -375,11 +397,9 @@ impl UpContext {
             .get("workspaceFolder")
             .and_then(|v| v.as_str())
             .map(String::from);
-        let workspace_basename = resolved.workspace_root.file_name().map_or_else(
-            || "workspace".to_string(),
-            |n| n.to_string_lossy().to_string(),
-        );
-        let default_workspace_folder = format!("/workspaces/{workspace_basename}");
+        let host_mount_folder = cella_git::find_git_root_folder(&resolved.workspace_root, true);
+        let default_workspace_folder =
+            compute_default_workspace_folder(&resolved.workspace_root, &host_mount_folder);
 
         Ok(Self {
             resolved,

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -8,7 +8,7 @@ use tracing::{debug, warn};
 
 use super::{ComposePullPolicy, ImagePullPolicy, OutputFormat, StrictnessLevel};
 
-use cella_backend::{BuildSecret, ContainerBackend, ExecOptions, container_name};
+use cella_backend::{BuildSecret, ContainerBackend, ExecOptions, MountConfig, container_name};
 use cella_config::devcontainer::resolve::{self, ResolvedConfig};
 use cella_orchestrator::env_cache::probe_and_cache_user_env;
 use cella_orchestrator::shell_detect::detect_shell;
@@ -89,12 +89,90 @@ pub struct UpArgs {
     /// Pull policy for Docker Compose services.
     #[arg(long = "pull-policy", value_enum)]
     pub(crate) pull_policy: Option<ComposePullPolicy>,
+
+    /// Additional mount point(s).
+    /// Format: type=<bind|volume>,source=<source>,target=<target>[,external=<true|false>]
+    #[arg(long = "mount")]
+    pub(crate) mount: Vec<String>,
 }
 
 impl UpArgs {
     pub const fn is_text_output(&self) -> bool {
         matches!(self.output, OutputFormat::Text)
     }
+}
+
+fn parse_cli_mount(s: &str) -> Result<MountConfig, String> {
+    let mut mount_type = None;
+    let mut source = None;
+    let mut target = None;
+    let mut external = false;
+
+    for part in s.split(',') {
+        if let Some((key, value)) = part.split_once('=') {
+            match key {
+                "type" => {
+                    if value != "bind" && value != "volume" {
+                        return Err(format!(
+                            "invalid mount type '{value}': expected 'bind' or 'volume'\n\
+                             Expected: type=<bind|volume>,source=<source>,target=<target>[,external=<true|false>]"
+                        ));
+                    }
+                    mount_type = Some(value.to_string());
+                }
+                "source" | "src" => source = Some(value.to_string()),
+                "target" | "dst" | "destination" => target = Some(value.to_string()),
+                "external" => match value {
+                    "true" => external = true,
+                    "false" => {}
+                    _ => {
+                        return Err(format!(
+                            "invalid external value '{value}': expected 'true' or 'false'"
+                        ));
+                    }
+                },
+                _ => {
+                    return Err(format!(
+                        "unknown mount key '{key}'\n\
+                         Expected: type=<bind|volume>,source=<source>,target=<target>[,external=<true|false>]"
+                    ));
+                }
+            }
+        } else {
+            return Err(format!(
+                "invalid mount format: {s}\n\
+                 Expected: type=<bind|volume>,source=<source>,target=<target>[,external=<true|false>]"
+            ));
+        }
+    }
+
+    let Some(mount_type) = mount_type else {
+        return Err(format!(
+            "missing 'type' in mount: {s}\n\
+             Expected: type=<bind|volume>,source=<source>,target=<target>[,external=<true|false>]"
+        ));
+    };
+    let Some(source) = source else {
+        return Err(format!(
+            "missing 'source' in mount: {s}\n\
+             Expected: type=<bind|volume>,source=<source>,target=<target>[,external=<true|false>]"
+        ));
+    };
+    let Some(target) = target else {
+        return Err(format!(
+            "missing 'target' in mount: {s}\n\
+             Expected: type=<bind|volume>,source=<source>,target=<target>[,external=<true|false>]"
+        ));
+    };
+
+    Ok(MountConfig {
+        mount_type,
+        source,
+        target,
+        consistency: None,
+        read_only: false,
+        external,
+    })
 }
 
 use cella_orchestrator::NetworkRulePolicy;
@@ -130,6 +208,8 @@ pub struct UpContext {
     build_secrets: Vec<BuildSecret>,
     /// Extra Docker networks to connect after container start (before lifecycle hooks).
     pub(crate) extra_networks: Vec<String>,
+    /// Additional CLI-specified mounts (`--mount` flag).
+    additional_cli_mounts: Vec<MountConfig>,
 }
 
 impl UpContext {
@@ -181,6 +261,13 @@ impl UpContext {
 
         let cella_cfg = cella_config::CellaConfig::load(&resolved.workspace_root, Some(&resolved))?;
 
+        let additional_cli_mounts = args
+            .mount
+            .iter()
+            .map(|s| parse_cli_mount(s))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })?;
+
         Ok(Self {
             resolved,
             client,
@@ -211,6 +298,7 @@ impl UpContext {
             compose_pull_policy: args.pull_policy.as_ref().map(|p| p.as_str().to_string()),
             build_secrets,
             extra_networks: Vec::new(),
+            additional_cli_mounts,
         })
     }
 
@@ -279,6 +367,7 @@ impl UpContext {
             compose_pull_policy: None,
             build_secrets: vec![],
             extra_networks: Vec::new(),
+            additional_cli_mounts: Vec::new(),
         })
     }
 
@@ -665,6 +754,7 @@ impl UpContext {
             pull_policy: self.pull_policy.as_deref(),
             build_secrets: self.build_secrets.clone(),
             extra_networks: self.extra_networks.clone(),
+            additional_cli_mounts: &self.additional_cli_mounts,
         };
 
         let result =
@@ -1046,6 +1136,81 @@ pub async fn write_daemon_addr_to_volume(client: &dyn ContainerBackend) -> bool 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── parse_cli_mount ────────────────────────────────────────────
+
+    #[test]
+    fn parse_cli_mount_bind() {
+        let m = parse_cli_mount("type=bind,source=/host,target=/container").unwrap();
+        assert_eq!(m.mount_type, "bind");
+        assert_eq!(m.source, "/host");
+        assert_eq!(m.target, "/container");
+        assert!(!m.external);
+    }
+
+    #[test]
+    fn parse_cli_mount_volume() {
+        let m = parse_cli_mount("type=volume,source=mydata,target=/data").unwrap();
+        assert_eq!(m.mount_type, "volume");
+        assert_eq!(m.source, "mydata");
+        assert_eq!(m.target, "/data");
+    }
+
+    #[test]
+    fn parse_cli_mount_with_external_true() {
+        let m = parse_cli_mount("type=volume,source=ext-vol,target=/ext,external=true").unwrap();
+        assert!(m.external);
+    }
+
+    #[test]
+    fn parse_cli_mount_with_external_false() {
+        let m = parse_cli_mount("type=volume,source=vol,target=/vol,external=false").unwrap();
+        assert!(!m.external);
+    }
+
+    #[test]
+    fn parse_cli_mount_missing_type() {
+        assert!(parse_cli_mount("source=/a,target=/b").is_err());
+    }
+
+    #[test]
+    fn parse_cli_mount_missing_source() {
+        assert!(parse_cli_mount("type=bind,target=/b").is_err());
+    }
+
+    #[test]
+    fn parse_cli_mount_missing_target() {
+        assert!(parse_cli_mount("type=bind,source=/a").is_err());
+    }
+
+    #[test]
+    fn parse_cli_mount_invalid_type() {
+        let err = parse_cli_mount("type=tmpfs,source=/a,target=/b").unwrap_err();
+        assert!(err.contains("invalid mount type"));
+    }
+
+    #[test]
+    fn parse_cli_mount_invalid_format() {
+        let err = parse_cli_mount("garbage").unwrap_err();
+        assert!(err.contains("invalid mount format"));
+    }
+
+    #[test]
+    fn parse_cli_mount_clap_flag() {
+        use clap::Parser;
+        let cli = crate::Cli::try_parse_from([
+            "cella",
+            "up",
+            "--mount",
+            "type=bind,source=/a,target=/b",
+            "--mount",
+            "type=volume,source=vol,target=/c",
+        ])
+        .unwrap();
+        if let crate::commands::Command::Up(args) = &cli.command {
+            assert_eq!(args.mount.len(), 2);
+        }
+    }
 
     // ── map_env_object ─────────────────────────────────────────────
 

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -6,7 +6,7 @@ use clap::Args;
 use serde_json::json;
 use tracing::{debug, warn};
 
-use super::{ComposePullPolicy, ImagePullPolicy, OutputFormat, StrictnessLevel};
+use super::{ComposePullPolicy, ImagePullPolicy, MountConsistency, OutputFormat, StrictnessLevel};
 
 use cella_backend::{BuildSecret, ContainerBackend, ExecOptions, MountConfig, container_name};
 use cella_config::devcontainer::resolve::{self, ResolvedConfig};
@@ -94,6 +94,10 @@ pub struct UpArgs {
     /// Format: type=<bind|volume>,source=<source>,target=<target>[,external=<true|false>]
     #[arg(long = "mount")]
     pub(crate) mount: Vec<String>,
+
+    /// Workspace mount consistency (ignored on Linux).
+    #[arg(long, value_enum, default_value = "cached")]
+    pub(crate) workspace_mount_consistency: MountConsistency,
 }
 
 impl UpArgs {
@@ -210,6 +214,8 @@ pub struct UpContext {
     pub(crate) extra_networks: Vec<String>,
     /// Additional CLI-specified mounts (`--mount` flag).
     additional_cli_mounts: Vec<MountConfig>,
+    /// Workspace mount consistency mode.
+    workspace_mount_consistency: Option<String>,
 }
 
 impl UpContext {
@@ -299,6 +305,9 @@ impl UpContext {
             build_secrets,
             extra_networks: Vec::new(),
             additional_cli_mounts,
+            workspace_mount_consistency: Some(
+                args.workspace_mount_consistency.as_str().to_string(),
+            ),
         })
     }
 
@@ -368,6 +377,7 @@ impl UpContext {
             build_secrets: vec![],
             extra_networks: Vec::new(),
             additional_cli_mounts: Vec::new(),
+            workspace_mount_consistency: None,
         })
     }
 
@@ -755,6 +765,7 @@ impl UpContext {
             build_secrets: self.build_secrets.clone(),
             extra_networks: self.extra_networks.clone(),
             additional_cli_mounts: &self.additional_cli_mounts,
+            workspace_mount_consistency: self.workspace_mount_consistency.as_deref(),
         };
 
         let result =

--- a/crates/cella-compose/src/mount_parity.rs
+++ b/crates/cella-compose/src/mount_parity.rs
@@ -1280,7 +1280,7 @@ mod tests {
             target: "/c".to_string(),
             consistency: None,
             read_only: false,
-        external: false,
+            external: false,
         }];
         let specs = mount_configs_to_specs(&configs);
         assert_eq!(specs.len(), 1);
@@ -1297,7 +1297,7 @@ mod tests {
             target: "/container/data".to_string(),
             consistency: None,
             read_only: true,
-        external: false,
+            external: false,
         };
         let spec = MountSpec::from_mount_config(&config).unwrap();
         assert!(

--- a/crates/cella-compose/src/mount_parity.rs
+++ b/crates/cella-compose/src/mount_parity.rs
@@ -1280,6 +1280,7 @@ mod tests {
             target: "/c".to_string(),
             consistency: None,
             read_only: false,
+        external: false,
         }];
         let specs = mount_configs_to_specs(&configs);
         assert_eq!(specs.len(), 1);
@@ -1296,6 +1297,7 @@ mod tests {
             target: "/container/data".to_string(),
             consistency: None,
             read_only: true,
+        external: false,
         };
         let spec = MountSpec::from_mount_config(&config).unwrap();
         assert!(

--- a/crates/cella-config/src/config_map/mod.rs
+++ b/crates/cella-config/src/config_map/mod.rs
@@ -25,6 +25,8 @@ pub struct MapConfigParams<'a, S: std::hash::BuildHasher> {
     pub image_name: &'a str,
     pub labels: HashMap<String, String, S>,
     pub workspace_root: &'a Path,
+    /// The host directory to mount (git root or workspace root).
+    pub host_mount_folder: &'a Path,
     pub feature_config: Option<&'a FeatureContainerConfig>,
     pub image_env: &'a [String],
     pub agent_arch: &'a str,
@@ -44,25 +46,44 @@ pub fn map_config<S: std::hash::BuildHasher>(
         image_name,
         labels,
         workspace_root,
+        host_mount_folder,
         feature_config,
         image_env,
         agent_arch,
         workspace_mount_consistency,
     } = params;
-    let workspace_basename = workspace_root.file_name().map_or_else(
+
+    let mount_basename = host_mount_folder.file_name().map_or_else(
         || "workspace".to_string(),
         |n| n.to_string_lossy().to_string(),
     );
+    let container_mount_folder = format!("/workspaces/{mount_basename}");
 
     let workspace_folder = config
         .get("workspaceFolder")
         .and_then(|v| v.as_str())
-        .map_or_else(|| format!("/workspaces/{workspace_basename}"), String::from);
+        .map_or_else(
+            || {
+                if host_mount_folder == workspace_root {
+                    container_mount_folder.clone()
+                } else if let Ok(rel) = workspace_root.strip_prefix(host_mount_folder) {
+                    let rel_posix = rel.to_string_lossy().replace('\\', "/");
+                    if rel_posix.is_empty() {
+                        container_mount_folder.clone()
+                    } else {
+                        format!("{container_mount_folder}/{rel_posix}")
+                    }
+                } else {
+                    container_mount_folder.clone()
+                }
+            },
+            String::from,
+        );
 
     let workspace_mount = map_workspace_mount(
         config,
-        workspace_root,
-        &workspace_folder,
+        host_mount_folder,
+        &container_mount_folder,
         workspace_mount_consistency,
     );
     let mounts = map_merged_mounts(config, feature_config);
@@ -316,6 +337,7 @@ mod tests {
             image_name: "ubuntu",
             labels: HashMap::new(),
             workspace_root: Path::new("/tmp/test"),
+            host_mount_folder: Path::new("/tmp/test"),
             feature_config,
             image_env,
             agent_arch: "x86_64",
@@ -336,6 +358,7 @@ mod tests {
             image_name: "ubuntu",
             labels: HashMap::new(),
             workspace_root: Path::new("/tmp/my-project"),
+            host_mount_folder: Path::new("/tmp/my-project"),
             feature_config: None,
             image_env: &[],
             agent_arch: "x86_64",
@@ -359,6 +382,7 @@ mod tests {
             image_name: "ubuntu",
             labels: HashMap::new(),
             workspace_root: Path::new("/tmp/my-project"),
+            host_mount_folder: Path::new("/tmp/my-project"),
             feature_config: None,
             image_env: &[],
             agent_arch: "x86_64",
@@ -468,6 +492,7 @@ mod tests {
             image_name: "ubuntu",
             labels: HashMap::new(),
             workspace_root: Path::new("/tmp/my-project"),
+            host_mount_folder: Path::new("/tmp/my-project"),
             feature_config: None,
             image_env: &[],
             agent_arch: "x86_64",
@@ -758,6 +783,7 @@ mod tests {
             image_name: "ubuntu",
             labels: HashMap::new(),
             workspace_root: Path::new("/home/user/myproject"),
+            host_mount_folder: Path::new("/home/user/myproject"),
             feature_config: Some(&substituted),
             image_env: &[],
             agent_arch: "x86_64",

--- a/crates/cella-config/src/config_map/mod.rs
+++ b/crates/cella-config/src/config_map/mod.rs
@@ -797,4 +797,71 @@ mod tests {
         );
         assert_eq!(opts.mounts[0].target, "/var/lib/docker");
     }
+
+    // ── host_mount_folder / git root ──────────────────────────────
+
+    #[test]
+    fn map_config_git_root_same_as_workspace() {
+        let config = json!({"image": "ubuntu"});
+        let opts = map_config(MapConfigParams {
+            config: &config,
+            container_name: "test",
+            image_name: "ubuntu",
+            labels: HashMap::new(),
+            workspace_root: Path::new("/home/user/project"),
+            host_mount_folder: Path::new("/home/user/project"),
+            feature_config: None,
+            image_env: &[],
+            agent_arch: "x86_64",
+            workspace_mount_consistency: None,
+        });
+        assert_eq!(opts.workspace_folder, "/workspaces/project");
+    }
+
+    #[test]
+    fn map_config_git_root_is_parent_monorepo() {
+        let config = json!({"image": "ubuntu"});
+        let opts = map_config(MapConfigParams {
+            config: &config,
+            container_name: "test",
+            image_name: "ubuntu",
+            labels: HashMap::new(),
+            workspace_root: Path::new("/home/user/monorepo/packages/app"),
+            host_mount_folder: Path::new("/home/user/monorepo"),
+            feature_config: None,
+            image_env: &[],
+            agent_arch: "x86_64",
+            workspace_mount_consistency: None,
+        });
+        assert_eq!(opts.workspace_folder, "/workspaces/monorepo/packages/app");
+        let ws_mount = opts.workspace_mount.unwrap();
+        assert!(
+            ws_mount.source.ends_with("monorepo"),
+            "mount source should be the git root"
+        );
+    }
+
+    #[test]
+    fn map_config_explicit_workspace_folder_overrides_git_root() {
+        let config = json!({
+            "image": "ubuntu",
+            "workspaceFolder": "/custom/path"
+        });
+        let opts = map_config(MapConfigParams {
+            config: &config,
+            container_name: "test",
+            image_name: "ubuntu",
+            labels: HashMap::new(),
+            workspace_root: Path::new("/home/user/monorepo/packages/app"),
+            host_mount_folder: Path::new("/home/user/monorepo"),
+            feature_config: None,
+            image_env: &[],
+            agent_arch: "x86_64",
+            workspace_mount_consistency: None,
+        });
+        assert_eq!(
+            opts.workspace_folder, "/custom/path",
+            "explicit workspaceFolder must override git root computation"
+        );
+    }
 }

--- a/crates/cella-config/src/config_map/mod.rs
+++ b/crates/cella-config/src/config_map/mod.rs
@@ -28,6 +28,10 @@ pub struct MapConfigParams<'a, S: std::hash::BuildHasher> {
     pub feature_config: Option<&'a FeatureContainerConfig>,
     pub image_env: &'a [String],
     pub agent_arch: &'a str,
+    /// Workspace mount consistency mode (e.g. "cached", "delegated").
+    /// `None` means use the default ("cached"), except on Linux where
+    /// consistency is always omitted.
+    pub workspace_mount_consistency: Option<&'a str>,
 }
 
 /// Map a resolved devcontainer config to container creation options.
@@ -43,6 +47,7 @@ pub fn map_config<S: std::hash::BuildHasher>(
         feature_config,
         image_env,
         agent_arch,
+        workspace_mount_consistency,
     } = params;
     let workspace_basename = workspace_root.file_name().map_or_else(
         || "workspace".to_string(),
@@ -54,7 +59,12 @@ pub fn map_config<S: std::hash::BuildHasher>(
         .and_then(|v| v.as_str())
         .map_or_else(|| format!("/workspaces/{workspace_basename}"), String::from);
 
-    let workspace_mount = map_workspace_mount(config, workspace_root, &workspace_folder);
+    let workspace_mount = map_workspace_mount(
+        config,
+        workspace_root,
+        &workspace_folder,
+        workspace_mount_consistency,
+    );
     let mounts = map_merged_mounts(config, feature_config);
     let env = map_merged_env(config, image_env);
     let remote_env = map_remote_env(config);
@@ -309,6 +319,7 @@ mod tests {
             feature_config,
             image_env,
             agent_arch: "x86_64",
+            workspace_mount_consistency: None,
         })
     }
 
@@ -328,6 +339,7 @@ mod tests {
             feature_config: None,
             image_env: &[],
             agent_arch: "x86_64",
+            workspace_mount_consistency: None,
         });
 
         assert_eq!(opts.image, "ubuntu");
@@ -350,6 +362,7 @@ mod tests {
             feature_config: None,
             image_env: &[],
             agent_arch: "x86_64",
+            workspace_mount_consistency: None,
         });
 
         assert_eq!(opts.workspace_folder, "/home/user/project");
@@ -458,6 +471,7 @@ mod tests {
             feature_config: None,
             image_env: &[],
             agent_arch: "x86_64",
+            workspace_mount_consistency: None,
         });
         assert!(opts.workspace_mount.is_some());
         let mount = opts.workspace_mount.unwrap();
@@ -747,6 +761,7 @@ mod tests {
             feature_config: Some(&substituted),
             image_env: &[],
             agent_arch: "x86_64",
+            workspace_mount_consistency: None,
         });
 
         assert_eq!(opts.mounts.len(), 1);

--- a/crates/cella-config/src/config_map/mounts.rs
+++ b/crates/cella-config/src/config_map/mounts.rs
@@ -245,4 +245,90 @@ mod tests {
             "absent readOnly must default to false"
         );
     }
+
+    // ── external field ────────────────────────────────────────────
+
+    #[test]
+    fn parse_mount_string_external_true() {
+        let mount =
+            parse_mount_string("type=volume,source=vol,target=/data,external=true").unwrap();
+        assert!(mount.external);
+    }
+
+    #[test]
+    fn parse_mount_string_external_false() {
+        let mount =
+            parse_mount_string("type=volume,source=vol,target=/data,external=false").unwrap();
+        assert!(!mount.external);
+    }
+
+    #[test]
+    fn parse_mount_string_external_defaults_false() {
+        let mount = parse_mount_string("type=bind,source=/a,target=/b").unwrap();
+        assert!(!mount.external);
+    }
+
+    // ── workspace mount consistency ───────────────────────────────
+
+    #[test]
+    fn map_workspace_mount_default_consistency() {
+        let config = json!({"image": "ubuntu"});
+        let mount = map_workspace_mount(&config, Path::new("/src"), "/workspaces/proj", None);
+        let m = mount.unwrap();
+        if cfg!(target_os = "linux") {
+            assert!(m.consistency.is_none());
+        } else {
+            assert_eq!(m.consistency.as_deref(), Some("cached"));
+        }
+    }
+
+    #[test]
+    fn map_workspace_mount_explicit_delegated() {
+        let config = json!({"image": "ubuntu"});
+        let mount = map_workspace_mount(
+            &config,
+            Path::new("/src"),
+            "/workspaces/proj",
+            Some("delegated"),
+        );
+        let m = mount.unwrap();
+        if cfg!(target_os = "linux") {
+            assert!(m.consistency.is_none());
+        } else {
+            assert_eq!(m.consistency.as_deref(), Some("delegated"));
+        }
+    }
+
+    #[test]
+    fn map_workspace_mount_explicit_consistent() {
+        let config = json!({"image": "ubuntu"});
+        let mount = map_workspace_mount(
+            &config,
+            Path::new("/src"),
+            "/workspaces/proj",
+            Some("consistent"),
+        );
+        let m = mount.unwrap();
+        if cfg!(target_os = "linux") {
+            assert!(m.consistency.is_none());
+        } else {
+            assert_eq!(m.consistency.as_deref(), Some("consistent"));
+        }
+    }
+
+    #[test]
+    fn map_workspace_mount_custom_ignores_consistency() {
+        let config = json!({"workspaceMount": "type=bind,source=/host,target=/code"});
+        let mount = map_workspace_mount(
+            &config,
+            Path::new("/src"),
+            "/workspaces/proj",
+            Some("delegated"),
+        );
+        let m = mount.unwrap();
+        assert!(
+            m.consistency.is_none(),
+            "custom workspaceMount should not get injected consistency"
+        );
+    }
 }

--- a/crates/cella-config/src/config_map/mounts.rs
+++ b/crates/cella-config/src/config_map/mounts.rs
@@ -6,6 +6,7 @@ pub(super) fn map_workspace_mount(
     config: &serde_json::Value,
     workspace_root: &Path,
     workspace_folder: &str,
+    consistency: Option<&str>,
 ) -> Option<MountConfig> {
     if let Some(mount_str) = config.get("workspaceMount").and_then(|v| v.as_str()) {
         if mount_str.is_empty() {
@@ -14,7 +15,8 @@ pub(super) fn map_workspace_mount(
         return parse_mount_string(mount_str);
     }
 
-    // Default workspace mount
+    // Default workspace mount — consistency is skipped on Linux (Podman
+    // rejects it; native Docker ignores it).
     Some(MountConfig {
         mount_type: "bind".to_string(),
         source: workspace_root
@@ -23,7 +25,11 @@ pub(super) fn map_workspace_mount(
             .to_string_lossy()
             .to_string(),
         target: workspace_folder.to_string(),
-        consistency: Some("cached".to_string()),
+        consistency: if cfg!(target_os = "linux") {
+            None
+        } else {
+            Some(consistency.unwrap_or("cached").to_string())
+        },
         read_only: false,
         external: false,
     })
@@ -152,14 +158,14 @@ mod tests {
     #[test]
     fn map_workspace_mount_explicitly_disabled() {
         let config = json!({"workspaceMount": ""});
-        let result = map_workspace_mount(&config, Path::new("/src"), "/workspaces/proj");
+        let result = map_workspace_mount(&config, Path::new("/src"), "/workspaces/proj", None);
         assert!(result.is_none());
     }
 
     #[test]
     fn map_workspace_mount_custom() {
         let config = json!({"workspaceMount": "type=bind,source=/host/code,target=/code"});
-        let result = map_workspace_mount(&config, Path::new("/src"), "/workspaces/proj");
+        let result = map_workspace_mount(&config, Path::new("/src"), "/workspaces/proj", None);
         let mount = result.unwrap();
         assert_eq!(mount.mount_type, "bind");
         assert_eq!(mount.source, "/host/code");

--- a/crates/cella-config/src/config_map/mounts.rs
+++ b/crates/cella-config/src/config_map/mounts.rs
@@ -25,6 +25,7 @@ pub(super) fn map_workspace_mount(
         target: workspace_folder.to_string(),
         consistency: Some("cached".to_string()),
         read_only: false,
+        external: false,
     })
 }
 
@@ -68,6 +69,7 @@ pub fn map_additional_mounts(config: &serde_json::Value) -> Vec<MountConfig> {
                     target,
                     consistency: None,
                     read_only,
+                    external: false,
                 })
             }
             _ => None,
@@ -81,6 +83,7 @@ pub fn parse_mount_string(s: &str) -> Option<MountConfig> {
     let mut target = String::new();
     let mut consistency = None;
     let mut read_only = false;
+    let mut external = false;
 
     for part in s.split(',') {
         let trimmed = part.trim();
@@ -91,6 +94,7 @@ pub fn parse_mount_string(s: &str) -> Option<MountConfig> {
                 "source" | "src" => source = value.to_string(),
                 "target" | "dst" | "destination" => target = value.to_string(),
                 "consistency" => consistency = Some(value.to_string()),
+                "external" => external = value == "true",
                 _ => {}
             }
         } else {
@@ -112,6 +116,7 @@ pub fn parse_mount_string(s: &str) -> Option<MountConfig> {
         target,
         consistency,
         read_only,
+        external,
     })
 }
 

--- a/crates/cella-container/src/backend.rs
+++ b/crates/cella-container/src/backend.rs
@@ -1000,7 +1000,7 @@ mod tests {
             target: "/workspace".to_string(),
             consistency: None,
             read_only: false,
-        external: false,
+            external: false,
         });
         let staging = PathBuf::from("/tmp/staging");
         let args = build_create_args(&opts, &staging);
@@ -1018,7 +1018,7 @@ mod tests {
             target: "/workspace".to_string(),
             consistency: None,
             read_only: true,
-        external: false,
+            external: false,
         });
         let staging = PathBuf::from("/tmp/staging");
         let args = build_create_args(&opts, &staging);
@@ -1246,7 +1246,7 @@ mod tests {
                 target: "/data".to_string(),
                 consistency: None,
                 read_only: false,
-            external: false,
+                external: false,
             },
             MountConfig {
                 mount_type: "volume".to_string(),
@@ -1254,7 +1254,7 @@ mod tests {
                 target: "/vol".to_string(),
                 consistency: None,
                 read_only: false,
-            external: false,
+                external: false,
             },
         ];
         let staging = PathBuf::from("/tmp/staging");
@@ -1289,7 +1289,7 @@ mod tests {
             target: "/data".to_string(),
             consistency: None,
             read_only: true,
-        external: false,
+            external: false,
         }];
         let staging = PathBuf::from("/tmp/staging");
         let args = build_create_args(&opts, &staging);

--- a/crates/cella-container/src/backend.rs
+++ b/crates/cella-container/src/backend.rs
@@ -1000,6 +1000,7 @@ mod tests {
             target: "/workspace".to_string(),
             consistency: None,
             read_only: false,
+        external: false,
         });
         let staging = PathBuf::from("/tmp/staging");
         let args = build_create_args(&opts, &staging);
@@ -1017,6 +1018,7 @@ mod tests {
             target: "/workspace".to_string(),
             consistency: None,
             read_only: true,
+        external: false,
         });
         let staging = PathBuf::from("/tmp/staging");
         let args = build_create_args(&opts, &staging);
@@ -1244,6 +1246,7 @@ mod tests {
                 target: "/data".to_string(),
                 consistency: None,
                 read_only: false,
+            external: false,
             },
             MountConfig {
                 mount_type: "volume".to_string(),
@@ -1251,6 +1254,7 @@ mod tests {
                 target: "/vol".to_string(),
                 consistency: None,
                 read_only: false,
+            external: false,
             },
         ];
         let staging = PathBuf::from("/tmp/staging");
@@ -1285,6 +1289,7 @@ mod tests {
             target: "/data".to_string(),
             consistency: None,
             read_only: true,
+        external: false,
         }];
         let staging = PathBuf::from("/tmp/staging");
         let args = build_create_args(&opts, &staging);

--- a/crates/cella-docker/src/config_map/mod.rs
+++ b/crates/cella-docker/src/config_map/mod.rs
@@ -420,6 +420,7 @@ mod tests {
                     target: "/shared-target".to_string(),
                     consistency: None,
                     read_only: false,
+                external: false,
                 },
                 MountConfig {
                     mount_type: "bind".to_string(),
@@ -427,6 +428,7 @@ mod tests {
                     target: "/shared-target".to_string(),
                     consistency: None,
                     read_only: false,
+                external: false,
                 },
             ],
             port_bindings: HashMap::new(),
@@ -463,6 +465,7 @@ mod tests {
                 target: "/workspace".to_string(),
                 consistency: Some("cached".to_string()),
                 read_only: false,
+            external: false,
             }),
             mounts: vec![MountConfig {
                 mount_type: "bind".to_string(),
@@ -470,6 +473,7 @@ mod tests {
                 target: "/workspace".to_string(),
                 consistency: None,
                 read_only: false,
+            external: false,
             }],
             port_bindings: HashMap::new(),
             entrypoint: None,
@@ -645,6 +649,7 @@ mod tests {
             target: "/data".to_string(),
             consistency: None,
             read_only: false,
+        external: false,
         };
         let bollard_mount = to_bollard_mount(&m).unwrap();
         assert_eq!(bollard_mount.typ, Some(MountTypeEnum::VOLUME));
@@ -658,6 +663,7 @@ mod tests {
             target: "/tmp".to_string(),
             consistency: None,
             read_only: false,
+        external: false,
         };
         let bollard_mount = to_bollard_mount(&m).unwrap();
         assert_eq!(bollard_mount.typ, Some(MountTypeEnum::TMPFS));
@@ -671,6 +677,7 @@ mod tests {
             target: "/container".to_string(),
             consistency: Some("cached".to_string()),
             read_only: false,
+        external: false,
         };
         let bollard_mount = to_bollard_mount(&m).unwrap();
         assert_eq!(bollard_mount.typ, Some(MountTypeEnum::BIND));
@@ -685,6 +692,7 @@ mod tests {
             target: "//./pipe/docker_engine".to_string(),
             consistency: None,
             read_only: false,
+        external: false,
         };
         let bollard_mount = to_bollard_mount(&m).unwrap();
         assert_eq!(
@@ -702,6 +710,7 @@ mod tests {
             target: "/b".to_string(),
             consistency: None,
             read_only: false,
+        external: false,
         };
         assert!(
             to_bollard_mount(&m).is_none(),
@@ -718,6 +727,7 @@ mod tests {
             target: "/container/data".to_string(),
             consistency: None,
             read_only: true,
+        external: false,
         };
         let rw = MountConfig {
             mount_type: "bind".to_string(),
@@ -725,6 +735,7 @@ mod tests {
             target: "/container/data".to_string(),
             consistency: None,
             read_only: false,
+        external: false,
         };
         assert_eq!(
             to_bollard_mount(&ro).unwrap().read_only,
@@ -1399,6 +1410,7 @@ mod tests {
             target: "/container".to_string(),
             consistency: None,
             read_only: false,
+        external: false,
         };
         let bollard_mount = to_bollard_mount(&m).unwrap();
         assert!(bollard_mount.consistency.is_none());
@@ -1412,6 +1424,7 @@ mod tests {
             target: "/container".to_string(),
             consistency: Some("delegated".to_string()),
             read_only: false,
+        external: false,
         };
         let bollard_mount = to_bollard_mount(&m).unwrap();
         assert_eq!(bollard_mount.consistency, Some("delegated".to_string()));
@@ -1430,6 +1443,7 @@ mod tests {
             target: "/workspace".to_string(),
             consistency: Some("cached".to_string()),
             read_only: false,
+        external: false,
         });
         let config = to_bollard_config(&opts);
         let hc = config.host_config.unwrap();

--- a/crates/cella-docker/src/config_map/mod.rs
+++ b/crates/cella-docker/src/config_map/mod.rs
@@ -420,7 +420,7 @@ mod tests {
                     target: "/shared-target".to_string(),
                     consistency: None,
                     read_only: false,
-                external: false,
+                    external: false,
                 },
                 MountConfig {
                     mount_type: "bind".to_string(),
@@ -428,7 +428,7 @@ mod tests {
                     target: "/shared-target".to_string(),
                     consistency: None,
                     read_only: false,
-                external: false,
+                    external: false,
                 },
             ],
             port_bindings: HashMap::new(),
@@ -465,7 +465,7 @@ mod tests {
                 target: "/workspace".to_string(),
                 consistency: Some("cached".to_string()),
                 read_only: false,
-            external: false,
+                external: false,
             }),
             mounts: vec![MountConfig {
                 mount_type: "bind".to_string(),
@@ -473,7 +473,7 @@ mod tests {
                 target: "/workspace".to_string(),
                 consistency: None,
                 read_only: false,
-            external: false,
+                external: false,
             }],
             port_bindings: HashMap::new(),
             entrypoint: None,
@@ -649,7 +649,7 @@ mod tests {
             target: "/data".to_string(),
             consistency: None,
             read_only: false,
-        external: false,
+            external: false,
         };
         let bollard_mount = to_bollard_mount(&m).unwrap();
         assert_eq!(bollard_mount.typ, Some(MountTypeEnum::VOLUME));
@@ -663,7 +663,7 @@ mod tests {
             target: "/tmp".to_string(),
             consistency: None,
             read_only: false,
-        external: false,
+            external: false,
         };
         let bollard_mount = to_bollard_mount(&m).unwrap();
         assert_eq!(bollard_mount.typ, Some(MountTypeEnum::TMPFS));
@@ -677,7 +677,7 @@ mod tests {
             target: "/container".to_string(),
             consistency: Some("cached".to_string()),
             read_only: false,
-        external: false,
+            external: false,
         };
         let bollard_mount = to_bollard_mount(&m).unwrap();
         assert_eq!(bollard_mount.typ, Some(MountTypeEnum::BIND));
@@ -692,7 +692,7 @@ mod tests {
             target: "//./pipe/docker_engine".to_string(),
             consistency: None,
             read_only: false,
-        external: false,
+            external: false,
         };
         let bollard_mount = to_bollard_mount(&m).unwrap();
         assert_eq!(
@@ -710,7 +710,7 @@ mod tests {
             target: "/b".to_string(),
             consistency: None,
             read_only: false,
-        external: false,
+            external: false,
         };
         assert!(
             to_bollard_mount(&m).is_none(),
@@ -727,7 +727,7 @@ mod tests {
             target: "/container/data".to_string(),
             consistency: None,
             read_only: true,
-        external: false,
+            external: false,
         };
         let rw = MountConfig {
             mount_type: "bind".to_string(),
@@ -735,7 +735,7 @@ mod tests {
             target: "/container/data".to_string(),
             consistency: None,
             read_only: false,
-        external: false,
+            external: false,
         };
         assert_eq!(
             to_bollard_mount(&ro).unwrap().read_only,
@@ -1410,7 +1410,7 @@ mod tests {
             target: "/container".to_string(),
             consistency: None,
             read_only: false,
-        external: false,
+            external: false,
         };
         let bollard_mount = to_bollard_mount(&m).unwrap();
         assert!(bollard_mount.consistency.is_none());
@@ -1424,7 +1424,7 @@ mod tests {
             target: "/container".to_string(),
             consistency: Some("delegated".to_string()),
             read_only: false,
-        external: false,
+            external: false,
         };
         let bollard_mount = to_bollard_mount(&m).unwrap();
         assert_eq!(bollard_mount.consistency, Some("delegated".to_string()));
@@ -1443,7 +1443,7 @@ mod tests {
             target: "/workspace".to_string(),
             consistency: Some("cached".to_string()),
             read_only: false,
-        external: false,
+            external: false,
         });
         let config = to_bollard_config(&opts);
         let hc = config.host_config.unwrap();

--- a/crates/cella-git/src/lib.rs
+++ b/crates/cella-git/src/lib.rs
@@ -12,6 +12,6 @@ pub use branch::{
     BranchState, delete_branch, fetch_prune, is_tracking_gone, merged_branches, resolve_branch,
 };
 pub use error::CellaGitError;
-pub use repo::{RepoInfo, default_branch, discover, is_inside_container};
+pub use repo::{RepoInfo, default_branch, discover, find_git_root_folder, is_inside_container};
 pub use sanitize::branch_to_dir_name;
 pub use worktree::{WorktreeInfo, create, list, parent_git_dir, remove, worktree_path};

--- a/crates/cella-git/src/repo.rs
+++ b/crates/cella-git/src/repo.rs
@@ -283,4 +283,40 @@ mod tests {
         );
         assert_eq!(info.head_branch, cloned.head_branch);
     }
+
+    // ── find_git_root_folder ──────────────────────────────────────
+
+    #[test]
+    fn find_git_root_folder_when_enabled() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        init_repo(tmp.path());
+
+        let subdir = tmp.path().join("packages").join("app");
+        std::fs::create_dir_all(&subdir).unwrap();
+
+        let root = find_git_root_folder(&subdir, true);
+        assert_eq!(
+            root.canonicalize().unwrap(),
+            tmp.path().canonicalize().unwrap()
+        );
+    }
+
+    #[test]
+    fn find_git_root_folder_when_disabled() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        init_repo(tmp.path());
+
+        let subdir = tmp.path().join("packages").join("app");
+        std::fs::create_dir_all(&subdir).unwrap();
+
+        let root = find_git_root_folder(&subdir, false);
+        assert_eq!(root, subdir);
+    }
+
+    #[test]
+    fn find_git_root_folder_not_a_repo() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = find_git_root_folder(tmp.path(), true);
+        assert_eq!(root, tmp.path());
+    }
 }

--- a/crates/cella-git/src/repo.rs
+++ b/crates/cella-git/src/repo.rs
@@ -38,6 +38,18 @@ pub fn discover(path: &Path) -> Result<RepoInfo, CellaGitError> {
     Ok(RepoInfo { root, head_branch })
 }
 
+/// Find the git root directory containing `path`.
+///
+/// Returns the git root if `mount_git_root` is true and the path is inside
+/// a git repository. Falls back to `path` itself if not in a git repo or
+/// if `mount_git_root` is false.
+pub fn find_git_root_folder(path: &Path, mount_git_root: bool) -> PathBuf {
+    if !mount_git_root {
+        return path.to_path_buf();
+    }
+    discover(path).map_or_else(|_| path.to_path_buf(), |info| info.root)
+}
+
 /// Detect the default branch name (main, master, etc.).
 ///
 /// Resolution priority:

--- a/crates/cella-orchestrator/Cargo.toml
+++ b/crates/cella-orchestrator/Cargo.toml
@@ -21,6 +21,8 @@ thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 
+[dev-dependencies]
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/cella-orchestrator/src/config.rs
+++ b/crates/cella-orchestrator/src/config.rs
@@ -7,6 +7,18 @@ use cella_backend::BuildSecret;
 use cella_config::devcontainer::resolve::ResolvedConfig;
 pub use cella_network::NetworkRulePolicy;
 
+/// Mount-related CLI flags for workspace configuration.
+pub struct MountFlags<'a> {
+    /// Additional mount points from CLI `--mount` flags.
+    pub additional_cli_mounts: &'a [cella_backend::MountConfig],
+    /// Workspace mount consistency mode (e.g. "cached", "delegated").
+    pub workspace_mount_consistency: Option<&'a str>,
+    /// Whether to mount the git root instead of the workspace folder.
+    pub mount_workspace_git_root: bool,
+    /// Whether to mount the git worktree common dir.
+    pub mount_git_worktree_common_dir: bool,
+}
+
 /// Configuration for the full container-up pipeline.
 pub struct UpConfig<'a> {
     /// Fully resolved devcontainer configuration.
@@ -38,12 +50,8 @@ pub struct UpConfig<'a> {
     /// Extra Docker networks to connect the container to after start,
     /// before lifecycle hooks run (e.g. parent compose network for worktrees).
     pub extra_networks: Vec<String>,
-    /// Additional mount points from CLI `--mount` flags.
-    pub additional_cli_mounts: &'a [cella_backend::MountConfig],
-    /// Workspace mount consistency mode (e.g. "cached", "delegated").
-    pub workspace_mount_consistency: Option<&'a str>,
-    /// Whether to mount the git root instead of the workspace folder.
-    pub mount_workspace_git_root: bool,
+    /// Mount-related CLI flags.
+    pub mount_flags: MountFlags<'a>,
 }
 
 /// How the up pipeline should handle the container image.

--- a/crates/cella-orchestrator/src/config.rs
+++ b/crates/cella-orchestrator/src/config.rs
@@ -42,6 +42,8 @@ pub struct UpConfig<'a> {
     pub additional_cli_mounts: &'a [cella_backend::MountConfig],
     /// Workspace mount consistency mode (e.g. "cached", "delegated").
     pub workspace_mount_consistency: Option<&'a str>,
+    /// Whether to mount the git root instead of the workspace folder.
+    pub mount_workspace_git_root: bool,
 }
 
 /// How the up pipeline should handle the container image.

--- a/crates/cella-orchestrator/src/config.rs
+++ b/crates/cella-orchestrator/src/config.rs
@@ -38,6 +38,8 @@ pub struct UpConfig<'a> {
     /// Extra Docker networks to connect the container to after start,
     /// before lifecycle hooks run (e.g. parent compose network for worktrees).
     pub extra_networks: Vec<String>,
+    /// Additional mount points from CLI `--mount` flags.
+    pub additional_cli_mounts: &'a [cella_backend::MountConfig],
 }
 
 /// How the up pipeline should handle the container image.

--- a/crates/cella-orchestrator/src/config.rs
+++ b/crates/cella-orchestrator/src/config.rs
@@ -40,6 +40,8 @@ pub struct UpConfig<'a> {
     pub extra_networks: Vec<String>,
     /// Additional mount points from CLI `--mount` flags.
     pub additional_cli_mounts: &'a [cella_backend::MountConfig],
+    /// Workspace mount consistency mode (e.g. "cached", "delegated").
+    pub workspace_mount_consistency: Option<&'a str>,
 }
 
 /// How the up pipeline should handle the container image.

--- a/crates/cella-orchestrator/src/lib.rs
+++ b/crates/cella-orchestrator/src/lib.rs
@@ -31,7 +31,8 @@ pub mod up;
 use crate::config_map::subst_ctx;
 
 pub use config::{
-    BranchConfig, HostRequirementPolicy, ImageStrategy, NetworkRulePolicy, PruneConfig, UpConfig,
+    BranchConfig, HostRequirementPolicy, ImageStrategy, MountFlags, NetworkRulePolicy, PruneConfig,
+    UpConfig,
 };
 pub use error::OrchestratorError;
 pub use progress::{PhaseChildHandle, PhaseHandle, ProgressEvent, ProgressSender, StepHandle};

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -939,6 +939,10 @@ impl EnsureUpContext<'_> {
             });
         }
 
+        for m in self.config.additional_cli_mounts {
+            create_opts.mounts.push(m.clone());
+        }
+
         let (vol_name, vol_target, _ro) = self.client.agent_volume_mount();
         if capabilities.managed_agent && !vol_name.is_empty() {
             create_opts.mounts.push(MountConfig {

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -939,7 +939,7 @@ impl EnsureUpContext<'_> {
             });
         }
 
-        for m in self.config.additional_cli_mounts {
+        for m in self.config.mount_flags.additional_cli_mounts {
             create_opts.mounts.push(m.clone());
         }
 
@@ -1250,10 +1250,17 @@ impl EnsureUpContext<'_> {
 
         let host_mount_folder = cella_git::find_git_root_folder(
             &self.config.resolved.workspace_root,
-            self.config.mount_workspace_git_root,
+            self.config.mount_flags.mount_workspace_git_root,
         );
 
-        let create_opts = crate::config_map::map_config(crate::config_map::MapConfigParams {
+        let worktree_result = resolve_worktree_common_dir(
+            &host_mount_folder,
+            self.config.mount_flags.mount_workspace_git_root,
+            self.config.mount_flags.mount_git_worktree_common_dir,
+            self.config.mount_flags.workspace_mount_consistency,
+        );
+
+        let mut create_opts = crate::config_map::map_config(crate::config_map::MapConfigParams {
             config,
             container_name: self.config.container_name,
             image_name: img_name,
@@ -1263,8 +1270,12 @@ impl EnsureUpContext<'_> {
             feature_config: effective_feature_config,
             image_env: &image_env,
             agent_arch,
-            workspace_mount_consistency: self.config.workspace_mount_consistency,
+            workspace_mount_consistency: self.config.mount_flags.workspace_mount_consistency,
         });
+
+        if let Some(wt) = worktree_result {
+            create_opts.mounts.push(wt.mount);
+        }
 
         Ok(ImageConfig {
             image_env,
@@ -1657,6 +1668,104 @@ pub async fn ensure_up(
     .map_err(|e| OrchestratorError::Other {
         message: e.to_string(),
     })
+}
+
+struct WorktreeCommonDirResult {
+    mount: MountConfig,
+}
+
+fn resolve_worktree_common_dir(
+    host_mount_folder: &std::path::Path,
+    mount_workspace_git_root: bool,
+    mount_git_worktree_common_dir: bool,
+    consistency: Option<&str>,
+) -> Option<WorktreeCommonDirResult> {
+    if !(mount_workspace_git_root && mount_git_worktree_common_dir) {
+        return None;
+    }
+
+    let dot_git = host_mount_folder.join(".git");
+    if !dot_git.is_file() {
+        return None;
+    }
+
+    let content = std::fs::read_to_string(&dot_git).ok()?;
+    let gitdir = content.strip_prefix("gitdir: ")?.trim();
+
+    let gitdir_path = std::path::Path::new(gitdir);
+    if gitdir_path.is_absolute() {
+        return None;
+    }
+
+    // Compute the git common dir (two levels up from gitdir).
+    // e.g. gitdir: ../../.git/worktrees/my-wt → common dir = ../../.git → resolved
+    let resolved_gitdir = host_mount_folder.join(gitdir);
+    let git_common_dir = resolved_gitdir.parent()?.parent()?.to_path_buf();
+    let git_common_dir = git_common_dir.canonicalize().unwrap_or(git_common_dir);
+
+    // Collect path segments from host_mount_folder up to where git_common_dir is reachable
+    let mut segments = Vec::new();
+    let mut current = host_mount_folder.to_path_buf();
+    loop {
+        if git_common_dir.starts_with(&current) {
+            break;
+        }
+        let Some(parent) = current.parent() else {
+            break;
+        };
+        if parent == current {
+            break;
+        }
+        if let Some(name) = current.file_name() {
+            segments.insert(0, name.to_string_lossy().to_string());
+        }
+        current = parent.to_path_buf();
+    }
+
+    let container_mount_folder = format!("/workspaces/{}", segments.join("/"));
+
+    // Compute container git common dir by resolving the relative gitdir from
+    // the container mount folder
+    let container_gitdir = std::path::PathBuf::from(&container_mount_folder).join(gitdir);
+    let container_git_common = container_gitdir.parent()?.parent()?.to_path_buf();
+    // Normalize the path (remove . and ..)
+    let container_git_common_str = normalize_path_string(&container_git_common.to_string_lossy());
+
+    let cons = if cfg!(target_os = "linux") {
+        None
+    } else {
+        Some(consistency.unwrap_or("consistent").to_string())
+    };
+
+    Some(WorktreeCommonDirResult {
+        mount: MountConfig {
+            mount_type: "bind".to_string(),
+            source: git_common_dir.to_string_lossy().to_string(),
+            target: container_git_common_str,
+            consistency: cons,
+            read_only: false,
+            external: false,
+        },
+    })
+}
+
+fn normalize_path_string(path: &str) -> String {
+    let mut parts: Vec<&str> = Vec::new();
+    for component in path.split('/') {
+        match component {
+            "." | "" => {}
+            ".." => {
+                parts.pop();
+            }
+            _ => parts.push(component),
+        }
+    }
+    let normalized = parts.join("/");
+    if path.starts_with('/') {
+        format!("/{normalized}")
+    } else {
+        normalized
+    }
 }
 
 /// Returns `true` if the post-start injection includes the cella-agent

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -1879,4 +1879,82 @@ mod tests {
             ProgressEvent::StepFailed { message, .. } if message == "boom"
         ));
     }
+
+    // ── normalize_path_string ─────────────────────────────────────
+
+    #[test]
+    fn normalize_removes_dot_segments() {
+        assert_eq!(normalize_path_string("/a/b/../c"), "/a/c");
+    }
+
+    #[test]
+    fn normalize_preserves_absolute_prefix() {
+        assert_eq!(normalize_path_string("/a/b/c"), "/a/b/c");
+    }
+
+    #[test]
+    fn normalize_collapses_multiple_dot_dot() {
+        assert_eq!(normalize_path_string("/a/b/c/../../d"), "/a/d");
+    }
+
+    #[test]
+    fn normalize_handles_relative_path() {
+        assert_eq!(normalize_path_string("a/b/../c"), "a/c");
+    }
+
+    // ── resolve_worktree_common_dir ───────────────────────────────
+
+    #[test]
+    fn worktree_common_dir_not_a_worktree() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir(tmp.path().join(".git")).unwrap();
+        let result = resolve_worktree_common_dir(tmp.path(), true, true, None);
+        assert!(result.is_none(), ".git directory → not a worktree");
+    }
+
+    #[test]
+    fn worktree_common_dir_disabled() {
+        let result = resolve_worktree_common_dir(std::path::Path::new("/tmp"), true, false, None);
+        assert!(result.is_none(), "must return None when flag is disabled");
+    }
+
+    #[test]
+    fn worktree_common_dir_git_root_disabled() {
+        let result = resolve_worktree_common_dir(std::path::Path::new("/tmp"), false, true, None);
+        assert!(
+            result.is_none(),
+            "must return None when git root mount is disabled"
+        );
+    }
+
+    #[test]
+    fn worktree_common_dir_absolute_gitdir_ignored() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join(".git"),
+            "gitdir: /absolute/path/.git/worktrees/wt",
+        )
+        .unwrap();
+        let result = resolve_worktree_common_dir(tmp.path(), true, true, None);
+        assert!(result.is_none(), "absolute gitdir paths must be ignored");
+    }
+
+    #[test]
+    fn worktree_common_dir_relative_gitdir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let git_dir = tmp.path().join(".git");
+        std::fs::create_dir_all(git_dir.join("worktrees/my-wt")).unwrap();
+        let worktree_dir = tmp.path().join("worktrees").join("my-wt");
+        std::fs::create_dir_all(&worktree_dir).unwrap();
+        std::fs::write(
+            worktree_dir.join(".git"),
+            "gitdir: ../../.git/worktrees/my-wt",
+        )
+        .unwrap();
+
+        let result = resolve_worktree_common_dir(&worktree_dir, true, true, None);
+        assert!(result.is_some(), "should resolve relative gitdir");
+        let wt = result.unwrap();
+        assert_eq!(wt.mount.mount_type, "bind");
+    }
 }

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -1248,12 +1248,18 @@ impl EnsureUpContext<'_> {
             .as_ref()
             .or(image_meta_config.as_ref());
 
+        let host_mount_folder = cella_git::find_git_root_folder(
+            &self.config.resolved.workspace_root,
+            self.config.mount_workspace_git_root,
+        );
+
         let create_opts = crate::config_map::map_config(crate::config_map::MapConfigParams {
             config,
             container_name: self.config.container_name,
             image_name: img_name,
             labels,
             workspace_root: &self.config.resolved.workspace_root,
+            host_mount_folder: &host_mount_folder,
             feature_config: effective_feature_config,
             image_env: &image_env,
             agent_arch,

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -856,6 +856,7 @@ impl EnsureUpContext<'_> {
                 target: m.target.clone(),
                 consistency: None,
                 read_only: false,
+                external: false,
             });
         }
 
@@ -934,6 +935,7 @@ impl EnsureUpContext<'_> {
                 target: path_str,
                 consistency: None,
                 read_only: false,
+                external: false,
             });
         }
 
@@ -945,6 +947,7 @@ impl EnsureUpContext<'_> {
                 target: vol_target,
                 consistency: None,
                 read_only: false,
+                external: false,
             });
         }
 
@@ -1371,6 +1374,7 @@ impl EnsureUpContext<'_> {
                                     target: ssh.mount_target.clone(),
                                     consistency: None,
                                     read_only: false,
+                                    external: false,
                                 });
                                 create_opts
                                     .env

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -1257,6 +1257,7 @@ impl EnsureUpContext<'_> {
             feature_config: effective_feature_config,
             image_env: &image_env,
             agent_arch,
+            workspace_mount_consistency: self.config.workspace_mount_consistency,
         });
 
         Ok(ImageConfig {


### PR DESCRIPTION
## Summary

- Add `--mount` repeatable flag for additional bind/volume mounts via CLI
- Add `--workspace-mount-consistency` flag (cached/delegated/consistent, ignored on Linux)
- Add `--mount-workspace-git-root` flag (default: true) to mount git root instead of workspace folder
- Add `--mount-git-worktree-common-dir` flag for worktrees with relative gitdir paths
- Add `external` field to `MountConfig` for pre-existing volumes

All four flags are up-only, image/Dockerfile-only (ignored for Docker Compose configs), matching the devcontainer CLI behavior.

## Test plan

- [x] Unit tests for `parse_cli_mount()` validation (valid formats, invalid types, missing fields)
- [x] Unit tests for `external` field parsing in `parse_mount_string()`
- [x] Unit tests for workspace mount consistency (default, explicit values, platform-aware)
- [x] Unit tests for `find_git_root_folder()` (enabled, disabled, not-a-repo)
- [x] Unit tests for `map_config()` with git root (same as workspace, monorepo, explicit override)
- [x] Unit tests for worktree common dir resolution (not-a-worktree, absolute gitdir, relative gitdir)
- [x] Unit tests for `normalize_path_string()`
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings -D clippy::all` passes
- [x] `cargo test --workspace` passes (0 failures)

Close #72
Close #73
Close #74
Close #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)