### PR TITLE
fix: task system deadlocks & agent CLI improvements

### DIFF
--- a/crates/cella-agent/src/cli.rs
+++ b/crates/cella-agent/src/cli.rs
@@ -1080,8 +1080,9 @@ async fn run_task_wait(branch: &str) -> Result<(), Box<dyn std::error::Error + S
     };
     client.send(&msg).await?;
 
+    // 60s timeout resets on each heartbeat (daemon sends every 30s).
     loop {
-        let resp = recv_timeout(&mut client, TIMEOUT_MEDIUM).await?;
+        let resp = recv_timeout(&mut client, Duration::from_mins(1)).await?;
         if let DaemonMessage::TaskWaitResult { exit_code, .. } = resp {
             if exit_code != 0 {
                 eprintln!("Task '{branch}' exited with code {exit_code}");
@@ -1090,6 +1091,7 @@ async fn run_task_wait(branch: &str) -> Result<(), Box<dyn std::error::Error + S
             eprintln!("Task '{branch}' completed successfully.");
             return Ok(());
         }
+        // TaskWaitHeartbeat and other messages just reset the timeout.
     }
 }
 

--- a/crates/cella-agent/src/cli.rs
+++ b/crates/cella-agent/src/cli.rs
@@ -2196,4 +2196,79 @@ mod tests {
         // Should not panic on empty slice.
         print_worktree_table(&[]);
     }
+
+    // --- JSON flag parsing ---
+
+    #[test]
+    fn parse_list_json() {
+        let args: Vec<String> = ["cella", "list", "--json"]
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+        let cmd = parse_cli_args(&args);
+        assert!(matches!(cmd, CliCommand::List { json: true }));
+    }
+
+    #[test]
+    fn parse_exec_json() {
+        let args: Vec<String> = ["cella", "exec", "feat/x", "--json", "--", "echo", "hi"]
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+        let cmd = parse_cli_args(&args);
+        assert!(matches!(cmd, CliCommand::Exec { branch, json: true, .. } if branch == "feat/x"));
+    }
+
+    #[test]
+    fn parse_doctor_json() {
+        let args: Vec<String> = ["cella", "doctor", "--json"]
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+        let cmd = parse_cli_args(&args);
+        assert!(matches!(cmd, CliCommand::Doctor { json: true }));
+    }
+
+    // --- per-command help ---
+
+    #[test]
+    fn parse_branch_help() {
+        let args: Vec<String> = ["cella", "branch", "--help"]
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+        let cmd = parse_cli_args(&args);
+        assert!(matches!(cmd, CliCommand::Help));
+    }
+
+    #[test]
+    fn parse_task_help() {
+        let args: Vec<String> = ["cella", "task", "--help"]
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+        let cmd = parse_cli_args(&args);
+        assert!(matches!(cmd, CliCommand::Help));
+    }
+
+    // --- branch name validation ---
+
+    #[test]
+    fn parse_branch_whitespace_rejected() {
+        let args: Vec<String> = ["cella", "branch", "bad name"]
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+        let cmd = parse_cli_args(&args);
+        assert!(matches!(cmd, CliCommand::Help));
+    }
+
+    #[test]
+    fn print_command_help_does_not_panic() {
+        for cmd in &[
+            "branch", "list", "exec", "down", "up", "prune", "task", "doctor", "switch", "bogus",
+        ] {
+            print_command_help(cmd);
+        }
+    }
 }

--- a/crates/cella-agent/src/cli.rs
+++ b/crates/cella-agent/src/cli.rs
@@ -37,7 +37,9 @@ pub enum CliCommand {
         base: Option<String>,
         labels: Vec<String>,
     },
-    List,
+    List {
+        json: bool,
+    },
     Down {
         branch: String,
         rm: bool,
@@ -51,6 +53,7 @@ pub enum CliCommand {
     Exec {
         branch: String,
         command: Vec<String>,
+        json: bool,
     },
     Prune {
         dry_run: bool,
@@ -78,7 +81,9 @@ pub enum CliCommand {
     Switch {
         branch: String,
     },
-    Doctor,
+    Doctor {
+        json: bool,
+    },
     Help,
     Unsupported {
         command: String,
@@ -91,20 +96,29 @@ pub fn parse_cli_args(args: &[String]) -> CliCommand {
 
     match subcmd {
         Some("branch") => parse_branch_subcommand(args),
-        Some("list" | "ls") => CliCommand::List,
+        Some("list" | "ls") => {
+            let json = args[2..].iter().any(|a| a == "--json");
+            CliCommand::List { json }
+        }
         Some("exec") => {
-            // Parse: cella exec <branch> -- <cmd...>
+            // Parse: cella exec <branch> [--json] -- <cmd...>
             let branch = match args.get(2) {
                 Some(b) if !b.starts_with('-') && b != "--" => b.clone(),
                 _ => return CliCommand::Help,
             };
-            // Find "--" separator
             let sep = args.iter().position(|a| a == "--");
             let command = sep.map_or_else(Vec::new, |i| args[i + 1..].to_vec());
             if command.is_empty() {
                 return CliCommand::Help;
             }
-            CliCommand::Exec { branch, command }
+            let json = args[3..sep.unwrap_or(args.len())]
+                .iter()
+                .any(|a| a == "--json");
+            CliCommand::Exec {
+                branch,
+                command,
+                json,
+            }
         }
         Some("down") => {
             let branch = match args.get(2) {
@@ -164,7 +178,10 @@ pub fn parse_cli_args(args: &[String]) -> CliCommand {
             };
             CliCommand::Switch { branch }
         }
-        Some("doctor") => CliCommand::Doctor,
+        Some("doctor") => {
+            let json = args[2..].iter().any(|a| a == "--json");
+            CliCommand::Doctor { json }
+        }
         Some("--help" | "-h") | None => CliCommand::Help,
         Some(cmd) => CliCommand::Unsupported {
             command: cmd.to_string(),
@@ -355,7 +372,13 @@ pub async fn run(command: CliCommand) -> Result<(), Box<dyn std::error::Error + 
             print_help();
             Ok(())
         }
-        CliCommand::Doctor => run_doctor().await,
+        CliCommand::Doctor { json } => {
+            if json {
+                run_doctor_json().await
+            } else {
+                run_doctor().await
+            }
+        }
         CliCommand::Unsupported { command } => {
             print_unsupported(&command);
             std::process::exit(1);
@@ -363,7 +386,7 @@ pub async fn run(command: CliCommand) -> Result<(), Box<dyn std::error::Error + 
         CliCommand::Branch { name, base, labels } => {
             run_branch(&name, base.as_deref(), &labels).await
         }
-        CliCommand::List => run_list().await,
+        CliCommand::List { json } => run_list(json).await,
         CliCommand::Down {
             branch,
             rm,
@@ -371,7 +394,11 @@ pub async fn run(command: CliCommand) -> Result<(), Box<dyn std::error::Error + 
             force,
         } => run_down(&branch, rm, volumes, force).await,
         CliCommand::Up { branch, rebuild } => run_up(&branch, rebuild).await,
-        CliCommand::Exec { branch, command } => run_exec(&branch, &command).await,
+        CliCommand::Exec {
+            branch,
+            command,
+            json,
+        } => run_exec(&branch, &command, json).await,
         CliCommand::Prune {
             dry_run,
             all,
@@ -544,6 +571,24 @@ async fn run_doctor() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     eprintln!();
     Ok(())
+}
+
+async fn run_doctor_json() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let mut client = connect_daemon().await?;
+    let id = request_id();
+    client
+        .send(&AgentMessage::DoctorRequest {
+            request_id: id.clone(),
+        })
+        .await?;
+
+    loop {
+        let resp = recv_timeout(&mut client, TIMEOUT_FAST).await?;
+        if let DaemonMessage::DoctorResult { data, .. } = resp {
+            println!("{}", serde_json::to_string_pretty(&data)?);
+            return Ok(());
+        }
+    }
 }
 
 fn report_main_agent_status() {
@@ -735,7 +780,7 @@ async fn run_branch(
     }
 }
 
-async fn run_list() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+async fn run_list(json: bool) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut client = connect_daemon().await?;
 
     let id = request_id();
@@ -747,45 +792,76 @@ async fn run_list() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     loop {
         let resp = recv_timeout(&mut client, TIMEOUT_FAST).await?;
         if let DaemonMessage::ListResult { worktrees, .. } = resp {
-            if worktrees.is_empty() {
+            if json {
+                println!("{}", serde_json::to_string_pretty(&worktrees)?);
+            } else if worktrees.is_empty() {
                 eprintln!("No worktree branches found.");
             } else {
                 print_worktree_table(&worktrees);
             }
             return Ok(());
         }
-        // Ignore unrelated messages (Ack, PortMapping, etc.)
     }
 }
 
 async fn run_exec(
     branch: &str,
     command: &[String],
+    json: bool,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut client = connect_daemon().await?;
-
     let id = request_id();
-    let msg = AgentMessage::ExecRequest {
-        request_id: id.clone(),
-        branch: branch.to_string(),
-        command: command.to_vec(),
-    };
-    client.send(&msg).await?;
 
-    loop {
-        let resp = recv_timeout(&mut client, TIMEOUT_MEDIUM).await?;
-        match resp {
-            DaemonMessage::OperationOutput { stream, data, .. } => match stream {
-                OutputStream::Stdout => print!("{data}"),
-                OutputStream::Stderr => eprint!("{data}"),
-            },
-            DaemonMessage::ExecResult { exit_code, .. } => {
+    if json {
+        let msg = AgentMessage::ExecCaptureRequest {
+            request_id: id.clone(),
+            branch: branch.to_string(),
+            command: command.to_vec(),
+        };
+        client.send(&msg).await?;
+        loop {
+            let resp = recv_timeout(&mut client, TIMEOUT_MEDIUM).await?;
+            if let DaemonMessage::ExecCaptureResult {
+                exit_code,
+                stdout,
+                stderr,
+                ..
+            } = resp
+            {
+                let envelope = serde_json::json!({
+                    "exit_code": exit_code,
+                    "stdout": stdout,
+                    "stderr": stderr,
+                });
+                println!("{}", serde_json::to_string_pretty(&envelope)?);
                 if exit_code != 0 {
                     std::process::exit(exit_code);
                 }
                 return Ok(());
             }
-            _ => {}
+        }
+    } else {
+        let msg = AgentMessage::ExecRequest {
+            request_id: id.clone(),
+            branch: branch.to_string(),
+            command: command.to_vec(),
+        };
+        client.send(&msg).await?;
+        loop {
+            let resp = recv_timeout(&mut client, TIMEOUT_MEDIUM).await?;
+            match resp {
+                DaemonMessage::OperationOutput { stream, data, .. } => match stream {
+                    OutputStream::Stdout => print!("{data}"),
+                    OutputStream::Stderr => eprint!("{data}"),
+                },
+                DaemonMessage::ExecResult { exit_code, .. } => {
+                    if exit_code != 0 {
+                        std::process::exit(exit_code);
+                    }
+                    return Ok(());
+                }
+                _ => {}
+            }
         }
     }
 }
@@ -1277,14 +1353,14 @@ mod tests {
     fn parse_list_command() {
         let args = vec!["cella".to_string(), "list".to_string()];
         let cmd = parse_cli_args(&args);
-        assert!(matches!(cmd, CliCommand::List));
+        assert!(matches!(cmd, CliCommand::List { json: false }));
     }
 
     #[test]
     fn parse_ls_alias() {
         let args = vec!["cella".to_string(), "ls".to_string()];
         let cmd = parse_cli_args(&args);
-        assert!(matches!(cmd, CliCommand::List));
+        assert!(matches!(cmd, CliCommand::List { json: false }));
     }
 
     #[test]
@@ -1326,8 +1402,10 @@ mod tests {
             "test".to_string(),
         ];
         let cmd = parse_cli_args(&args);
-        assert!(matches!(cmd, CliCommand::Exec { branch, command }
-                if branch == "feat/auth" && command == ["cargo", "test"]));
+        assert!(
+            matches!(cmd, CliCommand::Exec { branch, command, json: false }
+                if branch == "feat/auth" && command == ["cargo", "test"])
+        );
     }
 
     #[test]
@@ -1832,7 +1910,7 @@ mod tests {
             .map(ToString::to_string)
             .collect();
         let cmd = parse_cli_args(&args);
-        assert!(matches!(cmd, CliCommand::Doctor));
+        assert!(matches!(cmd, CliCommand::Doctor { json: false }));
     }
 
     #[test]

--- a/crates/cella-agent/src/cli.rs
+++ b/crates/cella-agent/src/cli.rs
@@ -94,6 +94,13 @@ pub enum CliCommand {
 pub fn parse_cli_args(args: &[String]) -> CliCommand {
     let subcmd = args.get(1).map(String::as_str);
 
+    if let Some(cmd) = subcmd.filter(|c| {
+        *c != "--help" && *c != "-h" && args[2..].iter().any(|a| a == "--help" || a == "-h")
+    }) {
+        print_command_help(cmd);
+        return CliCommand::Help;
+    }
+
     match subcmd {
         Some("branch") => parse_branch_subcommand(args),
         Some("list" | "ls") => {
@@ -194,6 +201,14 @@ fn parse_branch_subcommand(args: &[String]) -> CliCommand {
         Some(n) if !n.starts_with('-') => n.clone(),
         _ => return CliCommand::Help,
     };
+    if name.is_empty() {
+        eprintln!("Error: branch name cannot be empty");
+        return CliCommand::Help;
+    }
+    if name.contains(|c: char| c.is_whitespace()) {
+        eprintln!("Error: branch name cannot contain whitespace");
+        return CliCommand::Help;
+    }
     let mut base = None;
     let mut labels = Vec::new();
     let mut i = 3;
@@ -455,6 +470,100 @@ Options:
 
 Run `cella --help` on the host for all commands."
     );
+}
+
+fn print_command_help(command: &str) {
+    let text = match command {
+        "branch" => {
+            "\
+Usage: cella branch <name> [options]
+
+Create a worktree-backed branch with its own container.
+
+Options:
+  --base <ref>       Base branch or commit (default: current HEAD)
+  --label KEY=VALUE  Add a label to the container (repeatable)"
+        }
+        "list" | "ls" => {
+            "\
+Usage: cella list [options]
+
+List worktree branches and their container status.
+
+Options:
+  --json    Output as JSON array"
+        }
+        "exec" => {
+            "\
+Usage: cella exec <branch> [options] -- <command...>
+
+Run a command in another branch's container.
+
+Options:
+  --json    Capture stdout/stderr and output as JSON envelope"
+        }
+        "down" => {
+            "\
+Usage: cella down <branch> [options]
+
+Stop a worktree branch's container.
+
+Options:
+  --rm        Remove the container and worktree after stopping
+  --volumes   Also remove volumes (requires --rm)
+  --force     Force stop even when shutdownAction is \"none\""
+        }
+        "up" => {
+            "\
+Usage: cella up <branch> [options]
+
+Start or restart a worktree branch's container.
+
+Options:
+  --rebuild   Rebuild the container from scratch"
+        }
+        "prune" => {
+            "\
+Usage: cella prune [options]
+
+Remove worktrees and their containers.
+
+Options:
+  --all               Include unmerged worktrees
+  --dry-run           Show what would be pruned without doing it
+  --older-than <dur>  Only prune older than duration (e.g., 7d, 24h)
+  --missing-worktree  Only prune branches whose worktree is gone
+  --label KEY=VALUE   Only prune matching labels (repeatable)"
+        }
+        "task" => {
+            "\
+Usage: cella task <subcommand>
+
+Subcommands:
+  run <branch> [--base ref] -- <cmd...>   Run a background task
+  list                                    List active tasks
+  logs [-f|--follow] <branch>             Show task output
+  wait <branch>                           Wait for task completion
+  stop <branch>                           Stop a running task"
+        }
+        "doctor" => {
+            "\
+Usage: cella doctor [options]
+
+Check daemon connectivity and version status.
+
+Options:
+  --json    Output structured health data as JSON"
+        }
+        "switch" => {
+            "\
+Usage: cella switch <branch>
+
+Open an interactive shell in another branch's container."
+        }
+        _ => "No help available for this command.",
+    };
+    eprintln!("{text}");
 }
 
 fn print_unsupported(command: &str) {

--- a/crates/cella-cli/src/commands/branch.rs
+++ b/crates/cella-cli/src/commands/branch.rs
@@ -110,6 +110,12 @@ impl BranchArgs {
         freshly_created: bool,
         progress: &crate::progress::Progress,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        if !freshly_created && !self.labels.is_empty() {
+            progress.warn(
+                "Branch already exists, --label flags ignored (container labels are immutable)",
+            );
+        }
+
         // Prepare worktree-specific labels + user-supplied labels
         let mut extra_labels = worktree_labels(&self.name, repo_root);
         for label in &self.labels {
@@ -142,22 +148,8 @@ impl BranchArgs {
         )
         .await;
 
-        // For freshly-created worktrees, remove any leftover container from a
-        // previous failed attempt so ensure_up always runs the full first-create
-        // path (lifecycle hooks, tool setup, etc.).
-        // For existing worktrees (idempotent path), let ensure_up decide whether
-        // to reuse or rebuild the container based on config hash.
-        if freshly_created && let Ok(Some(existing)) = ctx.client.find_container(wt_path).await {
-            if let Some(mgmt_sock) = cella_env::paths::daemon_socket_path()
-                && mgmt_sock.exists()
-            {
-                let req = cella_protocol::ManagementRequest::DeregisterContainer {
-                    container_name: existing.name.clone(),
-                };
-                let _ = cella_daemon_client::send_management_request(&mgmt_sock, &req).await;
-            }
-            let _ = ctx.client.stop_container(&existing.id).await;
-            let _ = ctx.client.remove_container(&existing.id, false).await;
+        if freshly_created {
+            remove_leftover_container(&ctx, wt_path).await;
         }
 
         let create_result = if ctx.is_compose() {
@@ -223,6 +215,23 @@ impl BranchArgs {
         }
 
         Ok(())
+    }
+}
+
+/// Remove leftover container from a previous failed attempt so `ensure_up`
+/// runs the full first-create path (lifecycle hooks, tool setup, etc.).
+async fn remove_leftover_container(ctx: &UpContext, wt_path: &std::path::Path) {
+    if let Ok(Some(existing)) = ctx.client.find_container(wt_path).await {
+        if let Some(mgmt_sock) = cella_env::paths::daemon_socket_path()
+            && mgmt_sock.exists()
+        {
+            let req = cella_protocol::ManagementRequest::DeregisterContainer {
+                container_name: existing.name.clone(),
+            };
+            let _ = cella_daemon_client::send_management_request(&mgmt_sock, &req).await;
+        }
+        let _ = ctx.client.stop_container(&existing.id).await;
+        let _ = ctx.client.remove_container(&existing.id, false).await;
     }
 }
 

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -1932,32 +1932,62 @@ async fn handle_task_logs<W: AsyncWriteExt + Unpin>(
     writer: &mut W,
 ) -> Result<(), CellaDaemonError> {
     if follow {
-        // Send existing output snapshot first.
-        let snapshot = task_mgr
+        stream_task_logs_follow(request_id, branch, task_mgr, writer).await?;
+    } else {
+        let output = task_mgr
             .lock()
             .await
             .get_output(branch)
             .await
             .unwrap_or_default();
-        if !snapshot.is_empty() {
-            send_message(
-                writer,
-                &DaemonMessage::TaskLogsData {
-                    request_id: request_id.to_string(),
-                    data: snapshot,
-                    done: false,
-                },
-            )
-            .await?;
-        }
+        send_message(
+            writer,
+            &DaemonMessage::TaskLogsData {
+                request_id: request_id.to_string(),
+                data: output,
+                done: true,
+            },
+        )
+        .await?;
+    }
+    Ok(())
+}
 
-        // Subscribe and stream live output until task completes.
-        let mgr = task_mgr.lock().await;
-        let rx = mgr.subscribe(branch);
-        let exit_rx = mgr.subscribe_exit(branch);
-        drop(mgr);
+/// Stream task output in follow mode, handling snapshot + live output + completion.
+async fn stream_task_logs_follow<W: AsyncWriteExt + Unpin>(
+    request_id: &str,
+    branch: &str,
+    task_mgr: &crate::task_manager::SharedTaskManager,
+    writer: &mut W,
+) -> Result<(), CellaDaemonError> {
+    // Subscribe before snapshot to avoid losing output between the two.
+    let mgr = task_mgr.lock().await;
+    let rx = mgr.subscribe(branch);
+    let exit_rx = mgr.subscribe_exit(branch);
+    drop(mgr);
 
-        if let (Some(mut rx), Some(mut exit_rx)) = (rx, exit_rx) {
+    let snapshot = task_mgr
+        .lock()
+        .await
+        .get_output(branch)
+        .await
+        .unwrap_or_default();
+    if !snapshot.is_empty() {
+        send_message(
+            writer,
+            &DaemonMessage::TaskLogsData {
+                request_id: request_id.to_string(),
+                data: snapshot,
+                done: false,
+            },
+        )
+        .await?;
+    }
+
+    if let (Some(mut rx), Some(mut exit_rx)) = (rx, exit_rx) {
+        if exit_rx.borrow().is_some() {
+            drain_broadcast(request_id, &mut rx, writer).await?;
+        } else {
             loop {
                 tokio::select! {
                     msg = rx.recv() => {
@@ -1980,53 +2010,42 @@ async fn handle_task_logs<W: AsyncWriteExt + Unpin>(
                         }
                     }
                     _ = exit_rx.changed() => {
-                        // Drain remaining broadcast messages
-                        while let Ok(chunk) = rx.try_recv() {
-                            send_message(
-                                writer,
-                                &DaemonMessage::TaskLogsData {
-                                    request_id: request_id.to_string(),
-                                    data: chunk,
-                                    done: false,
-                                },
-                            )
-                            .await?;
-                        }
+                        drain_broadcast(request_id, &mut rx, writer).await?;
                         break;
                     }
                 }
             }
         }
+    }
 
+    send_message(
+        writer,
+        &DaemonMessage::TaskLogsData {
+            request_id: request_id.to_string(),
+            data: String::new(),
+            done: true,
+        },
+    )
+    .await
+}
+
+/// Drain remaining buffered broadcast messages.
+async fn drain_broadcast<W: AsyncWriteExt + Unpin>(
+    request_id: &str,
+    rx: &mut tokio::sync::broadcast::Receiver<String>,
+    writer: &mut W,
+) -> Result<(), CellaDaemonError> {
+    while let Ok(chunk) = rx.try_recv() {
         send_message(
             writer,
             &DaemonMessage::TaskLogsData {
                 request_id: request_id.to_string(),
-                data: String::new(),
-                done: true,
-            },
-        )
-        .await?;
-    } else {
-        // Snapshot mode: dump available output and signal stream complete.
-        let output = task_mgr
-            .lock()
-            .await
-            .get_output(branch)
-            .await
-            .unwrap_or_default();
-
-        send_message(
-            writer,
-            &DaemonMessage::TaskLogsData {
-                request_id: request_id.to_string(),
-                data: output,
-                done: true,
+                data: chunk,
+                done: false,
             },
         )
         .await?;
     }
-
     Ok(())
 }
 

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -2037,10 +2037,43 @@ async fn handle_task_wait<W: AsyncWriteExt + Unpin>(
     task_mgr: &crate::task_manager::SharedTaskManager,
     writer: &mut W,
 ) -> Result<(), CellaDaemonError> {
-    // We need to drop the lock while waiting, so clone what we need.
-    let exit_code = {
+    // Subscribe under the lock, then drop the lock before awaiting.
+    let rx = {
         let mgr = task_mgr.lock().await;
-        mgr.wait_for(branch).await
+        mgr.subscribe_exit(branch)
+    };
+
+    let exit_code = match rx {
+        Some(mut rx) => {
+            let current = *rx.borrow_and_update();
+            if current.is_some() {
+                current
+            } else {
+                loop {
+                    tokio::select! {
+                        result = rx.changed() => {
+                            if result.is_err() {
+                                break None;
+                            }
+                            let v = *rx.borrow_and_update();
+                            if v.is_some() {
+                                break v;
+                            }
+                        }
+                        () = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
+                            send_message(
+                                writer,
+                                &DaemonMessage::TaskWaitHeartbeat {
+                                    request_id: request_id.to_string(),
+                                },
+                            )
+                            .await?;
+                        }
+                    }
+                }
+            }
+        }
+        None => None,
     };
 
     send_message(

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -362,6 +362,8 @@ async fn handle_agent_connection_after_hello(
                     AgentMessage::BranchRequest { .. }
                         | AgentMessage::ListRequest { .. }
                         | AgentMessage::ExecRequest { .. }
+                        | AgentMessage::ExecCaptureRequest { .. }
+                        | AgentMessage::DoctorRequest { .. }
                         | AgentMessage::PruneRequest { .. }
                         | AgentMessage::DownRequest { .. }
                         | AgentMessage::UpRequest { .. }
@@ -731,6 +733,8 @@ pub(crate) async fn handle_agent_message(
         AgentMessage::BranchRequest { .. }
         | AgentMessage::ListRequest { .. }
         | AgentMessage::ExecRequest { .. }
+        | AgentMessage::ExecCaptureRequest { .. }
+        | AgentMessage::DoctorRequest { .. }
         | AgentMessage::PruneRequest { .. }
         | AgentMessage::DownRequest { .. }
         | AgentMessage::UpRequest { .. }
@@ -865,6 +869,14 @@ async fn handle_worktree_message<W: AsyncWriteExt + Unpin>(
             branch,
             command,
         } => handle_exec_request(&request_id, &branch, &command, &wt, writer).await?,
+        AgentMessage::ExecCaptureRequest {
+            request_id,
+            branch,
+            command,
+        } => handle_exec_capture(&request_id, &branch, &command, &wt, writer).await?,
+        AgentMessage::DoctorRequest { request_id } => {
+            handle_doctor_request(&request_id, &wt, writer).await?;
+        }
         AgentMessage::PruneRequest {
             request_id,
             dry_run,
@@ -1404,6 +1416,94 @@ async fn handle_exec_request<W: AsyncWriteExt + Unpin>(
         &DaemonMessage::ExecResult {
             request_id: request_id.to_string(),
             exit_code: status.code().unwrap_or(1),
+        },
+    )
+    .await?;
+
+    Ok(())
+}
+
+/// Handle `ExecCaptureRequest`: run command, capture stdout/stderr separately.
+async fn handle_exec_capture<W: AsyncWriteExt + Unpin>(
+    request_id: &str,
+    branch: &str,
+    command: &[String],
+    wt: &WorktreeHandlerCtx<'_>,
+    writer: &mut W,
+) -> Result<(), CellaDaemonError> {
+    let container_name = find_container_for_branch(branch, wt).await;
+    let Some(container_name) = container_name else {
+        send_message(
+            writer,
+            &DaemonMessage::ExecCaptureResult {
+                request_id: request_id.to_string(),
+                exit_code: 1,
+                stdout: String::new(),
+                stderr: format!("No running container found for branch '{branch}'\n"),
+            },
+        )
+        .await?;
+        return Ok(());
+    };
+
+    let mut cmd = tokio::process::Command::new(wt.cella_bin);
+    cmd.arg("exec");
+    forward_backend_flags(&mut cmd, wt).await;
+    cmd.arg("--container-name").arg(&container_name).arg("--");
+    for arg in command {
+        cmd.arg(arg);
+    }
+    let output = cmd.output().await.map_err(|e| CellaDaemonError::Protocol {
+        message: format!("failed to spawn cella exec: {e}"),
+    })?;
+
+    send_message(
+        writer,
+        &DaemonMessage::ExecCaptureResult {
+            request_id: request_id.to_string(),
+            exit_code: output.status.code().unwrap_or(1),
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        },
+    )
+    .await?;
+
+    Ok(())
+}
+
+/// Handle `DoctorRequest`: return structured daemon health data.
+async fn handle_doctor_request<W: AsyncWriteExt + Unpin>(
+    request_id: &str,
+    wt: &WorktreeHandlerCtx<'_>,
+    writer: &mut W,
+) -> Result<(), CellaDaemonError> {
+    let handles = wt.container_handles.lock().await;
+    let container_count = handles.len();
+    let containers: Vec<serde_json::Value> = handles
+        .iter()
+        .map(|(name, h)| {
+            serde_json::json!({
+                "container_name": name,
+                "agent_connected": h.agent_tx.is_some(),
+            })
+        })
+        .collect();
+    drop(handles);
+
+    let task_count = wt.task_mgr.lock().await.list_tasks().len();
+
+    let data = serde_json::json!({
+        "daemon_version": env!("CARGO_PKG_VERSION"),
+        "container_count": container_count,
+        "containers": containers,
+        "task_count": task_count,
+    });
+
+    send_message(
+        writer,
+        &DaemonMessage::DoctorResult {
+            request_id: request_id.to_string(),
+            data,
         },
     )
     .await?;

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -967,7 +967,7 @@ async fn handle_branch_request<W: AsyncWriteExt + Unpin>(
         &DaemonMessage::OperationProgress {
             request_id: request_id.to_string(),
             step: "starting".to_string(),
-            message: format!("Creating worktree branch '{branch}'..."),
+            message: format!("Ensuring worktree branch '{branch}'..."),
         },
     )
     .await?;

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -1889,7 +1889,7 @@ async fn handle_task_list<W: AsyncWriteExt + Unpin>(
     writer: &mut W,
 ) -> Result<(), CellaDaemonError> {
     let tasks = {
-        let infos = task_mgr.lock().await.list_tasks().await;
+        let infos = task_mgr.lock().await.list_tasks();
         infos
             .into_iter()
             .map(|t| cella_protocol::TaskEntry {
@@ -2008,27 +2008,20 @@ async fn handle_task_logs<W: AsyncWriteExt + Unpin>(
         )
         .await?;
     } else {
-        // Snapshot mode: dump available output and return.
+        // Snapshot mode: dump available output and signal stream complete.
         let output = task_mgr
             .lock()
             .await
             .get_output(branch)
             .await
             .unwrap_or_default();
-        let is_done = task_mgr
-            .lock()
-            .await
-            .list_tasks()
-            .await
-            .iter()
-            .any(|t| t.branch == branch && t.is_done);
 
         send_message(
             writer,
             &DaemonMessage::TaskLogsData {
                 request_id: request_id.to_string(),
                 data: output,
-                done: is_done,
+                done: true,
             },
         )
         .await?;

--- a/crates/cella-daemon/src/task_manager.rs
+++ b/crates/cella-daemon/src/task_manager.rs
@@ -5,9 +5,13 @@
 
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicI32, AtomicU32, Ordering};
 
 use tokio::sync::Mutex;
 use tracing::{info, warn};
+
+/// Sentinel value: task is still running (no valid exit code uses -1 on Unix).
+const EXIT_RUNNING: i32 = -1;
 
 const MAX_OUTPUT_BYTES: usize = 1024 * 1024; // 1 MB
 
@@ -60,8 +64,10 @@ struct TaskState {
     started_at: std::time::Instant,
     /// Captured output (stdout + stderr interleaved, ring buffer).
     output: Arc<Mutex<TaskOutput>>,
-    /// Set when the task completes.
-    exit_code: Arc<Mutex<Option<i32>>>,
+    /// `EXIT_RUNNING` (-1) while task is active; real exit code once done.
+    exit_code: Arc<AtomicI32>,
+    /// PID of the child `docker exec` process (0 = not yet known).
+    child_pid: Arc<AtomicU32>,
     /// Handle to abort the task.
     abort_handle: tokio::task::AbortHandle,
     /// Broadcast channel for live output streaming.
@@ -102,7 +108,7 @@ impl TaskManager {
         command: Vec<String>,
     ) -> Result<String, String> {
         if let Some(existing) = self.tasks.get(branch) {
-            if existing.exit_code.try_lock().map_or(true, |g| g.is_none()) {
+            if existing.exit_code.load(Ordering::Acquire) == EXIT_RUNNING {
                 return Err(format!("task already running for branch '{branch}'"));
             }
             self.tasks.remove(branch);
@@ -110,12 +116,14 @@ impl TaskManager {
 
         let task_id = branch.to_string();
         let output = Arc::new(Mutex::new(TaskOutput::new(MAX_OUTPUT_BYTES)));
-        let exit_code: Arc<Mutex<Option<i32>>> = Arc::new(Mutex::new(None));
+        let exit_code = Arc::new(AtomicI32::new(EXIT_RUNNING));
+        let child_pid = Arc::new(AtomicU32::new(0));
         let (output_tx, _) = tokio::sync::broadcast::channel(1024);
         let (exit_watch, _) = tokio::sync::watch::channel(None);
 
         let output_clone = output.clone();
         let exit_code_clone = exit_code.clone();
+        let child_pid_clone = child_pid.clone();
         let output_tx_clone = output_tx.clone();
         let exit_watch_clone = exit_watch.clone();
         let container = container_name.clone();
@@ -127,6 +135,7 @@ impl TaskManager {
                 &cmd,
                 &output_clone,
                 &exit_code_clone,
+                &child_pid_clone,
                 &output_tx_clone,
                 &exit_watch_clone,
             )
@@ -140,6 +149,7 @@ impl TaskManager {
             started_at: std::time::Instant::now(),
             output,
             exit_code,
+            child_pid,
             abort_handle: handle.abort_handle(),
             output_tx,
             exit_watch,
@@ -151,18 +161,19 @@ impl TaskManager {
     }
 
     /// List all tasks with their current info.
-    pub async fn list_tasks(&self) -> Vec<TaskInfo> {
+    pub fn list_tasks(&self) -> Vec<TaskInfo> {
         let mut infos = Vec::with_capacity(self.tasks.len());
         for (id, state) in &self.tasks {
-            let exit = *state.exit_code.lock().await;
+            let code = state.exit_code.load(Ordering::Acquire);
+            let done = code != EXIT_RUNNING;
             infos.push(TaskInfo {
                 task_id: id.clone(),
                 branch: state.branch.clone(),
                 container_name: state.container_name.clone(),
                 command: state.command.clone(),
                 elapsed_secs: state.started_at.elapsed().as_secs(),
-                is_done: exit.is_some(),
-                exit_code: exit,
+                is_done: done,
+                exit_code: if done { Some(code) } else { None },
             });
         }
         infos
@@ -182,12 +193,10 @@ impl TaskManager {
     }
 
     /// Check if a task is done.
-    pub async fn is_done(&self, branch: &str) -> bool {
-        if let Some(state) = self.tasks.get(branch) {
-            state.exit_code.lock().await.is_some()
-        } else {
-            true // no task = done
-        }
+    pub fn is_done(&self, branch: &str) -> bool {
+        self.tasks
+            .get(branch)
+            .is_none_or(|state| state.exit_code.load(Ordering::Acquire) != EXIT_RUNNING)
     }
 
     /// Get captured output for a task.
@@ -218,30 +227,43 @@ impl TaskManager {
         }
     }
 
-    /// Stop a running task.
+    /// Stop a running task. Only sets exit code 130 if still running.
     pub async fn stop_task(&mut self, branch: &str) -> bool {
-        if let Some(state) = self.tasks.get(branch) {
-            state.abort_handle.abort();
-            *state.exit_code.lock().await = Some(130);
-            let _ = state.exit_watch.send(Some(130));
-            info!("Stopped task '{branch}'");
-            true
-        } else {
-            false
+        let Some(state) = self.tasks.get(branch) else {
+            return false;
+        };
+
+        // Only stop if still running — never overwrite a completed exit code.
+        if state
+            .exit_code
+            .compare_exchange(EXIT_RUNNING, 130, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return false;
         }
+
+        // Kill the child process with SIGTERM.
+        let pid = state.child_pid.load(Ordering::Acquire);
+        if pid != 0 {
+            let _ = nix::sys::signal::kill(
+                nix::unistd::Pid::from_raw(pid.cast_signed()),
+                nix::sys::signal::Signal::SIGTERM,
+            );
+        }
+
+        // Give the process 2s to exit gracefully, then abort the Tokio task.
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        state.abort_handle.abort();
+
+        let _ = state.exit_watch.send(Some(130));
+        info!("Stopped task '{branch}'");
+        true
     }
 
     /// Remove completed tasks.
-    pub async fn cleanup_done(&mut self) {
-        let mut to_remove = Vec::new();
-        for (id, state) in &self.tasks {
-            if state.exit_code.lock().await.is_some() {
-                to_remove.push(id.clone());
-            }
-        }
-        for id in to_remove {
-            self.tasks.remove(&id);
-        }
+    pub fn cleanup_done(&mut self) {
+        self.tasks
+            .retain(|_, state| state.exit_code.load(Ordering::Acquire) == EXIT_RUNNING);
     }
 }
 
@@ -250,7 +272,8 @@ async fn run_task_process(
     container_name: &str,
     command: &[String],
     output: &Arc<Mutex<TaskOutput>>,
-    exit_code: &Arc<Mutex<Option<i32>>>,
+    exit_code: &Arc<AtomicI32>,
+    child_pid: &Arc<AtomicU32>,
     output_tx: &tokio::sync::broadcast::Sender<String>,
     exit_watch: &tokio::sync::watch::Sender<Option<i32>>,
 ) {
@@ -268,7 +291,7 @@ async fn run_task_process(
         Ok(c) => c,
         Err(e) => {
             warn!("Failed to spawn task process: {e}");
-            *exit_code.lock().await = Some(1);
+            exit_code.store(1, Ordering::Release);
             let _ = exit_watch.send(Some(1));
             let error_line = format!("Error: failed to spawn: {e}\n");
             output.lock().await.push(&error_line);
@@ -276,6 +299,8 @@ async fn run_task_process(
             return;
         }
     };
+
+    child_pid.store(child.id().unwrap_or(0), Ordering::Release);
 
     // Read stdout and stderr concurrently
     let child_stdout = child.stdout.take();
@@ -312,7 +337,8 @@ async fn run_task_process(
 
     let status = child.wait().await;
     let code = status.map_or(1, |s| s.code().unwrap_or(1));
-    *exit_code.lock().await = Some(code);
+    // Only set if still running — stop_task may have already set 130.
+    let _ = exit_code.compare_exchange(EXIT_RUNNING, code, Ordering::AcqRel, Ordering::Acquire);
     let _ = exit_watch.send(Some(code));
     info!("Task in '{container_name}' exited with code {code}");
 }
@@ -363,7 +389,7 @@ mod tests {
             .unwrap();
         mgr.start_task("b2", "ctr".into(), vec!["b".into()])
             .unwrap();
-        let list = mgr.list_tasks().await;
+        let list = mgr.list_tasks();
         assert_eq!(list.len(), 2);
     }
 
@@ -372,7 +398,7 @@ mod tests {
     #[tokio::test]
     async fn list_tasks_empty() {
         let mgr = manager();
-        assert!(mgr.list_tasks().await.is_empty());
+        assert!(mgr.list_tasks().is_empty());
     }
 
     #[tokio::test]
@@ -384,7 +410,7 @@ mod tests {
             vec!["cargo".into(), "test".into()],
         )
         .unwrap();
-        let tasks = mgr.list_tasks().await;
+        let tasks = mgr.list_tasks();
         assert_eq!(tasks.len(), 1);
 
         let t = &tasks[0];
@@ -417,7 +443,7 @@ mod tests {
     async fn is_done_returns_true_for_unknown_branch() {
         let mgr = manager();
         // "no task = done" per the implementation.
-        assert!(mgr.is_done("nonexistent").await);
+        assert!(mgr.is_done("nonexistent"));
     }
 
     #[tokio::test]
@@ -430,7 +456,7 @@ mod tests {
         // We check immediately, so it should still be false.
         // NOTE: there is a race, but it is extremely unlikely the spawned task
         // resolves before this line executes.
-        assert!(!mgr.is_done("br").await);
+        assert!(!mgr.is_done("br"));
     }
 
     // -- get_output --
@@ -459,51 +485,48 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stop_task_returns_true_and_sets_exit_130() {
+    async fn stop_task_on_already_completed_returns_false() {
         let mut mgr = manager();
         mgr.start_task("br", "c".into(), vec!["x".into()]).unwrap();
-        assert!(mgr.stop_task("br").await);
-
-        // After stop, the task should be marked as done with exit code 130.
-        assert!(mgr.is_done("br").await);
-        let tasks = mgr.list_tasks().await;
+        // In CI docker is unavailable, so the task exits almost immediately.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        // Task already completed — stop must not overwrite exit code.
+        assert!(!mgr.stop_task("br").await);
+        assert!(mgr.is_done("br"));
+        let tasks = mgr.list_tasks();
         let t = tasks.iter().find(|t| t.task_id == "br").unwrap();
-        assert_eq!(t.exit_code, Some(130));
+        assert_eq!(t.exit_code, Some(1));
     }
 
     // -- cleanup_done --
 
     #[tokio::test]
-    async fn cleanup_done_removes_stopped_tasks() {
+    async fn cleanup_done_removes_completed_tasks() {
         let mut mgr = manager();
         mgr.start_task("a", "c".into(), vec!["x".into()]).unwrap();
         mgr.start_task("b", "c".into(), vec!["x".into()]).unwrap();
-
-        // Stop only "a"
-        mgr.stop_task("a").await;
-        mgr.cleanup_done().await;
-
-        let tasks = mgr.list_tasks().await;
-        // "a" removed, "b" still present.
-        assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].task_id, "b");
+        // Let both tasks finish (docker unavailable → exit 1).
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        mgr.cleanup_done();
+        assert!(mgr.list_tasks().is_empty());
     }
 
     #[tokio::test]
     async fn cleanup_done_on_empty_manager_is_noop() {
         let mut mgr = manager();
-        mgr.cleanup_done().await;
-        assert!(mgr.list_tasks().await.is_empty());
+        mgr.cleanup_done();
+        assert!(mgr.list_tasks().is_empty());
     }
 
     // -- start_task after completion --
 
     #[tokio::test]
-    async fn start_task_after_stop_succeeds() {
+    async fn start_task_after_completion_succeeds() {
         let mut mgr = manager();
         mgr.start_task("br", "c".into(), vec!["x".into()]).unwrap();
-        mgr.stop_task("br").await;
-        // Task is done (exit_code=130), re-run should succeed
+        // Let task finish (docker unavailable → exit 1).
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        assert!(mgr.is_done("br"));
         let id = mgr
             .start_task("br", "c".into(), vec!["echo".into()])
             .unwrap();

--- a/crates/cella-daemon/src/task_manager.rs
+++ b/crates/cella-daemon/src/task_manager.rs
@@ -205,28 +205,6 @@ impl TaskManager {
         Some(state.output.lock().await.contents())
     }
 
-    /// Wait for a task to complete, returning its exit code.
-    ///
-    /// Uses a watch channel so it doesn't hold any lock while waiting.
-    pub async fn wait_for(&self, branch: &str) -> Option<i32> {
-        let mut rx = self.tasks.get(branch)?.exit_watch.subscribe();
-        // Check if already done
-        let current = *rx.borrow_and_update();
-        if current.is_some() {
-            return current;
-        }
-        // Wait for the value to change
-        loop {
-            if rx.changed().await.is_err() {
-                return None;
-            }
-            let value = *rx.borrow_and_update();
-            if value.is_some() {
-                return value;
-            }
-        }
-    }
-
     /// Stop a running task. Only sets exit code 130 if still running.
     pub async fn stop_task(&mut self, branch: &str) -> bool {
         let Some(state) = self.tasks.get(branch) else {
@@ -543,15 +521,6 @@ mod tests {
             .start_task("br", "c".into(), vec!["echo".into()])
             .unwrap_err();
         assert!(err.contains("already running"));
-    }
-
-    // -- wait_for --
-
-    #[tokio::test]
-    async fn wait_for_returns_none_for_unknown() {
-        let mgr = manager();
-        // Unknown branch returns None immediately (no state to poll).
-        assert!(mgr.wait_for("ghost").await.is_none());
     }
 
     // -- TaskOutput ring buffer --

--- a/crates/cella-protocol/src/lib.rs
+++ b/crates/cella-protocol/src/lib.rs
@@ -180,6 +180,14 @@ pub enum AgentMessage {
     TaskWaitRequest { request_id: String, branch: String },
     /// Stop a running background task.
     TaskStopRequest { request_id: String, branch: String },
+    /// Execute a command and capture stdout/stderr separately (JSON mode).
+    ExecCaptureRequest {
+        request_id: String,
+        branch: String,
+        command: Vec<String>,
+    },
+    /// Request structured health/status data.
+    DoctorRequest { request_id: String },
     /// Switch to another branch's container (run default shell).
     SwitchRequest { request_id: String, branch: String },
 }
@@ -448,10 +456,22 @@ pub enum DaemonMessage {
     TaskWaitResult { request_id: String, exit_code: i32 },
     /// Keep-alive during `task wait` so the agent knows the connection is alive.
     TaskWaitHeartbeat { request_id: String },
+    /// Result of a captured exec request (stdout/stderr separated).
+    ExecCaptureResult {
+        request_id: String,
+        exit_code: i32,
+        stdout: String,
+        stderr: String,
+    },
     /// Background task stopped.
     TaskStopResult { request_id: String },
     /// Stream channel is ready for TTY forwarding.
     StreamReady { request_id: String, port: u16 },
+    /// Structured health/status data.
+    DoctorResult {
+        request_id: String,
+        data: serde_json::Value,
+    },
     /// Result of a switch (shell exec in target container).
     SwitchResult { request_id: String, exit_code: i32 },
 }

--- a/crates/cella-protocol/src/lib.rs
+++ b/crates/cella-protocol/src/lib.rs
@@ -446,6 +446,8 @@ pub enum DaemonMessage {
     },
     /// Background task completed.
     TaskWaitResult { request_id: String, exit_code: i32 },
+    /// Keep-alive during `task wait` so the agent knows the connection is alive.
+    TaskWaitHeartbeat { request_id: String },
     /// Background task stopped.
     TaskStopResult { request_id: String },
     /// Stream channel is ready for TTY forwarding.


### PR DESCRIPTION
## Summary

- Fix task system deadlock where `task wait` held the mutex across an await, blocking all task operations system-wide
- Fix `task logs` snapshot mode sending wrong done signal (agent hangs forever) and follow mode race conditions
- `stop_task` now kills the child process with SIGTERM and never overwrites a completed task's exit code
- Add `--json` output to `list`, `exec`, and `doctor` commands for agent consumption
- Add per-command `--help`, branch name validation, and UX polish

## Details

**Critical bug fixes (Phase 1):**
- `exit_code` refactored from `Arc<Mutex<Option<i32>>>` to `Arc<AtomicI32>` — eliminates nested mutex deadlock in `list_tasks()`
- `handle_task_wait` now subscribes to exit watch, drops lock, then awaits (was holding lock during await)
- Added `TaskWaitHeartbeat` protocol message every 30s so long-running tasks don't timeout
- `task logs` follow mode subscribes before snapshot to prevent lost output; checks completion before entering select loop
- `stop_task` sends SIGTERM to child PID, waits 2s, then aborts — uses compare_exchange to never corrupt completed state

**JSON output (Phase 2):**
- `cella list --json` — WorktreeEntry array
- `cella exec <branch> --json -- cmd` — new ExecCaptureRequest/Result protocol, returns `{exit_code, stdout, stderr}`
- `cella doctor --json` — new DoctorRequest/Result protocol with daemon health data

**UX (Phase 3):**
- Per-command `--help` for all commands
- Branch name validation (empty, whitespace)
- Progress says "Ensuring" not "Creating" (idempotent-neutral)
- Warning when `--label` passed on existing branch (immutable)

**Deferred:** Task 1.7 (orphan tracking on disconnect) — cross-cutting change to handshake protocol and connection lifecycle, better as follow-up.

**Breaking:** Old agents that don't know `TaskWaitHeartbeat` will fail to deserialize it. Acceptable per project conventions.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` all passing
- [x] Manual E2E: `cella task run/list/logs/wait/stop` inside running container
- [x] Manual E2E: `cella list --json`, `cella exec --json`, `cella doctor --json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)