### PR TITLE
feat: hostname-based port forwarding proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,6 +658,7 @@ dependencies = [
 name = "cella-proxy"
 version = "0.0.40"
 dependencies = [
+ "futures-util",
  "hex",
  "http-body-util",
  "hyper",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,6 +332,7 @@ dependencies = [
  "cella-env",
  "cella-features",
  "cella-git",
+ "cella-proxy",
  "chrono",
  "futures-util",
  "hex",
@@ -465,6 +466,7 @@ dependencies = [
  "cella-daemon-client",
  "cella-port",
  "cella-protocol",
+ "cella-proxy",
  "hex",
  "miette",
  "nix 0.31.2",
@@ -650,6 +652,19 @@ version = "0.0.40"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "cella-proxy"
+version = "0.0.40"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "sha2 0.11.0",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "crates/cella-orchestrator",
     "crates/cella-tool-install",
     "crates/cella-protocol",
+    "crates/cella-proxy",
     "crates/cella-jsonc",
     "crates/cella-templates",
 ]
@@ -170,6 +171,7 @@ cella-orchestrator = { path = "crates/cella-orchestrator" }
 cella-tool-install = { path = "crates/cella-tool-install" }
 cella-port = { path = "crates/cella-port" }
 cella-protocol = { path = "crates/cella-protocol" }
+cella-proxy = { path = "crates/cella-proxy" }
 cella-templates = { path = "crates/cella-templates" }
 
 [profile.release]

--- a/crates/cella-backend/Cargo.toml
+++ b/crates/cella-backend/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 cella-env.workspace = true
 cella-features.workspace = true
 cella-git.workspace = true
+cella-proxy.workspace = true
 chrono.workspace = true
 nix.workspace = true
 tokio.workspace = true

--- a/crates/cella-backend/src/lib.rs
+++ b/crates/cella-backend/src/lib.rs
@@ -19,7 +19,8 @@ pub use lifecycle::{
 pub use mount::{MountKind, MountSpec};
 pub use names::{
     BACKEND_LABEL, compose_labels, compose_project_name, compute_features_digest, container_labels,
-    container_name, image_name, image_name_with_features, worktree_labels,
+    container_name, image_name, image_name_with_features, orbstack_domains_label,
+    orbstack_http_port_label, worktree_labels,
 };
 pub use network::{ManagedNetwork, RemovalOutcome};
 pub use resolve::ContainerTarget;

--- a/crates/cella-backend/src/names.rs
+++ b/crates/cella-backend/src/names.rs
@@ -179,6 +179,20 @@ pub fn worktree_labels(branch_name: &str, parent_repo: &Path) -> HashMap<String,
     labels
 }
 
+/// Generate `dev.orbstack.domains` label value for hostname-based routing.
+///
+/// Produces domains like `3000.feature-auth.myapp.local` for each forwarded port,
+/// plus a bare `feature-auth.myapp.local` for the default port.
+pub fn orbstack_domains_label(project: &str, branch: &str, forward_ports: &[u16]) -> String {
+    let sanitized = cella_proxy::hostname::sanitize_branch(branch);
+    let mut domains: Vec<String> = forward_ports
+        .iter()
+        .map(|port| format!("{port}.{sanitized}.{project}.local"))
+        .collect();
+    domains.push(format!("{sanitized}.{project}.local"));
+    domains.join(",")
+}
+
 /// Compute a SHA-256 digest of the features config for image tagging.
 pub fn compute_features_digest(config: &serde_json::Value) -> String {
     let features = config.get("features").unwrap_or(&serde_json::Value::Null);
@@ -382,5 +396,19 @@ mod tests {
         let path = PathBuf::from("/");
         let name = container_name(&path, None);
         assert!(name.starts_with("cella-unnamed-"));
+    }
+
+    #[test]
+    fn orbstack_domains_with_ports() {
+        let label = orbstack_domains_label("myapp", "feature/auth", &[3000, 8080]);
+        assert!(label.contains("3000.feature-auth.myapp.local"));
+        assert!(label.contains("8080.feature-auth.myapp.local"));
+        assert!(label.contains("feature-auth.myapp.local"));
+    }
+
+    #[test]
+    fn orbstack_domains_no_ports() {
+        let label = orbstack_domains_label("myapp", "main", &[]);
+        assert_eq!(label, "main.myapp.local");
     }
 }

--- a/crates/cella-backend/src/names.rs
+++ b/crates/cella-backend/src/names.rs
@@ -181,16 +181,16 @@ pub fn worktree_labels(branch_name: &str, parent_repo: &Path) -> HashMap<String,
 
 /// Generate `dev.orbstack.domains` label value for hostname-based routing.
 ///
-/// Produces domains like `3000.feature-auth.myapp.local` for each forwarded port,
-/// plus a bare `feature-auth.myapp.local` for the default port.
-pub fn orbstack_domains_label(project: &str, branch: &str, forward_ports: &[u16]) -> String {
+/// V1 uses a single native domain for the default web port. Additional ports
+/// stay on Cella's explicit hostname proxy URLs.
+pub fn orbstack_domains_label(project: &str, branch: &str) -> String {
     let sanitized = cella_proxy::hostname::sanitize_branch(branch);
-    let mut domains: Vec<String> = forward_ports
-        .iter()
-        .map(|port| format!("{port}.{sanitized}.{project}.local"))
-        .collect();
-    domains.push(format!("{sanitized}.{project}.local"));
-    domains.join(",")
+    format!("{sanitized}.{project}.local")
+}
+
+/// Generate `dev.orbstack.http-port` for the configured default web port.
+pub fn orbstack_http_port_label(forward_ports: &[u16]) -> Option<String> {
+    forward_ports.first().map(u16::to_string)
 }
 
 /// Compute a SHA-256 digest of the features config for image tagging.
@@ -399,16 +399,18 @@ mod tests {
     }
 
     #[test]
-    fn orbstack_domains_with_ports() {
-        let label = orbstack_domains_label("myapp", "feature/auth", &[3000, 8080]);
-        assert!(label.contains("3000.feature-auth.myapp.local"));
-        assert!(label.contains("8080.feature-auth.myapp.local"));
-        assert!(label.contains("feature-auth.myapp.local"));
+    fn orbstack_domains_uses_single_default_domain() {
+        let label = orbstack_domains_label("myapp", "feature/auth");
+        assert_eq!(label, "feature-auth.myapp.local");
+        assert!(!label.contains("3000."));
     }
 
     #[test]
-    fn orbstack_domains_no_ports() {
-        let label = orbstack_domains_label("myapp", "main", &[]);
-        assert_eq!(label, "main.myapp.local");
+    fn orbstack_http_port_uses_first_forward_port() {
+        assert_eq!(
+            orbstack_http_port_label(&[3000, 8080]).as_deref(),
+            Some("3000")
+        );
+        assert_eq!(orbstack_http_port_label(&[]), None);
     }
 }

--- a/crates/cella-cli/src/commands/ports.rs
+++ b/crates/cella-cli/src/commands/ports.rs
@@ -110,7 +110,7 @@ fn print_daemon_ports(ports: &[cella_protocol::ForwardedPortDetail]) {
         if has_hostnames {
             row.push(port.hostname.as_deref().unwrap_or("-").to_string());
         }
-        row.push(port.hostname.as_deref().unwrap_or(&port.url).to_string());
+        row.push(port.url.clone());
         table.add_row(row);
     }
 

--- a/crates/cella-cli/src/commands/ports.rs
+++ b/crates/cella-cli/src/commands/ports.rs
@@ -378,6 +378,7 @@ mod tests {
                 protocol: cella_protocol::PortProtocol::Tcp,
                 process: Some("node".to_string()),
                 url: "localhost:49152".to_string(),
+                hostname: None,
             },
             cella_protocol::ForwardedPortDetail {
                 container_name: "api".to_string(),
@@ -386,6 +387,7 @@ mod tests {
                 protocol: cella_protocol::PortProtocol::Tcp,
                 process: None,
                 url: "localhost:49153".to_string(),
+                hostname: None,
             },
         ];
 

--- a/crates/cella-cli/src/commands/ports.rs
+++ b/crates/cella-cli/src/commands/ports.rs
@@ -85,22 +85,33 @@ fn is_remote_docker_host(host: &str) -> bool {
 fn print_daemon_ports(ports: &[cella_protocol::ForwardedPortDetail]) {
     use crate::table::{Column, Table};
 
-    let mut table = Table::new(vec![
+    let has_hostnames = ports.iter().any(|p| p.hostname.is_some());
+
+    let mut columns = vec![
         Column::shrinkable("CONTAINER"),
         Column::fixed("PORT"),
         Column::fixed("PROCESS"),
         Column::fixed("HOST PORT"),
-        Column::fixed("URL"),
-    ]);
+    ];
+    if has_hostnames {
+        columns.push(Column::shrinkable("HOSTNAME"));
+    }
+    columns.push(Column::fixed("URL"));
+
+    let mut table = Table::new(columns);
 
     for port in ports {
-        table.add_row(vec![
+        let mut row = vec![
             port.container_name.clone(),
             port.container_port.to_string(),
             port.process.as_deref().unwrap_or("-").to_string(),
             port.host_port.to_string(),
-            port.url.clone(),
-        ]);
+        ];
+        if has_hostnames {
+            row.push(port.hostname.as_deref().unwrap_or("-").to_string());
+        }
+        row.push(port.hostname.as_deref().unwrap_or(&port.url).to_string());
+        table.add_row(row);
     }
 
     table.eprint();

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -468,6 +468,7 @@ impl UpContext {
 
         let registration = cella_orchestrator::daemon_registration::from_devcontainer_config(
             config,
+            &self.resolved.workspace_root,
             container_id,
             self.container_nm.clone(),
             container_ip,
@@ -643,6 +644,7 @@ pub struct UpResult {
 
 struct CliUpHooks<'a> {
     config: &'a serde_json::Value,
+    workspace_root: &'a std::path::Path,
     managed_agent: bool,
     backend_kind: String,
     docker_host: Option<String>,
@@ -677,6 +679,7 @@ impl cella_orchestrator::up::UpHooks for CliUpHooks<'_> {
         container_ip: Option<&str>,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         let config = self.config;
+        let workspace_root = self.workspace_root;
         let container_id = container_id.to_string();
         let container_name = container_name.to_string();
         let container_ip = container_ip.map(str::to_string);
@@ -699,6 +702,7 @@ impl cella_orchestrator::up::UpHooks for CliUpHooks<'_> {
 
             let registration = cella_orchestrator::daemon_registration::from_devcontainer_config(
                 config,
+                workspace_root,
                 container_id,
                 container_name,
                 container_ip,
@@ -775,6 +779,7 @@ impl UpContext {
         let (sender, renderer) = crate::progress::bridge(&self.progress);
         let hooks = CliUpHooks {
             config: self.config(),
+            workspace_root: &self.resolved.workspace_root,
             managed_agent: self.client.capabilities().managed_agent,
             backend_kind: self.client.kind().to_string(),
             docker_host: self.docker_host.clone(),

--- a/crates/cella-daemon-client/src/lib.rs
+++ b/crates/cella-daemon-client/src/lib.rs
@@ -65,6 +65,7 @@ impl DaemonClient {
                 daemon_started_at,
                 control_port,
                 control_token,
+                hostname_proxy,
             } => Ok(DaemonStatus {
                 pid,
                 uptime_secs,
@@ -75,6 +76,7 @@ impl DaemonClient {
                 daemon_started_at,
                 control_port,
                 control_token,
+                hostname_proxy,
             }),
             response => Err(DaemonClientError::unexpected("status", &response)),
         }
@@ -246,6 +248,7 @@ pub struct DaemonStatus {
     pub daemon_started_at: u64,
     pub control_port: u16,
     pub control_token: String,
+    pub hostname_proxy: Option<cella_protocol::HostnameProxyStatus>,
 }
 
 /// Successful SSH-agent proxy registration details.

--- a/crates/cella-daemon/Cargo.toml
+++ b/crates/cella-daemon/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 base64.workspace = true
 cella-port.workspace = true
 cella-protocol.workspace = true
+cella-proxy.workspace = true
 hex.workspace = true
 miette.workspace = true
 nix.workspace = true

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -548,6 +548,7 @@ async fn handle_port_closed(port: u16, protocol: PortProtocol, ctx: &AgentHandle
         let mut pm = ctx.port_manager.lock().await;
         let route = pm.hostname_route_for(&cid, port);
         let host_port = pm.handle_port_closed(&cid, port);
+        drop(pm);
         (host_port, route)
     };
 
@@ -3593,6 +3594,7 @@ branch refs/heads/feat-b
                 target.mode,
                 cella_proxy::router::ProxyMode::Localhost
             ));
+            drop(table);
         }
 
         let closed = AgentMessage::PortClosed {

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -2260,13 +2260,22 @@ mod tests {
     use cella_protocol::PortProtocol;
 
     use super::*;
+    use crate::port_manager::ContainerRegistrationInfo;
 
     /// Helper to set up a port manager with a forwarded port for testing.
     async fn pm_with_forwarded_port(container_port: u16) -> Arc<Mutex<PortManager>> {
         let pm = Arc::new(Mutex::new(PortManager::new(false)));
         {
             let mut guard = pm.lock().await;
-            guard.register_container("c1", "test", Some("172.20.0.5".to_string()), vec![], None);
+            guard.register_container(ContainerRegistrationInfo {
+                container_id: "c1".to_string(),
+                container_name: "test".to_string(),
+                container_ip: Some("172.20.0.5".to_string()),
+                ports_attributes: vec![],
+                other_ports_attributes: None,
+                project_name: None,
+                branch: None,
+            });
             guard.handle_port_open("c1", container_port, PortProtocol::Tcp, None);
         }
         pm
@@ -2285,8 +2294,24 @@ mod tests {
         let pm = Arc::new(Mutex::new(PortManager::new(false)));
         {
             let mut guard = pm.lock().await;
-            guard.register_container("c1", "test-a", Some("172.20.0.5".to_string()), vec![], None);
-            guard.register_container("c2", "test-b", Some("172.20.0.6".to_string()), vec![], None);
+            guard.register_container(ContainerRegistrationInfo {
+                container_id: "c1".to_string(),
+                container_name: "test-a".to_string(),
+                container_ip: Some("172.20.0.5".to_string()),
+                ports_attributes: vec![],
+                other_ports_attributes: None,
+                project_name: None,
+                branch: None,
+            });
+            guard.register_container(ContainerRegistrationInfo {
+                container_id: "c2".to_string(),
+                container_name: "test-b".to_string(),
+                container_ip: Some("172.20.0.6".to_string()),
+                ports_attributes: vec![],
+                other_ports_attributes: None,
+                project_name: None,
+                branch: None,
+            });
             // c1 gets port 3000
             guard.handle_port_open("c1", 3000, PortProtocol::Tcp, None);
             // c2 also wants 3000 — gets remapped to 3001
@@ -2301,8 +2326,24 @@ mod tests {
         let pm = Arc::new(Mutex::new(PortManager::new(false)));
         {
             let mut guard = pm.lock().await;
-            guard.register_container("c1", "a", Some("172.20.0.5".to_string()), vec![], None);
-            guard.register_container("c2", "b", Some("172.20.0.6".to_string()), vec![], None);
+            guard.register_container(ContainerRegistrationInfo {
+                container_id: "c1".to_string(),
+                container_name: "a".to_string(),
+                container_ip: Some("172.20.0.5".to_string()),
+                ports_attributes: vec![],
+                other_ports_attributes: None,
+                project_name: None,
+                branch: None,
+            });
+            guard.register_container(ContainerRegistrationInfo {
+                container_id: "c2".to_string(),
+                container_name: "b".to_string(),
+                container_ip: Some("172.20.0.6".to_string()),
+                ports_attributes: vec![],
+                other_ports_attributes: None,
+                project_name: None,
+                branch: None,
+            });
             guard.handle_port_open("c1", 8080, PortProtocol::Tcp, None);
             guard.handle_port_open("c2", 8080, PortProtocol::Tcp, None);
         }
@@ -3194,7 +3235,15 @@ branch refs/heads/feat-b
         let pm = Arc::new(Mutex::new(PortManager::new(false)));
         {
             let mut guard = pm.lock().await;
-            guard.register_container("c1", "test", Some("172.20.0.5".to_string()), vec![], None);
+            guard.register_container(ContainerRegistrationInfo {
+                container_id: "c1".to_string(),
+                container_name: "test".to_string(),
+                container_ip: Some("172.20.0.5".to_string()),
+                ports_attributes: vec![],
+                other_ports_attributes: None,
+                project_name: None,
+                branch: None,
+            });
         }
         let browser = Arc::new(BrowserHandler::new());
         let clipboard = Arc::new(crate::clipboard::ClipboardHandler::null());
@@ -3312,8 +3361,24 @@ branch refs/heads/feat-b
         let pm = Arc::new(Mutex::new(PortManager::new(false)));
         {
             let mut guard = pm.lock().await;
-            guard.register_container("c1", "a", Some("172.20.0.5".to_string()), vec![], None);
-            guard.register_container("c2", "b", Some("172.20.0.6".to_string()), vec![], None);
+            guard.register_container(ContainerRegistrationInfo {
+                container_id: "c1".to_string(),
+                container_name: "a".to_string(),
+                container_ip: Some("172.20.0.5".to_string()),
+                ports_attributes: vec![],
+                other_ports_attributes: None,
+                project_name: None,
+                branch: None,
+            });
+            guard.register_container(ContainerRegistrationInfo {
+                container_id: "c2".to_string(),
+                container_name: "b".to_string(),
+                container_ip: Some("172.20.0.6".to_string()),
+                ports_attributes: vec![],
+                other_ports_attributes: None,
+                project_name: None,
+                branch: None,
+            });
             guard.handle_port_open("c1", 4000, PortProtocol::Tcp, None);
             guard.handle_port_open("c2", 4000, PortProtocol::Tcp, None);
         }
@@ -3337,7 +3402,15 @@ branch refs/heads/feat-b
         let pm = Arc::new(Mutex::new(PortManager::new(false)));
         {
             let mut guard = pm.lock().await;
-            guard.register_container("c1", "test", Some("172.20.0.5".to_string()), vec![], None);
+            guard.register_container(ContainerRegistrationInfo {
+                container_id: "c1".to_string(),
+                container_name: "test".to_string(),
+                container_ip: Some("172.20.0.5".to_string()),
+                ports_attributes: vec![],
+                other_ports_attributes: None,
+                project_name: None,
+                branch: None,
+            });
         }
         let browser = Arc::new(BrowserHandler::new());
         let clipboard = Arc::new(crate::clipboard::ClipboardHandler::null());
@@ -3379,17 +3452,19 @@ branch refs/heads/feat-b
         let pm = Arc::new(Mutex::new(PortManager::new(false)));
         {
             let mut guard = pm.lock().await;
-            guard.register_container(
-                "c1",
-                "test",
-                Some("172.20.0.5".to_string()),
-                vec![cella_protocol::PortAttributes {
+            guard.register_container(ContainerRegistrationInfo {
+                container_id: "c1".to_string(),
+                container_name: "test".to_string(),
+                container_ip: Some("172.20.0.5".to_string()),
+                ports_attributes: vec![cella_protocol::PortAttributes {
                     port: cella_protocol::PortPattern::Single(9229),
                     on_auto_forward: cella_protocol::OnAutoForward::Ignore,
                     ..cella_protocol::PortAttributes::default()
                 }],
-                None,
-            );
+                other_ports_attributes: None,
+                project_name: None,
+                branch: None,
+            });
         }
         let browser = Arc::new(BrowserHandler::new());
         let clipboard = Arc::new(crate::clipboard::ClipboardHandler::null());
@@ -3425,7 +3500,15 @@ branch refs/heads/feat-b
         let pm = Arc::new(Mutex::new(PortManager::new(false)));
         {
             let mut guard = pm.lock().await;
-            guard.register_container("c1", "test", None, vec![], None);
+            guard.register_container(ContainerRegistrationInfo {
+                container_id: "c1".to_string(),
+                container_name: "test".to_string(),
+                container_ip: None,
+                ports_attributes: vec![],
+                other_ports_attributes: None,
+                project_name: None,
+                branch: None,
+            });
         }
         let browser = Arc::new(BrowserHandler::new());
         let clipboard = Arc::new(crate::clipboard::ClipboardHandler::null());
@@ -3462,7 +3545,15 @@ branch refs/heads/feat-b
         let pm = Arc::new(Mutex::new(PortManager::new(false)));
         pm.lock()
             .await
-            .register_container("c1", "test", None, vec![], None);
+            .register_container(ContainerRegistrationInfo {
+                container_id: "c1".to_string(),
+                container_name: "test".to_string(),
+                container_ip: None,
+                ports_attributes: vec![],
+                other_ports_attributes: None,
+                project_name: None,
+                branch: None,
+            });
         assert!(
             pm.lock()
                 .await

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -38,6 +38,7 @@ pub(crate) struct ControlContext {
     pub cella_bin: std::path::PathBuf,
     pub tunnel_broker: Arc<TunnelBroker>,
     pub is_orbstack: bool,
+    pub hostname_route_table: cella_proxy::server::SharedRouteTable,
 }
 
 /// Tracks whether an agent has actually connected and sent messages.
@@ -395,6 +396,7 @@ async fn handle_agent_connection_after_hello(
                     container_ip: hs.container_ip.as_deref(),
                     container_name: Some(&hs.container_name),
                     is_orbstack: ctx.is_orbstack,
+                    hostname_route_table: ctx.hostname_route_table.clone(),
                 };
                 let response = handle_agent_message(msg, &handler_ctx, &hs.agent_state).await;
 
@@ -435,6 +437,7 @@ pub(crate) struct AgentHandlerContext<'a> {
     pub container_ip: Option<&'a str>,
     pub container_name: Option<&'a str>,
     pub is_orbstack: bool,
+    pub hostname_route_table: cella_proxy::server::SharedRouteTable,
 }
 
 use crate::proxy::ProxyStartTarget;
@@ -442,7 +445,7 @@ use crate::proxy::ProxyStartTarget;
 /// Start a TCP proxy for a forwarded port and verify it bound successfully.
 ///
 /// Returns `false` if the proxy bind failed and the allocation should be rolled back.
-async fn start_port_proxy(
+pub(crate) async fn start_port_proxy(
     host_port: u16,
     target: ProxyStartTarget,
     proxy_cmd_tx: &tokio::sync::mpsc::Sender<ProxyCommand>,
@@ -483,9 +486,11 @@ async fn handle_port_open(
     );
     let host_port = {
         let mut pm = ctx.port_manager.lock().await;
+        let existing = pm.host_port_for(&cid, port);
         pm.handle_port_open(&cid, port, protocol, process)
+            .map(|hp| (hp, existing == Some(hp)))
     };
-    let Some(hp) = host_port else {
+    let Some((hp, already_forwarded)) = host_port else {
         return Some(DaemonMessage::Ack { id: None });
     };
 
@@ -495,7 +500,9 @@ async fn handle_port_open(
         pm.container_ip(&cid).map(str::to_string)
     };
 
-    if let Some(tx) = ctx.proxy_cmd_tx {
+    if let Some(tx) = ctx.proxy_cmd_tx
+        && !already_forwarded
+    {
         let use_direct_ip = cfg!(target_os = "linux") || ctx.is_orbstack;
         let target = if use_direct_ip {
             if let Some(ip) = current_container_ip.as_deref().or(ctx.container_ip) {
@@ -525,6 +532,8 @@ async fn handle_port_open(
         }
     }
 
+    sync_hostname_route(&cid, port, ctx).await;
+
     Some(DaemonMessage::PortMapping {
         container_port: port,
         host_port: hp,
@@ -535,14 +544,56 @@ async fn handle_port_open(
 async fn handle_port_closed(port: u16, protocol: PortProtocol, ctx: &AgentHandlerContext<'_>) {
     let cid = ctx.container_id.unwrap_or("unknown").to_string();
     debug!("Port closed: {port}/{protocol} from {cid}");
-    let host_port = {
+    let (host_port, route) = {
         let mut pm = ctx.port_manager.lock().await;
-        pm.handle_port_closed(&cid, port)
+        let route = pm.hostname_route_for(&cid, port);
+        let host_port = pm.handle_port_closed(&cid, port);
+        (host_port, route)
     };
 
     if let (Some(hp), Some(tx)) = (host_port, ctx.proxy_cmd_tx) {
         let _ = tx.send(ProxyCommand::Stop { host_port: hp }).await;
     }
+    remove_hostname_route(route, ctx).await;
+}
+
+async fn sync_hostname_route(container_id: &str, port: u16, ctx: &AgentHandlerContext<'_>) {
+    let route = {
+        let pm = ctx.port_manager.lock().await;
+        pm.hostname_route_for(container_id, port)
+    };
+    let Some(route) = route else { return };
+    let container_name = ctx.container_name.unwrap_or("unknown").to_string();
+
+    let mut rt = ctx.hostname_route_table.write().await;
+    rt.insert(
+        cella_proxy::router::RouteKey {
+            project: route.project.clone(),
+            branch: route.branch.clone(),
+            port: route.container_port,
+        },
+        cella_proxy::router::BackendTarget {
+            container_id: container_id.to_string(),
+            container_name,
+            target_port: route.host_port,
+            mode: cella_proxy::router::ProxyMode::Localhost,
+        },
+    );
+    rt.set_default_port_if_absent(&route.project, &route.branch, route.container_port);
+}
+
+async fn remove_hostname_route(
+    route: Option<crate::port_manager::HostnameRouteInfo>,
+    ctx: &AgentHandlerContext<'_>,
+) {
+    let Some(route) = route else { return };
+
+    let mut rt = ctx.hostname_route_table.write().await;
+    rt.remove(&cella_proxy::router::RouteKey {
+        project: route.project,
+        branch: route.branch,
+        port: route.container_port,
+    });
 }
 
 /// Handle a browser open request from an agent.
@@ -2430,6 +2481,9 @@ mod tests {
             cella_bin: std::path::PathBuf::from("/nonexistent"),
             tunnel_broker: Arc::new(TunnelBroker::new()),
             is_orbstack: false,
+            hostname_route_table: Arc::new(tokio::sync::RwLock::new(
+                cella_proxy::router::RouteTable::new(),
+            )),
         }
     }
 
@@ -3103,6 +3157,9 @@ branch refs/heads/feat-b
             container_ip: None,
             container_name: None,
             is_orbstack: false,
+            hostname_route_table: Arc::new(tokio::sync::RwLock::new(
+                cella_proxy::router::RouteTable::new(),
+            )),
         };
 
         let msg = AgentMessage::Health {
@@ -3135,6 +3192,9 @@ branch refs/heads/feat-b
             container_ip: None,
             container_name: None,
             is_orbstack: false,
+            hostname_route_table: Arc::new(tokio::sync::RwLock::new(
+                cella_proxy::router::RouteTable::new(),
+            )),
         };
 
         let msg = AgentMessage::ClipboardCopy {
@@ -3161,6 +3221,9 @@ branch refs/heads/feat-b
             container_ip: None,
             container_name: None,
             is_orbstack: false,
+            hostname_route_table: Arc::new(tokio::sync::RwLock::new(
+                cella_proxy::router::RouteTable::new(),
+            )),
         };
 
         let msg = AgentMessage::ClipboardCopy {
@@ -3187,6 +3250,9 @@ branch refs/heads/feat-b
             container_ip: None,
             container_name: None,
             is_orbstack: false,
+            hostname_route_table: Arc::new(tokio::sync::RwLock::new(
+                cella_proxy::router::RouteTable::new(),
+            )),
         };
 
         let msg = AgentMessage::ClipboardPaste {
@@ -3215,6 +3281,9 @@ branch refs/heads/feat-b
             container_ip: None,
             container_name: None,
             is_orbstack: false,
+            hostname_route_table: Arc::new(tokio::sync::RwLock::new(
+                cella_proxy::router::RouteTable::new(),
+            )),
         };
 
         let msg = AgentMessage::ClipboardPaste { mime_type: None };
@@ -3257,6 +3326,9 @@ branch refs/heads/feat-b
             container_ip: None,
             container_name: None,
             is_orbstack: false,
+            hostname_route_table: Arc::new(tokio::sync::RwLock::new(
+                cella_proxy::router::RouteTable::new(),
+            )),
         };
 
         let msg = AgentMessage::PortClosed {
@@ -3286,6 +3358,9 @@ branch refs/heads/feat-b
             container_ip: None,
             container_name: None,
             is_orbstack: false,
+            hostname_route_table: Arc::new(tokio::sync::RwLock::new(
+                cella_proxy::router::RouteTable::new(),
+            )),
         };
 
         // Use an unknown operation so it fails fast without needing real git
@@ -3329,6 +3404,9 @@ branch refs/heads/feat-b
             container_ip: None,
             container_name: None,
             is_orbstack: false,
+            hostname_route_table: Arc::new(tokio::sync::RwLock::new(
+                cella_proxy::router::RouteTable::new(),
+            )),
         };
 
         let msg = AgentMessage::Health {
@@ -3424,6 +3502,9 @@ branch refs/heads/feat-b
             container_ip: None,
             container_name: None,
             is_orbstack: false,
+            hostname_route_table: Arc::new(tokio::sync::RwLock::new(
+                cella_proxy::router::RouteTable::new(),
+            )),
         };
 
         let msg = AgentMessage::PortOpen {
@@ -3445,6 +3526,87 @@ branch refs/heads/feat-b
             }
             other => panic!("Expected PortMapping, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn port_open_duplicate_and_close_update_hostname_routes() {
+        let pm = Arc::new(Mutex::new(PortManager::new(false)));
+        {
+            let mut guard = pm.lock().await;
+            guard.register_container(ContainerRegistrationInfo {
+                container_id: "c1".to_string(),
+                container_name: "test".to_string(),
+                container_ip: Some("172.20.0.5".to_string()),
+                ports_attributes: vec![],
+                other_ports_attributes: None,
+                project_name: Some("My App".to_string()),
+                branch: Some("feature/auth".to_string()),
+            });
+        }
+        let browser = Arc::new(BrowserHandler::new());
+        let clipboard = Arc::new(crate::clipboard::ClipboardHandler::null());
+        let state = Arc::new(AgentConnectionState::new());
+        let routes = Arc::new(tokio::sync::RwLock::new(
+            cella_proxy::router::RouteTable::new(),
+        ));
+        let ctx = AgentHandlerContext {
+            port_manager: &pm,
+            browser_handler: &browser,
+            clipboard_handler: &clipboard,
+            container_id: Some("c1"),
+            proxy_cmd_tx: None,
+            container_ip: None,
+            container_name: Some("test"),
+            is_orbstack: false,
+            hostname_route_table: routes.clone(),
+        };
+
+        let msg = AgentMessage::PortOpen {
+            port: 3000,
+            protocol: PortProtocol::Tcp,
+            process: None,
+            bind: cella_protocol::BindAddress::All,
+            proxy_port: None,
+        };
+        let first = handle_agent_message(msg.clone(), &ctx, &state).await;
+        let second = handle_agent_message(msg, &ctx, &state).await;
+        assert!(matches!(
+            first,
+            Some(DaemonMessage::PortMapping {
+                container_port: 3000,
+                host_port: 3000
+            })
+        ));
+        assert!(matches!(
+            second,
+            Some(DaemonMessage::PortMapping {
+                container_port: 3000,
+                host_port: 3000
+            })
+        ));
+
+        {
+            let table = routes.read().await;
+            let target = table.lookup("my-app", "feature-auth", 3000).unwrap();
+            assert_eq!(target.target_port, 3000);
+            assert!(matches!(
+                target.mode,
+                cella_proxy::router::ProxyMode::Localhost
+            ));
+        }
+
+        let closed = AgentMessage::PortClosed {
+            port: 3000,
+            protocol: PortProtocol::Tcp,
+        };
+        assert!(handle_agent_message(closed, &ctx, &state).await.is_none());
+        assert!(
+            routes
+                .read()
+                .await
+                .lookup("my-app", "feature-auth", 3000)
+                .is_none()
+        );
     }
 
     #[tokio::test]
@@ -3478,6 +3640,9 @@ branch refs/heads/feat-b
             container_ip: Some("172.20.0.5"),
             container_name: Some("test"),
             is_orbstack: false,
+            hostname_route_table: Arc::new(tokio::sync::RwLock::new(
+                cella_proxy::router::RouteTable::new(),
+            )),
         };
 
         let msg = AgentMessage::PortOpen {
@@ -3523,6 +3688,9 @@ branch refs/heads/feat-b
             container_ip: None,
             container_name: Some("test"),
             is_orbstack: false,
+            hostname_route_table: Arc::new(tokio::sync::RwLock::new(
+                cella_proxy::router::RouteTable::new(),
+            )),
         };
 
         let msg = AgentMessage::PortOpen {
@@ -3598,6 +3766,9 @@ branch refs/heads/feat-b
             container_ip: None,
             container_name: Some("test"),
             is_orbstack: false,
+            hostname_route_table: Arc::new(tokio::sync::RwLock::new(
+                cella_proxy::router::RouteTable::new(),
+            )),
         };
 
         let msg = AgentMessage::PortOpen {

--- a/crates/cella-daemon/src/daemon.rs
+++ b/crates/cella-daemon/src/daemon.rs
@@ -49,6 +49,23 @@ fn write_control_file(
     Ok(control_file_path)
 }
 
+async fn start_hostname_proxy(is_orbstack: bool) -> cella_proxy::server::SharedRouteTable {
+    let rt = Arc::new(tokio::sync::RwLock::new(
+        cella_proxy::router::RouteTable::new(),
+    ));
+    if !is_orbstack {
+        let addr: std::net::SocketAddr = ([127, 0, 0, 1], 80).into();
+        match cella_proxy::server::start_proxy_server(addr, rt.clone()).await {
+            Ok(_handle) => info!("Hostname proxy started on {addr}"),
+            Err(e) => {
+                warn!("Could not start hostname proxy on port 80: {e}");
+                info!("Hostname-based routing unavailable; using port-based forwarding only");
+            }
+        }
+    }
+    rt
+}
+
 /// Run the unified cella daemon.
 ///
 /// Starts the control server and health monitor.
@@ -142,6 +159,8 @@ pub async fn run_daemon(socket_path: &Path, pid_path: &Path) -> Result<(), Cella
         .unwrap_or_default()
         .as_secs();
 
+    let hostname_route_table = start_hostname_proxy(is_orbstack).await;
+
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
     let ctx = ManagementContext {
@@ -159,6 +178,7 @@ pub async fn run_daemon(socket_path: &Path, pid_path: &Path) -> Result<(), Cella
         ssh_proxy_manager,
         container_handles,
         tunnel_broker,
+        hostname_route_table,
     };
 
     // Run the management server (CLI protocol) — blocks until shutdown

--- a/crates/cella-daemon/src/daemon.rs
+++ b/crates/cella-daemon/src/daemon.rs
@@ -49,21 +49,84 @@ fn write_control_file(
     Ok(control_file_path)
 }
 
-async fn start_hostname_proxy(is_orbstack: bool) -> cella_proxy::server::SharedRouteTable {
-    let rt = Arc::new(tokio::sync::RwLock::new(
+struct HostnameProxyRuntime {
+    route_table: cella_proxy::server::SharedRouteTable,
+    status: Option<cella_protocol::HostnameProxyStatus>,
+}
+
+async fn start_hostname_proxy(is_orbstack: bool, socket_path: &Path) -> HostnameProxyRuntime {
+    let route_table = Arc::new(tokio::sync::RwLock::new(
         cella_proxy::router::RouteTable::new(),
     ));
     if !is_orbstack {
-        let addr: std::net::SocketAddr = ([127, 0, 0, 1], 80).into();
-        match cella_proxy::server::start_proxy_server(addr, rt.clone()).await {
-            Ok(_handle) => info!("Hostname proxy started on {addr}"),
-            Err(e) => {
-                warn!("Could not start hostname proxy on port 80: {e}");
-                info!("Hostname-based routing unavailable; using port-based forwarding only");
+        for (addr, using_fallback_port) in hostname_proxy_bind_candidates(socket_path) {
+            match cella_proxy::server::start_proxy_server(addr, route_table.clone()).await {
+                Ok(_handle) => {
+                    info!("Hostname proxy started on {addr}");
+                    persist_hostname_proxy_port(socket_path, addr.port(), using_fallback_port);
+                    return HostnameProxyRuntime {
+                        route_table,
+                        status: Some(cella_protocol::HostnameProxyStatus {
+                            enabled: true,
+                            address: Some(addr.to_string()),
+                            port: Some(addr.port()),
+                            using_fallback_port,
+                        }),
+                    };
+                }
+                Err(e) => {
+                    warn!("Could not start hostname proxy on {addr}: {e}");
+                }
             }
         }
+        info!("Hostname-based routing unavailable; using port-based forwarding only");
     }
-    rt
+    HostnameProxyRuntime {
+        route_table,
+        status: Some(cella_protocol::HostnameProxyStatus {
+            enabled: false,
+            address: None,
+            port: None,
+            using_fallback_port: false,
+        }),
+    }
+}
+
+fn hostname_proxy_bind_candidates(socket_path: &Path) -> Vec<(std::net::SocketAddr, bool)> {
+    let persisted_port = read_persisted_hostname_proxy_port(socket_path);
+    let mut candidates = vec![(([127, 0, 0, 1], 80).into(), false)];
+    if let Some(port) = persisted_port
+        && port != 80
+    {
+        candidates.push((([127, 0, 0, 1], port).into(), true));
+    }
+    candidates.push((([127, 0, 0, 1], 0).into(), true));
+    candidates
+}
+
+fn hostname_proxy_port_file(socket_path: &Path) -> PathBuf {
+    socket_path.with_file_name("hostname-proxy.port")
+}
+
+fn read_persisted_hostname_proxy_port(socket_path: &Path) -> Option<u16> {
+    std::fs::read_to_string(hostname_proxy_port_file(socket_path))
+        .ok()
+        .and_then(|s| s.trim().parse::<u16>().ok())
+        .filter(|port| *port > 0)
+}
+
+fn persist_hostname_proxy_port(socket_path: &Path, port: u16, using_fallback_port: bool) {
+    let path = hostname_proxy_port_file(socket_path);
+    if using_fallback_port {
+        if let Err(e) = std::fs::write(&path, port.to_string()) {
+            warn!(
+                "failed to persist hostname proxy port {}: {e}",
+                path.display()
+            );
+        }
+    } else {
+        let _ = std::fs::remove_file(path);
+    }
 }
 
 /// Run the unified cella daemon.
@@ -159,7 +222,7 @@ pub async fn run_daemon(socket_path: &Path, pid_path: &Path) -> Result<(), Cella
         .unwrap_or_default()
         .as_secs();
 
-    let hostname_route_table = start_hostname_proxy(is_orbstack).await;
+    let hostname_proxy = start_hostname_proxy(is_orbstack, socket_path).await;
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
@@ -178,7 +241,8 @@ pub async fn run_daemon(socket_path: &Path, pid_path: &Path) -> Result<(), Cella
         ssh_proxy_manager,
         container_handles,
         tunnel_broker,
-        hostname_route_table,
+        hostname_route_table: hostname_proxy.route_table,
+        hostname_proxy: hostname_proxy.status,
     };
 
     // Run the management server (CLI protocol) — blocks until shutdown
@@ -439,6 +503,19 @@ mod tests {
         let control = dir.path().join("daemon.sock");
         let token = load_or_create_auth_token(&control).unwrap();
         assert!(is_valid_token(&token));
+    }
+
+    #[test]
+    fn hostname_proxy_bind_candidates_include_persisted_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("daemon.sock");
+        std::fs::write(hostname_proxy_port_file(&socket), "49180").unwrap();
+
+        let candidates = hostname_proxy_bind_candidates(&socket);
+
+        assert_eq!(candidates[0], (([127, 0, 0, 1], 80).into(), false));
+        assert_eq!(candidates[1], (([127, 0, 0, 1], 49180).into(), true));
+        assert_eq!(candidates[2], (([127, 0, 0, 1], 0).into(), true));
     }
 
     #[cfg(unix)]

--- a/crates/cella-daemon/src/daemon.rs
+++ b/crates/cella-daemon/src/daemon.rs
@@ -61,15 +61,19 @@ async fn start_hostname_proxy(is_orbstack: bool, socket_path: &Path) -> Hostname
     if !is_orbstack {
         for (addr, using_fallback_port) in hostname_proxy_bind_candidates(socket_path) {
             match cella_proxy::server::start_proxy_server(addr, route_table.clone()).await {
-                Ok(_handle) => {
-                    info!("Hostname proxy started on {addr}");
-                    persist_hostname_proxy_port(socket_path, addr.port(), using_fallback_port);
+                Ok((bound_addr, _handle)) => {
+                    info!("Hostname proxy started on {bound_addr}");
+                    persist_hostname_proxy_port(
+                        socket_path,
+                        bound_addr.port(),
+                        using_fallback_port,
+                    );
                     return HostnameProxyRuntime {
                         route_table,
                         status: Some(cella_protocol::HostnameProxyStatus {
                             enabled: true,
-                            address: Some(addr.to_string()),
-                            port: Some(addr.port()),
+                            address: Some(bound_addr.to_string()),
+                            port: Some(bound_addr.port()),
                             using_fallback_port,
                         }),
                     };

--- a/crates/cella-daemon/src/management.rs
+++ b/crates/cella-daemon/src/management.rs
@@ -39,6 +39,7 @@ pub(crate) struct ManagementContext {
     pub container_handles: Arc<Mutex<HashMap<String, ContainerHandle>>>,
     pub tunnel_broker: Arc<crate::tunnel::TunnelBroker>,
     pub hostname_route_table: cella_proxy::server::SharedRouteTable,
+    pub hostname_proxy: Option<cella_protocol::HostnameProxyStatus>,
 }
 
 /// Bind the management Unix socket, cleaning up stale sockets and setting permissions.
@@ -236,7 +237,9 @@ async fn handle_management_request(
             )
             .await
         }
-        ManagementRequest::QueryPorts => handle_query_ports(&ctx.port_manager).await,
+        ManagementRequest::QueryPorts => {
+            handle_query_ports(&ctx.port_manager, ctx.hostname_proxy.as_ref()).await
+        }
         ManagementRequest::QueryStatus => {
             handle_query_status(
                 &ctx.port_manager,
@@ -246,6 +249,7 @@ async fn handle_management_request(
                 ctx.daemon_started_at,
                 &ctx.auth_token,
                 ctx.control_port,
+                ctx.hostname_proxy.clone(),
             )
             .await
         }
@@ -527,13 +531,18 @@ async fn handle_deregister(
 }
 
 /// Handle port query.
-async fn handle_query_ports(port_manager: &Arc<Mutex<PortManager>>) -> ManagementResponse {
+async fn handle_query_ports(
+    port_manager: &Arc<Mutex<PortManager>>,
+    hostname_proxy: Option<&cella_protocol::HostnameProxyStatus>,
+) -> ManagementResponse {
+    let hostname_proxy_port =
+        hostname_proxy.and_then(|status| if status.enabled { status.port } else { None });
     let ports = {
         let pm = port_manager.lock().await;
         pm.all_forwarded_ports()
             .into_iter()
             .map(|p| {
-                let hostname = p.hostname_url();
+                let hostname = p.hostname_url(hostname_proxy_port);
                 ForwardedPortDetail {
                     container_name: p.container_name.clone(),
                     container_port: p.container_port,
@@ -559,6 +568,7 @@ async fn handle_query_status(
     daemon_started_at: u64,
     auth_token: &str,
     control_port: u16,
+    hostname_proxy: Option<cella_protocol::HostnameProxyStatus>,
 ) -> ManagementResponse {
     let handles = container_handles.lock().await;
     let pm = port_manager.lock().await;
@@ -600,6 +610,7 @@ async fn handle_query_status(
         daemon_started_at,
         control_port,
         control_token: auth_token.to_string(),
+        hostname_proxy,
     }
 }
 
@@ -631,6 +642,12 @@ mod tests {
             hostname_route_table: Arc::new(tokio::sync::RwLock::new(
                 cella_proxy::router::RouteTable::new(),
             )),
+            hostname_proxy: Some(cella_protocol::HostnameProxyStatus {
+                enabled: true,
+                address: Some("127.0.0.1:80".to_string()),
+                port: Some(80),
+                using_fallback_port: false,
+            }),
         };
         (ctx, srx)
     }
@@ -757,6 +774,40 @@ mod tests {
         );
 
         server_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn query_ports_includes_hostname_proxy_fallback_port() {
+        let pm = Arc::new(Mutex::new(PortManager::new(false)));
+        {
+            let mut guard = pm.lock().await;
+            guard.register_container(crate::port_manager::ContainerRegistrationInfo {
+                container_id: "c1".to_string(),
+                container_name: "test-container".to_string(),
+                container_ip: Some("172.20.0.5".to_string()),
+                ports_attributes: vec![],
+                other_ports_attributes: None,
+                project_name: Some("myapp".to_string()),
+                branch: Some("feature/auth".to_string()),
+            });
+            guard.handle_port_open("c1", 3000, cella_protocol::PortProtocol::Tcp, None);
+        }
+        let status = cella_protocol::HostnameProxyStatus {
+            enabled: true,
+            address: Some("127.0.0.1:49180".to_string()),
+            port: Some(49180),
+            using_fallback_port: true,
+        };
+
+        let resp = handle_query_ports(&pm, Some(&status)).await;
+
+        let ManagementResponse::Ports { ports } = resp else {
+            panic!("expected ports response");
+        };
+        assert_eq!(
+            ports[0].hostname.as_deref(),
+            Some("http://3000.feature-auth.myapp.localhost:49180")
+        );
     }
 
     /// Stand up an echo server on `path` to mimic an upstream ssh-agent.

--- a/crates/cella-daemon/src/management.rs
+++ b/crates/cella-daemon/src/management.rs
@@ -38,6 +38,7 @@ pub(crate) struct ManagementContext {
     pub ssh_proxy_manager: crate::ssh_proxy::SharedSshProxyManager,
     pub container_handles: Arc<Mutex<HashMap<String, ContainerHandle>>>,
     pub tunnel_broker: Arc<crate::tunnel::TunnelBroker>,
+    pub hostname_route_table: cella_proxy::server::SharedRouteTable,
 }
 
 /// Bind the management Unix socket, cleaning up stale sockets and setting permissions.
@@ -215,10 +216,23 @@ async fn handle_management_request(
                 project_name: data.project_name,
                 branch: data.branch,
             };
-            handle_register(reg, &ctx.port_manager, container_handles, &ctx.proxy_cmd_tx).await
+            handle_register(
+                reg,
+                &ctx.port_manager,
+                container_handles,
+                &ctx.proxy_cmd_tx,
+                &ctx.hostname_route_table,
+            )
+            .await
         }
         ManagementRequest::DeregisterContainer { container_name } => {
-            handle_deregister(&container_name, &ctx.port_manager, container_handles).await
+            handle_deregister(
+                &container_name,
+                &ctx.port_manager,
+                container_handles,
+                &ctx.hostname_route_table,
+            )
+            .await
         }
         ManagementRequest::QueryPorts => handle_query_ports(&ctx.port_manager).await,
         ManagementRequest::QueryStatus => {
@@ -337,10 +351,14 @@ async fn handle_register(
     port_manager: &Arc<Mutex<PortManager>>,
     container_handles: &Arc<Mutex<HashMap<String, ContainerHandle>>>,
     proxy_cmd_tx: &mpsc::Sender<ProxyCommand>,
+    route_table: &cella_proxy::server::SharedRouteTable,
 ) -> ManagementResponse {
     // Register with port manager
     let container_id = reg.container_id.clone();
     let container_name = reg.container_name.clone();
+    let project_name = reg.project_name.clone();
+    let branch = reg.branch.clone();
+    let container_ip_clone = reg.container_ip.clone();
     {
         use crate::port_manager::ContainerRegistrationInfo;
         let mut pm = port_manager.lock().await;
@@ -372,6 +390,18 @@ async fn handle_register(
         }
     }
 
+    // Populate hostname route table
+    populate_routes(
+        route_table,
+        &container_id,
+        &container_name,
+        project_name.as_deref(),
+        branch.as_deref(),
+        container_ip_clone.as_deref(),
+        &reg.forward_ports,
+    )
+    .await;
+
     // Store handle for agent connection tracking
     {
         let mut handles = container_handles.lock().await;
@@ -392,11 +422,50 @@ async fn handle_register(
     ManagementResponse::ContainerRegistered { container_name }
 }
 
+async fn populate_routes(
+    route_table: &cella_proxy::server::SharedRouteTable,
+    container_id: &str,
+    container_name: &str,
+    project: Option<&str>,
+    branch: Option<&str>,
+    container_ip: Option<&str>,
+    forward_ports: &[u16],
+) {
+    let Some(project) = project else { return };
+    let sanitized = cella_proxy::hostname::sanitize_branch(branch.unwrap_or("main"));
+    let mode = container_ip.and_then(|ip| ip.parse().ok()).map_or_else(
+        || cella_proxy::router::ProxyMode::AgentTunnel(container_name.to_string()),
+        cella_proxy::router::ProxyMode::DirectIp,
+    );
+
+    let mut rt = route_table.write().await;
+    rt.remove_container(container_id);
+    for (i, &port) in forward_ports.iter().enumerate() {
+        rt.insert(
+            cella_proxy::router::RouteKey {
+                project: project.to_string(),
+                branch: sanitized.clone(),
+                port,
+            },
+            cella_proxy::router::BackendTarget {
+                container_id: container_id.to_string(),
+                container_name: container_name.to_string(),
+                target_port: port,
+                mode: mode.clone(),
+            },
+        );
+        if i == 0 {
+            rt.set_default_port(project, &sanitized, port);
+        }
+    }
+}
+
 /// Handle container deregistration.
 async fn handle_deregister(
     container_name: &str,
     port_manager: &Arc<Mutex<PortManager>>,
     container_handles: &Arc<Mutex<HashMap<String, ContainerHandle>>>,
+    route_table: &cella_proxy::server::SharedRouteTable,
 ) -> ManagementResponse {
     let mut ports_released = 0;
 
@@ -414,6 +483,12 @@ async fn handle_deregister(
         let ports_after = pm.all_forwarded_ports().len();
         drop(pm);
         ports_released = ports_before.saturating_sub(ports_after);
+
+        // Remove hostname routes
+        route_table
+            .write()
+            .await
+            .remove_container(&handle.container_id);
     }
 
     info!("Deregistered container {container_name} ({ports_released} ports released)");
@@ -526,6 +601,9 @@ mod tests {
             ssh_proxy_manager: crate::ssh_proxy::new_shared(tmp.keep(), "test-token".to_string()),
             container_handles: Arc::new(Mutex::new(HashMap::new())),
             tunnel_broker: Arc::new(crate::tunnel::TunnelBroker::new()),
+            hostname_route_table: Arc::new(tokio::sync::RwLock::new(
+                cella_proxy::router::RouteTable::new(),
+            )),
         };
         (ctx, srx)
     }

--- a/crates/cella-daemon/src/management.rs
+++ b/crates/cella-daemon/src/management.rs
@@ -212,6 +212,8 @@ async fn handle_management_request(
                 forward_ports: data.forward_ports,
                 backend_kind: data.backend_kind,
                 docker_host: data.docker_host,
+                project_name: data.project_name,
+                branch: data.branch,
             };
             handle_register(reg, &ctx.port_manager, container_handles, &ctx.proxy_cmd_tx).await
         }
@@ -325,6 +327,8 @@ struct ContainerRegistration {
     forward_ports: Vec<u16>,
     backend_kind: Option<String>,
     docker_host: Option<String>,
+    project_name: Option<String>,
+    branch: Option<String>,
 }
 
 /// Handle container registration.
@@ -335,15 +339,20 @@ async fn handle_register(
     proxy_cmd_tx: &mpsc::Sender<ProxyCommand>,
 ) -> ManagementResponse {
     // Register with port manager
+    let container_id = reg.container_id.clone();
+    let container_name = reg.container_name.clone();
     {
+        use crate::port_manager::ContainerRegistrationInfo;
         let mut pm = port_manager.lock().await;
-        let released = pm.register_container(
-            &reg.container_id,
-            &reg.container_name,
-            reg.container_ip,
-            reg.ports_attributes,
-            reg.other_ports_attributes,
-        );
+        let released = pm.register_container(ContainerRegistrationInfo {
+            container_id: reg.container_id,
+            container_name: reg.container_name,
+            container_ip: reg.container_ip,
+            ports_attributes: reg.ports_attributes,
+            other_ports_attributes: reg.other_ports_attributes,
+            project_name: reg.project_name,
+            branch: reg.branch,
+        });
 
         // Stop coordinator-owned proxies for ports released by re-registration.
         for hp in released {
@@ -355,7 +364,7 @@ async fn handle_register(
         // Pre-allocate host ports for forwardPorts
         for &fwd_port in &reg.forward_ports {
             pm.handle_port_open(
-                &reg.container_id,
+                &container_id,
                 fwd_port,
                 cella_protocol::PortProtocol::Tcp,
                 None,
@@ -367,9 +376,9 @@ async fn handle_register(
     {
         let mut handles = container_handles.lock().await;
         handles.insert(
-            reg.container_name.clone(),
+            container_name.clone(),
             ContainerHandle {
-                container_id: reg.container_id,
+                container_id,
                 agent_state: Arc::new(AgentConnectionState::new()),
                 backend_kind: reg.backend_kind,
                 docker_host: reg.docker_host,
@@ -378,11 +387,9 @@ async fn handle_register(
         );
     }
 
-    info!("Registered container {}", reg.container_name);
+    info!("Registered container {container_name}");
 
-    ManagementResponse::ContainerRegistered {
-        container_name: reg.container_name,
-    }
+    ManagementResponse::ContainerRegistered { container_name }
 }
 
 /// Handle container deregistration.
@@ -423,14 +430,17 @@ async fn handle_query_ports(port_manager: &Arc<Mutex<PortManager>>) -> Managemen
         let pm = port_manager.lock().await;
         pm.all_forwarded_ports()
             .into_iter()
-            .map(|p| ForwardedPortDetail {
-                container_name: p.container_name.clone(),
-                container_port: p.container_port,
-                host_port: p.host_port,
-                protocol: p.protocol,
-                process: p.process.clone(),
-                url: p.url(),
-                hostname: None,
+            .map(|p| {
+                let hostname = p.hostname_url();
+                ForwardedPortDetail {
+                    container_name: p.container_name.clone(),
+                    container_port: p.container_port,
+                    host_port: p.host_port,
+                    protocol: p.protocol,
+                    process: p.process.clone(),
+                    url: p.url(),
+                    hostname,
+                }
             })
             .collect()
     };

--- a/crates/cella-daemon/src/management.rs
+++ b/crates/cella-daemon/src/management.rs
@@ -430,6 +430,7 @@ async fn handle_query_ports(port_manager: &Arc<Mutex<PortManager>>) -> Managemen
                 protocol: p.protocol,
                 process: p.process.clone(),
                 url: p.url(),
+                hostname: None,
             })
             .collect()
     };
@@ -590,6 +591,8 @@ mod tests {
                     shutdown_action: None,
                     backend_kind: Some("docker".to_string()),
                     docker_host: None,
+                    project_name: None,
+                    branch: None,
                 },
             )),
         )
@@ -903,6 +906,8 @@ mod tests {
                     shutdown_action: None,
                     backend_kind: Some("docker".to_string()),
                     docker_host: None,
+                    project_name: None,
+                    branch: None,
                 },
             )),
         )

--- a/crates/cella-daemon/src/management.rs
+++ b/crates/cella-daemon/src/management.rs
@@ -218,15 +218,7 @@ async fn handle_management_request(
                 project_name: data.project_name,
                 branch: data.branch,
             };
-            handle_register(
-                reg,
-                &ctx.port_manager,
-                container_handles,
-                &ctx.proxy_cmd_tx,
-                &ctx.hostname_route_table,
-                ctx.is_orbstack,
-            )
-            .await
+            handle_register(reg, ctx, container_handles).await
         }
         ManagementRequest::DeregisterContainer { container_name } => {
             handle_deregister(
@@ -240,19 +232,7 @@ async fn handle_management_request(
         ManagementRequest::QueryPorts => {
             handle_query_ports(&ctx.port_manager, ctx.hostname_proxy.as_ref()).await
         }
-        ManagementRequest::QueryStatus => {
-            handle_query_status(
-                &ctx.port_manager,
-                container_handles,
-                ctx.start_time,
-                ctx.is_orbstack,
-                ctx.daemon_started_at,
-                &ctx.auth_token,
-                ctx.control_port,
-                ctx.hostname_proxy.clone(),
-            )
-            .await
-        }
+        ManagementRequest::QueryStatus => handle_query_status(ctx, container_handles).await,
         ManagementRequest::UpdateContainerIp {
             container_id,
             container_ip,
@@ -354,62 +334,56 @@ struct ContainerRegistration {
 /// Handle container registration.
 async fn handle_register(
     reg: ContainerRegistration,
-    port_manager: &Arc<Mutex<PortManager>>,
+    ctx: &ManagementContext,
     container_handles: &Arc<Mutex<HashMap<String, ContainerHandle>>>,
-    proxy_cmd_tx: &mpsc::Sender<ProxyCommand>,
-    route_table: &cella_proxy::server::SharedRouteTable,
-    is_orbstack: bool,
 ) -> ManagementResponse {
     // Register with port manager
     let container_id = reg.container_id.clone();
     let container_name = reg.container_name.clone();
     let container_ip_clone = reg.container_ip.clone();
-    {
+    let released = {
         use crate::port_manager::ContainerRegistrationInfo;
-        let mut pm = port_manager.lock().await;
-        let released = pm.register_container(ContainerRegistrationInfo {
-            container_id: reg.container_id,
-            container_name: reg.container_name,
-            container_ip: reg.container_ip,
-            ports_attributes: reg.ports_attributes,
-            other_ports_attributes: reg.other_ports_attributes,
-            project_name: reg.project_name,
-            branch: reg.branch,
-        });
+        ctx.port_manager
+            .lock()
+            .await
+            .register_container(ContainerRegistrationInfo {
+                container_id: reg.container_id,
+                container_name: reg.container_name,
+                container_ip: reg.container_ip,
+                ports_attributes: reg.ports_attributes,
+                other_ports_attributes: reg.other_ports_attributes,
+                project_name: reg.project_name,
+                branch: reg.branch,
+            })
+    };
 
-        // Stop coordinator-owned proxies for ports released by re-registration.
-        for hp in released {
-            let _ = proxy_cmd_tx
-                .send(ProxyCommand::Stop { host_port: hp })
-                .await;
-        }
+    // Stop coordinator-owned proxies for ports released by re-registration.
+    for hp in released {
+        let _ = ctx
+            .proxy_cmd_tx
+            .send(ProxyCommand::Stop { host_port: hp })
+            .await;
     }
 
     // Store handle before starting tunnel-mode forwardPorts so those proxies
     // can resolve the agent channel once it connects.
-    {
-        let mut handles = container_handles.lock().await;
-        handles.insert(
-            container_name.clone(),
-            ContainerHandle {
-                container_id: container_id.clone(),
-                agent_state: Arc::new(AgentConnectionState::new()),
-                backend_kind: reg.backend_kind,
-                docker_host: reg.docker_host,
-                agent_tx: None,
-            },
-        );
-    }
+    container_handles.lock().await.insert(
+        container_name.clone(),
+        ContainerHandle {
+            container_id: container_id.clone(),
+            agent_state: Arc::new(AgentConnectionState::new()),
+            backend_kind: reg.backend_kind,
+            docker_host: reg.docker_host,
+            agent_tx: None,
+        },
+    );
 
     preload_forward_ports(
-        port_manager,
-        proxy_cmd_tx,
-        route_table,
+        ctx,
         &container_id,
         &container_name,
         container_ip_clone.as_deref(),
         &reg.forward_ports,
-        is_orbstack,
     )
     .await;
 
@@ -419,25 +393,25 @@ async fn handle_register(
 }
 
 async fn preload_forward_ports(
-    port_manager: &Arc<Mutex<PortManager>>,
-    proxy_cmd_tx: &mpsc::Sender<ProxyCommand>,
-    route_table: &cella_proxy::server::SharedRouteTable,
+    ctx: &ManagementContext,
     container_id: &str,
     container_name: &str,
     container_ip: Option<&str>,
     forward_ports: &[u16],
-    is_orbstack: bool,
 ) {
-    route_table.write().await.remove_container(container_id);
+    ctx.hostname_route_table
+        .write()
+        .await
+        .remove_container(container_id);
 
     for &port in forward_ports {
         let host_port = {
-            let mut pm = port_manager.lock().await;
+            let mut pm = ctx.port_manager.lock().await;
             pm.handle_port_open(container_id, port, cella_protocol::PortProtocol::Tcp, None)
         };
         let Some(host_port) = host_port else { continue };
 
-        let use_direct_ip = cfg!(target_os = "linux") || is_orbstack;
+        let use_direct_ip = cfg!(target_os = "linux") || ctx.is_orbstack;
         let target = if use_direct_ip {
             if let Some(ip) = container_ip {
                 crate::proxy::ProxyStartTarget::DirectIp {
@@ -446,7 +420,7 @@ async fn preload_forward_ports(
                 }
             } else {
                 warn!("No container IP for direct proxy, skipping forwardPort {port}");
-                port_manager
+                ctx.port_manager
                     .lock()
                     .await
                     .handle_port_closed(container_id, port);
@@ -459,20 +433,21 @@ async fn preload_forward_ports(
             }
         };
 
-        if !crate::control_server::start_port_proxy(host_port, target, proxy_cmd_tx).await {
-            port_manager
+        if !crate::control_server::start_port_proxy(host_port, target, &ctx.proxy_cmd_tx).await {
+            ctx.port_manager
                 .lock()
                 .await
                 .handle_port_closed(container_id, port);
             continue;
         }
 
-        let route = {
-            let pm = port_manager.lock().await;
-            pm.hostname_route_for(container_id, port)
-        };
+        let route = ctx
+            .port_manager
+            .lock()
+            .await
+            .hostname_route_for(container_id, port);
         if let Some(route) = route {
-            let mut rt = route_table.write().await;
+            let mut rt = ctx.hostname_route_table.write().await;
             rt.insert(
                 cella_proxy::router::RouteKey {
                     project: route.project.clone(),
@@ -561,17 +536,11 @@ async fn handle_query_ports(
 
 /// Handle status query.
 async fn handle_query_status(
-    port_manager: &Arc<Mutex<PortManager>>,
+    ctx: &ManagementContext,
     container_handles: &Arc<Mutex<HashMap<String, ContainerHandle>>>,
-    start_time: std::time::Instant,
-    is_orbstack: bool,
-    daemon_started_at: u64,
-    auth_token: &str,
-    control_port: u16,
-    hostname_proxy: Option<cella_protocol::HostnameProxyStatus>,
 ) -> ManagementResponse {
     let handles = container_handles.lock().await;
-    let pm = port_manager.lock().await;
+    let pm = ctx.port_manager.lock().await;
 
     let containers: Vec<ContainerSummary> = handles
         .iter()
@@ -602,15 +571,15 @@ async fn handle_query_status(
 
     ManagementResponse::Status {
         pid: std::process::id(),
-        uptime_secs: start_time.elapsed().as_secs(),
+        uptime_secs: ctx.start_time.elapsed().as_secs(),
         container_count,
         containers,
-        is_orbstack,
+        is_orbstack: ctx.is_orbstack,
         daemon_version: env!("CARGO_PKG_VERSION").to_string(),
-        daemon_started_at,
-        control_port,
-        control_token: auth_token.to_string(),
-        hostname_proxy,
+        daemon_started_at: ctx.daemon_started_at,
+        control_port: ctx.control_port,
+        control_token: ctx.auth_token.clone(),
+        hostname_proxy: ctx.hostname_proxy.clone(),
     }
 }
 

--- a/crates/cella-daemon/src/management.rs
+++ b/crates/cella-daemon/src/management.rs
@@ -97,6 +97,7 @@ pub(crate) async fn run_management_server(
             cella_bin: crate::control_server::resolve_cella_binary(),
             tunnel_broker: ctx.tunnel_broker.clone(),
             is_orbstack: ctx.is_orbstack,
+            hostname_route_table: ctx.hostname_route_table.clone(),
         };
         tokio::spawn(async move {
             crate::control_server::run_control_server(
@@ -222,6 +223,7 @@ async fn handle_management_request(
                 container_handles,
                 &ctx.proxy_cmd_tx,
                 &ctx.hostname_route_table,
+                ctx.is_orbstack,
             )
             .await
         }
@@ -352,12 +354,11 @@ async fn handle_register(
     container_handles: &Arc<Mutex<HashMap<String, ContainerHandle>>>,
     proxy_cmd_tx: &mpsc::Sender<ProxyCommand>,
     route_table: &cella_proxy::server::SharedRouteTable,
+    is_orbstack: bool,
 ) -> ManagementResponse {
     // Register with port manager
     let container_id = reg.container_id.clone();
     let container_name = reg.container_name.clone();
-    let project_name = reg.project_name.clone();
-    let branch = reg.branch.clone();
     let container_ip_clone = reg.container_ip.clone();
     {
         use crate::port_manager::ContainerRegistrationInfo;
@@ -378,37 +379,16 @@ async fn handle_register(
                 .send(ProxyCommand::Stop { host_port: hp })
                 .await;
         }
-
-        // Pre-allocate host ports for forwardPorts
-        for &fwd_port in &reg.forward_ports {
-            pm.handle_port_open(
-                &container_id,
-                fwd_port,
-                cella_protocol::PortProtocol::Tcp,
-                None,
-            );
-        }
     }
 
-    // Populate hostname route table
-    populate_routes(
-        route_table,
-        &container_id,
-        &container_name,
-        project_name.as_deref(),
-        branch.as_deref(),
-        container_ip_clone.as_deref(),
-        &reg.forward_ports,
-    )
-    .await;
-
-    // Store handle for agent connection tracking
+    // Store handle before starting tunnel-mode forwardPorts so those proxies
+    // can resolve the agent channel once it connects.
     {
         let mut handles = container_handles.lock().await;
         handles.insert(
             container_name.clone(),
             ContainerHandle {
-                container_id,
+                container_id: container_id.clone(),
                 agent_state: Arc::new(AgentConnectionState::new()),
                 backend_kind: reg.backend_kind,
                 docker_host: reg.docker_host,
@@ -417,45 +397,92 @@ async fn handle_register(
         );
     }
 
+    preload_forward_ports(
+        port_manager,
+        proxy_cmd_tx,
+        route_table,
+        &container_id,
+        &container_name,
+        container_ip_clone.as_deref(),
+        &reg.forward_ports,
+        is_orbstack,
+    )
+    .await;
+
     info!("Registered container {container_name}");
 
     ManagementResponse::ContainerRegistered { container_name }
 }
 
-async fn populate_routes(
+async fn preload_forward_ports(
+    port_manager: &Arc<Mutex<PortManager>>,
+    proxy_cmd_tx: &mpsc::Sender<ProxyCommand>,
     route_table: &cella_proxy::server::SharedRouteTable,
     container_id: &str,
     container_name: &str,
-    project: Option<&str>,
-    branch: Option<&str>,
     container_ip: Option<&str>,
     forward_ports: &[u16],
+    is_orbstack: bool,
 ) {
-    let Some(project) = project else { return };
-    let sanitized = cella_proxy::hostname::sanitize_branch(branch.unwrap_or("main"));
-    let mode = container_ip.and_then(|ip| ip.parse().ok()).map_or_else(
-        || cella_proxy::router::ProxyMode::AgentTunnel(container_name.to_string()),
-        cella_proxy::router::ProxyMode::DirectIp,
-    );
+    route_table.write().await.remove_container(container_id);
 
-    let mut rt = route_table.write().await;
-    rt.remove_container(container_id);
-    for (i, &port) in forward_ports.iter().enumerate() {
-        rt.insert(
-            cella_proxy::router::RouteKey {
-                project: project.to_string(),
-                branch: sanitized.clone(),
-                port,
-            },
-            cella_proxy::router::BackendTarget {
-                container_id: container_id.to_string(),
+    for &port in forward_ports {
+        let host_port = {
+            let mut pm = port_manager.lock().await;
+            pm.handle_port_open(container_id, port, cella_protocol::PortProtocol::Tcp, None)
+        };
+        let Some(host_port) = host_port else { continue };
+
+        let use_direct_ip = cfg!(target_os = "linux") || is_orbstack;
+        let target = if use_direct_ip {
+            if let Some(ip) = container_ip {
+                crate::proxy::ProxyStartTarget::DirectIp {
+                    ip: ip.to_string(),
+                    port,
+                }
+            } else {
+                warn!("No container IP for direct proxy, skipping forwardPort {port}");
+                port_manager
+                    .lock()
+                    .await
+                    .handle_port_closed(container_id, port);
+                continue;
+            }
+        } else {
+            crate::proxy::ProxyStartTarget::AgentTunnel {
                 container_name: container_name.to_string(),
-                target_port: port,
-                mode: mode.clone(),
-            },
-        );
-        if i == 0 {
-            rt.set_default_port(project, &sanitized, port);
+                port,
+            }
+        };
+
+        if !crate::control_server::start_port_proxy(host_port, target, proxy_cmd_tx).await {
+            port_manager
+                .lock()
+                .await
+                .handle_port_closed(container_id, port);
+            continue;
+        }
+
+        let route = {
+            let pm = port_manager.lock().await;
+            pm.hostname_route_for(container_id, port)
+        };
+        if let Some(route) = route {
+            let mut rt = route_table.write().await;
+            rt.insert(
+                cella_proxy::router::RouteKey {
+                    project: route.project.clone(),
+                    branch: route.branch.clone(),
+                    port: route.container_port,
+                },
+                cella_proxy::router::BackendTarget {
+                    container_id: container_id.to_string(),
+                    container_name: container_name.to_string(),
+                    target_port: route.host_port,
+                    mode: cella_proxy::router::ProxyMode::Localhost,
+                },
+            );
+            rt.set_default_port_if_absent(&route.project, &route.branch, route.container_port);
         }
     }
 }

--- a/crates/cella-daemon/src/port_manager.rs
+++ b/crates/cella-daemon/src/port_manager.rs
@@ -34,6 +34,8 @@ struct ContainerPorts {
     other_ports_attributes: Option<PortAttributes>,
     project_name: Option<String>,
     branch: Option<String>,
+    project_slug: Option<String>,
+    branch_slug: Option<String>,
 }
 
 /// A port detected by the in-container agent.
@@ -103,6 +105,16 @@ impl PortManager {
             self.allocation.release_container(&info.container_id);
         }
 
+        let project_slug = info
+            .project_name
+            .as_deref()
+            .map(cella_proxy::hostname::sanitize_branch)
+            .filter(|slug| !slug.is_empty());
+        let branch = info.branch.clone().unwrap_or_else(|| "main".to_string());
+        let branch_slug = project_slug
+            .as_ref()
+            .map(|project| self.collision_safe_branch_slug(project, &branch));
+
         self.containers.insert(
             info.container_id,
             ContainerPorts {
@@ -113,10 +125,33 @@ impl PortManager {
                 other_ports_attributes: info.other_ports_attributes,
                 project_name: info.project_name,
                 branch: info.branch,
+                project_slug,
+                branch_slug,
             },
         );
 
         released_ports
+    }
+
+    fn collision_safe_branch_slug(&self, project_slug: &str, branch: &str) -> String {
+        let sanitized = cella_proxy::hostname::sanitize_branch(branch);
+        let fallback = if sanitized.is_empty() {
+            "main".to_string()
+        } else {
+            sanitized
+        };
+
+        let collides = self.containers.values().any(|container| {
+            container.project_slug.as_deref() == Some(project_slug)
+                && container.branch_slug.as_deref() == Some(fallback.as_str())
+                && container.branch.as_deref().unwrap_or("main") != branch
+        });
+
+        if collides {
+            cella_proxy::hostname::sanitize_branch_with_suffix(branch)
+        } else {
+            fallback
+        }
     }
 
     /// Update a container's IP address without touching ports or allocations.
@@ -137,6 +172,28 @@ impl PortManager {
         self.containers
             .get(container_id)
             .and_then(|c| c.container_ip.as_deref())
+    }
+
+    /// Return the allocated host port for an already-detected container port.
+    pub fn host_port_for(&self, container_id: &str, port: u16) -> Option<u16> {
+        self.containers
+            .get(container_id)?
+            .detected_ports
+            .iter()
+            .find(|p| p.port == port)
+            .and_then(|p| p.host_port)
+    }
+
+    /// Return hostname route metadata for an allocated forwarded port.
+    pub fn hostname_route_for(&self, container_id: &str, port: u16) -> Option<HostnameRouteInfo> {
+        let container = self.containers.get(container_id)?;
+        let host_port = self.host_port_for(container_id, port)?;
+        Some(HostnameRouteInfo {
+            project: container.project_slug.clone()?,
+            branch: container.branch_slug.clone()?,
+            container_port: port,
+            host_port,
+        })
     }
 
     /// Allocate a host port using the port checker if configured.
@@ -288,6 +345,8 @@ impl PortManager {
                         is_orbstack: self.is_orbstack,
                         project_name: container.project_name.clone(),
                         branch: container.branch.clone(),
+                        project_slug: container.project_slug.clone(),
+                        branch_slug: container.branch_slug.clone(),
                     });
                 }
             }
@@ -323,6 +382,17 @@ pub struct ForwardedPortInfo {
     pub is_orbstack: bool,
     pub project_name: Option<String>,
     pub branch: Option<String>,
+    pub project_slug: Option<String>,
+    pub branch_slug: Option<String>,
+}
+
+/// Metadata needed to add/remove a hostname route.
+#[derive(Debug, Clone)]
+pub struct HostnameRouteInfo {
+    pub project: String,
+    pub branch: String,
+    pub container_port: u16,
+    pub host_port: u16,
 }
 
 impl ForwardedPortInfo {
@@ -345,8 +415,8 @@ impl ForwardedPortInfo {
 
     /// Get the hostname-based URL, if project and branch metadata are available.
     pub fn hostname_url(&self) -> Option<String> {
-        let project = self.project_name.as_ref()?;
-        let branch = self.branch.as_deref().unwrap_or("main");
+        let project = self.project_slug.as_ref()?;
+        let branch = self.branch_slug.as_deref().unwrap_or("main");
         Some(cella_proxy::hostname::build_hostname_url(
             self.container_port,
             branch,
@@ -501,6 +571,8 @@ mod tests {
             is_orbstack: true,
             project_name: None,
             branch: None,
+            project_slug: None,
+            branch_slug: None,
         };
         // url() always returns localhost
         assert_eq!(info.url(), "localhost:3000");
@@ -523,6 +595,8 @@ mod tests {
             is_orbstack: false,
             project_name: None,
             branch: None,
+            project_slug: None,
+            branch_slug: None,
         };
         assert_eq!(info.orb_url(), None);
     }
@@ -539,6 +613,8 @@ mod tests {
             is_orbstack: false,
             project_name: None,
             branch: None,
+            project_slug: None,
+            branch_slug: None,
         };
         assert_eq!(info.url(), "localhost:3001");
     }
@@ -561,6 +637,58 @@ mod tests {
         assert_eq!(hp2, Some(3000));
         let ports = pm.all_forwarded_ports();
         assert_eq!(ports.len(), 1);
+    }
+
+    #[test]
+    fn hostname_route_uses_sanitized_project_branch_and_host_port() {
+        let mut pm = PortManager::new(false);
+        pm.register_container(ContainerRegistrationInfo {
+            container_id: "c1".to_string(),
+            container_name: "test".to_string(),
+            container_ip: None,
+            ports_attributes: vec![],
+            other_ports_attributes: None,
+            project_name: Some("My App".to_string()),
+            branch: Some("feature/auth".to_string()),
+        });
+        pm.handle_port_open("c1", 3000, PortProtocol::Tcp, None);
+
+        let route = pm.hostname_route_for("c1", 3000).unwrap();
+        assert_eq!(route.project, "my-app");
+        assert_eq!(route.branch, "feature-auth");
+        assert_eq!(route.container_port, 3000);
+        assert_eq!(route.host_port, 3000);
+    }
+
+    #[test]
+    fn branch_slug_collision_gets_suffix_for_second_branch() {
+        let mut pm = PortManager::new(false);
+        pm.register_container(ContainerRegistrationInfo {
+            container_id: "c1".to_string(),
+            container_name: "one".to_string(),
+            container_ip: None,
+            ports_attributes: vec![],
+            other_ports_attributes: None,
+            project_name: Some("myapp".to_string()),
+            branch: Some("a/b".to_string()),
+        });
+        pm.register_container(ContainerRegistrationInfo {
+            container_id: "c2".to_string(),
+            container_name: "two".to_string(),
+            container_ip: None,
+            ports_attributes: vec![],
+            other_ports_attributes: None,
+            project_name: Some("myapp".to_string()),
+            branch: Some("a-b".to_string()),
+        });
+        pm.handle_port_open("c1", 3000, PortProtocol::Tcp, None);
+        pm.handle_port_open("c2", 3000, PortProtocol::Tcp, None);
+
+        let first = pm.hostname_route_for("c1", 3000).unwrap();
+        let second = pm.hostname_route_for("c2", 3000).unwrap();
+        assert_eq!(first.branch, "a-b");
+        assert!(second.branch.starts_with("a-b-"));
+        assert_ne!(first.branch, second.branch);
     }
 
     #[test]

--- a/crates/cella-daemon/src/port_manager.rs
+++ b/crates/cella-daemon/src/port_manager.rs
@@ -32,6 +32,8 @@ struct ContainerPorts {
     detected_ports: Vec<DetectedPort>,
     ports_attributes: Vec<PortAttributes>,
     other_ports_attributes: Option<PortAttributes>,
+    project_name: Option<String>,
+    branch: Option<String>,
 }
 
 /// A port detected by the in-container agent.
@@ -41,6 +43,17 @@ struct DetectedPort {
     protocol: PortProtocol,
     process: Option<String>,
     host_port: Option<u16>,
+}
+
+/// Data needed to register a container for port management.
+pub struct ContainerRegistrationInfo {
+    pub container_id: String,
+    pub container_name: String,
+    pub container_ip: Option<String>,
+    pub ports_attributes: Vec<PortAttributes>,
+    pub other_ports_attributes: Option<PortAttributes>,
+    pub project_name: Option<String>,
+    pub branch: Option<String>,
 }
 
 impl PortManager {
@@ -76,35 +89,30 @@ impl PortManager {
     /// Returns the list of host ports that were released. The caller must
     /// send `ProxyCommand::Stop` for each to stop the coordinator-owned
     /// TCP proxies.
-    pub fn register_container(
-        &mut self,
-        container_id: &str,
-        container_name: &str,
-        container_ip: Option<String>,
-        ports_attributes: Vec<PortAttributes>,
-        other_ports_attributes: Option<PortAttributes>,
-    ) -> Vec<u16> {
+    pub fn register_container(&mut self, info: ContainerRegistrationInfo) -> Vec<u16> {
         let mut released_ports = Vec::new();
 
         // Release stale allocations from a previous registration.
-        if self.containers.contains_key(container_id) {
+        if self.containers.contains_key(&info.container_id) {
             released_ports = self
                 .allocation
-                .container_ports(container_id)
+                .container_ports(&info.container_id)
                 .iter()
                 .map(|p| p.host_port)
                 .collect();
-            self.allocation.release_container(container_id);
+            self.allocation.release_container(&info.container_id);
         }
 
         self.containers.insert(
-            container_id.to_string(),
+            info.container_id,
             ContainerPorts {
-                container_name: container_name.to_string(),
-                container_ip,
+                container_name: info.container_name,
+                container_ip: info.container_ip,
                 detected_ports: Vec::new(),
-                ports_attributes,
-                other_ports_attributes,
+                ports_attributes: info.ports_attributes,
+                other_ports_attributes: info.other_ports_attributes,
+                project_name: info.project_name,
+                branch: info.branch,
             },
         );
 
@@ -278,6 +286,8 @@ impl PortManager {
                         protocol: detected.protocol,
                         process: detected.process.clone(),
                         is_orbstack: self.is_orbstack,
+                        project_name: container.project_name.clone(),
+                        branch: container.branch.clone(),
                     });
                 }
             }
@@ -311,6 +321,8 @@ pub struct ForwardedPortInfo {
     pub protocol: PortProtocol,
     pub process: Option<String>,
     pub is_orbstack: bool,
+    pub project_name: Option<String>,
+    pub branch: Option<String>,
 }
 
 impl ForwardedPortInfo {
@@ -330,6 +342,18 @@ impl ForwardedPortInfo {
             None
         }
     }
+
+    /// Get the hostname-based URL, if project and branch metadata are available.
+    pub fn hostname_url(&self) -> Option<String> {
+        let project = self.project_name.as_ref()?;
+        let branch = self.branch.as_deref().unwrap_or("main");
+        Some(cella_proxy::hostname::build_hostname_url(
+            self.container_port,
+            branch,
+            project,
+            self.is_orbstack,
+        ))
+    }
 }
 
 #[cfg(test)]
@@ -341,7 +365,15 @@ mod tests {
     #[test]
     fn register_and_detect_port() {
         let mut pm = PortManager::new(false);
-        pm.register_container("c1", "test-container", None, vec![], None);
+        pm.register_container(ContainerRegistrationInfo {
+            container_id: "c1".to_string(),
+            container_name: "test-container".to_string(),
+            container_ip: None,
+            ports_attributes: vec![],
+            other_ports_attributes: None,
+            project_name: None,
+            branch: None,
+        });
         pm.handle_port_open("c1", 3000, PortProtocol::Tcp, Some("node".to_string()));
 
         let ports = pm.all_forwarded_ports();
@@ -353,8 +385,24 @@ mod tests {
     #[test]
     fn port_remapping_on_conflict() {
         let mut pm = PortManager::new(false);
-        pm.register_container("c1", "container-a", None, vec![], None);
-        pm.register_container("c2", "container-b", None, vec![], None);
+        pm.register_container(ContainerRegistrationInfo {
+            container_id: "c1".to_string(),
+            container_name: "container-a".to_string(),
+            container_ip: None,
+            ports_attributes: vec![],
+            other_ports_attributes: None,
+            project_name: None,
+            branch: None,
+        });
+        pm.register_container(ContainerRegistrationInfo {
+            container_id: "c2".to_string(),
+            container_name: "container-b".to_string(),
+            container_ip: None,
+            ports_attributes: vec![],
+            other_ports_attributes: None,
+            project_name: None,
+            branch: None,
+        });
 
         pm.handle_port_open("c1", 3000, PortProtocol::Tcp, None);
         pm.handle_port_open("c2", 3000, PortProtocol::Tcp, None);
@@ -375,7 +423,15 @@ mod tests {
             on_auto_forward: OnAutoForward::Ignore,
             ..PortAttributes::default()
         }];
-        pm.register_container("c1", "test", None, attrs, None);
+        pm.register_container(ContainerRegistrationInfo {
+            container_id: "c1".to_string(),
+            container_name: "test".to_string(),
+            container_ip: None,
+            ports_attributes: attrs,
+            other_ports_attributes: None,
+            project_name: None,
+            branch: None,
+        });
         pm.handle_port_open("c1", 9229, PortProtocol::Tcp, Some("node".to_string()));
 
         let ports = pm.all_forwarded_ports();
@@ -385,7 +441,15 @@ mod tests {
     #[test]
     fn unregister_releases_ports() {
         let mut pm = PortManager::new(false);
-        pm.register_container("c1", "test", None, vec![], None);
+        pm.register_container(ContainerRegistrationInfo {
+            container_id: "c1".to_string(),
+            container_name: "test".to_string(),
+            container_ip: None,
+            ports_attributes: vec![],
+            other_ports_attributes: None,
+            project_name: None,
+            branch: None,
+        });
         pm.handle_port_open("c1", 3000, PortProtocol::Tcp, None);
 
         pm.unregister_container("c1");
@@ -397,7 +461,15 @@ mod tests {
     #[test]
     fn register_stores_container_ip() {
         let mut pm = PortManager::new(false);
-        pm.register_container("c1", "test", Some("172.20.0.5".to_string()), vec![], None);
+        pm.register_container(ContainerRegistrationInfo {
+            container_id: "c1".to_string(),
+            container_name: "test".to_string(),
+            container_ip: Some("172.20.0.5".to_string()),
+            ports_attributes: vec![],
+            other_ports_attributes: None,
+            project_name: None,
+            branch: None,
+        });
         assert_eq!(pm.container_ip("c1"), Some("172.20.0.5"));
         assert_eq!(pm.container_ip("c2"), None);
     }
@@ -405,7 +477,15 @@ mod tests {
     #[test]
     fn register_without_container_ip() {
         let mut pm = PortManager::new(false);
-        pm.register_container("c1", "test", None, vec![], None);
+        pm.register_container(ContainerRegistrationInfo {
+            container_id: "c1".to_string(),
+            container_name: "test".to_string(),
+            container_ip: None,
+            ports_attributes: vec![],
+            other_ports_attributes: None,
+            project_name: None,
+            branch: None,
+        });
         assert_eq!(pm.container_ip("c1"), None);
     }
 
@@ -419,6 +499,8 @@ mod tests {
             protocol: PortProtocol::Tcp,
             process: Some("node".to_string()),
             is_orbstack: true,
+            project_name: None,
+            branch: None,
         };
         // url() always returns localhost
         assert_eq!(info.url(), "localhost:3000");
@@ -439,6 +521,8 @@ mod tests {
             protocol: PortProtocol::Tcp,
             process: None,
             is_orbstack: false,
+            project_name: None,
+            branch: None,
         };
         assert_eq!(info.orb_url(), None);
     }
@@ -453,6 +537,8 @@ mod tests {
             protocol: PortProtocol::Tcp,
             process: None,
             is_orbstack: false,
+            project_name: None,
+            branch: None,
         };
         assert_eq!(info.url(), "localhost:3001");
     }
@@ -460,7 +546,15 @@ mod tests {
     #[test]
     fn duplicate_port_open_returns_existing() {
         let mut pm = PortManager::new(false);
-        pm.register_container("c1", "test", None, vec![], None);
+        pm.register_container(ContainerRegistrationInfo {
+            container_id: "c1".to_string(),
+            container_name: "test".to_string(),
+            container_ip: None,
+            ports_attributes: vec![],
+            other_ports_attributes: None,
+            project_name: None,
+            branch: None,
+        });
         let hp1 = pm.handle_port_open("c1", 3000, PortProtocol::Tcp, Some("node".to_string()));
         let hp2 = pm.handle_port_open("c1", 3000, PortProtocol::Tcp, Some("node".to_string()));
         assert_eq!(hp1, Some(3000));
@@ -472,7 +566,15 @@ mod tests {
     #[test]
     fn port_close_releases_allocation() {
         let mut pm = PortManager::new(false);
-        pm.register_container("c1", "test", None, vec![], None);
+        pm.register_container(ContainerRegistrationInfo {
+            container_id: "c1".to_string(),
+            container_name: "test".to_string(),
+            container_ip: None,
+            ports_attributes: vec![],
+            other_ports_attributes: None,
+            project_name: None,
+            branch: None,
+        });
         pm.handle_port_open("c1", 3000, PortProtocol::Tcp, None);
         pm.handle_port_closed("c1", 3000);
         // Re-opening should get the same port back, not 3001
@@ -483,13 +585,29 @@ mod tests {
     #[test]
     fn re_register_releases_old_allocations() {
         let mut pm = PortManager::new(false);
-        pm.register_container("c1", "test", None, vec![], None);
+        pm.register_container(ContainerRegistrationInfo {
+            container_id: "c1".to_string(),
+            container_name: "test".to_string(),
+            container_ip: None,
+            ports_attributes: vec![],
+            other_ports_attributes: None,
+            project_name: None,
+            branch: None,
+        });
         let hp1 = pm.handle_port_open("c1", 3000, PortProtocol::Tcp, None);
         assert_eq!(hp1, Some(3000));
 
         // Re-register simulates a container restart: old allocations must be
         // released so the agent can reclaim the native port.
-        pm.register_container("c1", "test", None, vec![], None);
+        pm.register_container(ContainerRegistrationInfo {
+            container_id: "c1".to_string(),
+            container_name: "test".to_string(),
+            container_ip: None,
+            ports_attributes: vec![],
+            other_ports_attributes: None,
+            project_name: None,
+            branch: None,
+        });
         let hp2 = pm.handle_port_open("c1", 3000, PortProtocol::Tcp, None);
         assert_eq!(
             hp2,
@@ -501,7 +619,15 @@ mod tests {
     #[test]
     fn update_container_ip_preserves_ports() {
         let mut pm = PortManager::new(false);
-        pm.register_container("c1", "test", None, vec![], None);
+        pm.register_container(ContainerRegistrationInfo {
+            container_id: "c1".to_string(),
+            container_name: "test".to_string(),
+            container_ip: None,
+            ports_attributes: vec![],
+            other_ports_attributes: None,
+            project_name: None,
+            branch: None,
+        });
         pm.handle_port_open("c1", 3000, PortProtocol::Tcp, None);
 
         assert!(pm.update_container_ip("c1", Some("172.20.0.5".to_string())));

--- a/crates/cella-daemon/src/port_manager.rs
+++ b/crates/cella-daemon/src/port_manager.rs
@@ -417,13 +417,7 @@ impl ForwardedPortInfo {
     pub fn hostname_url(&self, proxy_port: Option<u16>) -> Option<String> {
         let project = self.project_slug.as_ref()?;
         let branch = self.branch_slug.as_deref().unwrap_or("main");
-        Some(cella_proxy::hostname::build_hostname_url_with_proxy_port(
-            self.container_port,
-            branch,
-            project,
-            self.is_orbstack,
-            proxy_port,
-        ))
+        cella_proxy::hostname::build_hostname_url(self.container_port, branch, project, proxy_port)
     }
 }
 

--- a/crates/cella-daemon/src/port_manager.rs
+++ b/crates/cella-daemon/src/port_manager.rs
@@ -414,14 +414,15 @@ impl ForwardedPortInfo {
     }
 
     /// Get the hostname-based URL, if project and branch metadata are available.
-    pub fn hostname_url(&self) -> Option<String> {
+    pub fn hostname_url(&self, proxy_port: Option<u16>) -> Option<String> {
         let project = self.project_slug.as_ref()?;
         let branch = self.branch_slug.as_deref().unwrap_or("main");
-        Some(cella_proxy::hostname::build_hostname_url(
+        Some(cella_proxy::hostname::build_hostname_url_with_proxy_port(
             self.container_port,
             branch,
             project,
             self.is_orbstack,
+            proxy_port,
         ))
     }
 }

--- a/crates/cella-orchestrator/src/daemon_registration.rs
+++ b/crates/cella-orchestrator/src/daemon_registration.rs
@@ -75,10 +75,10 @@ fn project_name_from_config(config: &serde_json::Value, workspace_root: &Path) -
         .filter(|name| !name.trim().is_empty())
         .map_or_else(
             || {
-                workspace_root
-                    .file_name()
-                    .map(|n| n.to_string_lossy().to_string())
-                    .unwrap_or_else(|| "workspace".to_string())
+                workspace_root.file_name().map_or_else(
+                    || "workspace".to_string(),
+                    |n| n.to_string_lossy().to_string(),
+                )
             },
             String::from,
         )

--- a/crates/cella-orchestrator/src/daemon_registration.rs
+++ b/crates/cella-orchestrator/src/daemon_registration.rs
@@ -1,5 +1,8 @@
 //! Helpers for building daemon container registration payloads.
 
+use std::collections::HashMap;
+use std::path::Path;
+
 use cella_backend::{BACKEND_LABEL, ContainerInfo};
 use cella_protocol::ContainerRegistrationData;
 
@@ -55,9 +58,16 @@ pub fn from_container_labels(
         shutdown_action: container.labels.get("dev.cella.shutdown_action").cloned(),
         backend_kind: container.labels.get(BACKEND_LABEL).cloned(),
         docker_host,
-        project_name: None,
+        project_name: project_name_from_labels(&container.labels),
         branch: container.labels.get("dev.cella.branch").cloned(),
     }
+}
+
+fn project_name_from_labels(labels: &HashMap<String, String>) -> Option<String> {
+    labels
+        .get("dev.cella.workspace_path")
+        .and_then(|p| Path::new(p).file_name())
+        .map(|n| n.to_string_lossy().to_string())
 }
 
 fn parse_forward_ports(config: &serde_json::Value) -> Vec<u16> {
@@ -155,5 +165,48 @@ mod tests {
             data.docker_host.as_deref(),
             Some("unix:///var/run/docker.sock")
         );
+    }
+
+    #[test]
+    fn container_labels_derives_project_name_from_workspace_path() {
+        let mut labels = HashMap::new();
+        labels.insert(
+            "dev.cella.workspace_path".to_string(),
+            "/home/user/myapp".to_string(),
+        );
+        labels.insert("dev.cella.branch".to_string(), "feature/auth".to_string());
+
+        let container = ContainerInfo {
+            id: "c1".to_string(),
+            name: "cella-myapp-abc123".to_string(),
+            state: ContainerState::Running,
+            exit_code: None,
+            labels,
+            config_hash: None,
+            ports: Vec::new(),
+            created_at: None,
+            container_user: None,
+            image: None,
+            mounts: Vec::new(),
+            backend: BackendKind::Docker,
+        };
+
+        let data = from_container_labels(&container, None, None);
+        assert_eq!(data.project_name.as_deref(), Some("myapp"));
+        assert_eq!(data.branch.as_deref(), Some("feature/auth"));
+    }
+
+    #[test]
+    fn devcontainer_config_extracts_project_name_from_name_field() {
+        let config = json!({ "name": "my-project" });
+        let data = from_devcontainer_config(&config, "id", "name", None, None, None);
+        assert_eq!(data.project_name.as_deref(), Some("my-project"));
+    }
+
+    #[test]
+    fn devcontainer_config_without_name_has_no_project_name() {
+        let config = json!({});
+        let data = from_devcontainer_config(&config, "id", "name", None, None, None);
+        assert_eq!(data.project_name, None);
     }
 }

--- a/crates/cella-orchestrator/src/daemon_registration.rs
+++ b/crates/cella-orchestrator/src/daemon_registration.rs
@@ -25,6 +25,11 @@ pub fn from_devcontainer_config(
             .map(String::from),
         backend_kind,
         docker_host,
+        project_name: config
+            .get("name")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        branch: None,
     }
 }
 
@@ -50,6 +55,8 @@ pub fn from_container_labels(
         shutdown_action: container.labels.get("dev.cella.shutdown_action").cloned(),
         backend_kind: container.labels.get(BACKEND_LABEL).cloned(),
         docker_host,
+        project_name: None,
+        branch: container.labels.get("dev.cella.branch").cloned(),
     }
 }
 

--- a/crates/cella-orchestrator/src/daemon_registration.rs
+++ b/crates/cella-orchestrator/src/daemon_registration.rs
@@ -9,6 +9,7 @@ use cella_protocol::ContainerRegistrationData;
 /// Build daemon registration data from a devcontainer config.
 pub fn from_devcontainer_config(
     config: &serde_json::Value,
+    workspace_root: &Path,
     container_id: impl Into<String>,
     container_name: impl Into<String>,
     container_ip: Option<String>,
@@ -28,11 +29,8 @@ pub fn from_devcontainer_config(
             .map(String::from),
         backend_kind,
         docker_host,
-        project_name: config
-            .get("name")
-            .and_then(|v| v.as_str())
-            .map(String::from),
-        branch: None,
+        project_name: Some(project_name_from_config(config, workspace_root)),
+        branch: Some(current_branch_or_main(workspace_root)),
     }
 }
 
@@ -70,6 +68,30 @@ fn project_name_from_labels(labels: &HashMap<String, String>) -> Option<String> 
         .map(|n| n.to_string_lossy().to_string())
 }
 
+fn project_name_from_config(config: &serde_json::Value, workspace_root: &Path) -> String {
+    config
+        .get("name")
+        .and_then(|v| v.as_str())
+        .filter(|name| !name.trim().is_empty())
+        .map_or_else(
+            || {
+                workspace_root
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_else(|| "workspace".to_string())
+            },
+            String::from,
+        )
+}
+
+fn current_branch_or_main(workspace_root: &Path) -> String {
+    cella_git::discover(workspace_root)
+        .ok()
+        .and_then(|repo| repo.head_branch)
+        .filter(|branch| !branch.trim().is_empty())
+        .unwrap_or_else(|| "main".to_string())
+}
+
 fn parse_forward_ports(config: &serde_json::Value) -> Vec<u16> {
     config
         .get("forwardPorts")
@@ -101,9 +123,11 @@ mod tests {
             "otherPortsAttributes": {"onAutoForward": "silent"},
             "shutdownAction": "none"
         });
+        let tmp = tempfile::tempdir().unwrap();
 
         let data = from_devcontainer_config(
             &config,
+            tmp.path(),
             "abc123",
             "cella-test",
             Some("172.20.0.5".to_string()),
@@ -199,14 +223,43 @@ mod tests {
     #[test]
     fn devcontainer_config_extracts_project_name_from_name_field() {
         let config = json!({ "name": "my-project" });
-        let data = from_devcontainer_config(&config, "id", "name", None, None, None);
+        let tmp = tempfile::tempdir().unwrap();
+        let data = from_devcontainer_config(&config, tmp.path(), "id", "name", None, None, None);
         assert_eq!(data.project_name.as_deref(), Some("my-project"));
+        assert_eq!(data.branch.as_deref(), Some("main"));
     }
 
     #[test]
-    fn devcontainer_config_without_name_has_no_project_name() {
+    fn devcontainer_config_without_name_uses_workspace_directory() {
         let config = json!({});
-        let data = from_devcontainer_config(&config, "id", "name", None, None, None);
-        assert_eq!(data.project_name, None);
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("my-workspace");
+        std::fs::create_dir(&workspace).unwrap();
+        let data = from_devcontainer_config(&config, &workspace, "id", "name", None, None, None);
+        assert_eq!(data.project_name.as_deref(), Some("my-workspace"));
+        assert_eq!(data.branch.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn devcontainer_config_uses_current_git_branch() {
+        let config = json!({});
+        let tmp = tempfile::tempdir().unwrap();
+        for args in [
+            &["init"][..],
+            &["config", "user.email", "test@example.com"],
+            &["config", "user.name", "Test User"],
+            &["commit", "--allow-empty", "-m", "init"],
+            &["checkout", "-b", "feature/auth"],
+        ] {
+            std::process::Command::new("git")
+                .args(args)
+                .current_dir(tmp.path())
+                .output()
+                .unwrap();
+        }
+
+        let data = from_devcontainer_config(&config, tmp.path(), "id", "name", None, None, None);
+
+        assert_eq!(data.branch.as_deref(), Some("feature/auth"));
     }
 }

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -805,7 +805,7 @@ impl EnsureUpContext<'_> {
                 &mut labels,
                 config,
                 &self.config.resolved.workspace_root,
-                &self.config.extra_labels,
+                self.config.extra_labels,
             );
         }
         labels
@@ -1654,10 +1654,10 @@ fn add_orbstack_hostname_labels(
         .filter(|name| !name.trim().is_empty())
         .map_or_else(
             || {
-                workspace_root
-                    .file_name()
-                    .map(|n| n.to_string_lossy().to_string())
-                    .unwrap_or_else(|| "workspace".to_string())
+                workspace_root.file_name().map_or_else(
+                    || "workspace".to_string(),
+                    |n| n.to_string_lossy().to_string(),
+                )
             },
             String::from,
         );

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -800,6 +800,14 @@ impl EnsureUpContext<'_> {
         }
 
         labels.extend(self.config.extra_labels.clone());
+        if runtime == cella_env::DockerRuntime::OrbStack {
+            add_orbstack_hostname_labels(
+                &mut labels,
+                config,
+                &self.config.resolved.workspace_root,
+                &self.config.extra_labels,
+            );
+        }
         labels
     }
 
@@ -1630,6 +1638,58 @@ impl EnsureUpContext<'_> {
     }
 }
 
+fn add_orbstack_hostname_labels(
+    labels: &mut std::collections::HashMap<String, String>,
+    config: &serde_json::Value,
+    workspace_root: &std::path::Path,
+    extra_labels: &std::collections::HashMap<String, String>,
+) {
+    let forward_ports = parse_forward_ports(config);
+    let Some(default_port) = cella_backend::orbstack_http_port_label(&forward_ports) else {
+        return;
+    };
+    let project = config
+        .get("name")
+        .and_then(|v| v.as_str())
+        .filter(|name| !name.trim().is_empty())
+        .map_or_else(
+            || {
+                workspace_root
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_else(|| "workspace".to_string())
+            },
+            String::from,
+        );
+    let branch = extra_labels
+        .get("dev.cella.branch")
+        .cloned()
+        .or_else(|| {
+            cella_git::discover(workspace_root)
+                .ok()
+                .and_then(|r| r.head_branch)
+        })
+        .unwrap_or_else(|| "main".to_string());
+
+    labels.insert(
+        "dev.orbstack.domains".to_string(),
+        cella_backend::orbstack_domains_label(&project, &branch),
+    );
+    labels.insert("dev.orbstack.http-port".to_string(), default_port);
+}
+
+fn parse_forward_ports(config: &serde_json::Value) -> Vec<u16> {
+    config
+        .get("forwardPorts")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_u64().and_then(|n| u16::try_from(n).ok()))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 /// Run the full non-compose container-up pipeline.
 ///
 /// # Errors
@@ -1843,6 +1903,39 @@ mod tests {
         hooks.on_container_stopping("test-container").await;
         assert!(hooks.daemon_env("test", "host").await.is_empty());
         assert!(hooks.update_container_ip("container-123", None).await);
+    }
+
+    #[test]
+    fn orbstack_hostname_labels_use_default_port_only() {
+        let mut labels = std::collections::HashMap::new();
+        let mut extra = std::collections::HashMap::new();
+        extra.insert("dev.cella.branch".to_string(), "feature/auth".to_string());
+        let config = serde_json::json!({
+            "name": "myapp",
+            "forwardPorts": [3000, 8080]
+        });
+
+        add_orbstack_hostname_labels(
+            &mut labels,
+            &config,
+            std::path::Path::new("/tmp/app"),
+            &extra,
+        );
+
+        assert_eq!(
+            labels.get("dev.orbstack.domains").map(String::as_str),
+            Some("feature-auth.myapp.local")
+        );
+        assert_eq!(
+            labels.get("dev.orbstack.http-port").map(String::as_str),
+            Some("3000")
+        );
+        assert!(
+            !labels
+                .get("dev.orbstack.domains")
+                .unwrap()
+                .contains("8080.")
+        );
     }
 
     #[tokio::test]

--- a/crates/cella-protocol/README.md
+++ b/crates/cella-protocol/README.md
@@ -33,7 +33,8 @@ See [docs/specs/ipc-protocol.md](../../docs/specs/ipc-protocol.md) for the full 
 - `WorktreeOperationResult` / `DownOperationResult` / `TaskRunOperationResult` — operation result enums (Success or Error)
 - `TaskEntry` — background task state (id, branch, container, status, command, elapsed)
 - `WorktreeEntry` — worktree listing entry (branch, path, container association)
-- `ForwardedPortDetail` — forwarded port info (container, ports, protocol, process, URL)
+- `ForwardedPortDetail` — forwarded port info (container, ports, protocol, process, `localhost:<host_port>` URL, optional full hostname URL)
+- `HostnameProxyStatus` — hostname HTTP proxy listener diagnostics, including high-port fallback state
 - `ContainerSummary` — registered container summary (name, id, port count, agent connection)
 
 ### Modules

--- a/crates/cella-protocol/src/lib.rs
+++ b/crates/cella-protocol/src/lib.rs
@@ -197,6 +197,12 @@ pub struct ContainerRegistrationData {
     /// Docker host override used when the container was created.
     #[serde(default)]
     pub docker_host: Option<String>,
+    /// Project name from devcontainer.json `name` field or repo directory.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_name: Option<String>,
+    /// Git branch name (for worktree containers).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
 }
 
 /// Requests from CLI tools to the daemon management socket.
@@ -301,6 +307,9 @@ pub struct ForwardedPortDetail {
     pub protocol: PortProtocol,
     pub process: Option<String>,
     pub url: String,
+    /// Hostname-based URL (e.g., `http://3000.main.myapp.localhost`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hostname: Option<String>,
 }
 
 /// Summary of a registered container.
@@ -866,6 +875,8 @@ mod tests {
             shutdown_action: None,
             backend_kind: Some("docker".to_string()),
             docker_host: None,
+            project_name: None,
+            branch: None,
         }));
         let json = serde_json::to_string(&req).unwrap();
         assert!(json.contains("\"type\":\"register_container\""));
@@ -926,6 +937,7 @@ mod tests {
                 protocol: PortProtocol::Tcp,
                 process: Some("node".to_string()),
                 url: "localhost:3000".to_string(),
+                hostname: None,
             }],
         };
         let json = serde_json::to_string(&resp).unwrap();

--- a/crates/cella-protocol/src/lib.rs
+++ b/crates/cella-protocol/src/lib.rs
@@ -275,6 +275,9 @@ pub enum ManagementResponse {
         /// Auth token for agent connections.
         #[serde(default)]
         control_token: String,
+        /// Hostname proxy bind state for diagnostics and URL rendering.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        hostname_proxy: Option<HostnameProxyStatus>,
     },
     /// Daemon is shutting down.
     ShuttingDown { pid: u32 },
@@ -310,6 +313,18 @@ pub struct ForwardedPortDetail {
     /// Hostname-based URL (e.g., `http://3000.main.myapp.localhost`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hostname: Option<String>,
+}
+
+/// Runtime state for the hostname HTTP proxy listener.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostnameProxyStatus {
+    pub enabled: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub address: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub port: Option<u16>,
+    #[serde(default)]
+    pub using_fallback_port: bool,
 }
 
 /// Summary of a registered container.
@@ -964,6 +979,12 @@ mod tests {
             daemon_started_at: 1_700_000_000,
             control_port: 54321,
             control_token: "abc123".to_string(),
+            hostname_proxy: Some(HostnameProxyStatus {
+                enabled: true,
+                address: Some("127.0.0.1:49180".to_string()),
+                port: Some(49180),
+                using_fallback_port: true,
+            }),
         };
         let json = serde_json::to_string(&resp).unwrap();
         let decoded: ManagementResponse = serde_json::from_str(&json).unwrap();
@@ -981,11 +1002,13 @@ mod tests {
         if let ManagementResponse::Status {
             daemon_version,
             daemon_started_at,
+            hostname_proxy,
             ..
         } = decoded
         {
             assert!(daemon_version.is_empty());
             assert_eq!(daemon_started_at, 0);
+            assert!(hostname_proxy.is_none());
         } else {
             panic!("Expected Status");
         }

--- a/crates/cella-proxy/Cargo.toml
+++ b/crates/cella-proxy/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "cella-proxy"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Hostname-based HTTP reverse proxy for cella dev containers"
+
+[dependencies]
+hyper.workspace = true
+hyper-util.workspace = true
+http-body-util.workspace = true
+sha2.workspace = true
+hex.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
+
+[lints]
+workspace = true

--- a/crates/cella-proxy/Cargo.toml
+++ b/crates/cella-proxy/Cargo.toml
@@ -15,6 +15,7 @@ tokio.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+futures-util.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 
 [lints]

--- a/crates/cella-proxy/src/error_page.rs
+++ b/crates/cella-proxy/src/error_page.rs
@@ -5,17 +5,30 @@ use std::fmt::Write;
 use crate::router::{BackendTarget, RouteKey, RouteTable};
 
 /// Generate an HTML page for when no route matches the requested hostname.
-pub fn no_route_found(requested_host: &str, route_table: &RouteTable) -> String {
+pub fn no_route_found(
+    requested_host: &str,
+    route_table: &RouteTable,
+    proxy_port: Option<u16>,
+) -> String {
     let mut services = String::new();
     let mut routes: Vec<_> = route_table.all_routes().collect();
     routes.sort_by(|a, b| a.0.project.cmp(&b.0.project).then(a.0.port.cmp(&b.0.port)));
 
+    let port_suffix = match proxy_port {
+        Some(p) if p != 80 => format!(":{p}"),
+        _ => String::new(),
+    };
+
     for (key, target) in &routes {
-        let hostname = format!("{}.{}.{}.localhost", key.port, key.branch, key.project);
+        let hostname = format!(
+            "{}.{}.{}.localhost{port_suffix}",
+            key.port, key.branch, key.project
+        );
         let _ = writeln!(
             services,
             "  <li><a href=\"http://{hostname}\">{hostname}</a> → {}:{}</li>",
-            target.container_name, target.target_port
+            html_escape(&target.container_name),
+            target.target_port
         );
     }
 
@@ -23,6 +36,7 @@ pub fn no_route_found(requested_host: &str, route_table: &RouteTable) -> String 
         services = "  <li>No services registered</li>\n".to_string();
     }
 
+    let escaped_host = html_escape(requested_host);
     format!(
         r#"<!DOCTYPE html>
 <html>
@@ -34,7 +48,7 @@ pub fn no_route_found(requested_host: &str, route_table: &RouteTable) -> String 
 <body>
 <div class="container">
 <h1>No service found</h1>
-<p>Requested: <code>{requested_host}</code></p>
+<p>Requested: <code>{escaped_host}</code></p>
 
 <h2>Available services</h2>
 <ul>
@@ -51,6 +65,7 @@ rejecting the <code>Host</code> header. Configure it to accept <code>*.localhost
 
 /// Generate an HTML page for when the route exists but the backend is unreachable.
 pub fn backend_unreachable(key: &RouteKey, target: &BackendTarget) -> String {
+    let escaped_name = html_escape(&target.container_name);
     format!(
         r#"<!DOCTYPE html>
 <html>
@@ -62,12 +77,19 @@ pub fn backend_unreachable(key: &RouteKey, target: &BackendTarget) -> String {
 <body>
 <div class="container">
 <h1>Service unavailable</h1>
-<p>Container <code>{}</code> is not responding on port {}.</p>
+<p>Container <code>{escaped_name}</code> is not responding on port {}.</p>
 </div>
 </body>
 </html>"#,
-        target.container_name, key.port
+        key.port
     )
+}
+
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
 }
 
 const CSS: &str = r"
@@ -93,7 +115,7 @@ mod tests {
     #[test]
     fn no_route_page_contains_requested_host() {
         let rt = RouteTable::new();
-        let html = no_route_found("3000.nonexistent.myapp.localhost", &rt);
+        let html = no_route_found("3000.nonexistent.myapp.localhost", &rt, Some(80));
         assert!(html.contains("3000.nonexistent.myapp.localhost"));
         assert!(html.contains("No services registered"));
     }
@@ -115,9 +137,38 @@ mod tests {
             },
         );
 
-        let html = no_route_found("3000.nonexistent.myapp.localhost", &rt);
+        let html = no_route_found("3000.nonexistent.myapp.localhost", &rt, Some(80));
         assert!(html.contains("3000.main.myapp.localhost"));
         assert!(html.contains("cella-myapp-main:3000"));
+    }
+
+    #[test]
+    fn no_route_page_includes_fallback_port_in_links() {
+        let mut rt = RouteTable::new();
+        rt.insert(
+            RouteKey {
+                project: "myapp".to_string(),
+                branch: "main".to_string(),
+                port: 3000,
+            },
+            BackendTarget {
+                container_id: "c1".to_string(),
+                container_name: "cella-myapp-main".to_string(),
+                target_port: 3000,
+                mode: ProxyMode::DirectIp(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+            },
+        );
+
+        let html = no_route_found("test.localhost:49180", &rt, Some(49180));
+        assert!(html.contains("3000.main.myapp.localhost:49180"));
+    }
+
+    #[test]
+    fn no_route_page_escapes_html_in_host() {
+        let rt = RouteTable::new();
+        let html = no_route_found("<script>alert(1)</script>.localhost", &rt, Some(80));
+        assert!(!html.contains("<script>"));
+        assert!(html.contains("&lt;script&gt;"));
     }
 
     #[test]
@@ -142,7 +193,7 @@ mod tests {
     #[test]
     fn pages_are_valid_html() {
         let rt = RouteTable::new();
-        let html = no_route_found("test.localhost", &rt);
+        let html = no_route_found("test.localhost", &rt, Some(80));
         assert!(html.starts_with("<!DOCTYPE html>"));
         assert!(html.contains("</html>"));
     }

--- a/crates/cella-proxy/src/error_page.rs
+++ b/crates/cella-proxy/src/error_page.rs
@@ -1,0 +1,149 @@
+//! HTML error page generation for proxy error responses.
+
+use std::fmt::Write;
+
+use crate::router::{BackendTarget, RouteKey, RouteTable};
+
+/// Generate an HTML page for when no route matches the requested hostname.
+pub fn no_route_found(requested_host: &str, route_table: &RouteTable) -> String {
+    let mut services = String::new();
+    let mut routes: Vec<_> = route_table.all_routes().collect();
+    routes.sort_by(|a, b| a.0.project.cmp(&b.0.project).then(a.0.port.cmp(&b.0.port)));
+
+    for (key, target) in &routes {
+        let hostname = format!("{}.{}.{}.localhost", key.port, key.branch, key.project);
+        let _ = writeln!(
+            services,
+            "  <li><a href=\"http://{hostname}\">{hostname}</a> → {}:{}</li>",
+            target.container_name, target.target_port
+        );
+    }
+
+    if services.is_empty() {
+        services = "  <li>No services registered</li>\n".to_string();
+    }
+
+    format!(
+        r#"<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>No service found</title>
+<style>{CSS}</style>
+</head>
+<body>
+<div class="container">
+<h1>No service found</h1>
+<p>Requested: <code>{requested_host}</code></p>
+
+<h2>Available services</h2>
+<ul>
+{services}</ul>
+
+<h2>Troubleshooting</h2>
+<p>If your service is running but returns 4xx errors, your dev server may be
+rejecting the <code>Host</code> header. Configure it to accept <code>*.localhost</code> hostnames.</p>
+</div>
+</body>
+</html>"#
+    )
+}
+
+/// Generate an HTML page for when the route exists but the backend is unreachable.
+pub fn backend_unreachable(key: &RouteKey, target: &BackendTarget) -> String {
+    format!(
+        r#"<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Service unavailable</title>
+<style>{CSS}</style>
+</head>
+<body>
+<div class="container">
+<h1>Service unavailable</h1>
+<p>Container <code>{}</code> is not responding on port {}.</p>
+</div>
+</body>
+</html>"#,
+        target.container_name, key.port
+    )
+}
+
+const CSS: &str = r"
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+       margin: 0; padding: 2rem; background: #f5f5f5; color: #333; }
+.container { max-width: 640px; margin: 0 auto; background: #fff;
+             padding: 2rem; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+h1 { color: #e53e3e; margin-top: 0; }
+h2 { color: #555; font-size: 1.1rem; }
+code { background: #f0f0f0; padding: 2px 6px; border-radius: 3px; font-size: 0.9em; }
+a { color: #3182ce; }
+ul { padding-left: 1.5rem; }
+li { margin: 0.3rem 0; }
+";
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use super::*;
+    use crate::router::ProxyMode;
+
+    #[test]
+    fn no_route_page_contains_requested_host() {
+        let rt = RouteTable::new();
+        let html = no_route_found("3000.nonexistent.myapp.localhost", &rt);
+        assert!(html.contains("3000.nonexistent.myapp.localhost"));
+        assert!(html.contains("No services registered"));
+    }
+
+    #[test]
+    fn no_route_page_lists_available_services() {
+        let mut rt = RouteTable::new();
+        rt.insert(
+            RouteKey {
+                project: "myapp".to_string(),
+                branch: "main".to_string(),
+                port: 3000,
+            },
+            BackendTarget {
+                container_id: "c1".to_string(),
+                container_name: "cella-myapp-main".to_string(),
+                target_port: 3000,
+                mode: ProxyMode::DirectIp(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+            },
+        );
+
+        let html = no_route_found("3000.nonexistent.myapp.localhost", &rt);
+        assert!(html.contains("3000.main.myapp.localhost"));
+        assert!(html.contains("cella-myapp-main:3000"));
+    }
+
+    #[test]
+    fn backend_unreachable_page_shows_container_info() {
+        let key = RouteKey {
+            project: "myapp".to_string(),
+            branch: "main".to_string(),
+            port: 3000,
+        };
+        let target = BackendTarget {
+            container_id: "c1".to_string(),
+            container_name: "cella-myapp-main".to_string(),
+            target_port: 3000,
+            mode: ProxyMode::DirectIp(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+        };
+
+        let html = backend_unreachable(&key, &target);
+        assert!(html.contains("cella-myapp-main"));
+        assert!(html.contains("port 3000"));
+    }
+
+    #[test]
+    fn pages_are_valid_html() {
+        let rt = RouteTable::new();
+        let html = no_route_found("test.localhost", &rt);
+        assert!(html.starts_with("<!DOCTYPE html>"));
+        assert!(html.contains("</html>"));
+    }
+}

--- a/crates/cella-proxy/src/hostname.rs
+++ b/crates/cella-proxy/src/hostname.rs
@@ -54,6 +54,97 @@ pub fn sanitize_branch_with_suffix(branch: &str) -> String {
     format!("{trimmed}-{suffix}")
 }
 
+/// Parsed components from a `*.localhost` or `*.local` hostname.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedHostname {
+    /// Container port (`None` for bare hostnames → use default port).
+    pub port: Option<u16>,
+    /// Sanitized branch slug.
+    pub branch: String,
+    /// Project slug.
+    pub project: String,
+}
+
+/// Which TLD family the hostname belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostnameTld {
+    Localhost,
+    Local,
+}
+
+/// Parse a `Host` header value into routing components.
+///
+/// Expected formats:
+/// - `{port}.{branch}.{project}.localhost` → port + branch + project
+/// - `{branch}.{project}.localhost`        → bare (default port)
+/// - Same patterns with `.local` (`OrbStack`)
+///
+/// Strips any `:port` suffix from the Host header before parsing.
+pub fn parse_hostname(host: &str) -> Option<ParsedHostname> {
+    // Strip port suffix (e.g., "foo.localhost:80" → "foo.localhost")
+    let hostname = host.split(':').next().unwrap_or(host);
+    let (labels, _tld) = split_tld(hostname)?;
+
+    match labels.len() {
+        // {branch}.{project}.{tld}
+        2 => Some(ParsedHostname {
+            port: None,
+            branch: labels[0].to_string(),
+            project: labels[1].to_string(),
+        }),
+        // {port}.{branch}.{project}.{tld}
+        3 => {
+            let port: u16 = labels[0].parse().ok()?;
+            Some(ParsedHostname {
+                port: Some(port),
+                branch: labels[1].to_string(),
+                project: labels[2].to_string(),
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Split a hostname into (labels-before-tld, tld).
+/// Returns `None` if the TLD is not `.localhost` or `.local`.
+fn split_tld(hostname: &str) -> Option<(Vec<&str>, HostnameTld)> {
+    let parts: Vec<&str> = hostname.split('.').collect();
+    if parts.len() < 2 {
+        return None;
+    }
+
+    let last = *parts.last()?;
+    if last.eq_ignore_ascii_case("localhost") {
+        Some((parts[..parts.len() - 1].to_vec(), HostnameTld::Localhost))
+    } else if parts.len() >= 3 && parts[parts.len() - 1].eq_ignore_ascii_case("local") {
+        // For .local we don't want to confuse "something.local" (2 parts)
+        // with our routing hostnames which always have 3+ parts before .local
+        Some((parts[..parts.len() - 1].to_vec(), HostnameTld::Local))
+    } else {
+        None
+    }
+}
+
+/// Build a hostname URL for a forwarded port.
+pub fn build_hostname_url(port: u16, branch: &str, project: &str, is_orbstack: bool) -> String {
+    let sanitized = sanitize_branch(branch);
+    if is_orbstack {
+        format!("https://{port}.{sanitized}.{project}.local")
+    } else {
+        format!("http://{port}.{sanitized}.{project}.localhost")
+    }
+}
+
+/// Build the bare hostname (without port) for default-port access.
+pub fn build_bare_hostname(branch: &str, project: &str, is_orbstack: bool) -> String {
+    let sanitized = sanitize_branch(branch);
+    if is_orbstack {
+        format!("{sanitized}.{project}.local")
+    } else {
+        format!("{sanitized}.{project}.localhost")
+    }
+}
+
 fn collapse_hyphens(s: &str) -> String {
     let mut result = String::with_capacity(s.len());
     let mut prev_hyphen = false;
@@ -177,5 +268,112 @@ mod tests {
         let a = sanitize_branch_with_suffix("feature/auth");
         let b = sanitize_branch_with_suffix("feature/auth");
         assert_eq!(a, b);
+    }
+
+    // -- parse_hostname tests --
+
+    #[test]
+    fn parse_port_branch_project_localhost() {
+        let parsed = parse_hostname("3000.feature-auth.myapp.localhost").unwrap();
+        assert_eq!(parsed.port, Some(3000));
+        assert_eq!(parsed.branch, "feature-auth");
+        assert_eq!(parsed.project, "myapp");
+    }
+
+    #[test]
+    fn parse_bare_hostname_localhost() {
+        let parsed = parse_hostname("feature-auth.myapp.localhost").unwrap();
+        assert_eq!(parsed.port, None);
+        assert_eq!(parsed.branch, "feature-auth");
+        assert_eq!(parsed.project, "myapp");
+    }
+
+    #[test]
+    fn parse_port_branch_project_local() {
+        let parsed = parse_hostname("3000.feature-auth.myapp.local").unwrap();
+        assert_eq!(parsed.port, Some(3000));
+        assert_eq!(parsed.branch, "feature-auth");
+        assert_eq!(parsed.project, "myapp");
+    }
+
+    #[test]
+    fn parse_bare_hostname_local() {
+        let parsed = parse_hostname("feature-auth.myapp.local").unwrap();
+        assert_eq!(parsed.port, None);
+        assert_eq!(parsed.branch, "feature-auth");
+        assert_eq!(parsed.project, "myapp");
+    }
+
+    #[test]
+    fn parse_strips_host_port_suffix() {
+        let parsed = parse_hostname("3000.main.myapp.localhost:80").unwrap();
+        assert_eq!(parsed.port, Some(3000));
+        assert_eq!(parsed.branch, "main");
+    }
+
+    #[test]
+    fn parse_rejects_plain_localhost() {
+        assert!(parse_hostname("localhost").is_none());
+    }
+
+    #[test]
+    fn parse_rejects_single_label_before_tld() {
+        assert!(parse_hostname("myapp.localhost").is_none());
+    }
+
+    #[test]
+    fn parse_rejects_unknown_tld() {
+        assert!(parse_hostname("3000.main.myapp.example.com").is_none());
+    }
+
+    #[test]
+    fn parse_rejects_too_many_labels() {
+        assert!(parse_hostname("extra.3000.main.myapp.localhost").is_none());
+    }
+
+    #[test]
+    fn parse_rejects_non_numeric_port_label() {
+        // "abc" is not a valid port, so 3-label form fails
+        assert!(parse_hostname("abc.main.myapp.localhost").is_none());
+    }
+
+    #[test]
+    fn parse_rejects_something_dot_local() {
+        // "something.local" is only 2 parts total — not enough labels
+        assert!(parse_hostname("something.local").is_none());
+    }
+
+    // -- build_hostname_url tests --
+
+    #[test]
+    fn build_url_non_orbstack() {
+        assert_eq!(
+            build_hostname_url(3000, "feature/auth", "myapp", false),
+            "http://3000.feature-auth.myapp.localhost"
+        );
+    }
+
+    #[test]
+    fn build_url_orbstack() {
+        assert_eq!(
+            build_hostname_url(3000, "feature/auth", "myapp", true),
+            "https://3000.feature-auth.myapp.local"
+        );
+    }
+
+    #[test]
+    fn build_bare_non_orbstack() {
+        assert_eq!(
+            build_bare_hostname("main", "myapp", false),
+            "main.myapp.localhost"
+        );
+    }
+
+    #[test]
+    fn build_bare_orbstack() {
+        assert_eq!(
+            build_bare_hostname("main", "myapp", true),
+            "main.myapp.local"
+        );
     }
 }

--- a/crates/cella-proxy/src/hostname.rs
+++ b/crates/cella-proxy/src/hostname.rs
@@ -125,30 +125,27 @@ fn split_tld(hostname: &str) -> Option<(Vec<&str>, HostnameTld)> {
     }
 }
 
-/// Build a hostname URL for a forwarded port.
-pub fn build_hostname_url(port: u16, branch: &str, project: &str, is_orbstack: bool) -> String {
-    build_hostname_url_with_proxy_port(port, branch, project, is_orbstack, None)
-}
-
 /// Build a hostname URL for a forwarded port, including the hostname proxy
 /// listener port when it is not the default HTTP port.
-pub fn build_hostname_url_with_proxy_port(
+///
+/// Returns `None` when `proxy_port` is `None`, since hostname URLs require the
+/// proxy to be running. `OrbStack`'s `.local` default-port domain is exposed via
+/// Docker labels, not through this function.
+pub fn build_hostname_url(
     port: u16,
     branch: &str,
     project: &str,
-    is_orbstack: bool,
     proxy_port: Option<u16>,
-) -> String {
+) -> Option<String> {
+    proxy_port?;
     let sanitized = sanitize_branch(branch);
-    if is_orbstack {
-        format!("http://{port}.{sanitized}.{project}.local")
-    } else if matches!(proxy_port, Some(p) if p != 80) {
-        format!(
+    if matches!(proxy_port, Some(p) if p != 80) {
+        Some(format!(
             "http://{port}.{sanitized}.{project}.localhost:{}",
             proxy_port.unwrap_or(80)
-        )
+        ))
     } else {
-        format!("http://{port}.{sanitized}.{project}.localhost")
+        Some(format!("http://{port}.{sanitized}.{project}.localhost"))
     }
 }
 
@@ -363,34 +360,26 @@ mod tests {
     // -- build_hostname_url tests --
 
     #[test]
-    fn build_url_non_orbstack() {
+    fn build_url_with_default_proxy_port() {
         assert_eq!(
-            build_hostname_url(3000, "feature/auth", "myapp", false),
-            "http://3000.feature-auth.myapp.localhost"
+            build_hostname_url(3000, "feature/auth", "myapp", Some(80)),
+            Some("http://3000.feature-auth.myapp.localhost".to_string())
         );
     }
 
     #[test]
-    fn build_url_orbstack() {
+    fn build_url_returns_none_without_proxy() {
         assert_eq!(
-            build_hostname_url(3000, "feature/auth", "myapp", true),
-            "http://3000.feature-auth.myapp.local"
+            build_hostname_url(3000, "feature/auth", "myapp", None),
+            None
         );
     }
 
     #[test]
-    fn build_url_non_orbstack_includes_fallback_proxy_port() {
+    fn build_url_includes_fallback_proxy_port() {
         assert_eq!(
-            build_hostname_url_with_proxy_port(3000, "feature/auth", "myapp", false, Some(49180)),
-            "http://3000.feature-auth.myapp.localhost:49180"
-        );
-    }
-
-    #[test]
-    fn build_url_non_orbstack_omits_default_proxy_port() {
-        assert_eq!(
-            build_hostname_url_with_proxy_port(3000, "feature/auth", "myapp", false, Some(80)),
-            "http://3000.feature-auth.myapp.localhost"
+            build_hostname_url(3000, "feature/auth", "myapp", Some(49180)),
+            Some("http://3000.feature-auth.myapp.localhost:49180".to_string())
         );
     }
 

--- a/crates/cella-proxy/src/hostname.rs
+++ b/crates/cella-proxy/src/hostname.rs
@@ -1,0 +1,1 @@
+//! Hostname parsing and DNS label sanitization.

--- a/crates/cella-proxy/src/hostname.rs
+++ b/crates/cella-proxy/src/hostname.rs
@@ -1,1 +1,181 @@
 //! Hostname parsing and DNS label sanitization.
+
+use sha2::{Digest, Sha256};
+
+const DNS_LABEL_MAX: usize = 63;
+
+/// Sanitize a git branch name into a valid DNS label.
+///
+/// Rules applied in order:
+/// 1. Lowercase
+/// 2. Replace `/`, `_`, `.` with `-`
+/// 3. Remove characters that aren't alphanumeric or `-`
+/// 4. Collapse consecutive hyphens
+/// 5. Strip leading/trailing hyphens
+/// 6. Truncate to 63 characters (DNS label limit)
+pub fn sanitize_branch(branch: &str) -> String {
+    let replaced: String = branch
+        .to_ascii_lowercase()
+        .chars()
+        .map(|c| match c {
+            '/' | '_' | '.' => '-',
+            c if c.is_ascii_alphanumeric() || c == '-' => c,
+            _ => '-',
+        })
+        .collect();
+
+    let collapsed = collapse_hyphens(&replaced);
+    let trimmed = collapsed.trim_matches('-');
+
+    if trimmed.len() > DNS_LABEL_MAX {
+        let truncated = &trimmed[..DNS_LABEL_MAX];
+        truncated.trim_end_matches('-').to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// Produce a collision-safe slug by appending a 4-char hash suffix when
+/// two different branch names sanitize to the same label.
+///
+/// Callers should check for collisions and call this only when needed.
+pub fn sanitize_branch_with_suffix(branch: &str) -> String {
+    let hash = hex::encode(Sha256::digest(branch.as_bytes()));
+    let suffix = &hash[..4];
+    let base = sanitize_branch(branch);
+
+    let max_base = DNS_LABEL_MAX - 5; // "-" + 4-char hash
+    let trimmed = if base.len() > max_base {
+        base[..max_base].trim_end_matches('-').to_string()
+    } else {
+        base
+    };
+
+    format!("{trimmed}-{suffix}")
+}
+
+fn collapse_hyphens(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut prev_hyphen = false;
+    for c in s.chars() {
+        if c == '-' {
+            if !prev_hyphen {
+                result.push('-');
+            }
+            prev_hyphen = true;
+        } else {
+            result.push(c);
+            prev_hyphen = false;
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slashes_become_hyphens() {
+        assert_eq!(sanitize_branch("feature/auth-v2"), "feature-auth-v2");
+    }
+
+    #[test]
+    fn nested_slashes() {
+        assert_eq!(
+            sanitize_branch("user/alice/experiment"),
+            "user-alice-experiment"
+        );
+    }
+
+    #[test]
+    fn underscores_and_dots() {
+        assert_eq!(sanitize_branch("bugfix_login.flow"), "bugfix-login-flow");
+    }
+
+    #[test]
+    fn consecutive_hyphens_collapse() {
+        assert_eq!(sanitize_branch("a---b"), "a-b");
+    }
+
+    #[test]
+    fn mixed_separators_collapse() {
+        assert_eq!(sanitize_branch("a/._b"), "a-b");
+    }
+
+    #[test]
+    fn leading_trailing_hyphens_stripped() {
+        assert_eq!(sanitize_branch("-abc-"), "abc");
+        assert_eq!(sanitize_branch("/abc/"), "abc");
+    }
+
+    #[test]
+    fn lowercased() {
+        assert_eq!(sanitize_branch("Feature/Auth"), "feature-auth");
+    }
+
+    #[test]
+    fn truncates_to_63_chars() {
+        let long = "a".repeat(100);
+        let result = sanitize_branch(&long);
+        assert!(result.len() <= DNS_LABEL_MAX);
+        assert_eq!(result.len(), DNS_LABEL_MAX);
+    }
+
+    #[test]
+    fn truncation_strips_trailing_hyphen() {
+        // 62 'a's + "/" puts a hyphen at position 63, which gets stripped
+        let branch = format!("{}/rest", "a".repeat(62));
+        let result = sanitize_branch(&branch);
+        assert!(result.len() <= DNS_LABEL_MAX);
+        assert!(!result.ends_with('-'));
+    }
+
+    #[test]
+    fn main_branch() {
+        assert_eq!(sanitize_branch("main"), "main");
+    }
+
+    #[test]
+    fn empty_input() {
+        assert_eq!(sanitize_branch(""), "");
+    }
+
+    #[test]
+    fn only_separators() {
+        assert_eq!(sanitize_branch("///"), "");
+    }
+
+    #[test]
+    fn special_characters_replaced() {
+        assert_eq!(sanitize_branch("feat@v2#patch"), "feat-v2-patch");
+    }
+
+    #[test]
+    fn collision_suffix_appended() {
+        let result = sanitize_branch_with_suffix("feature/auth");
+        assert!(result.starts_with("feature-auth-"));
+        assert_eq!(result.len(), "feature-auth-".len() + 4);
+    }
+
+    #[test]
+    fn collision_suffix_different_for_different_branches() {
+        let a = sanitize_branch_with_suffix("a/b");
+        let b = sanitize_branch_with_suffix("a-b");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn collision_suffix_fits_dns_limit() {
+        let long = "a".repeat(100);
+        let result = sanitize_branch_with_suffix(&long);
+        assert!(result.len() <= DNS_LABEL_MAX);
+    }
+
+    #[test]
+    fn collision_suffix_deterministic() {
+        let a = sanitize_branch_with_suffix("feature/auth");
+        let b = sanitize_branch_with_suffix("feature/auth");
+        assert_eq!(a, b);
+    }
+}

--- a/crates/cella-proxy/src/hostname.rs
+++ b/crates/cella-proxy/src/hostname.rs
@@ -127,9 +127,26 @@ fn split_tld(hostname: &str) -> Option<(Vec<&str>, HostnameTld)> {
 
 /// Build a hostname URL for a forwarded port.
 pub fn build_hostname_url(port: u16, branch: &str, project: &str, is_orbstack: bool) -> String {
+    build_hostname_url_with_proxy_port(port, branch, project, is_orbstack, None)
+}
+
+/// Build a hostname URL for a forwarded port, including the hostname proxy
+/// listener port when it is not the default HTTP port.
+pub fn build_hostname_url_with_proxy_port(
+    port: u16,
+    branch: &str,
+    project: &str,
+    is_orbstack: bool,
+    proxy_port: Option<u16>,
+) -> String {
     let sanitized = sanitize_branch(branch);
     if is_orbstack {
-        format!("https://{port}.{sanitized}.{project}.local")
+        format!("http://{port}.{sanitized}.{project}.local")
+    } else if matches!(proxy_port, Some(p) if p != 80) {
+        format!(
+            "http://{port}.{sanitized}.{project}.localhost:{}",
+            proxy_port.unwrap_or(80)
+        )
     } else {
         format!("http://{port}.{sanitized}.{project}.localhost")
     }
@@ -357,7 +374,23 @@ mod tests {
     fn build_url_orbstack() {
         assert_eq!(
             build_hostname_url(3000, "feature/auth", "myapp", true),
-            "https://3000.feature-auth.myapp.local"
+            "http://3000.feature-auth.myapp.local"
+        );
+    }
+
+    #[test]
+    fn build_url_non_orbstack_includes_fallback_proxy_port() {
+        assert_eq!(
+            build_hostname_url_with_proxy_port(3000, "feature/auth", "myapp", false, Some(49180)),
+            "http://3000.feature-auth.myapp.localhost:49180"
+        );
+    }
+
+    #[test]
+    fn build_url_non_orbstack_omits_default_proxy_port() {
+        assert_eq!(
+            build_hostname_url_with_proxy_port(3000, "feature/auth", "myapp", false, Some(80)),
+            "http://3000.feature-auth.myapp.localhost"
         );
     }
 

--- a/crates/cella-proxy/src/lib.rs
+++ b/crates/cella-proxy/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod hostname;
+pub mod router;

--- a/crates/cella-proxy/src/lib.rs
+++ b/crates/cella-proxy/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod error_page;
 pub mod hostname;
 pub mod router;
+pub mod server;

--- a/crates/cella-proxy/src/lib.rs
+++ b/crates/cella-proxy/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod error_page;
 pub mod hostname;
 pub mod router;

--- a/crates/cella-proxy/src/router.rs
+++ b/crates/cella-proxy/src/router.rs
@@ -1,7 +1,6 @@
 //! Route table for hostname-based request routing.
 
 use std::collections::{HashMap, HashSet};
-use std::net::IpAddr;
 
 /// Lookup key for a hostname route.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -14,7 +13,9 @@ pub struct RouteKey {
 /// How to reach the backend container.
 #[derive(Debug, Clone)]
 pub enum ProxyMode {
-    DirectIp(IpAddr),
+    /// Connect to Cella's existing host-port proxy on `127.0.0.1:target_port`.
+    Localhost,
+    DirectIp(std::net::IpAddr),
     AgentTunnel(String),
 }
 
@@ -130,7 +131,7 @@ impl RouteTable {
 
 #[cfg(test)]
 mod tests {
-    use std::net::Ipv4Addr;
+    use std::net::{IpAddr, Ipv4Addr};
 
     use super::*;
 
@@ -254,6 +255,24 @@ mod tests {
         assert!(matches!(target.mode, ProxyMode::AgentTunnel(ref n) if n == "cella-c1"));
         let target = rt.lookup("myapp", "main", 8080).unwrap();
         assert!(matches!(target.mode, ProxyMode::AgentTunnel(ref n) if n == "cella-c1"));
+    }
+
+    #[test]
+    fn route_target_can_use_existing_localhost_proxy() {
+        let mut rt = RouteTable::new();
+        rt.insert(
+            test_key("myapp", "main", 3000),
+            BackendTarget {
+                container_id: "c1".to_string(),
+                container_name: "cella-c1".to_string(),
+                target_port: 49152,
+                mode: ProxyMode::Localhost,
+            },
+        );
+
+        let target = rt.lookup("myapp", "main", 3000).unwrap();
+        assert_eq!(target.target_port, 49152);
+        assert!(matches!(target.mode, ProxyMode::Localhost));
     }
 
     #[test]

--- a/crates/cella-proxy/src/router.rs
+++ b/crates/cella-proxy/src/router.rs
@@ -56,6 +56,13 @@ impl RouteTable {
             .insert((project.to_string(), branch.to_string()), port);
     }
 
+    /// Set the default port only when this project/branch has no default yet.
+    pub fn set_default_port_if_absent(&mut self, project: &str, branch: &str, port: u16) {
+        self.defaults
+            .entry((project.to_string(), branch.to_string()))
+            .or_insert(port);
+    }
+
     /// Look up a route by exact key.
     pub fn lookup(&self, project: &str, branch: &str, port: u16) -> Option<&BackendTarget> {
         let key = RouteKey {
@@ -77,6 +84,10 @@ impl RouteTable {
     /// Remove a single route.
     pub fn remove(&mut self, key: &RouteKey) -> Option<BackendTarget> {
         let target = self.routes.remove(key)?;
+        let default_key = (key.project.clone(), key.branch.clone());
+        if self.defaults.get(&default_key) == Some(&key.port) {
+            self.defaults.remove(&default_key);
+        }
         if let Some(keys) = self.by_container.get_mut(&target.container_id) {
             keys.remove(key);
             if keys.is_empty() {
@@ -191,6 +202,20 @@ mod tests {
     }
 
     #[test]
+    fn default_port_if_absent_preserves_first_default() {
+        let mut rt = RouteTable::new();
+        rt.insert(test_key("myapp", "main", 3000), test_target("c1", 3000));
+        rt.insert(test_key("myapp", "main", 8080), test_target("c1", 8080));
+        rt.set_default_port_if_absent("myapp", "main", 3000);
+        rt.set_default_port_if_absent("myapp", "main", 8080);
+
+        assert_eq!(
+            rt.lookup_default("myapp", "main").unwrap().target_port,
+            3000
+        );
+    }
+
+    #[test]
     fn remove_single_route() {
         let mut rt = RouteTable::new();
         let key = test_key("myapp", "main", 3000);
@@ -199,6 +224,7 @@ mod tests {
         let removed = rt.remove(&key);
         assert!(removed.is_some());
         assert!(rt.lookup("myapp", "main", 3000).is_none());
+        assert!(rt.lookup_default("myapp", "main").is_none());
         assert!(rt.is_empty());
     }
 

--- a/crates/cella-proxy/src/router.rs
+++ b/crates/cella-proxy/src/router.rs
@@ -1,1 +1,313 @@
 //! Route table for hostname-based request routing.
+
+use std::collections::{HashMap, HashSet};
+use std::net::IpAddr;
+
+/// Lookup key for a hostname route.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RouteKey {
+    pub project: String,
+    pub branch: String,
+    pub port: u16,
+}
+
+/// How to reach the backend container.
+#[derive(Debug, Clone)]
+pub enum ProxyMode {
+    DirectIp(IpAddr),
+    AgentTunnel(String),
+}
+
+/// Target backend for a matched route.
+#[derive(Debug, Clone)]
+pub struct BackendTarget {
+    pub container_id: String,
+    pub container_name: String,
+    pub target_port: u16,
+    pub mode: ProxyMode,
+}
+
+/// Thread-safe route table for hostname → backend lookups.
+#[derive(Debug, Default)]
+pub struct RouteTable {
+    routes: HashMap<RouteKey, BackendTarget>,
+    defaults: HashMap<(String, String), u16>,
+    by_container: HashMap<String, HashSet<RouteKey>>,
+}
+
+impl RouteTable {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a route. Overwrites any existing route for the same key.
+    pub fn insert(&mut self, key: RouteKey, target: BackendTarget) {
+        self.by_container
+            .entry(target.container_id.clone())
+            .or_default()
+            .insert(key.clone());
+        self.routes.insert(key, target);
+    }
+
+    /// Set the default port for a (project, branch) pair.
+    pub fn set_default_port(&mut self, project: &str, branch: &str, port: u16) {
+        self.defaults
+            .insert((project.to_string(), branch.to_string()), port);
+    }
+
+    /// Look up a route by exact key.
+    pub fn lookup(&self, project: &str, branch: &str, port: u16) -> Option<&BackendTarget> {
+        let key = RouteKey {
+            project: project.to_string(),
+            branch: branch.to_string(),
+            port,
+        };
+        self.routes.get(&key)
+    }
+
+    /// Look up the default port for a (project, branch), then resolve the route.
+    pub fn lookup_default(&self, project: &str, branch: &str) -> Option<&BackendTarget> {
+        let port = self
+            .defaults
+            .get(&(project.to_string(), branch.to_string()))?;
+        self.lookup(project, branch, *port)
+    }
+
+    /// Remove a single route.
+    pub fn remove(&mut self, key: &RouteKey) -> Option<BackendTarget> {
+        let target = self.routes.remove(key)?;
+        if let Some(keys) = self.by_container.get_mut(&target.container_id) {
+            keys.remove(key);
+            if keys.is_empty() {
+                self.by_container.remove(&target.container_id);
+            }
+        }
+        Some(target)
+    }
+
+    /// Remove all routes for a container. Returns the removed keys.
+    pub fn remove_container(&mut self, container_id: &str) -> Vec<RouteKey> {
+        let keys = self.by_container.remove(container_id).unwrap_or_default();
+        let mut removed = Vec::with_capacity(keys.len());
+        for key in keys {
+            self.routes.remove(&key);
+            // Clean up defaults that reference removed routes
+            let default_key = (key.project.clone(), key.branch.clone());
+            if self.defaults.get(&default_key) == Some(&key.port) {
+                self.defaults.remove(&default_key);
+            }
+            removed.push(key);
+        }
+        removed
+    }
+
+    /// Update the proxy mode for all routes belonging to a container.
+    pub fn update_container_mode(&mut self, container_id: &str, mode: &ProxyMode) {
+        if let Some(keys) = self.by_container.get(container_id) {
+            let keys: Vec<_> = keys.iter().cloned().collect();
+            for key in keys {
+                if let Some(target) = self.routes.get_mut(&key) {
+                    target.mode = mode.clone();
+                }
+            }
+        }
+    }
+
+    /// All registered routes (for error page listing).
+    pub fn all_routes(&self) -> impl Iterator<Item = (&RouteKey, &BackendTarget)> {
+        self.routes.iter()
+    }
+
+    /// Number of active routes.
+    pub fn len(&self) -> usize {
+        self.routes.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.routes.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use super::*;
+
+    fn test_key(project: &str, branch: &str, port: u16) -> RouteKey {
+        RouteKey {
+            project: project.to_string(),
+            branch: branch.to_string(),
+            port,
+        }
+    }
+
+    fn test_target(container_id: &str, port: u16) -> BackendTarget {
+        BackendTarget {
+            container_id: container_id.to_string(),
+            container_name: format!("cella-{container_id}"),
+            target_port: port,
+            mode: ProxyMode::DirectIp(IpAddr::V4(Ipv4Addr::new(172, 20, 0, 2))),
+        }
+    }
+
+    #[test]
+    fn insert_and_lookup() {
+        let mut rt = RouteTable::new();
+        let key = test_key("myapp", "main", 3000);
+        rt.insert(key, test_target("c1", 3000));
+
+        let result = rt.lookup("myapp", "main", 3000);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().container_id, "c1");
+    }
+
+    #[test]
+    fn lookup_miss() {
+        let rt = RouteTable::new();
+        assert!(rt.lookup("myapp", "main", 3000).is_none());
+    }
+
+    #[test]
+    fn default_port_lookup() {
+        let mut rt = RouteTable::new();
+        let key = test_key("myapp", "main", 3000);
+        rt.insert(key, test_target("c1", 3000));
+        rt.set_default_port("myapp", "main", 3000);
+
+        let result = rt.lookup_default("myapp", "main");
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().target_port, 3000);
+    }
+
+    #[test]
+    fn default_port_no_default_set() {
+        let mut rt = RouteTable::new();
+        let key = test_key("myapp", "main", 3000);
+        rt.insert(key, test_target("c1", 3000));
+
+        assert!(rt.lookup_default("myapp", "main").is_none());
+    }
+
+    #[test]
+    fn remove_single_route() {
+        let mut rt = RouteTable::new();
+        let key = test_key("myapp", "main", 3000);
+        rt.insert(key.clone(), test_target("c1", 3000));
+
+        let removed = rt.remove(&key);
+        assert!(removed.is_some());
+        assert!(rt.lookup("myapp", "main", 3000).is_none());
+        assert!(rt.is_empty());
+    }
+
+    #[test]
+    fn remove_nonexistent() {
+        let mut rt = RouteTable::new();
+        let key = test_key("myapp", "main", 3000);
+        assert!(rt.remove(&key).is_none());
+    }
+
+    #[test]
+    fn remove_container_clears_all_routes() {
+        let mut rt = RouteTable::new();
+        rt.insert(test_key("myapp", "main", 3000), test_target("c1", 3000));
+        rt.insert(test_key("myapp", "main", 8080), test_target("c1", 8080));
+        rt.set_default_port("myapp", "main", 3000);
+
+        let removed = rt.remove_container("c1");
+        assert_eq!(removed.len(), 2);
+        assert!(rt.is_empty());
+        assert!(rt.lookup_default("myapp", "main").is_none());
+    }
+
+    #[test]
+    fn remove_container_unknown_is_empty() {
+        let mut rt = RouteTable::new();
+        let removed = rt.remove_container("nonexistent");
+        assert!(removed.is_empty());
+    }
+
+    #[test]
+    fn remove_container_preserves_other_containers() {
+        let mut rt = RouteTable::new();
+        rt.insert(test_key("myapp", "main", 3000), test_target("c1", 3000));
+        rt.insert(
+            test_key("myapp", "feature-auth", 3000),
+            test_target("c2", 3000),
+        );
+
+        rt.remove_container("c1");
+        assert_eq!(rt.len(), 1);
+        assert!(rt.lookup("myapp", "feature-auth", 3000).is_some());
+    }
+
+    #[test]
+    fn update_container_mode() {
+        let mut rt = RouteTable::new();
+        rt.insert(test_key("myapp", "main", 3000), test_target("c1", 3000));
+        rt.insert(test_key("myapp", "main", 8080), test_target("c1", 8080));
+
+        rt.update_container_mode("c1", &ProxyMode::AgentTunnel("cella-c1".to_string()));
+
+        let target = rt.lookup("myapp", "main", 3000).unwrap();
+        assert!(matches!(target.mode, ProxyMode::AgentTunnel(ref n) if n == "cella-c1"));
+        let target = rt.lookup("myapp", "main", 8080).unwrap();
+        assert!(matches!(target.mode, ProxyMode::AgentTunnel(ref n) if n == "cella-c1"));
+    }
+
+    #[test]
+    fn overwrite_existing_route() {
+        let mut rt = RouteTable::new();
+        let key = test_key("myapp", "main", 3000);
+        rt.insert(key.clone(), test_target("c1", 3000));
+        rt.insert(key, test_target("c2", 3000));
+
+        let result = rt.lookup("myapp", "main", 3000).unwrap();
+        assert_eq!(result.container_id, "c2");
+        assert_eq!(rt.len(), 1);
+    }
+
+    #[test]
+    fn len_and_is_empty() {
+        let mut rt = RouteTable::new();
+        assert!(rt.is_empty());
+        assert_eq!(rt.len(), 0);
+
+        rt.insert(test_key("myapp", "main", 3000), test_target("c1", 3000));
+        assert!(!rt.is_empty());
+        assert_eq!(rt.len(), 1);
+    }
+
+    #[test]
+    fn all_routes_iterates() {
+        let mut rt = RouteTable::new();
+        rt.insert(test_key("myapp", "main", 3000), test_target("c1", 3000));
+        rt.insert(test_key("myapp", "main", 8080), test_target("c1", 8080));
+
+        assert_eq!(rt.all_routes().count(), 2);
+    }
+
+    #[test]
+    fn multiple_containers_different_branches() {
+        let mut rt = RouteTable::new();
+        rt.insert(test_key("myapp", "main", 3000), test_target("c1", 3000));
+        rt.insert(
+            test_key("myapp", "feature-auth", 3000),
+            test_target("c2", 3000),
+        );
+        rt.set_default_port("myapp", "main", 3000);
+        rt.set_default_port("myapp", "feature-auth", 3000);
+
+        assert_eq!(
+            rt.lookup_default("myapp", "main").unwrap().container_id,
+            "c1"
+        );
+        assert_eq!(
+            rt.lookup_default("myapp", "feature-auth")
+                .unwrap()
+                .container_id,
+            "c2"
+        );
+    }
+}

--- a/crates/cella-proxy/src/router.rs
+++ b/crates/cella-proxy/src/router.rs
@@ -1,0 +1,1 @@
+//! Route table for hostname-based request routing.

--- a/crates/cella-proxy/src/server.rs
+++ b/crates/cella-proxy/src/server.rs
@@ -1,0 +1,567 @@
+//! HTTP reverse proxy server with hostname-based routing.
+
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use http_body_util::{BodyExt, Full};
+use hyper::body::{Bytes, Incoming};
+use hyper::header::{self, HeaderValue};
+use hyper::service::service_fn;
+use hyper::{Request, Response, StatusCode};
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::RwLock;
+use tracing::{debug, info, warn};
+
+use crate::error_page;
+use crate::hostname::parse_hostname;
+use crate::router::{BackendTarget, ProxyMode, RouteKey, RouteTable};
+
+/// Shared state for the proxy server.
+pub type SharedRouteTable = Arc<RwLock<RouteTable>>;
+
+/// Start the HTTP reverse proxy server.
+///
+/// Binds to the given address and routes requests based on the `Host` header.
+///
+/// # Errors
+///
+/// Returns `Err` if binding fails (e.g., port 80 already in use).
+pub async fn start_proxy_server(
+    addr: SocketAddr,
+    route_table: SharedRouteTable,
+) -> std::io::Result<tokio::task::JoinHandle<()>> {
+    let listener = TcpListener::bind(addr).await?;
+    info!("Hostname proxy listening on {addr}");
+
+    let handle = tokio::spawn(async move {
+        loop {
+            let (stream, peer) = match listener.accept().await {
+                Ok(conn) => conn,
+                Err(e) => {
+                    warn!("Proxy accept error: {e}");
+                    continue;
+                }
+            };
+
+            let rt = route_table.clone();
+            tokio::spawn(async move {
+                if let Err(e) = handle_connection(stream, peer, rt).await {
+                    debug!("Connection error from {peer}: {e}");
+                }
+            });
+        }
+    });
+
+    Ok(handle)
+}
+
+async fn handle_connection(
+    stream: TcpStream,
+    peer: SocketAddr,
+    route_table: SharedRouteTable,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let io = TokioIo::new(stream);
+
+    hyper_util::server::conn::auto::Builder::new(TokioExecutor::new())
+        .http1()
+        .keep_alive(true)
+        .serve_connection(
+            io,
+            service_fn(move |req| {
+                let rt = route_table.clone();
+                async move { Ok::<_, Infallible>(handle_request(req, peer, &rt).await) }
+            }),
+        )
+        .await?;
+
+    Ok(())
+}
+
+async fn handle_request(
+    req: Request<Incoming>,
+    peer: SocketAddr,
+    route_table: &SharedRouteTable,
+) -> Response<Full<Bytes>> {
+    let host = req
+        .headers()
+        .get(header::HOST)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+
+    let Some(parsed) = parse_hostname(&host) else {
+        let rt = route_table.read().await;
+        return html_response(
+            StatusCode::NOT_FOUND,
+            error_page::no_route_found(&host, &rt),
+        );
+    };
+
+    let rt = route_table.read().await;
+    let target = if let Some(port) = parsed.port {
+        rt.lookup(&parsed.project, &parsed.branch, port)
+    } else {
+        rt.lookup_default(&parsed.project, &parsed.branch)
+    };
+
+    let target = match target {
+        Some(t) => t.clone(),
+        None => {
+            return html_response(
+                StatusCode::NOT_FOUND,
+                error_page::no_route_found(&host, &rt),
+            );
+        }
+    };
+    drop(rt);
+
+    let is_ws = is_websocket_upgrade_headers(req.headers());
+    proxy_request(req, peer, &host, &target, is_ws).await
+}
+
+async fn proxy_request(
+    req: Request<Incoming>,
+    peer: SocketAddr,
+    original_host: &str,
+    target: &BackendTarget,
+    is_websocket: bool,
+) -> Response<Full<Bytes>> {
+    let backend_addr = match &target.mode {
+        ProxyMode::DirectIp(ip) => format!("{ip}:{}", target.target_port),
+        ProxyMode::AgentTunnel(_) => {
+            return unavailable_response(target);
+        }
+    };
+
+    let backend_stream = match TcpStream::connect(&backend_addr).await {
+        Ok(s) => s,
+        Err(e) => {
+            debug!("Backend connect to {backend_addr} failed: {e}");
+            return unavailable_response(target);
+        }
+    };
+
+    let io = TokioIo::new(backend_stream);
+    let (mut sender, conn) = match hyper::client::conn::http1::handshake(io).await {
+        Ok(parts) => parts,
+        Err(e) => {
+            warn!("Backend handshake failed: {e}");
+            return error_response(StatusCode::BAD_GATEWAY, "Backend handshake failed");
+        }
+    };
+
+    if is_websocket {
+        tokio::spawn(async move {
+            if let Err(e) = conn.with_upgrades().await {
+                debug!("WebSocket backend connection error: {e}");
+            }
+        });
+    } else {
+        tokio::spawn(async move {
+            if let Err(e) = conn.await {
+                debug!("Backend connection error: {e}");
+            }
+        });
+    }
+
+    let proxied_req = build_proxied_request(req, original_host, peer, is_websocket);
+    match sender.send_request(proxied_req).await {
+        Ok(resp) => {
+            let (parts, body) = resp.into_parts();
+            let bytes = body
+                .collect()
+                .await
+                .map(http_body_util::Collected::to_bytes)
+                .unwrap_or_default();
+            Response::from_parts(parts, Full::new(bytes))
+        }
+        Err(e) => {
+            debug!("Backend request failed: {e}");
+            error_response(StatusCode::BAD_GATEWAY, "Backend request failed")
+        }
+    }
+}
+
+/// Hop-by-hop headers that must not be forwarded (except during upgrades).
+const HOP_BY_HOP: &[&str] = &[
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+];
+
+fn build_proxied_request(
+    mut req: Request<Incoming>,
+    original_host: &str,
+    peer: SocketAddr,
+    is_websocket: bool,
+) -> Request<Incoming> {
+    let headers = req.headers_mut();
+
+    if !is_websocket {
+        for &hop in HOP_BY_HOP {
+            headers.remove(hop);
+        }
+    }
+
+    if let Ok(v) = HeaderValue::from_str(original_host) {
+        headers.insert("x-forwarded-host", v);
+    }
+    headers.insert("x-forwarded-proto", HeaderValue::from_static("http"));
+    if let Ok(v) = HeaderValue::from_str(&peer.ip().to_string()) {
+        headers.insert("x-forwarded-for", v);
+    }
+
+    req
+}
+
+fn is_websocket_upgrade_headers(headers: &hyper::HeaderMap) -> bool {
+    let has_upgrade = headers
+        .get(header::CONNECTION)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v.to_lowercase().contains("upgrade"));
+
+    let is_websocket = headers
+        .get(header::UPGRADE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v.eq_ignore_ascii_case("websocket"));
+
+    has_upgrade && is_websocket
+}
+
+fn unavailable_response(target: &BackendTarget) -> Response<Full<Bytes>> {
+    html_response(
+        StatusCode::BAD_GATEWAY,
+        error_page::backend_unreachable(
+            &RouteKey {
+                project: String::new(),
+                branch: String::new(),
+                port: target.target_port,
+            },
+            target,
+        ),
+    )
+}
+
+fn html_response(status: StatusCode, body: String) -> Response<Full<Bytes>> {
+    Response::builder()
+        .status(status)
+        .header(header::CONTENT_TYPE, "text/html; charset=utf-8")
+        .body(Full::new(Bytes::from(body)))
+        .unwrap_or_else(|_| {
+            Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(Full::new(Bytes::from("Internal error")))
+                .expect("static response")
+        })
+}
+
+fn error_response(status: StatusCode, message: &str) -> Response<Full<Bytes>> {
+    Response::builder()
+        .status(status)
+        .header(header::CONTENT_TYPE, "text/plain")
+        .body(Full::new(Bytes::from(message.to_string())))
+        .unwrap_or_else(|_| {
+            Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(Full::new(Bytes::from("Internal error")))
+                .expect("static response")
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use super::*;
+
+    #[test]
+    fn websocket_upgrade_detection() {
+        let mut headers = hyper::HeaderMap::new();
+        headers.insert("Connection", HeaderValue::from_static("Upgrade"));
+        headers.insert("Upgrade", HeaderValue::from_static("websocket"));
+        assert!(is_websocket_upgrade_headers(&headers));
+    }
+
+    #[test]
+    fn non_websocket_not_detected() {
+        let mut headers = hyper::HeaderMap::new();
+        headers.insert("Connection", HeaderValue::from_static("keep-alive"));
+        assert!(!is_websocket_upgrade_headers(&headers));
+    }
+
+    #[test]
+    fn websocket_detection_case_insensitive() {
+        let mut headers = hyper::HeaderMap::new();
+        headers.insert("Connection", HeaderValue::from_static("upgrade"));
+        headers.insert("Upgrade", HeaderValue::from_static("WebSocket"));
+        assert!(is_websocket_upgrade_headers(&headers));
+    }
+
+    #[test]
+    fn empty_headers_no_websocket() {
+        let headers = hyper::HeaderMap::new();
+        assert!(!is_websocket_upgrade_headers(&headers));
+    }
+
+    #[test]
+    fn html_response_sets_content_type() {
+        let resp = html_response(StatusCode::NOT_FOUND, "<h1>test</h1>".to_string());
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "text/html; charset=utf-8"
+        );
+    }
+
+    #[test]
+    fn error_response_sets_content_type() {
+        let resp = error_response(StatusCode::BAD_GATEWAY, "fail");
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "text/plain"
+        );
+    }
+
+    #[test]
+    fn unavailable_response_is_502() {
+        let target = BackendTarget {
+            container_id: "c1".to_string(),
+            container_name: "cella-test".to_string(),
+            target_port: 3000,
+            mode: ProxyMode::DirectIp(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+        };
+        let resp = unavailable_response(&target);
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    #[tokio::test]
+    async fn proxy_server_binds_and_responds() {
+        let rt = Arc::new(RwLock::new(RouteTable::new()));
+        let handle = start_proxy_server("127.0.0.1:0".parse().unwrap(), rt)
+            .await
+            .unwrap();
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn proxy_server_returns_404_for_unknown_host() {
+        let rt = Arc::new(RwLock::new(RouteTable::new()));
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let listener = TcpListener::bind(addr).await.unwrap();
+        let bound_addr = listener.local_addr().unwrap();
+
+        let rt_clone = rt.clone();
+        let server = tokio::spawn(async move {
+            let (stream, peer) = listener.accept().await.unwrap();
+            let _ = handle_connection(stream, peer, rt_clone).await;
+        });
+
+        let stream = TcpStream::connect(bound_addr).await.unwrap();
+        let io = TokioIo::new(stream);
+        let (mut sender, conn) = hyper::client::conn::http1::handshake(io).await.unwrap();
+        tokio::spawn(conn);
+
+        let req = Request::builder()
+            .header("Host", "3000.main.myapp.localhost")
+            .body(Full::<Bytes>::default())
+            .unwrap();
+        let resp = sender.send_request(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn proxy_server_returns_502_for_unreachable_backend() {
+        let mut table = RouteTable::new();
+        table.insert(
+            RouteKey {
+                project: "myapp".to_string(),
+                branch: "main".to_string(),
+                port: 3000,
+            },
+            BackendTarget {
+                container_id: "c1".to_string(),
+                container_name: "cella-myapp".to_string(),
+                target_port: 19999,
+                mode: ProxyMode::DirectIp(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+            },
+        );
+        let rt: SharedRouteTable = Arc::new(RwLock::new(table));
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let listener = TcpListener::bind(addr).await.unwrap();
+        let bound_addr = listener.local_addr().unwrap();
+
+        let rt_clone = rt.clone();
+        let server = tokio::spawn(async move {
+            let (stream, peer) = listener.accept().await.unwrap();
+            let _ = handle_connection(stream, peer, rt_clone).await;
+        });
+
+        let stream = TcpStream::connect(bound_addr).await.unwrap();
+        let io = TokioIo::new(stream);
+        let (mut sender, conn) = hyper::client::conn::http1::handshake(io).await.unwrap();
+        tokio::spawn(conn);
+
+        let req = Request::builder()
+            .header("Host", "3000.main.myapp.localhost")
+            .body(Full::<Bytes>::default())
+            .unwrap();
+        let resp = sender.send_request(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn proxy_forwards_to_real_backend() {
+        // Start a simple backend server
+        let backend_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let backend_addr = backend_listener.local_addr().unwrap();
+        let backend = tokio::spawn(async move {
+            let (stream, _) = backend_listener.accept().await.unwrap();
+            let io = TokioIo::new(stream);
+            hyper::server::conn::http1::Builder::new()
+                .serve_connection(
+                    io,
+                    service_fn(|_req| async {
+                        Ok::<_, Infallible>(
+                            Response::builder()
+                                .status(200)
+                                .body(Full::new(Bytes::from("hello from backend")))
+                                .unwrap(),
+                        )
+                    }),
+                )
+                .await
+                .unwrap();
+        });
+
+        let mut table = RouteTable::new();
+        table.insert(
+            RouteKey {
+                project: "myapp".to_string(),
+                branch: "main".to_string(),
+                port: 3000,
+            },
+            BackendTarget {
+                container_id: "c1".to_string(),
+                container_name: "cella-myapp".to_string(),
+                target_port: backend_addr.port(),
+                mode: ProxyMode::DirectIp(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+            },
+        );
+        let rt: SharedRouteTable = Arc::new(RwLock::new(table));
+        let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_addr = proxy_listener.local_addr().unwrap();
+
+        let rt_clone = rt.clone();
+        let server = tokio::spawn(async move {
+            let (stream, peer) = proxy_listener.accept().await.unwrap();
+            let _ = handle_connection(stream, peer, rt_clone).await;
+        });
+
+        let stream = TcpStream::connect(proxy_addr).await.unwrap();
+        let io = TokioIo::new(stream);
+        let (mut sender, conn) = hyper::client::conn::http1::handshake(io).await.unwrap();
+        tokio::spawn(conn);
+
+        let req = Request::builder()
+            .header("Host", "3000.main.myapp.localhost")
+            .body(Full::<Bytes>::default())
+            .unwrap();
+        let resp = sender.send_request(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(&body[..], b"hello from backend");
+
+        server.abort();
+        backend.abort();
+    }
+
+    #[tokio::test]
+    async fn proxy_sets_forwarding_headers() {
+        use tokio::sync::oneshot;
+
+        let (headers_tx, headers_rx) = oneshot::channel::<hyper::HeaderMap>();
+        let backend_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let backend_addr = backend_listener.local_addr().unwrap();
+
+        let backend = tokio::spawn(async move {
+            let (stream, _) = backend_listener.accept().await.unwrap();
+            let io = TokioIo::new(stream);
+            let tx = std::sync::Mutex::new(Some(headers_tx));
+            hyper::server::conn::http1::Builder::new()
+                .serve_connection(
+                    io,
+                    service_fn(move |req: Request<Incoming>| {
+                        let captured_tx = tx.lock().unwrap().take();
+                        if let Some(tx) = captured_tx {
+                            let _ = tx.send(req.headers().clone());
+                        }
+                        async {
+                            Ok::<_, Infallible>(
+                                Response::builder().body(Full::new(Bytes::new())).unwrap(),
+                            )
+                        }
+                    }),
+                )
+                .await
+                .unwrap();
+        });
+
+        let mut table = RouteTable::new();
+        table.insert(
+            RouteKey {
+                project: "myapp".to_string(),
+                branch: "main".to_string(),
+                port: 3000,
+            },
+            BackendTarget {
+                container_id: "c1".to_string(),
+                container_name: "cella-myapp".to_string(),
+                target_port: backend_addr.port(),
+                mode: ProxyMode::DirectIp(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+            },
+        );
+        let rt: SharedRouteTable = Arc::new(RwLock::new(table));
+        let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_addr = proxy_listener.local_addr().unwrap();
+
+        let rt_clone = rt.clone();
+        let server = tokio::spawn(async move {
+            let (stream, peer) = proxy_listener.accept().await.unwrap();
+            let _ = handle_connection(stream, peer, rt_clone).await;
+        });
+
+        let stream = TcpStream::connect(proxy_addr).await.unwrap();
+        let io = TokioIo::new(stream);
+        let (mut sender, conn) = hyper::client::conn::http1::handshake(io).await.unwrap();
+        tokio::spawn(conn);
+
+        let req = Request::builder()
+            .header("Host", "3000.main.myapp.localhost")
+            .body(Full::<Bytes>::default())
+            .unwrap();
+        let _resp = sender.send_request(req).await.unwrap();
+
+        let received_headers = headers_rx.await.unwrap();
+        assert_eq!(
+            received_headers.get("x-forwarded-host").unwrap(),
+            "3000.main.myapp.localhost"
+        );
+        assert_eq!(received_headers.get("x-forwarded-proto").unwrap(), "http");
+        assert!(received_headers.get("x-forwarded-for").is_some());
+
+        server.abort();
+        backend.abort();
+    }
+}

--- a/crates/cella-proxy/src/server.rs
+++ b/crates/cella-proxy/src/server.rs
@@ -172,28 +172,29 @@ async fn proxy_request(
     let proxied_req = build_proxied_request(req, original_host, peer, is_websocket);
     match sender.send_request(proxied_req).await {
         Ok(mut resp) => {
-            if is_websocket && resp.status() == StatusCode::SWITCHING_PROTOCOLS {
-                if let Some(client_upgrade) = client_upgrade {
-                    let upstream_upgrade = hyper::upgrade::on(&mut resp);
-                    let host = original_host.to_string();
-                    tokio::spawn(async move {
-                        let (client_io, upstream_io) =
-                            match tokio::join!(client_upgrade, upstream_upgrade) {
-                                (Ok(client), Ok(upstream)) => (client, upstream),
-                                (Err(e), _) | (_, Err(e)) => {
-                                    debug!("WebSocket upgrade for {host} failed: {e}");
-                                    return;
-                                }
-                            };
-                        let mut client_io = TokioIo::new(client_io);
-                        let mut upstream_io = TokioIo::new(upstream_io);
-                        if let Err(e) =
-                            tokio::io::copy_bidirectional(&mut client_io, &mut upstream_io).await
-                        {
-                            debug!("WebSocket stream for {host} ended: {e}");
-                        }
-                    });
-                }
+            if is_websocket
+                && resp.status() == StatusCode::SWITCHING_PROTOCOLS
+                && let Some(client_upgrade) = client_upgrade
+            {
+                let upstream_upgrade = hyper::upgrade::on(&mut resp);
+                let host = original_host.to_string();
+                tokio::spawn(async move {
+                    let (client_io, upstream_io) =
+                        match tokio::join!(client_upgrade, upstream_upgrade) {
+                            (Ok(client), Ok(upstream)) => (client, upstream),
+                            (Err(e), _) | (_, Err(e)) => {
+                                debug!("WebSocket upgrade for {host} failed: {e}");
+                                return;
+                            }
+                        };
+                    let mut client_io = TokioIo::new(client_io);
+                    let mut upstream_io = TokioIo::new(upstream_io);
+                    if let Err(e) =
+                        tokio::io::copy_bidirectional(&mut client_io, &mut upstream_io).await
+                    {
+                        debug!("WebSocket stream for {host} ended: {e}");
+                    }
+                });
             }
             resp.map(|body| body.map_err(Into::into).boxed())
         }

--- a/crates/cella-proxy/src/server.rs
+++ b/crates/cella-proxy/src/server.rs
@@ -32,10 +32,11 @@ type ProxyBody = BoxBody<Bytes, Box<dyn std::error::Error + Send + Sync>>;
 pub async fn start_proxy_server(
     addr: SocketAddr,
     route_table: SharedRouteTable,
-) -> std::io::Result<tokio::task::JoinHandle<()>> {
+) -> std::io::Result<(SocketAddr, tokio::task::JoinHandle<()>)> {
     let listener = TcpListener::bind(addr).await?;
-    let proxy_port = addr.port();
-    info!("Hostname proxy listening on {addr}");
+    let bound_addr = listener.local_addr()?;
+    let proxy_port = bound_addr.port();
+    info!("Hostname proxy listening on {bound_addr}");
 
     let handle = tokio::spawn(async move {
         loop {
@@ -56,7 +57,7 @@ pub async fn start_proxy_server(
         }
     });
 
-    Ok(handle)
+    Ok((bound_addr, handle))
 }
 
 async fn handle_connection(
@@ -379,7 +380,7 @@ mod tests {
     #[tokio::test]
     async fn proxy_server_binds_and_responds() {
         let rt = Arc::new(RwLock::new(RouteTable::new()));
-        let handle = start_proxy_server("127.0.0.1:0".parse().unwrap(), rt)
+        let (_, handle) = start_proxy_server("127.0.0.1:0".parse().unwrap(), rt)
             .await
             .unwrap();
         handle.abort();

--- a/crates/cella-proxy/src/server.rs
+++ b/crates/cella-proxy/src/server.rs
@@ -34,6 +34,7 @@ pub async fn start_proxy_server(
     route_table: SharedRouteTable,
 ) -> std::io::Result<tokio::task::JoinHandle<()>> {
     let listener = TcpListener::bind(addr).await?;
+    let proxy_port = addr.port();
     info!("Hostname proxy listening on {addr}");
 
     let handle = tokio::spawn(async move {
@@ -48,7 +49,7 @@ pub async fn start_proxy_server(
 
             let rt = route_table.clone();
             tokio::spawn(async move {
-                if let Err(e) = handle_connection(stream, peer, rt).await {
+                if let Err(e) = handle_connection(stream, peer, rt, proxy_port).await {
                     debug!("Connection error from {peer}: {e}");
                 }
             });
@@ -62,6 +63,7 @@ async fn handle_connection(
     stream: TcpStream,
     peer: SocketAddr,
     route_table: SharedRouteTable,
+    proxy_port: u16,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let io = TokioIo::new(stream);
 
@@ -72,7 +74,7 @@ async fn handle_connection(
             io,
             service_fn(move |req| {
                 let rt = route_table.clone();
-                async move { Ok::<_, Infallible>(handle_request(req, peer, &rt).await) }
+                async move { Ok::<_, Infallible>(handle_request(req, peer, &rt, proxy_port).await) }
             }),
         )
         .await?;
@@ -84,6 +86,7 @@ async fn handle_request(
     req: Request<Incoming>,
     peer: SocketAddr,
     route_table: &SharedRouteTable,
+    proxy_port: u16,
 ) -> Response<ProxyBody> {
     let host = req
         .headers()
@@ -96,7 +99,7 @@ async fn handle_request(
         let rt = route_table.read().await;
         return html_response(
             StatusCode::NOT_FOUND,
-            error_page::no_route_found(&host, &rt),
+            error_page::no_route_found(&host, &rt, Some(proxy_port)),
         );
     };
 
@@ -112,14 +115,19 @@ async fn handle_request(
         None => {
             return html_response(
                 StatusCode::NOT_FOUND,
-                error_page::no_route_found(&host, &rt),
+                error_page::no_route_found(&host, &rt, Some(proxy_port)),
             );
         }
     };
     drop(rt);
 
+    let route_key = RouteKey {
+        project: parsed.project,
+        branch: parsed.branch,
+        port: parsed.port.unwrap_or(0),
+    };
     let is_ws = is_websocket_upgrade_headers(req.headers());
-    proxy_request(req, peer, &host, &target, is_ws).await
+    proxy_request(req, peer, &host, &target, &route_key, is_ws).await
 }
 
 async fn proxy_request(
@@ -127,6 +135,7 @@ async fn proxy_request(
     peer: SocketAddr,
     original_host: &str,
     target: &BackendTarget,
+    route_key: &RouteKey,
     is_websocket: bool,
 ) -> Response<ProxyBody> {
     let client_upgrade = is_websocket.then(|| hyper::upgrade::on(&mut req));
@@ -134,7 +143,7 @@ async fn proxy_request(
         ProxyMode::Localhost => format!("127.0.0.1:{}", target.target_port),
         ProxyMode::DirectIp(ip) => format!("{ip}:{}", target.target_port),
         ProxyMode::AgentTunnel(_) => {
-            return unavailable_response(target);
+            return unavailable_response(route_key, target);
         }
     };
 
@@ -142,7 +151,7 @@ async fn proxy_request(
         Ok(s) => s,
         Err(e) => {
             debug!("Backend connect to {backend_addr} failed: {e}");
-            return unavailable_response(target);
+            return unavailable_response(route_key, target);
         }
     };
 
@@ -214,6 +223,7 @@ const HOP_BY_HOP: &[&str] = &[
     "te",
     "trailer",
     "transfer-encoding",
+    "upgrade",
 ];
 
 fn build_proxied_request(
@@ -255,17 +265,10 @@ fn is_websocket_upgrade_headers(headers: &hyper::HeaderMap) -> bool {
     has_upgrade && is_websocket
 }
 
-fn unavailable_response(target: &BackendTarget) -> Response<ProxyBody> {
+fn unavailable_response(route_key: &RouteKey, target: &BackendTarget) -> Response<ProxyBody> {
     html_response(
         StatusCode::BAD_GATEWAY,
-        error_page::backend_unreachable(
-            &RouteKey {
-                project: String::new(),
-                branch: String::new(),
-                port: target.target_port,
-            },
-            target,
-        ),
+        error_page::backend_unreachable(route_key, target),
     )
 }
 
@@ -358,13 +361,18 @@ mod tests {
 
     #[test]
     fn unavailable_response_is_502() {
+        let key = RouteKey {
+            project: "myapp".to_string(),
+            branch: "main".to_string(),
+            port: 3000,
+        };
         let target = BackendTarget {
             container_id: "c1".to_string(),
             container_name: "cella-test".to_string(),
             target_port: 3000,
             mode: ProxyMode::DirectIp(IpAddr::V4(Ipv4Addr::LOCALHOST)),
         };
-        let resp = unavailable_response(&target);
+        let resp = unavailable_response(&key, &target);
         assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
     }
 
@@ -387,7 +395,7 @@ mod tests {
         let rt_clone = rt.clone();
         let server = tokio::spawn(async move {
             let (stream, peer) = listener.accept().await.unwrap();
-            let _ = handle_connection(stream, peer, rt_clone).await;
+            let _ = handle_connection(stream, peer, rt_clone, 80).await;
         });
 
         let stream = TcpStream::connect(bound_addr).await.unwrap();
@@ -429,7 +437,7 @@ mod tests {
         let rt_clone = rt.clone();
         let server = tokio::spawn(async move {
             let (stream, peer) = listener.accept().await.unwrap();
-            let _ = handle_connection(stream, peer, rt_clone).await;
+            let _ = handle_connection(stream, peer, rt_clone, 80).await;
         });
 
         let stream = TcpStream::connect(bound_addr).await.unwrap();
@@ -492,7 +500,7 @@ mod tests {
         let rt_clone = rt.clone();
         let server = tokio::spawn(async move {
             let (stream, peer) = proxy_listener.accept().await.unwrap();
-            let _ = handle_connection(stream, peer, rt_clone).await;
+            let _ = handle_connection(stream, peer, rt_clone, 80).await;
         });
 
         let stream = TcpStream::connect(proxy_addr).await.unwrap();
@@ -557,7 +565,7 @@ mod tests {
 
         let server = tokio::spawn(async move {
             let (stream, peer) = proxy_listener.accept().await.unwrap();
-            let _ = handle_connection(stream, peer, rt).await;
+            let _ = handle_connection(stream, peer, rt, 80).await;
         });
 
         let stream = TcpStream::connect(proxy_addr).await.unwrap();
@@ -639,7 +647,7 @@ mod tests {
 
         let server = tokio::spawn(async move {
             let (stream, peer) = proxy_listener.accept().await.unwrap();
-            let _ = handle_connection(stream, peer, rt).await;
+            let _ = handle_connection(stream, peer, rt, 80).await;
         });
 
         let stream = TcpStream::connect(proxy_addr).await.unwrap();
@@ -724,7 +732,7 @@ mod tests {
 
         let server = tokio::spawn(async move {
             let (stream, peer) = proxy_listener.accept().await.unwrap();
-            let _ = handle_connection(stream, peer, rt).await;
+            let _ = handle_connection(stream, peer, rt, 80).await;
         });
 
         let mut client = TcpStream::connect(proxy_addr).await.unwrap();
@@ -816,7 +824,7 @@ mod tests {
         let rt_clone = rt.clone();
         let server = tokio::spawn(async move {
             let (stream, peer) = proxy_listener.accept().await.unwrap();
-            let _ = handle_connection(stream, peer, rt_clone).await;
+            let _ = handle_connection(stream, peer, rt_clone, 80).await;
         });
 
         let stream = TcpStream::connect(proxy_addr).await.unwrap();

--- a/crates/cella-proxy/src/server.rs
+++ b/crates/cella-proxy/src/server.rs
@@ -129,6 +129,7 @@ async fn proxy_request(
     is_websocket: bool,
 ) -> Response<Full<Bytes>> {
     let backend_addr = match &target.mode {
+        ProxyMode::Localhost => format!("127.0.0.1:{}", target.target_port),
         ProxyMode::DirectIp(ip) => format!("{ip}:{}", target.target_port),
         ProxyMode::AgentTunnel(_) => {
             return unavailable_response(target);
@@ -482,6 +483,71 @@ mod tests {
 
         let body = resp.into_body().collect().await.unwrap().to_bytes();
         assert_eq!(&body[..], b"hello from backend");
+
+        server.abort();
+        backend.abort();
+    }
+
+    #[tokio::test]
+    async fn proxy_forwards_to_existing_localhost_host_port() {
+        let backend_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let backend_addr = backend_listener.local_addr().unwrap();
+        let backend = tokio::spawn(async move {
+            let (stream, _) = backend_listener.accept().await.unwrap();
+            let io = TokioIo::new(stream);
+            hyper::server::conn::http1::Builder::new()
+                .serve_connection(
+                    io,
+                    service_fn(|_req| async {
+                        Ok::<_, Infallible>(
+                            Response::builder()
+                                .status(200)
+                                .body(Full::new(Bytes::from("via host port")))
+                                .unwrap(),
+                        )
+                    }),
+                )
+                .await
+                .unwrap();
+        });
+
+        let mut table = RouteTable::new();
+        table.insert(
+            RouteKey {
+                project: "myapp".to_string(),
+                branch: "main".to_string(),
+                port: 3000,
+            },
+            BackendTarget {
+                container_id: "c1".to_string(),
+                container_name: "cella-myapp".to_string(),
+                target_port: backend_addr.port(),
+                mode: ProxyMode::Localhost,
+            },
+        );
+        let rt: SharedRouteTable = Arc::new(RwLock::new(table));
+        let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_addr = proxy_listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            let (stream, peer) = proxy_listener.accept().await.unwrap();
+            let _ = handle_connection(stream, peer, rt).await;
+        });
+
+        let stream = TcpStream::connect(proxy_addr).await.unwrap();
+        let io = TokioIo::new(stream);
+        let (mut sender, conn) = hyper::client::conn::http1::handshake(io).await.unwrap();
+        tokio::spawn(conn);
+
+        let req = Request::builder()
+            .header("Host", "3000.main.myapp.localhost")
+            .body(Full::<Bytes>::default())
+            .unwrap();
+        let resp = sender.send_request(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(&body[..], b"via host port");
 
         server.abort();
         backend.abort();

--- a/crates/cella-proxy/src/server.rs
+++ b/crates/cella-proxy/src/server.rs
@@ -4,7 +4,7 @@ use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use http_body_util::{BodyExt, Full};
+use http_body_util::{BodyExt, Full, combinators::BoxBody};
 use hyper::body::{Bytes, Incoming};
 use hyper::header::{self, HeaderValue};
 use hyper::service::service_fn;
@@ -20,6 +20,7 @@ use crate::router::{BackendTarget, ProxyMode, RouteKey, RouteTable};
 
 /// Shared state for the proxy server.
 pub type SharedRouteTable = Arc<RwLock<RouteTable>>;
+type ProxyBody = BoxBody<Bytes, Box<dyn std::error::Error + Send + Sync>>;
 
 /// Start the HTTP reverse proxy server.
 ///
@@ -67,7 +68,7 @@ async fn handle_connection(
     hyper_util::server::conn::auto::Builder::new(TokioExecutor::new())
         .http1()
         .keep_alive(true)
-        .serve_connection(
+        .serve_connection_with_upgrades(
             io,
             service_fn(move |req| {
                 let rt = route_table.clone();
@@ -83,7 +84,7 @@ async fn handle_request(
     req: Request<Incoming>,
     peer: SocketAddr,
     route_table: &SharedRouteTable,
-) -> Response<Full<Bytes>> {
+) -> Response<ProxyBody> {
     let host = req
         .headers()
         .get(header::HOST)
@@ -122,12 +123,13 @@ async fn handle_request(
 }
 
 async fn proxy_request(
-    req: Request<Incoming>,
+    mut req: Request<Incoming>,
     peer: SocketAddr,
     original_host: &str,
     target: &BackendTarget,
     is_websocket: bool,
-) -> Response<Full<Bytes>> {
+) -> Response<ProxyBody> {
+    let client_upgrade = is_websocket.then(|| hyper::upgrade::on(&mut req));
     let backend_addr = match &target.mode {
         ProxyMode::Localhost => format!("127.0.0.1:{}", target.target_port),
         ProxyMode::DirectIp(ip) => format!("{ip}:{}", target.target_port),
@@ -169,14 +171,31 @@ async fn proxy_request(
 
     let proxied_req = build_proxied_request(req, original_host, peer, is_websocket);
     match sender.send_request(proxied_req).await {
-        Ok(resp) => {
-            let (parts, body) = resp.into_parts();
-            let bytes = body
-                .collect()
-                .await
-                .map(http_body_util::Collected::to_bytes)
-                .unwrap_or_default();
-            Response::from_parts(parts, Full::new(bytes))
+        Ok(mut resp) => {
+            if is_websocket && resp.status() == StatusCode::SWITCHING_PROTOCOLS {
+                if let Some(client_upgrade) = client_upgrade {
+                    let upstream_upgrade = hyper::upgrade::on(&mut resp);
+                    let host = original_host.to_string();
+                    tokio::spawn(async move {
+                        let (client_io, upstream_io) =
+                            match tokio::join!(client_upgrade, upstream_upgrade) {
+                                (Ok(client), Ok(upstream)) => (client, upstream),
+                                (Err(e), _) | (_, Err(e)) => {
+                                    debug!("WebSocket upgrade for {host} failed: {e}");
+                                    return;
+                                }
+                            };
+                        let mut client_io = TokioIo::new(client_io);
+                        let mut upstream_io = TokioIo::new(upstream_io);
+                        if let Err(e) =
+                            tokio::io::copy_bidirectional(&mut client_io, &mut upstream_io).await
+                        {
+                            debug!("WebSocket stream for {host} ended: {e}");
+                        }
+                    });
+                }
+            }
+            resp.map(|body| body.map_err(Into::into).boxed())
         }
         Err(e) => {
             debug!("Backend request failed: {e}");
@@ -235,7 +254,7 @@ fn is_websocket_upgrade_headers(headers: &hyper::HeaderMap) -> bool {
     has_upgrade && is_websocket
 }
 
-fn unavailable_response(target: &BackendTarget) -> Response<Full<Bytes>> {
+fn unavailable_response(target: &BackendTarget) -> Response<ProxyBody> {
     html_response(
         StatusCode::BAD_GATEWAY,
         error_page::backend_unreachable(
@@ -249,30 +268,36 @@ fn unavailable_response(target: &BackendTarget) -> Response<Full<Bytes>> {
     )
 }
 
-fn html_response(status: StatusCode, body: String) -> Response<Full<Bytes>> {
+fn html_response(status: StatusCode, body: String) -> Response<ProxyBody> {
     Response::builder()
         .status(status)
         .header(header::CONTENT_TYPE, "text/html; charset=utf-8")
-        .body(Full::new(Bytes::from(body)))
+        .body(full(body))
         .unwrap_or_else(|_| {
             Response::builder()
                 .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body(Full::new(Bytes::from("Internal error")))
+                .body(full("Internal error".to_string()))
                 .expect("static response")
         })
 }
 
-fn error_response(status: StatusCode, message: &str) -> Response<Full<Bytes>> {
+fn error_response(status: StatusCode, message: &str) -> Response<ProxyBody> {
     Response::builder()
         .status(status)
         .header(header::CONTENT_TYPE, "text/plain")
-        .body(Full::new(Bytes::from(message.to_string())))
+        .body(full(message.to_string()))
         .unwrap_or_else(|_| {
             Response::builder()
                 .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body(Full::new(Bytes::from("Internal error")))
+                .body(full("Internal error".to_string()))
                 .expect("static response")
         })
+}
+
+fn full(data: String) -> ProxyBody {
+    Full::new(Bytes::from(data))
+        .map_err(|never| match never {})
+        .boxed()
 }
 
 #[cfg(test)]
@@ -548,6 +573,191 @@ mod tests {
 
         let body = resp.into_body().collect().await.unwrap().to_bytes();
         assert_eq!(&body[..], b"via host port");
+
+        server.abort();
+        backend.abort();
+    }
+
+    #[tokio::test]
+    async fn proxy_streams_response_body_without_buffering() {
+        use futures_util::StreamExt;
+        use http_body_util::StreamBody;
+        use hyper::body::Frame;
+        use tokio::sync::oneshot;
+
+        let (release_tx, release_rx) = oneshot::channel::<()>();
+        let backend_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let backend_addr = backend_listener.local_addr().unwrap();
+        let backend = tokio::spawn(async move {
+            let (stream, _) = backend_listener.accept().await.unwrap();
+            let io = TokioIo::new(stream);
+            let release_rx = std::sync::Mutex::new(Some(release_rx));
+            hyper::server::conn::http1::Builder::new()
+                .serve_connection(
+                    io,
+                    service_fn(move |_req| {
+                        let rx = release_rx.lock().unwrap().take().unwrap();
+                        async move {
+                            let first = futures_util::stream::once(async {
+                                Ok::<_, Infallible>(Frame::data(Bytes::from_static(b"first")))
+                            });
+                            let second = futures_util::stream::once(async move {
+                                let _ = rx.await;
+                                Ok::<_, Infallible>(Frame::data(Bytes::from_static(b"second")))
+                            });
+                            Ok::<_, Infallible>(
+                                Response::builder()
+                                    .status(200)
+                                    .body(StreamBody::new(first.chain(second)))
+                                    .unwrap(),
+                            )
+                        }
+                    }),
+                )
+                .await
+                .unwrap();
+        });
+
+        let mut table = RouteTable::new();
+        table.insert(
+            RouteKey {
+                project: "myapp".to_string(),
+                branch: "main".to_string(),
+                port: 3000,
+            },
+            BackendTarget {
+                container_id: "c1".to_string(),
+                container_name: "cella-myapp".to_string(),
+                target_port: backend_addr.port(),
+                mode: ProxyMode::Localhost,
+            },
+        );
+        let rt: SharedRouteTable = Arc::new(RwLock::new(table));
+        let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_addr = proxy_listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            let (stream, peer) = proxy_listener.accept().await.unwrap();
+            let _ = handle_connection(stream, peer, rt).await;
+        });
+
+        let stream = TcpStream::connect(proxy_addr).await.unwrap();
+        let io = TokioIo::new(stream);
+        let (mut sender, conn) = hyper::client::conn::http1::handshake(io).await.unwrap();
+        tokio::spawn(conn);
+
+        let req = Request::builder()
+            .header("Host", "3000.main.myapp.localhost")
+            .body(Full::<Bytes>::default())
+            .unwrap();
+        let mut resp = sender.send_request(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let first = tokio::time::timeout(
+            std::time::Duration::from_millis(200),
+            resp.body_mut().frame(),
+        )
+        .await
+        .expect("first body chunk should arrive before backend finishes")
+        .expect("body should have a frame")
+        .unwrap()
+        .into_data()
+        .unwrap();
+        assert_eq!(&first[..], b"first");
+
+        release_tx.send(()).unwrap();
+        server.abort();
+        backend.abort();
+    }
+
+    #[tokio::test]
+    async fn proxy_forwards_websocket_upgrade_bytes() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let backend_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let backend_addr = backend_listener.local_addr().unwrap();
+        let backend = tokio::spawn(async move {
+            let (mut stream, _) = backend_listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            let mut buf = [0u8; 1];
+            while !request.ends_with(b"\r\n\r\n") {
+                stream.read_exact(&mut buf).await.unwrap();
+                request.push(buf[0]);
+            }
+            assert!(
+                String::from_utf8_lossy(&request)
+                    .to_ascii_lowercase()
+                    .contains("upgrade: websocket")
+            );
+            stream
+                .write_all(
+                    b"HTTP/1.1 101 Switching Protocols\r\n\
+                      Connection: Upgrade\r\n\
+                      Upgrade: websocket\r\n\
+                      \r\n",
+                )
+                .await
+                .unwrap();
+            let mut payload = [0u8; 4];
+            stream.read_exact(&mut payload).await.unwrap();
+            stream.write_all(&payload).await.unwrap();
+        });
+
+        let mut table = RouteTable::new();
+        table.insert(
+            RouteKey {
+                project: "myapp".to_string(),
+                branch: "main".to_string(),
+                port: 3000,
+            },
+            BackendTarget {
+                container_id: "c1".to_string(),
+                container_name: "cella-myapp".to_string(),
+                target_port: backend_addr.port(),
+                mode: ProxyMode::Localhost,
+            },
+        );
+        let rt: SharedRouteTable = Arc::new(RwLock::new(table));
+        let proxy_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_addr = proxy_listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            let (stream, peer) = proxy_listener.accept().await.unwrap();
+            let _ = handle_connection(stream, peer, rt).await;
+        });
+
+        let mut client = TcpStream::connect(proxy_addr).await.unwrap();
+        client
+            .write_all(
+                b"GET /socket HTTP/1.1\r\n\
+                  Host: 3000.main.myapp.localhost\r\n\
+                  Connection: Upgrade\r\n\
+                  Upgrade: websocket\r\n\
+                  Sec-WebSocket-Version: 13\r\n\
+                  Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\
+                  \r\n",
+            )
+            .await
+            .unwrap();
+
+        let mut response = Vec::new();
+        let mut b = [0u8; 1];
+        while !response.ends_with(b"\r\n\r\n") {
+            client.read_exact(&mut b).await.unwrap();
+            response.push(b[0]);
+        }
+        assert!(String::from_utf8_lossy(&response).contains("101 Switching Protocols"));
+
+        client.write_all(b"ping").await.unwrap();
+        let mut echoed = [0u8; 4];
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            client.read_exact(&mut echoed),
+        )
+        .await
+        .expect("upgraded bytes should be forwarded")
+        .unwrap();
+        assert_eq!(&echoed, b"ping");
 
         server.abort();
         backend.abort();

--- a/docs/port-forwarding.md
+++ b/docs/port-forwarding.md
@@ -9,7 +9,7 @@ When a service starts listening on a port inside your container, cella detects i
 1. **Hostname URLs** (recommended): `http://3000.main.myapp.localhost`
 2. **Port numbers** (traditional): `http://localhost:3000`
 
-Hostname URLs are stable across restarts and each worktree gets its own unique hostname.
+Hostname URLs are stable per project/branch identity and each worktree gets its own unique hostname. `localhost:<host_port>` remains the compatibility fallback for every forwarded port.
 
 ## Hostname Format
 
@@ -30,16 +30,22 @@ http://8080.feature-auth.myapp.localhost   # feature/auth branch, port 8080
 http://feature-auth.myapp.localhost        # feature/auth branch, default port
 ```
 
+If the hostname proxy cannot bind `127.0.0.1:80`, cella binds a high loopback port and shows full URLs:
+
+```
+http://3000.feature-auth.myapp.localhost:49180
+```
+
 ## OrbStack Users
 
-On OrbStack, cella uses OrbStack's native proxy with automatic HTTPS:
+On OrbStack, V1 uses OrbStack's native `.local` domain for the configured default web port only:
 
 ```
-https://3000.main.myapp.local
-https://3000.feature-auth.myapp.local
+http://main.myapp.local
+http://feature-auth.myapp.local
 ```
 
-Note the `.local` TLD (instead of `.localhost`) and `https://` (OrbStack provides automatic TLS).
+Additional forwarded ports are shown as explicit fallback URLs by `cella ports`. Cella does not claim arbitrary TLDs, LAN exposure, HTTPS/CA trust, command running, or native per-port OrbStack custom domains in V1.
 
 ## Viewing Forwarded Ports
 
@@ -118,7 +124,7 @@ The hostname doesn't match any running container. Run `cella ports --all` to see
 Your dev server is likely rejecting the `Host` header. See the dev server configuration section above.
 
 **Port 80 not available:**
-Another service is using port 80. The proxy will fall back to port-based forwarding. Stop the conflicting service or use `cella ports` to see the port-based URLs.
+Another service is using port 80. The proxy binds a high loopback port instead, and `cella ports` prints hostname URLs with that port suffix. `localhost:<host_port>` URLs still work.
 
 **Safari doesn't resolve `*.localhost`:**
 Safari may not resolve deep `*.localhost` subdomains. Use Chrome or Firefox, or add specific entries to `/etc/hosts`:

--- a/docs/port-forwarding.md
+++ b/docs/port-forwarding.md
@@ -1,0 +1,128 @@
+# Port Forwarding
+
+cella automatically forwards ports from dev containers to your host machine, making services accessible in your browser.
+
+## How It Works
+
+When a service starts listening on a port inside your container, cella detects it and makes it accessible on your host. There are two ways to access forwarded ports:
+
+1. **Hostname URLs** (recommended): `http://3000.main.myapp.localhost`
+2. **Port numbers** (traditional): `http://localhost:3000`
+
+Hostname URLs are stable across restarts and each worktree gets its own unique hostname.
+
+## Hostname Format
+
+```
+http://{port}.{branch}.{project}.localhost
+```
+
+- **port**: The container port number (e.g., `3000`)
+- **branch**: Your git branch name, sanitized for DNS (e.g., `feature/auth` -> `feature-auth`)
+- **project**: Your project name from devcontainer.json `name` field, or the repository directory name
+
+Examples:
+
+```
+http://3000.main.myapp.localhost           # main branch, port 3000
+http://3000.feature-auth.myapp.localhost   # feature/auth branch, port 3000
+http://8080.feature-auth.myapp.localhost   # feature/auth branch, port 8080
+http://feature-auth.myapp.localhost        # feature/auth branch, default port
+```
+
+## OrbStack Users
+
+On OrbStack, cella uses OrbStack's native proxy with automatic HTTPS:
+
+```
+https://3000.main.myapp.local
+https://3000.feature-auth.myapp.local
+```
+
+Note the `.local` TLD (instead of `.localhost`) and `https://` (OrbStack provides automatic TLS).
+
+## Viewing Forwarded Ports
+
+```bash
+cella ports                # show ports for current container
+cella ports --all          # show ports across all worktrees
+```
+
+## Configuration
+
+```jsonc
+{
+  "name": "myapp",                    // Used as {project} in hostnames
+  "forwardPorts": [3000, 8080],       // Ports to forward (first = default)
+  "portsAttributes": {
+    "3000": {
+      "label": "Frontend",
+      "onAutoForward": "openBrowser",
+      "protocol": "http"
+    },
+    "8080": {
+      "label": "API",
+      "onAutoForward": "silent"
+    }
+  }
+}
+```
+
+## Parallel Development with Worktrees
+
+When using `cella branch create` to work on multiple features, each worktree container gets its own hostname:
+
+```bash
+cella branch create feature/auth     # accessible at feature-auth.myapp.localhost
+cella branch create feature/billing  # accessible at feature-billing.myapp.localhost
+```
+
+Both containers can run the same services on the same ports internally.
+
+## Dev Server Configuration
+
+Some dev servers validate the `Host` header and may reject requests with unfamiliar hostnames. Configure your dev server to accept `*.localhost`:
+
+**Vite:**
+```js
+// vite.config.js
+export default {
+  server: { host: true, allowedHosts: true }
+}
+```
+
+**Next.js:**
+```js
+// next.config.js
+module.exports = { allowedDevHosts: ['*.localhost'] }
+```
+
+**Django:**
+```python
+# settings.py
+ALLOWED_HOSTS = ['.localhost']
+```
+
+**Rails:**
+```ruby
+# config/environments/development.rb
+config.hosts << /.*\.localhost\z/
+```
+
+## Troubleshooting
+
+**"No service found" error page:**
+The hostname doesn't match any running container. Run `cella ports --all` to see available services.
+
+**Service returns 403/404 instead of your app:**
+Your dev server is likely rejecting the `Host` header. See the dev server configuration section above.
+
+**Port 80 not available:**
+Another service is using port 80. The proxy will fall back to port-based forwarding. Stop the conflicting service or use `cella ports` to see the port-based URLs.
+
+**Safari doesn't resolve `*.localhost`:**
+Safari may not resolve deep `*.localhost` subdomains. Use Chrome or Firefox, or add specific entries to `/etc/hosts`:
+```
+127.0.0.1  3000.main.myapp.localhost
+127.0.0.1  3000.feature-auth.myapp.localhost
+```

--- a/docs/specs/hostname-proxy.md
+++ b/docs/specs/hostname-proxy.md
@@ -7,8 +7,9 @@ cella routes HTTP traffic to dev containers via stable, human-readable hostnames
 ## Hostname Scheme
 
 ```
-{port}.{branch}.{project}.localhost     (non-OrbStack)
-{port}.{branch}.{project}.local         (OrbStack via dev.orbstack.domains)
+{port}.{branch}.{project}.localhost          (generic Cella HTTP proxy)
+{port}.{branch}.{project}.localhost:{proxy}  (when port 80 is unavailable)
+{branch}.{project}.local                     (OrbStack default web port)
 ```
 
 | Component | Source | Example |
@@ -17,7 +18,7 @@ cella routes HTTP traffic to dev containers via stable, human-readable hostnames
 | `{branch}` | Sanitized git branch name | `feature-auth` |
 | `{project}` | devcontainer.json `name` field, fallback to repo dir | `myapp` |
 
-When port is omitted (`{branch}.{project}.localhost`), the proxy routes to the first `forwardPorts` entry or first auto-detected port.
+When port is omitted (`{branch}.{project}.localhost`), the generic proxy routes to the first `forwardPorts` entry or first auto-detected port.
 
 ### Branch Name Sanitization
 
@@ -32,12 +33,12 @@ Collision handling: append 4-char SHA-256 suffix when two branches sanitize iden
 ## Architecture
 
 ```
-Browser → Port 80 (hostname proxy) → Route Table → Backend Container
+Browser → Hostname proxy → 127.0.0.1:<host_port> → Existing Cella port proxy → Container
 ```
 
-The proxy is a hyper-based HTTP reverse proxy in the `cella-proxy` crate. It parses the `Host` header, looks up the route table, and forwards to the backend container via direct IP or agent tunnel.
+The proxy is a hyper-based HTTP reverse proxy in the `cella-proxy` crate. It parses the `Host` header, looks up the route table, and forwards to Cella's already allocated loopback host port. This keeps Docker Desktop, Colima, Linux, and OrbStack behavior on the same routing path.
 
-On OrbStack, the proxy is bypassed. Instead, `dev.orbstack.domains` container labels delegate routing to OrbStack's built-in reverse proxy with automatic TLS.
+On OrbStack, `dev.orbstack.domains` and `dev.orbstack.http-port` are used only for the default web port. Additional ports use explicit fallback URLs from `cella ports`; V1 does not promise native per-port OrbStack custom domains.
 
 ## Proxy Behavior
 
@@ -53,8 +54,8 @@ Routes are managed via `PortManager` events:
 
 | Event | Action |
 |-------|--------|
-| Container registration | Insert routes for `forwardPorts` |
-| Port detected | Insert route for new port |
+| Container registration | Preload `forwardPorts`, start host-port proxies, insert routes |
+| Port detected | Insert or update route using the allocated host port |
 | Port closed | Remove route |
 | Container deregistered | Remove all routes |
 
@@ -67,8 +68,10 @@ Routes are managed via `PortManager` events:
 
 ## Known Limitations
 
-1. Cookie leakage across branches with `Domain=myapp.localhost`
-2. Dev servers may reject unfamiliar `Host` headers (Vite, Next.js, Django, Rails)
-3. Safari `.localhost` resolution may be inconsistent
-4. Port 80 conflicts fall back to port-based forwarding
-5. Non-HTTP traffic (databases, gRPC) uses port-based allocation only
+1. HTTP only for the generic Cella hostname proxy; no CA install or HTTPS termination.
+2. Loopback only; no LAN exposure or arbitrary TLD support.
+3. Cookie leakage can happen across branches with `Domain=myapp.localhost`.
+4. Dev servers may reject unfamiliar `Host` headers (Vite, Next.js, Django, Rails).
+5. Safari `.localhost` resolution may be inconsistent.
+6. Non-HTTP traffic (databases, raw TCP, UDP) uses port-based allocation only.
+7. OrbStack native custom domains are limited to the default web port in V1.

--- a/docs/specs/hostname-proxy.md
+++ b/docs/specs/hostname-proxy.md
@@ -64,7 +64,7 @@ Routes are managed via `PortManager` events:
 - `cella-proxy` - hostname parsing, route table, HTTP server, error pages
 - `cella-daemon` - lifecycle management, port manager integration
 - `cella-backend` - OrbStack label generation
-- `cella-protocol` - `project_name`, `branch`, `hostname` fields
+- `cella-protocol` - `project_name`, `branch`, `ForwardedPortDetail.hostname`, `HostnameProxyStatus`
 
 ## Known Limitations
 

--- a/docs/specs/hostname-proxy.md
+++ b/docs/specs/hostname-proxy.md
@@ -1,0 +1,74 @@
+# Hostname-Based Port Forwarding
+
+## Overview
+
+cella routes HTTP traffic to dev containers via stable, human-readable hostnames instead of arbitrary port numbers. Each worktree container gets a unique hostname derived from its branch and project name.
+
+## Hostname Scheme
+
+```
+{port}.{branch}.{project}.localhost     (non-OrbStack)
+{port}.{branch}.{project}.local         (OrbStack via dev.orbstack.domains)
+```
+
+| Component | Source | Example |
+|-----------|--------|---------|
+| `{port}` | Container port number | `3000` |
+| `{branch}` | Sanitized git branch name | `feature-auth` |
+| `{project}` | devcontainer.json `name` field, fallback to repo dir | `myapp` |
+
+When port is omitted (`{branch}.{project}.localhost`), the proxy routes to the first `forwardPorts` entry or first auto-detected port.
+
+### Branch Name Sanitization
+
+1. Replace `/`, `_`, `.` with `-`
+2. Collapse consecutive hyphens
+3. Strip leading/trailing hyphens
+4. Truncate to 63 characters (DNS label limit)
+5. Lowercase
+
+Collision handling: append 4-char SHA-256 suffix when two branches sanitize identically.
+
+## Architecture
+
+```
+Browser → Port 80 (hostname proxy) → Route Table → Backend Container
+```
+
+The proxy is a hyper-based HTTP reverse proxy in the `cella-proxy` crate. It parses the `Host` header, looks up the route table, and forwards to the backend container via direct IP or agent tunnel.
+
+On OrbStack, the proxy is bypassed. Instead, `dev.orbstack.domains` container labels delegate routing to OrbStack's built-in reverse proxy with automatic TLS.
+
+## Proxy Behavior
+
+- Routes HTTP requests by `Host` header
+- Supports WebSocket upgrades (`Connection: Upgrade` + `Upgrade: websocket`)
+- Sets `X-Forwarded-Host`, `X-Forwarded-Proto`, `X-Forwarded-For` headers
+- Strips hop-by-hop headers (except during WebSocket upgrades)
+- Returns friendly HTML error pages for unmatched routes and unreachable backends
+
+## Route Table
+
+Routes are managed via `PortManager` events:
+
+| Event | Action |
+|-------|--------|
+| Container registration | Insert routes for `forwardPorts` |
+| Port detected | Insert route for new port |
+| Port closed | Remove route |
+| Container deregistered | Remove all routes |
+
+## Crate Organization
+
+- `cella-proxy` - hostname parsing, route table, HTTP server, error pages
+- `cella-daemon` - lifecycle management, port manager integration
+- `cella-backend` - OrbStack label generation
+- `cella-protocol` - `project_name`, `branch`, `hostname` fields
+
+## Known Limitations
+
+1. Cookie leakage across branches with `Domain=myapp.localhost`
+2. Dev servers may reject unfamiliar `Host` headers (Vite, Next.js, Django, Rails)
+3. Safari `.localhost` resolution may be inconsistent
+4. Port 80 conflicts fall back to port-based forwarding
+5. Non-HTTP traffic (databases, gRPC) uses port-based allocation only

--- a/docs/specs/ipc-protocol.md
+++ b/docs/specs/ipc-protocol.md
@@ -822,7 +822,7 @@ All variants are tagged with `"type"` in snake_case.
 | `ports` | `ForwardedPortDetail[]` | All forwarded ports across all containers |
 
 ```json
-{"type":"ports","ports":[{"container_name":"cella-myapp-main","container_port":3000,"host_port":3000,"protocol":"tcp","process":"node","url":"localhost:3000"}]}
+{"type":"ports","ports":[{"container_name":"cella-myapp-main","container_port":3000,"host_port":3000,"protocol":"tcp","process":"node","url":"localhost:3000","hostname":"http://3000.main.myapp.localhost"}]}
 ```
 
 **`status`** -- Daemon status.
@@ -838,9 +838,10 @@ All variants are tagged with `"type"` in snake_case.
 | `daemon_started_at` | `u64` | Unix timestamp when daemon started (default: `0`) |
 | `control_port` | `u16` | TCP control port for agent connections (default: `0`) |
 | `control_token` | `string` | Auth token for agent connections (default: `""`) |
+| `hostname_proxy` | `HostnameProxyStatus?` | Hostname HTTP proxy listener state for diagnostics and URL rendering |
 
 ```json
-{"type":"status","pid":12345,"uptime_secs":3600,"container_count":2,"containers":[],"is_orbstack":true,"daemon_version":"0.1.0","daemon_started_at":1711929600,"control_port":9876,"control_token":"secret"}
+{"type":"status","pid":12345,"uptime_secs":3600,"container_count":2,"containers":[],"is_orbstack":false,"daemon_version":"0.1.0","daemon_started_at":1711929600,"control_port":9876,"control_token":"secret","hostname_proxy":{"enabled":true,"address":"127.0.0.1:49180","port":49180,"using_fallback_port":true}}
 ```
 
 **`shutting_down`** -- Daemon is shutting down.
@@ -911,7 +912,17 @@ All variants are tagged with `"type"` in snake_case.
 | `host_port` | `u16` | Port on the host |
 | `protocol` | `PortProtocol` | `"tcp"` or `"udp"` |
 | `process` | `string?` | Process name, if known |
-| `url` | `string` | URL for accessing this port |
+| `url` | `string` | Compatibility URL for accessing this port via `localhost:<host_port>` |
+| `hostname` | `string?` | Full hostname URL when hostname routing is available; includes the fallback proxy port when needed |
+
+**`HostnameProxyStatus`** -- Runtime state for the hostname HTTP proxy listener.
+
+| Field | Type | Description |
+|---|---|---|
+| `enabled` | `bool` | Whether the hostname proxy listener is available |
+| `address` | `string?` | Bound loopback address, for example `127.0.0.1:80` or `127.0.0.1:49180` |
+| `port` | `u16?` | Bound listener port |
+| `using_fallback_port` | `bool` | `true` when port 80 was unavailable and a high loopback port is used |
 
 **`ContainerSummary`** -- Summary of a registered container.
 


### PR DESCRIPTION
## Summary

- Add `cella-proxy` crate with an HTTP reverse proxy that routes traffic to dev containers via human-readable hostnames (`3000.feature-auth.myapp.localhost`) instead of arbitrary port numbers
- Integrate hostname routes into the daemon's port manager lifecycle — routes are added/removed as ports are detected or containers register/deregister
- Support WebSocket upgrades, forwarding headers, and friendly HTML error pages for unmatched routes
- Add OrbStack hostname domain label generation for the default web port
- Show hostname column in `cella ports` output

## Test plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-features --all-targets` clean
- [x] Start a container with forwarded ports, verify hostname URLs appear in `cella ports`
- [x] Hit a hostname URL in a browser and confirm it proxies to the container
- [x] Verify WebSocket connections upgrade correctly through the proxy
- [x] Stop a container and confirm routes are cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)