### PR TITLE
fix: parallel workspace bugs & agent protocol improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,8 +570,10 @@ name = "cella-git"
 version = "0.0.43"
 dependencies = [
  "fs4",
+ "hex",
  "insta",
  "miette",
+ "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",

--- a/crates/cella-agent/src/cli.rs
+++ b/crates/cella-agent/src/cli.rs
@@ -107,6 +107,9 @@ pub fn parse_cli_args(args: &[String]) -> CliCommand {
                             return CliCommand::Help;
                         }
                     }
+                } else if args[i].starts_with('-') {
+                    eprintln!("Error: unknown flag '{}' for branch command", args[i]);
+                    return CliCommand::Help;
                 } else {
                     i += 1;
                 }
@@ -133,9 +136,25 @@ pub fn parse_cli_args(args: &[String]) -> CliCommand {
                 Some(b) if !b.starts_with('-') => b.clone(),
                 _ => return CliCommand::Help,
             };
-            let rm = args.iter().any(|a| a == "--rm");
-            let volumes = args.iter().any(|a| a == "--volumes");
-            let force = args.iter().any(|a| a == "--force");
+            let mut rm = false;
+            let mut volumes = false;
+            let mut force = false;
+            for arg in &args[3..] {
+                match arg.as_str() {
+                    "--rm" => rm = true,
+                    "--volumes" => volumes = true,
+                    "--force" => force = true,
+                    f if f.starts_with('-') => {
+                        eprintln!("Error: unknown flag '{f}' for down command");
+                        return CliCommand::Help;
+                    }
+                    _ => {}
+                }
+            }
+            if volumes && !rm {
+                eprintln!("Error: --volumes requires --rm");
+                return CliCommand::Help;
+            }
             CliCommand::Down {
                 branch,
                 rm,
@@ -148,12 +167,33 @@ pub fn parse_cli_args(args: &[String]) -> CliCommand {
                 Some(b) if !b.starts_with('-') => b.clone(),
                 _ => return CliCommand::Help,
             };
-            let rebuild = args.iter().any(|a| a == "--rebuild");
+            let mut rebuild = false;
+            for arg in &args[3..] {
+                match arg.as_str() {
+                    "--rebuild" => rebuild = true,
+                    f if f.starts_with('-') => {
+                        eprintln!("Error: unknown flag '{f}' for up command");
+                        return CliCommand::Help;
+                    }
+                    _ => {}
+                }
+            }
             CliCommand::Up { branch, rebuild }
         }
         Some("prune") => {
-            let dry_run = args.iter().any(|a| a == "--dry-run");
-            let all = args.iter().any(|a| a == "--all");
+            let mut dry_run = false;
+            let mut all = false;
+            for arg in &args[2..] {
+                match arg.as_str() {
+                    "--dry-run" => dry_run = true,
+                    "--all" => all = true,
+                    f if f.starts_with('-') => {
+                        eprintln!("Error: unknown flag '{f}' for prune command");
+                        return CliCommand::Help;
+                    }
+                    _ => {}
+                }
+            }
             CliCommand::Prune { dry_run, all }
         }
         Some("task") => parse_task_subcommand(args),
@@ -201,6 +241,9 @@ fn parse_task_subcommand(args: &[String]) -> CliCommand {
                             return CliCommand::Help;
                         }
                     }
+                } else if args[i].starts_with('-') {
+                    eprintln!("Error: unknown flag '{}' for task run command", args[i]);
+                    return CliCommand::Help;
                 } else {
                     i += 1;
                 }
@@ -1536,21 +1579,13 @@ mod tests {
     }
 
     #[test]
-    fn parse_down_volumes_only() {
+    fn parse_down_volumes_without_rm_rejected() {
         let args: Vec<String> = ["cella", "down", "feat/auth", "--volumes"]
             .iter()
             .map(ToString::to_string)
             .collect();
         let cmd = parse_cli_args(&args);
-        assert!(matches!(
-            cmd,
-            CliCommand::Down {
-                volumes: true,
-                rm: false,
-                force: false,
-                ..
-            }
-        ));
+        assert!(matches!(cmd, CliCommand::Help));
     }
 
     #[test]
@@ -1716,15 +1751,13 @@ mod tests {
     }
 
     #[test]
-    fn parse_branch_ignores_unknown_flags() {
+    fn parse_branch_rejects_unknown_flags() {
         let args: Vec<String> = ["cella", "branch", "my-branch", "--unknown"]
             .iter()
             .map(ToString::to_string)
             .collect();
         let cmd = parse_cli_args(&args);
-        assert!(
-            matches!(cmd, CliCommand::Branch { name, base } if name == "my-branch" && base.is_none())
-        );
+        assert!(matches!(cmd, CliCommand::Help));
     }
 
     #[test]

--- a/crates/cella-agent/src/cli.rs
+++ b/crates/cella-agent/src/cli.rs
@@ -806,7 +806,11 @@ async fn run_prune(
             },
             DaemonMessage::PruneResult { pruned, errors, .. } => {
                 if !pruned.is_empty() {
-                    eprintln!("Pruned {} worktree(s).", pruned.len());
+                    if dry_run {
+                        eprintln!("Would prune {} worktree(s).", pruned.len());
+                    } else {
+                        eprintln!("Pruned {} worktree(s).", pruned.len());
+                    }
                 }
                 if !errors.is_empty() {
                     for e in &errors {

--- a/crates/cella-agent/src/cli.rs
+++ b/crates/cella-agent/src/cli.rs
@@ -35,6 +35,7 @@ pub enum CliCommand {
     Branch {
         name: String,
         base: Option<String>,
+        labels: Vec<String>,
     },
     List,
     Down {
@@ -94,6 +95,7 @@ pub fn parse_cli_args(args: &[String]) -> CliCommand {
                 }
             };
             let mut base = None;
+            let mut labels = Vec::new();
             let mut i = 3;
             while i < args.len() {
                 if args[i] == "--base" {
@@ -107,6 +109,23 @@ pub fn parse_cli_args(args: &[String]) -> CliCommand {
                             return CliCommand::Help;
                         }
                     }
+                } else if args[i] == "--label" {
+                    match args.get(i + 1) {
+                        Some(val) if val.contains('=') => {
+                            if val.starts_with("dev.cella.") || val.starts_with("devcontainer.") {
+                                eprintln!(
+                                    "Error: reserved label prefix in '{val}' (dev.cella.* and devcontainer.* are reserved)"
+                                );
+                                return CliCommand::Help;
+                            }
+                            labels.push(val.clone());
+                            i += 2;
+                        }
+                        _ => {
+                            eprintln!("Error: --label requires KEY=VALUE format");
+                            return CliCommand::Help;
+                        }
+                    }
                 } else if args[i].starts_with('-') {
                     eprintln!("Error: unknown flag '{}' for branch command", args[i]);
                     return CliCommand::Help;
@@ -114,7 +133,7 @@ pub fn parse_cli_args(args: &[String]) -> CliCommand {
                     i += 1;
                 }
             }
-            CliCommand::Branch { name, base }
+            CliCommand::Branch { name, base, labels }
         }
         Some("list" | "ls") => CliCommand::List,
         Some("exec") => {
@@ -294,7 +313,9 @@ pub async fn run(command: CliCommand) -> Result<(), Box<dyn std::error::Error + 
             print_unsupported(&command);
             std::process::exit(1);
         }
-        CliCommand::Branch { name, base } => run_branch(&name, base.as_deref()).await,
+        CliCommand::Branch { name, base, labels } => {
+            run_branch(&name, base.as_deref(), &labels).await
+        }
         CliCommand::List => run_list().await,
         CliCommand::Down {
             branch,
@@ -605,6 +626,7 @@ mod doctor_tests {
 async fn run_branch(
     name: &str,
     base: Option<&str>,
+    labels: &[String],
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut client = connect_daemon().await?;
 
@@ -613,6 +635,11 @@ async fn run_branch(
         request_id: id.clone(),
         branch: name.to_string(),
         base: base.map(String::from),
+        labels: if labels.is_empty() {
+            None
+        } else {
+            Some(labels.to_vec())
+        },
     };
     client.send(&msg).await?;
 
@@ -1154,7 +1181,7 @@ mod tests {
         ];
         let cmd = parse_cli_args(&args);
         assert!(
-            matches!(cmd, CliCommand::Branch { name, base } if name == "feat/auth" && base.is_none())
+            matches!(cmd, CliCommand::Branch { name, base, .. } if name == "feat/auth" && base.is_none())
         );
     }
 
@@ -1168,7 +1195,7 @@ mod tests {
             "main".to_string(),
         ];
         let cmd = parse_cli_args(&args);
-        assert!(matches!(cmd, CliCommand::Branch { name, base }
+        assert!(matches!(cmd, CliCommand::Branch { name, base, .. }
             if name == "feat/auth" && base.as_deref() == Some("main")));
     }
 

--- a/crates/cella-agent/src/cli.rs
+++ b/crates/cella-agent/src/cli.rs
@@ -55,6 +55,9 @@ pub enum CliCommand {
     Prune {
         dry_run: bool,
         all: bool,
+        older_than: Option<String>,
+        missing_worktree: bool,
+        labels: Vec<String>,
     },
     TaskRun {
         branch: String,
@@ -202,18 +205,62 @@ pub fn parse_cli_args(args: &[String]) -> CliCommand {
         Some("prune") => {
             let mut dry_run = false;
             let mut all = false;
-            for arg in &args[2..] {
-                match arg.as_str() {
-                    "--dry-run" => dry_run = true,
-                    "--all" => all = true,
+            let mut older_than = None;
+            let mut missing_worktree = false;
+            let mut labels = Vec::new();
+            let mut i = 2;
+            while i < args.len() {
+                match args[i].as_str() {
+                    "--dry-run" => {
+                        dry_run = true;
+                        i += 1;
+                    }
+                    "--all" => {
+                        all = true;
+                        i += 1;
+                    }
+                    "--missing-worktree" => {
+                        missing_worktree = true;
+                        i += 1;
+                    }
+                    "--older-than" => match args.get(i + 1) {
+                        Some(val) if !val.starts_with('-') => {
+                            older_than = Some(val.clone());
+                            i += 2;
+                        }
+                        _ => {
+                            eprintln!(
+                                "Error: --older-than requires a value (e.g., --older-than 7d)"
+                            );
+                            return CliCommand::Help;
+                        }
+                    },
+                    "--label" => match args.get(i + 1) {
+                        Some(val) if val.contains('=') => {
+                            labels.push(val.clone());
+                            i += 2;
+                        }
+                        _ => {
+                            eprintln!("Error: --label requires KEY=VALUE format");
+                            return CliCommand::Help;
+                        }
+                    },
                     f if f.starts_with('-') => {
                         eprintln!("Error: unknown flag '{f}' for prune command");
                         return CliCommand::Help;
                     }
-                    _ => {}
+                    _ => {
+                        i += 1;
+                    }
                 }
             }
-            CliCommand::Prune { dry_run, all }
+            CliCommand::Prune {
+                dry_run,
+                all,
+                older_than,
+                missing_worktree,
+                labels,
+            }
         }
         Some("task") => parse_task_subcommand(args),
         Some("switch") => {
@@ -325,7 +372,22 @@ pub async fn run(command: CliCommand) -> Result<(), Box<dyn std::error::Error + 
         } => run_down(&branch, rm, volumes, force).await,
         CliCommand::Up { branch, rebuild } => run_up(&branch, rebuild).await,
         CliCommand::Exec { branch, command } => run_exec(&branch, &command).await,
-        CliCommand::Prune { dry_run, all } => run_prune(dry_run, all).await,
+        CliCommand::Prune {
+            dry_run,
+            all,
+            older_than,
+            missing_worktree,
+            labels,
+        } => {
+            run_prune(
+                dry_run,
+                all,
+                older_than.as_deref(),
+                missing_worktree,
+                &labels,
+            )
+            .await
+        }
         CliCommand::TaskRun {
             branch,
             command,
@@ -856,6 +918,9 @@ async fn run_up(
 async fn run_prune(
     dry_run: bool,
     all: bool,
+    older_than: Option<&str>,
+    missing_worktree: bool,
+    labels: &[String],
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut client = connect_daemon().await?;
 
@@ -864,6 +929,13 @@ async fn run_prune(
         request_id: id.clone(),
         dry_run,
         all,
+        older_than: older_than.map(String::from),
+        missing_worktree,
+        labels: if labels.is_empty() {
+            None
+        } else {
+            Some(labels.to_vec())
+        },
     };
     client.send(&msg).await?;
 

--- a/crates/cella-agent/src/cli.rs
+++ b/crates/cella-agent/src/cli.rs
@@ -1001,7 +1001,7 @@ async fn run_task_run(
                     eprintln!("Task '{task_id}' started in container {container_name}");
                     return Ok(());
                 }
-                cella_protocol::TaskRunOperationResult::Error { message } => {
+                cella_protocol::TaskRunOperationResult::Error { message, .. } => {
                     return Err(format!("Failed to start task: {message}").into());
                 }
             },

--- a/crates/cella-agent/src/cli.rs
+++ b/crates/cella-agent/src/cli.rs
@@ -90,54 +90,7 @@ pub fn parse_cli_args(args: &[String]) -> CliCommand {
     let subcmd = args.get(1).map(String::as_str);
 
     match subcmd {
-        Some("branch") => {
-            let name = match args.get(2) {
-                Some(n) if !n.starts_with('-') => n.clone(),
-                _ => {
-                    return CliCommand::Help;
-                }
-            };
-            let mut base = None;
-            let mut labels = Vec::new();
-            let mut i = 3;
-            while i < args.len() {
-                if args[i] == "--base" {
-                    match args.get(i + 1) {
-                        Some(val) if !val.starts_with('-') => {
-                            base = Some(val.clone());
-                            i += 2;
-                        }
-                        _ => {
-                            eprintln!("Error: --base requires a value (e.g., --base main)");
-                            return CliCommand::Help;
-                        }
-                    }
-                } else if args[i] == "--label" {
-                    match args.get(i + 1) {
-                        Some(val) if val.contains('=') => {
-                            if val.starts_with("dev.cella.") || val.starts_with("devcontainer.") {
-                                eprintln!(
-                                    "Error: reserved label prefix in '{val}' (dev.cella.* and devcontainer.* are reserved)"
-                                );
-                                return CliCommand::Help;
-                            }
-                            labels.push(val.clone());
-                            i += 2;
-                        }
-                        _ => {
-                            eprintln!("Error: --label requires KEY=VALUE format");
-                            return CliCommand::Help;
-                        }
-                    }
-                } else if args[i].starts_with('-') {
-                    eprintln!("Error: unknown flag '{}' for branch command", args[i]);
-                    return CliCommand::Help;
-                } else {
-                    i += 1;
-                }
-            }
-            CliCommand::Branch { name, base, labels }
-        }
+        Some("branch") => parse_branch_subcommand(args),
         Some("list" | "ls") => CliCommand::List,
         Some("exec") => {
             // Parse: cella exec <branch> -- <cmd...>
@@ -202,66 +155,7 @@ pub fn parse_cli_args(args: &[String]) -> CliCommand {
             }
             CliCommand::Up { branch, rebuild }
         }
-        Some("prune") => {
-            let mut dry_run = false;
-            let mut all = false;
-            let mut older_than = None;
-            let mut missing_worktree = false;
-            let mut labels = Vec::new();
-            let mut i = 2;
-            while i < args.len() {
-                match args[i].as_str() {
-                    "--dry-run" => {
-                        dry_run = true;
-                        i += 1;
-                    }
-                    "--all" => {
-                        all = true;
-                        i += 1;
-                    }
-                    "--missing-worktree" => {
-                        missing_worktree = true;
-                        i += 1;
-                    }
-                    "--older-than" => match args.get(i + 1) {
-                        Some(val) if !val.starts_with('-') => {
-                            older_than = Some(val.clone());
-                            i += 2;
-                        }
-                        _ => {
-                            eprintln!(
-                                "Error: --older-than requires a value (e.g., --older-than 7d)"
-                            );
-                            return CliCommand::Help;
-                        }
-                    },
-                    "--label" => match args.get(i + 1) {
-                        Some(val) if val.contains('=') => {
-                            labels.push(val.clone());
-                            i += 2;
-                        }
-                        _ => {
-                            eprintln!("Error: --label requires KEY=VALUE format");
-                            return CliCommand::Help;
-                        }
-                    },
-                    f if f.starts_with('-') => {
-                        eprintln!("Error: unknown flag '{f}' for prune command");
-                        return CliCommand::Help;
-                    }
-                    _ => {
-                        i += 1;
-                    }
-                }
-            }
-            CliCommand::Prune {
-                dry_run,
-                all,
-                older_than,
-                missing_worktree,
-                labels,
-            }
-        }
+        Some("prune") => parse_prune_subcommand(args),
         Some("task") => parse_task_subcommand(args),
         Some("switch") => {
             let branch = match args.get(2) {
@@ -275,6 +169,112 @@ pub fn parse_cli_args(args: &[String]) -> CliCommand {
         Some(cmd) => CliCommand::Unsupported {
             command: cmd.to_string(),
         },
+    }
+}
+
+fn parse_branch_subcommand(args: &[String]) -> CliCommand {
+    let name = match args.get(2) {
+        Some(n) if !n.starts_with('-') => n.clone(),
+        _ => return CliCommand::Help,
+    };
+    let mut base = None;
+    let mut labels = Vec::new();
+    let mut i = 3;
+    while i < args.len() {
+        if args[i] == "--base" {
+            match args.get(i + 1) {
+                Some(val) if !val.starts_with('-') => {
+                    base = Some(val.clone());
+                    i += 2;
+                }
+                _ => {
+                    eprintln!("Error: --base requires a value (e.g., --base main)");
+                    return CliCommand::Help;
+                }
+            }
+        } else if args[i] == "--label" {
+            match args.get(i + 1) {
+                Some(val) if val.contains('=') => {
+                    if val.starts_with("dev.cella.") || val.starts_with("devcontainer.") {
+                        eprintln!(
+                            "Error: reserved label prefix in '{val}' (dev.cella.* and devcontainer.* are reserved)"
+                        );
+                        return CliCommand::Help;
+                    }
+                    labels.push(val.clone());
+                    i += 2;
+                }
+                _ => {
+                    eprintln!("Error: --label requires KEY=VALUE format");
+                    return CliCommand::Help;
+                }
+            }
+        } else if args[i].starts_with('-') {
+            eprintln!("Error: unknown flag '{}' for branch command", args[i]);
+            return CliCommand::Help;
+        } else {
+            i += 1;
+        }
+    }
+    CliCommand::Branch { name, base, labels }
+}
+
+fn parse_prune_subcommand(args: &[String]) -> CliCommand {
+    let mut dry_run = false;
+    let mut all = false;
+    let mut older_than = None;
+    let mut missing_worktree = false;
+    let mut labels = Vec::new();
+    let mut i = 2;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--dry-run" => {
+                dry_run = true;
+                i += 1;
+            }
+            "--all" => {
+                all = true;
+                i += 1;
+            }
+            "--missing-worktree" => {
+                missing_worktree = true;
+                i += 1;
+            }
+            "--older-than" => match args.get(i + 1) {
+                Some(val) if !val.starts_with('-') => {
+                    older_than = Some(val.clone());
+                    i += 2;
+                }
+                _ => {
+                    eprintln!("Error: --older-than requires a value (e.g., --older-than 7d)");
+                    return CliCommand::Help;
+                }
+            },
+            "--label" => match args.get(i + 1) {
+                Some(val) if val.contains('=') => {
+                    labels.push(val.clone());
+                    i += 2;
+                }
+                _ => {
+                    eprintln!("Error: --label requires KEY=VALUE format");
+                    return CliCommand::Help;
+                }
+            },
+            f if f.starts_with('-') => {
+                eprintln!("Error: unknown flag '{f}' for prune command");
+                return CliCommand::Help;
+            }
+            _ => {
+                i += 1;
+            }
+        }
+    }
+    CliCommand::Prune {
+        dry_run,
+        all,
+        older_than,
+        missing_worktree,
+        labels,
     }
 }
 
@@ -1347,7 +1347,8 @@ mod tests {
             cmd,
             CliCommand::Prune {
                 dry_run: false,
-                all: false
+                all: false,
+                ..
             }
         ));
     }
@@ -1364,7 +1365,8 @@ mod tests {
             cmd,
             CliCommand::Prune {
                 dry_run: true,
-                all: false
+                all: false,
+                ..
             }
         ));
     }
@@ -1381,7 +1383,8 @@ mod tests {
             cmd,
             CliCommand::Prune {
                 dry_run: false,
-                all: true
+                all: true,
+                ..
             }
         ));
     }
@@ -1805,6 +1808,7 @@ mod tests {
             CliCommand::Prune {
                 dry_run: true,
                 all: true,
+                ..
             }
         ));
     }

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -1940,25 +1940,48 @@ async fn handle_task_logs<W: AsyncWriteExt + Unpin>(
             .await?;
         }
 
-        // Subscribe and stream live output.
-        let rx = task_mgr.lock().await.subscribe(branch);
-        if let Some(mut rx) = rx {
+        // Subscribe and stream live output until task completes.
+        let mgr = task_mgr.lock().await;
+        let rx = mgr.subscribe(branch);
+        let exit_rx = mgr.subscribe_exit(branch);
+        drop(mgr);
+
+        if let (Some(mut rx), Some(mut exit_rx)) = (rx, exit_rx) {
             loop {
-                match rx.recv().await {
-                    Ok(chunk) => {
-                        send_message(
-                            writer,
-                            &DaemonMessage::TaskLogsData {
-                                request_id: request_id.to_string(),
-                                data: chunk,
-                                done: false,
-                            },
-                        )
-                        .await?;
+                tokio::select! {
+                    msg = rx.recv() => {
+                        match msg {
+                            Ok(chunk) => {
+                                send_message(
+                                    writer,
+                                    &DaemonMessage::TaskLogsData {
+                                        request_id: request_id.to_string(),
+                                        data: chunk,
+                                        done: false,
+                                    },
+                                )
+                                .await?;
+                            }
+                            Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                            Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                                tracing::warn!("task logs subscriber lagged by {n} messages");
+                            }
+                        }
                     }
-                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
-                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                        tracing::warn!("task logs subscriber lagged by {n} messages");
+                    _ = exit_rx.changed() => {
+                        // Drain remaining broadcast messages
+                        while let Ok(chunk) = rx.try_recv() {
+                            send_message(
+                                writer,
+                                &DaemonMessage::TaskLogsData {
+                                    request_id: request_id.to_string(),
+                                    data: chunk,
+                                    done: false,
+                                },
+                            )
+                            .await?;
+                        }
+                        break;
                     }
                 }
             }

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -869,8 +869,21 @@ async fn handle_worktree_message<W: AsyncWriteExt + Unpin>(
             request_id,
             dry_run,
             all,
+            older_than,
+            missing_worktree,
+            labels,
         } => {
-            handle_prune_request(&request_id, dry_run, all, &wt, writer).await?;
+            handle_prune_request(
+                &request_id,
+                dry_run,
+                all,
+                older_than.as_deref(),
+                missing_worktree,
+                labels.as_deref(),
+                &wt,
+                writer,
+            )
+            .await?;
         }
         AgentMessage::DownRequest {
             request_id,
@@ -1406,6 +1419,9 @@ async fn handle_prune_request<W: AsyncWriteExt + Unpin>(
     request_id: &str,
     dry_run: bool,
     all: bool,
+    older_than: Option<&str>,
+    missing_worktree: bool,
+    labels: Option<&[String]>,
     wt: &WorktreeHandlerCtx<'_>,
     writer: &mut W,
 ) -> Result<(), CellaDaemonError> {
@@ -1418,6 +1434,17 @@ async fn handle_prune_request<W: AsyncWriteExt + Unpin>(
     }
     if all {
         cmd.arg("--all");
+    }
+    if let Some(duration) = older_than {
+        cmd.arg("--older-than").arg(duration);
+    }
+    if missing_worktree {
+        cmd.arg("--missing-worktree");
+    }
+    if let Some(lbls) = labels {
+        for label in lbls {
+            cmd.arg("--label").arg(label);
+        }
     }
     if let Some(ws) = wt.workspace_path {
         cmd.current_dir(ws);

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -1820,7 +1820,10 @@ async fn handle_task_run<W: AsyncWriteExt + Unpin>(
                 writer,
                 &DaemonMessage::TaskRunResult {
                     request_id: request_id.to_string(),
-                    result: cella_protocol::TaskRunOperationResult::Error { message: error_msg },
+                    result: cella_protocol::TaskRunOperationResult::Error {
+                        message: error_msg,
+                        code: Some(cella_protocol::TaskErrorCode::ContainerNotRunning),
+                    },
                 },
             )
             .await?;
@@ -1847,7 +1850,14 @@ async fn handle_task_run<W: AsyncWriteExt + Unpin>(
                     writer,
                     &DaemonMessage::TaskRunResult {
                         request_id: request_id.to_string(),
-                        result: cella_protocol::TaskRunOperationResult::Error { message: e },
+                        result: cella_protocol::TaskRunOperationResult::Error {
+                            message: e.clone(),
+                            code: if e.contains("already running") {
+                                Some(cella_protocol::TaskErrorCode::AlreadyRunning)
+                            } else {
+                                Some(cella_protocol::TaskErrorCode::ExecFailed)
+                            },
+                        },
                     },
                 )
                 .await?;

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -972,15 +972,15 @@ async fn handle_branch_request<W: AsyncWriteExt + Unpin>(
         }
     };
 
-    let (status, last_stdout_line, stderr_collected) =
+    let (status, stdout_collected, stderr_collected) =
         stream_child_output(&mut child, request_id, writer).await?;
 
     // Send final result.
     let result = if status.success() {
-        parse_branch_json_output(&last_stdout_line).unwrap_or_else(|| {
+        parse_branch_json_output(&stdout_collected).unwrap_or_else(|| {
             WorktreeOperationResult::Error {
                 message: format!(
-                    "operation may have succeeded but output was unparseable: {last_stdout_line}"
+                    "operation may have succeeded but output was unparseable: {stdout_collected}"
                 ),
             }
         })
@@ -1011,7 +1011,7 @@ async fn handle_branch_request<W: AsyncWriteExt + Unpin>(
 
 /// Stream a child process's stdout and stderr line-by-line as `OperationOutput` messages.
 ///
-/// Returns the exit status, last stdout line (for JSON parsing), and collected stderr.
+/// Returns the exit status, accumulated stdout, and collected stderr.
 async fn stream_child_output<W: AsyncWriteExt + Unpin>(
     child: &mut tokio::process::Child,
     request_id: &str,
@@ -1021,7 +1021,7 @@ async fn stream_child_output<W: AsyncWriteExt + Unpin>(
 
     let child_stdout = child.stdout.take();
     let child_stderr = child.stderr.take();
-    let mut last_stdout_line = String::new();
+    let mut stdout_collected = String::new();
 
     let mut stdout_reader = child_stdout.map(|s| BufReader::new(s).lines());
     let mut stderr_reader = child_stderr.map(|s| BufReader::new(s).lines());
@@ -1036,7 +1036,8 @@ async fn stream_child_output<W: AsyncWriteExt + Unpin>(
             }, if !stdout_done => {
                 match line {
                     Ok(Some(text)) => {
-                        last_stdout_line.clone_from(&text);
+                        stdout_collected.push_str(&text);
+                        stdout_collected.push('\n');
                         send_message(writer, &DaemonMessage::OperationOutput {
                             request_id: request_id.to_string(),
                             stream: OutputStream::Stdout,
@@ -1069,34 +1070,44 @@ async fn stream_child_output<W: AsyncWriteExt + Unpin>(
         message: format!("failed to wait for child process: {e}"),
     })?;
 
-    Ok((status, last_stdout_line, stderr_collected))
+    Ok((status, stdout_collected, stderr_collected))
 }
 
 /// Try to parse the JSON output from `cella branch --output json`.
 fn parse_branch_json_output(stdout: &str) -> Option<cella_protocol::WorktreeOperationResult> {
-    // The JSON output may contain multiple lines; find the last JSON object
-    // which should be the final result.
+    // Try parsing the full output as a single JSON object first (handles pretty-printed JSON).
+    if let Some(result) = try_parse_branch_json(stdout) {
+        return Some(result);
+    }
+    // Fall back to scanning individual lines in reverse.
     for line in stdout.lines().rev() {
-        if let Ok(v) = serde_json::from_str::<serde_json::Value>(line.trim()) {
-            let container_name = v
-                .get("containerId")
-                .or_else(|| v.get("containerName"))
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            let worktree_path = v
-                .get("workspaceFolder")
-                .or_else(|| v.get("remoteWorkspaceFolder"))
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            if v.get("outcome").is_some() || v.get("containerId").is_some() {
-                return Some(cella_protocol::WorktreeOperationResult::Success {
-                    container_name,
-                    worktree_path,
-                });
-            }
+        if let Some(result) = try_parse_branch_json(line.trim()) {
+            return Some(result);
         }
+    }
+    None
+}
+
+fn try_parse_branch_json(text: &str) -> Option<cella_protocol::WorktreeOperationResult> {
+    let v = serde_json::from_str::<serde_json::Value>(text).ok()?;
+    let container_name = v
+        .get("containerId")
+        .or_else(|| v.get("containerName"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let worktree_path = v
+        .get("worktreePath")
+        .or_else(|| v.get("workspaceFolder"))
+        .or_else(|| v.get("remoteWorkspaceFolder"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    if v.get("outcome").is_some() || v.get("containerId").is_some() {
+        return Some(cella_protocol::WorktreeOperationResult::Success {
+            container_name,
+            worktree_path,
+        });
     }
     None
 }

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -1157,6 +1157,9 @@ async fn handle_list_request<W: AsyncWriteExt + Unpin>(
         {
             wt.container_name = Some(c.name.clone());
             wt.container_state = Some(c.state.clone());
+            if let Some(ref label) = c.branch_label {
+                wt.branch = Some(label.clone());
+            }
         }
     }
 
@@ -1245,6 +1248,7 @@ struct CellaContainer {
     name: String,
     state: String,
     workspace_path: Option<String>,
+    branch_label: Option<String>,
 }
 
 /// List all cella-managed containers with their workspace paths.
@@ -1257,7 +1261,7 @@ async fn list_cella_containers() -> Vec<CellaContainer> {
             "--filter",
             "label=dev.cella.tool=cella",
             "--format",
-            "{{.Names}}\t{{.State}}\t{{.Label \"dev.cella.workspace_path\"}}",
+            "{{.Names}}\t{{.State}}\t{{.Label \"dev.cella.workspace_path\"}}\t{{.Label \"dev.cella.branch\"}}",
         ])
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())
@@ -1276,10 +1280,14 @@ async fn list_cella_containers() -> Vec<CellaContainer> {
         .lines()
         .filter(|line| !line.is_empty())
         .filter_map(|line| {
-            let mut parts = line.splitn(3, '\t');
+            let mut parts = line.splitn(4, '\t');
             let name = parts.next()?.to_string();
             let state = parts.next()?.to_string();
             let ws = parts
+                .next()
+                .map(ToString::to_string)
+                .filter(|s| !s.is_empty());
+            let branch = parts
                 .next()
                 .map(ToString::to_string)
                 .filter(|s| !s.is_empty());
@@ -1287,6 +1295,7 @@ async fn list_cella_containers() -> Vec<CellaContainer> {
                 name,
                 state,
                 workspace_path: ws,
+                branch_label: branch,
             })
         })
         .collect()

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -845,8 +845,17 @@ async fn handle_worktree_message<W: AsyncWriteExt + Unpin>(
             request_id,
             branch,
             base,
+            labels,
         } => {
-            handle_branch_request(&request_id, &branch, base.as_deref(), &wt, writer).await?;
+            handle_branch_request(
+                &request_id,
+                &branch,
+                base.as_deref(),
+                labels.as_deref(),
+                &wt,
+                writer,
+            )
+            .await?;
         }
         AgentMessage::ListRequest { request_id } => {
             handle_list_request(&request_id, wt.workspace_path, writer).await?;
@@ -918,6 +927,7 @@ async fn handle_branch_request<W: AsyncWriteExt + Unpin>(
     request_id: &str,
     branch: &str,
     base: Option<&str>,
+    labels: Option<&[String]>,
     wt: &WorktreeHandlerCtx<'_>,
     writer: &mut W,
 ) -> Result<(), CellaDaemonError> {
@@ -947,6 +957,11 @@ async fn handle_branch_request<W: AsyncWriteExt + Unpin>(
     cmd.arg(branch).arg("--output").arg("json");
     if let Some(b) = base {
         cmd.arg("--base").arg(b);
+    }
+    if let Some(lbls) = labels {
+        for label in lbls {
+            cmd.arg("--label").arg(label);
+        }
     }
     if let Some(ws) = wt.workspace_path {
         cmd.current_dir(ws);

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -873,17 +873,14 @@ async fn handle_worktree_message<W: AsyncWriteExt + Unpin>(
             missing_worktree,
             labels,
         } => {
-            handle_prune_request(
-                &request_id,
+            let opts = PruneOpts {
                 dry_run,
                 all,
-                older_than.as_deref(),
+                older_than: older_than.as_deref(),
                 missing_worktree,
-                labels.as_deref(),
-                &wt,
-                writer,
-            )
-            .await?;
+                labels: labels.as_deref(),
+            };
+            handle_prune_request(&request_id, &opts, &wt, writer).await?;
         }
         AgentMessage::DownRequest {
             request_id,
@@ -1414,14 +1411,18 @@ async fn handle_exec_request<W: AsyncWriteExt + Unpin>(
     Ok(())
 }
 
+struct PruneOpts<'a> {
+    dry_run: bool,
+    all: bool,
+    older_than: Option<&'a str>,
+    missing_worktree: bool,
+    labels: Option<&'a [String]>,
+}
+
 /// Handle a `PruneRequest` by spawning `cella prune` as a subprocess.
 async fn handle_prune_request<W: AsyncWriteExt + Unpin>(
     request_id: &str,
-    dry_run: bool,
-    all: bool,
-    older_than: Option<&str>,
-    missing_worktree: bool,
-    labels: Option<&[String]>,
+    opts: &PruneOpts<'_>,
     wt: &WorktreeHandlerCtx<'_>,
     writer: &mut W,
 ) -> Result<(), CellaDaemonError> {
@@ -1429,19 +1430,19 @@ async fn handle_prune_request<W: AsyncWriteExt + Unpin>(
     cmd.arg("prune");
     forward_backend_flags(&mut cmd, wt).await;
     cmd.arg("--force").arg("--output").arg("json");
-    if dry_run {
+    if opts.dry_run {
         cmd.arg("--dry-run");
     }
-    if all {
+    if opts.all {
         cmd.arg("--all");
     }
-    if let Some(duration) = older_than {
+    if let Some(duration) = opts.older_than {
         cmd.arg("--older-than").arg(duration);
     }
-    if missing_worktree {
+    if opts.missing_worktree {
         cmd.arg("--missing-worktree");
     }
-    if let Some(lbls) = labels {
+    if let Some(lbls) = opts.labels {
         for label in lbls {
             cmd.arg("--label").arg(label);
         }

--- a/crates/cella-daemon/src/task_manager.rs
+++ b/crates/cella-daemon/src/task_manager.rs
@@ -18,7 +18,7 @@ struct TaskOutput {
 }
 
 impl TaskOutput {
-    fn new(max_bytes: usize) -> Self {
+    const fn new(max_bytes: usize) -> Self {
         Self {
             buffer: VecDeque::new(),
             max_bytes,
@@ -202,16 +202,18 @@ impl TaskManager {
     pub async fn wait_for(&self, branch: &str) -> Option<i32> {
         let mut rx = self.tasks.get(branch)?.exit_watch.subscribe();
         // Check if already done
-        if let Some(code) = *rx.borrow() {
-            return Some(code);
+        let current = *rx.borrow_and_update();
+        if current.is_some() {
+            return current;
         }
         // Wait for the value to change
         loop {
             if rx.changed().await.is_err() {
                 return None;
             }
-            if let Some(code) = *rx.borrow() {
-                return Some(code);
+            let value = *rx.borrow_and_update();
+            if value.is_some() {
+                return value;
             }
         }
     }

--- a/crates/cella-daemon/src/task_manager.rs
+++ b/crates/cella-daemon/src/task_manager.rs
@@ -70,8 +70,11 @@ impl TaskManager {
         container_name: String,
         command: Vec<String>,
     ) -> Result<String, String> {
-        if self.tasks.contains_key(branch) {
-            return Err(format!("task already running for branch '{branch}'"));
+        if let Some(existing) = self.tasks.get(branch) {
+            if existing.exit_code.try_lock().map_or(true, |g| g.is_none()) {
+                return Err(format!("task already running for branch '{branch}'"));
+            }
+            self.tasks.remove(branch);
         }
 
         let task_id = branch.to_string();
@@ -437,6 +440,32 @@ mod tests {
         let mut mgr = manager();
         mgr.cleanup_done().await;
         assert!(mgr.list_tasks().await.is_empty());
+    }
+
+    // -- start_task after completion --
+
+    #[tokio::test]
+    async fn start_task_after_stop_succeeds() {
+        let mut mgr = manager();
+        mgr.start_task("br", "c".into(), vec!["x".into()]).unwrap();
+        mgr.stop_task("br").await;
+        // Task is done (exit_code=130), re-run should succeed
+        let id = mgr
+            .start_task("br", "c".into(), vec!["echo".into()])
+            .unwrap();
+        assert_eq!(id, "br");
+    }
+
+    #[tokio::test]
+    async fn start_task_while_running_still_errors() {
+        let mut mgr = manager();
+        mgr.start_task("br", "c".into(), vec!["sleep".into(), "9999".into()])
+            .unwrap();
+        // Task is still running (exit_code=None)
+        let err = mgr
+            .start_task("br", "c".into(), vec!["echo".into()])
+            .unwrap_err();
+        assert!(err.contains("already running"));
     }
 
     // -- wait_for --

--- a/crates/cella-daemon/src/task_manager.rs
+++ b/crates/cella-daemon/src/task_manager.rs
@@ -3,12 +3,41 @@
 //! Tracks `cella task run` background processes: their Docker exec handles,
 //! output capture, and lifecycle state. Tasks are identified by branch name.
 
-use std::collections::HashMap;
-use std::fmt::Write;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 
 use tokio::sync::Mutex;
 use tracing::{info, warn};
+
+const MAX_OUTPUT_BYTES: usize = 1024 * 1024; // 1 MB
+
+/// Ring buffer for captured task output.
+struct TaskOutput {
+    buffer: VecDeque<u8>,
+    max_bytes: usize,
+}
+
+impl TaskOutput {
+    fn new(max_bytes: usize) -> Self {
+        Self {
+            buffer: VecDeque::new(),
+            max_bytes,
+        }
+    }
+
+    fn push(&mut self, data: &str) {
+        let bytes = data.as_bytes();
+        self.buffer.extend(bytes);
+        while self.buffer.len() > self.max_bytes {
+            self.buffer.pop_front();
+        }
+    }
+
+    fn contents(&self) -> String {
+        let bytes: Vec<u8> = self.buffer.iter().copied().collect();
+        String::from_utf8_lossy(&bytes).into_owned()
+    }
+}
 
 /// Shared task manager state.
 pub type SharedTaskManager = Arc<Mutex<TaskManager>>;
@@ -29,8 +58,8 @@ struct TaskState {
     container_name: String,
     command: Vec<String>,
     started_at: std::time::Instant,
-    /// Captured output (stdout + stderr interleaved).
-    output: Arc<Mutex<String>>,
+    /// Captured output (stdout + stderr interleaved, ring buffer).
+    output: Arc<Mutex<TaskOutput>>,
     /// Set when the task completes.
     exit_code: Arc<Mutex<Option<i32>>>,
     /// Handle to abort the task.
@@ -80,7 +109,7 @@ impl TaskManager {
         }
 
         let task_id = branch.to_string();
-        let output = Arc::new(Mutex::new(String::new()));
+        let output = Arc::new(Mutex::new(TaskOutput::new(MAX_OUTPUT_BYTES)));
         let exit_code: Arc<Mutex<Option<i32>>> = Arc::new(Mutex::new(None));
         let (output_tx, _) = tokio::sync::broadcast::channel(1024);
         let (exit_watch, _) = tokio::sync::watch::channel(None);
@@ -156,7 +185,7 @@ impl TaskManager {
     /// Get captured output for a task.
     pub async fn get_output(&self, branch: &str) -> Option<String> {
         let state = self.tasks.get(branch)?;
-        Some(state.output.lock().await.clone())
+        Some(state.output.lock().await.contents())
     }
 
     /// Wait for a task to complete, returning its exit code.
@@ -210,7 +239,7 @@ impl TaskManager {
 async fn run_task_process(
     container_name: &str,
     command: &[String],
-    output: &Arc<Mutex<String>>,
+    output: &Arc<Mutex<TaskOutput>>,
     exit_code: &Arc<Mutex<Option<i32>>>,
     output_tx: &tokio::sync::broadcast::Sender<String>,
     exit_watch: &tokio::sync::watch::Sender<Option<i32>>,
@@ -231,9 +260,9 @@ async fn run_task_process(
             warn!("Failed to spawn task process: {e}");
             *exit_code.lock().await = Some(1);
             let _ = exit_watch.send(Some(1));
-            let error_line = format!("Error: failed to spawn: {e}");
-            let _ = writeln!(output.lock().await, "{error_line}");
-            let _ = output_tx.send(format!("{error_line}\n"));
+            let error_line = format!("Error: failed to spawn: {e}\n");
+            output.lock().await.push(&error_line);
+            let _ = output_tx.send(error_line);
             return;
         }
     };
@@ -249,7 +278,7 @@ async fn run_task_process(
             let mut reader = tokio::io::BufReader::new(stdout).lines();
             while let Ok(Some(line)) = reader.next_line().await {
                 let formatted = format!("{line}\n");
-                output_stdout.lock().await.push_str(&formatted);
+                output_stdout.lock().await.push(&formatted);
                 let _ = tx_stdout.send(formatted);
             }
         }
@@ -262,7 +291,7 @@ async fn run_task_process(
             let mut reader = tokio::io::BufReader::new(stderr).lines();
             while let Ok(Some(line)) = reader.next_line().await {
                 let formatted = format!("{line}\n");
-                output_stderr.lock().await.push_str(&formatted);
+                output_stderr.lock().await.push(&formatted);
                 let _ = tx_stderr.send(formatted);
             }
         }
@@ -490,5 +519,24 @@ mod tests {
         let mgr = manager();
         // Unknown branch returns None immediately (no state to poll).
         assert!(mgr.wait_for("ghost").await.is_none());
+    }
+
+    // -- TaskOutput ring buffer --
+
+    #[test]
+    fn task_output_caps_at_max_bytes() {
+        let mut out = TaskOutput::new(10);
+        out.push("hello"); // 5 bytes
+        out.push("world!"); // 6 bytes, total 11 > 10
+        let contents = out.contents();
+        assert_eq!(contents.len(), 10);
+        assert_eq!(contents, "elloworld!");
+    }
+
+    #[test]
+    fn task_output_under_limit_preserved() {
+        let mut out = TaskOutput::new(100);
+        out.push("small");
+        assert_eq!(out.contents(), "small");
     }
 }

--- a/crates/cella-daemon/src/task_manager.rs
+++ b/crates/cella-daemon/src/task_manager.rs
@@ -173,6 +173,14 @@ impl TaskManager {
         self.tasks.get(branch).map(|s| s.output_tx.subscribe())
     }
 
+    /// Subscribe to exit notification for a task.
+    pub fn subscribe_exit(
+        &self,
+        branch: &str,
+    ) -> Option<tokio::sync::watch::Receiver<Option<i32>>> {
+        self.tasks.get(branch).map(|s| s.exit_watch.subscribe())
+    }
+
     /// Check if a task is done.
     pub async fn is_done(&self, branch: &str) -> bool {
         if let Some(state) = self.tasks.get(branch) {

--- a/crates/cella-daemon/src/task_manager.rs
+++ b/crates/cella-daemon/src/task_manager.rs
@@ -37,6 +37,8 @@ struct TaskState {
     abort_handle: tokio::task::AbortHandle,
     /// Broadcast channel for live output streaming.
     output_tx: tokio::sync::broadcast::Sender<String>,
+    /// Watch channel for non-blocking wait on task completion.
+    exit_watch: tokio::sync::watch::Sender<Option<i32>>,
 }
 
 /// Public task info for list responses.
@@ -81,10 +83,12 @@ impl TaskManager {
         let output = Arc::new(Mutex::new(String::new()));
         let exit_code: Arc<Mutex<Option<i32>>> = Arc::new(Mutex::new(None));
         let (output_tx, _) = tokio::sync::broadcast::channel(1024);
+        let (exit_watch, _) = tokio::sync::watch::channel(None);
 
         let output_clone = output.clone();
         let exit_code_clone = exit_code.clone();
         let output_tx_clone = output_tx.clone();
+        let exit_watch_clone = exit_watch.clone();
         let container = container_name.clone();
         let cmd = command.clone();
 
@@ -95,6 +99,7 @@ impl TaskManager {
                 &output_clone,
                 &exit_code_clone,
                 &output_tx_clone,
+                &exit_watch_clone,
             )
             .await;
         });
@@ -108,6 +113,7 @@ impl TaskManager {
             exit_code,
             abort_handle: handle.abort_handle(),
             output_tx,
+            exit_watch,
         };
 
         self.tasks.insert(task_id.clone(), state);
@@ -154,16 +160,22 @@ impl TaskManager {
     }
 
     /// Wait for a task to complete, returning its exit code.
+    ///
+    /// Uses a watch channel so it doesn't hold any lock while waiting.
     pub async fn wait_for(&self, branch: &str) -> Option<i32> {
-        let state = self.tasks.get(branch)?;
-        let exit_code = state.exit_code.clone();
-        // Poll until done
+        let mut rx = self.tasks.get(branch)?.exit_watch.subscribe();
+        // Check if already done
+        if let Some(code) = *rx.borrow() {
+            return Some(code);
+        }
+        // Wait for the value to change
         loop {
-            let code = *exit_code.lock().await;
-            if let Some(c) = code {
-                return Some(c);
+            if rx.changed().await.is_err() {
+                return None;
             }
-            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            if let Some(code) = *rx.borrow() {
+                return Some(code);
+            }
         }
     }
 
@@ -171,8 +183,8 @@ impl TaskManager {
     pub async fn stop_task(&mut self, branch: &str) -> bool {
         if let Some(state) = self.tasks.get(branch) {
             state.abort_handle.abort();
-            // Set exit code to signal interrupted
-            *state.exit_code.lock().await = Some(130); // SIGINT convention
+            *state.exit_code.lock().await = Some(130);
+            let _ = state.exit_watch.send(Some(130));
             info!("Stopped task '{branch}'");
             true
         } else {
@@ -201,6 +213,7 @@ async fn run_task_process(
     output: &Arc<Mutex<String>>,
     exit_code: &Arc<Mutex<Option<i32>>>,
     output_tx: &tokio::sync::broadcast::Sender<String>,
+    exit_watch: &tokio::sync::watch::Sender<Option<i32>>,
 ) {
     use tokio::io::AsyncBufReadExt;
 
@@ -217,6 +230,7 @@ async fn run_task_process(
         Err(e) => {
             warn!("Failed to spawn task process: {e}");
             *exit_code.lock().await = Some(1);
+            let _ = exit_watch.send(Some(1));
             let error_line = format!("Error: failed to spawn: {e}");
             let _ = writeln!(output.lock().await, "{error_line}");
             let _ = output_tx.send(format!("{error_line}\n"));
@@ -260,6 +274,7 @@ async fn run_task_process(
     let status = child.wait().await;
     let code = status.map_or(1, |s| s.code().unwrap_or(1));
     *exit_code.lock().await = Some(code);
+    let _ = exit_watch.send(Some(code));
     info!("Task in '{container_name}' exited with code {code}");
 }
 

--- a/crates/cella-git/Cargo.toml
+++ b/crates/cella-git/Cargo.toml
@@ -6,7 +6,9 @@ license.workspace = true
 
 [dependencies]
 fs4.workspace = true
+hex.workspace = true
 miette.workspace = true
+sha2.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 

--- a/crates/cella-git/src/lib.rs
+++ b/crates/cella-git/src/lib.rs
@@ -15,7 +15,7 @@ pub use branch::{
 pub use error::CellaGitError;
 pub use lock::BranchLock;
 pub use repo::{RepoInfo, default_branch, discover, find_git_root_folder, is_inside_container};
-pub use sanitize::branch_to_dir_name;
+pub use sanitize::{branch_to_dir_name, branch_to_dir_name_legacy};
 pub use worktree::{
     WorktreeInfo, create, create_strict, list, parent_git_dir, remove, worktree_path,
 };

--- a/crates/cella-git/src/lock.rs
+++ b/crates/cella-git/src/lock.rs
@@ -42,10 +42,15 @@ impl BranchLock {
         let lock_path = lock_dir.join(format!("cella-{sanitized}.lock"));
 
         let file = File::create(&lock_path).map_err(CellaGitError::Io)?;
-        file.lock().map_err(|e| {
-            debug!("failed to acquire lock at {}: {e}", lock_path.display());
-            CellaGitError::Io(e)
-        })?;
+        if file.try_lock().is_err() {
+            tracing::info!(
+                "Waiting for lock on branch '{branch}' (another operation in progress)..."
+            );
+            file.lock().map_err(|e| {
+                debug!("failed to acquire lock at {}: {e}", lock_path.display());
+                CellaGitError::Io(e)
+            })?;
+        }
 
         debug!("acquired branch lock: {}", lock_path.display());
         Ok(Self { _file: file })

--- a/crates/cella-git/src/sanitize.rs
+++ b/crates/cella-git/src/sanitize.rs
@@ -1,18 +1,35 @@
 //! Branch name to filesystem-safe directory name conversion.
 
+use sha2::{Digest, Sha256};
+
 /// Convert a branch name to a filesystem-safe directory name.
 ///
-/// Replaces `/` with `-`, collapses consecutive dashes, and trims
-/// leading/trailing dashes.
+/// Replaces `/` with `-`, collapses consecutive dashes, trims
+/// leading/trailing dashes, and appends a 4-char hash suffix to
+/// prevent collisions (e.g. `feature/auth` vs `feature-auth`).
 ///
 /// # Examples
 ///
 /// ```
 /// # use cella_git::branch_to_dir_name;
-/// assert_eq!(branch_to_dir_name("feature/auth/oauth2"), "feature-auth-oauth2");
-/// assert_eq!(branch_to_dir_name("main"), "main");
+/// let a = branch_to_dir_name("feature/auth");
+/// let b = branch_to_dir_name("feature-auth");
+/// assert_ne!(a, b);
+/// assert!(a.starts_with("feature-auth-"));
+/// assert!(b.starts_with("feature-auth-"));
 /// ```
 pub fn branch_to_dir_name(branch: &str) -> String {
+    let sanitized = sanitize_chars(branch);
+    let hash = short_hash(branch);
+    format!("{sanitized}-{hash}")
+}
+
+/// Convert a branch name without the hash suffix (for backward compatibility lookups).
+pub fn branch_to_dir_name_legacy(branch: &str) -> String {
+    sanitize_chars(branch)
+}
+
+fn sanitize_chars(branch: &str) -> String {
     let mut result = String::with_capacity(branch.len());
     let mut prev_dash = false;
 
@@ -31,48 +48,67 @@ pub fn branch_to_dir_name(branch: &str) -> String {
     result.trim_matches('-').to_string()
 }
 
+fn short_hash(input: &str) -> String {
+    let hash = Sha256::digest(input.as_bytes());
+    hex::encode(&hash[..2])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn simple_branch_unchanged() {
-        assert_eq!(branch_to_dir_name("main"), "main");
+    fn simple_branch_gets_hash_suffix() {
+        let name = branch_to_dir_name("main");
+        assert!(name.starts_with("main-"));
+        assert_eq!(name.len(), "main-".len() + 4);
     }
 
     #[test]
-    fn slashes_replaced() {
-        assert_eq!(
-            branch_to_dir_name("feature/auth/oauth2"),
-            "feature-auth-oauth2"
-        );
+    fn slashes_replaced_with_hash() {
+        let name = branch_to_dir_name("feature/auth/oauth2");
+        assert!(name.starts_with("feature-auth-oauth2-"));
+    }
+
+    #[test]
+    fn collision_prevention() {
+        let a = branch_to_dir_name("feature/auth");
+        let b = branch_to_dir_name("feature-auth");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn deterministic() {
+        assert_eq!(branch_to_dir_name("main"), branch_to_dir_name("main"));
     }
 
     #[test]
     fn double_slashes_collapsed() {
-        assert_eq!(
-            branch_to_dir_name("feature//double-slash"),
-            "feature-double-slash"
-        );
+        let name = branch_to_dir_name("feature//double-slash");
+        assert!(name.starts_with("feature-double-slash-"));
     }
 
     #[test]
     fn leading_slash_trimmed() {
-        assert_eq!(branch_to_dir_name("/leading-slash"), "leading-slash");
+        let name = branch_to_dir_name("/leading-slash");
+        assert!(name.starts_with("leading-slash-"));
     }
 
     #[test]
     fn trailing_slash_trimmed() {
-        assert_eq!(branch_to_dir_name("trailing/"), "trailing");
-    }
-
-    #[test]
-    fn single_segment() {
-        assert_eq!(branch_to_dir_name("hotfix"), "hotfix");
+        let name = branch_to_dir_name("trailing/");
+        assert!(name.starts_with("trailing-"));
     }
 
     #[test]
     fn deeply_nested() {
-        assert_eq!(branch_to_dir_name("a/b/c/d/e"), "a-b-c-d-e");
+        let name = branch_to_dir_name("a/b/c/d/e");
+        assert!(name.starts_with("a-b-c-d-e-"));
+    }
+
+    #[test]
+    fn legacy_no_hash() {
+        assert_eq!(branch_to_dir_name_legacy("feature/auth"), "feature-auth");
+        assert_eq!(branch_to_dir_name_legacy("main"), "main");
     }
 }

--- a/crates/cella-git/src/worktree.rs
+++ b/crates/cella-git/src/worktree.rs
@@ -7,7 +7,7 @@ use tracing::debug;
 use crate::CellaGitError;
 use crate::branch::BranchState;
 use crate::cmd;
-use crate::sanitize::branch_to_dir_name;
+use crate::sanitize::{branch_to_dir_name, branch_to_dir_name_legacy};
 
 /// Information about a single git worktree.
 #[derive(Debug, Clone)]
@@ -49,19 +49,35 @@ pub fn parent_git_dir(workspace_root: &Path) -> Option<PathBuf> {
 /// If `worktree_root` is provided (from `cella.toml` config), the worktree
 /// is placed under that root. Otherwise, the default sibling pattern is used:
 /// `{repo_parent}/{repo_dir_name}-worktrees/{sanitized_branch}`.
+///
+/// For backward compatibility, if a legacy-named directory (without hash suffix)
+/// already exists, that path is returned instead of the new-style name.
 pub fn worktree_path(repo_root: &Path, branch: &str, worktree_root: Option<&Path>) -> PathBuf {
     let dir_name = branch_to_dir_name(branch);
+    let legacy_dir_name = branch_to_dir_name_legacy(branch);
+
+    let compute_path = |root: &Path| -> PathBuf {
+        let new_path = root.join(&dir_name);
+        if new_path.exists() {
+            return new_path;
+        }
+        let legacy_path = root.join(&legacy_dir_name);
+        if legacy_path.exists() {
+            return legacy_path;
+        }
+        new_path
+    };
+
     worktree_root.map_or_else(
         || {
             let repo_name = repo_root
                 .file_name()
                 .map_or("repo", |n| n.to_str().unwrap_or("repo"));
             let parent = repo_root.parent().unwrap_or(repo_root);
-            parent
-                .join(format!("{repo_name}-worktrees"))
-                .join(&dir_name)
+            let root = parent.join(format!("{repo_name}-worktrees"));
+            compute_path(&root)
         },
-        |root| root.join(&dir_name),
+        compute_path,
     )
 }
 
@@ -296,9 +312,10 @@ mod tests {
     fn worktree_path_default_sibling() {
         let repo = Path::new("/home/user/my-project");
         let path = worktree_path(repo, "feature/auth", None);
+        let dir_name = branch_to_dir_name("feature/auth");
         assert_eq!(
             path,
-            PathBuf::from("/home/user/my-project-worktrees/feature-auth")
+            PathBuf::from(format!("/home/user/my-project-worktrees/{dir_name}"))
         );
     }
 
@@ -307,7 +324,8 @@ mod tests {
         let repo = Path::new("/home/user/my-project");
         let custom = Path::new("/tmp/worktrees");
         let path = worktree_path(repo, "feature/auth", Some(custom));
-        assert_eq!(path, PathBuf::from("/tmp/worktrees/feature-auth"));
+        let dir_name = branch_to_dir_name("feature/auth");
+        assert_eq!(path, PathBuf::from(format!("/tmp/worktrees/{dir_name}")));
     }
 
     #[test]
@@ -641,7 +659,11 @@ detached
         // Repo at filesystem root edge case
         let repo = Path::new("/my-project");
         let path = worktree_path(repo, "fix/bug", None);
-        assert_eq!(path, PathBuf::from("/my-project-worktrees/fix-bug"));
+        let dir_name = branch_to_dir_name("fix/bug");
+        assert_eq!(
+            path,
+            PathBuf::from(format!("/my-project-worktrees/{dir_name}"))
+        );
     }
 
     #[test]

--- a/crates/cella-protocol/src/lib.rs
+++ b/crates/cella-protocol/src/lib.rs
@@ -104,6 +104,8 @@ pub enum AgentMessage {
         branch: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         base: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        labels: Option<Vec<String>>,
     },
     /// Request to list worktree branches and their container status.
     ListRequest { request_id: String },
@@ -1219,12 +1221,13 @@ mod tests {
             request_id: "br-1".to_string(),
             branch: "feat/auth".to_string(),
             base: Some("main".to_string()),
+            labels: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         assert!(json.contains("\"type\":\"branch_request\""));
         let decoded: AgentMessage = serde_json::from_str(&json).unwrap();
         assert!(
-            matches!(decoded, AgentMessage::BranchRequest { request_id, branch, base }
+            matches!(decoded, AgentMessage::BranchRequest { request_id, branch, base, .. }
                 if request_id == "br-1" && branch == "feat/auth" && base.as_deref() == Some("main"))
         );
     }
@@ -1235,6 +1238,7 @@ mod tests {
             request_id: "br-2".to_string(),
             branch: "fix/bug".to_string(),
             base: None,
+            labels: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         // base=None should be omitted

--- a/crates/cella-protocol/src/lib.rs
+++ b/crates/cella-protocol/src/lib.rs
@@ -125,6 +125,15 @@ pub enum AgentMessage {
         /// When true, include unmerged worktrees (not just merged ones).
         #[serde(default)]
         all: bool,
+        /// Only prune worktrees older than this duration (e.g. "7d", "24h").
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        older_than: Option<String>,
+        /// Only prune worktrees whose git branch no longer exists.
+        #[serde(default)]
+        missing_worktree: bool,
+        /// Only prune worktrees matching these labels.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        labels: Option<Vec<String>>,
     },
     /// Stop (and optionally remove) a worktree branch's container.
     DownRequest {

--- a/crates/cella-protocol/src/lib.rs
+++ b/crates/cella-protocol/src/lib.rs
@@ -609,7 +609,20 @@ pub enum TaskRunOperationResult {
     },
     Error {
         message: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        code: Option<TaskErrorCode>,
     },
+}
+
+/// Structured error codes for task operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskErrorCode {
+    AlreadyRunning,
+    NotFound,
+    BranchNotFound,
+    ContainerNotRunning,
+    ExecFailed,
 }
 
 /// A background task entry.

--- a/crates/cella-protocol/src/lib.rs
+++ b/crates/cella-protocol/src/lib.rs
@@ -1426,6 +1426,9 @@ mod tests {
             request_id: "pr-1".to_string(),
             dry_run: true,
             all: false,
+            older_than: None,
+            missing_worktree: false,
+            labels: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let decoded: AgentMessage = serde_json::from_str(&json).unwrap();
@@ -1441,6 +1444,9 @@ mod tests {
             request_id: "pr-2".to_string(),
             dry_run: false,
             all: true,
+            older_than: None,
+            missing_worktree: false,
+            labels: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let decoded: AgentMessage = serde_json::from_str(&json).unwrap();


### PR DESCRIPTION
## Summary

- Fix branch "unparseable" error — daemon now accumulates full stdout instead of only the last line
- Fix tasks permanently blocking re-runs — completed tasks are replaced on next start
- Fix prune dry-run showing "Pruned" instead of "Would prune"
- Fix branch name routing — list now shows creation name matching what exec/down/up use
- Fix sanitization collisions (`feature/auth` vs `feature-auth`) with hash suffix
- Add lock wait feedback so users know why an operation is blocked
- Reject unknown flags in agent CLI instead of silently ignoring them
- Validate `--volumes` requires `--rm` in down command
- Add `--label` support to branch and prune commands
- Add `--older-than`, `--missing-worktree` prune filters
- Replace polling wait with watch channel (no longer blocks all task operations)
- Cap task output at 1 MB ring buffer to prevent OOM
- Fix `logs --follow` hanging after task completes
- Add structured `TaskErrorCode` enum for programmatic error handling

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings -D clippy::all` passes
- [x] `cargo test --workspace` — all 48 test suites pass
- [x] Manual E2E from inside a running container (branch creation, task re-run, prune dry-run, unknown flag rejection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)