### PR TITLE
fix: agent protocol polish & exec stderr separation

### DIFF
--- a/crates/cella-agent/src/cli.rs
+++ b/crates/cella-agent/src/cli.rs
@@ -67,7 +67,9 @@ pub enum CliCommand {
         command: Vec<String>,
         base: Option<String>,
     },
-    TaskList,
+    TaskList {
+        json: bool,
+    },
     TaskLogs {
         branch: String,
         follow: bool,
@@ -85,6 +87,7 @@ pub enum CliCommand {
         json: bool,
     },
     Help,
+    CommandHelp,
     Unsupported {
         command: String,
     },
@@ -98,7 +101,7 @@ pub fn parse_cli_args(args: &[String]) -> CliCommand {
         *c != "--help" && *c != "-h" && args[2..].iter().any(|a| a == "--help" || a == "-h")
     }) {
         print_command_help(cmd);
-        return CliCommand::Help;
+        return CliCommand::CommandHelp;
     }
 
     match subcmd {
@@ -352,7 +355,10 @@ fn parse_task_subcommand(args: &[String]) -> CliCommand {
                 base,
             }
         }
-        Some("list" | "ls") => CliCommand::TaskList,
+        Some("list" | "ls") => {
+            let json = args[3..].iter().any(|a| a == "--json");
+            CliCommand::TaskList { json }
+        }
         Some("logs") => {
             // Parse: cella task logs [-f|--follow] <branch>
             let follow = args[3..].iter().any(|a| a == "-f" || a == "--follow");
@@ -387,6 +393,7 @@ pub async fn run(command: CliCommand) -> Result<(), Box<dyn std::error::Error + 
             print_help();
             Ok(())
         }
+        CliCommand::CommandHelp => Ok(()),
         CliCommand::Doctor { json } => {
             if json {
                 run_doctor_json().await
@@ -435,7 +442,7 @@ pub async fn run(command: CliCommand) -> Result<(), Box<dyn std::error::Error + 
             command,
             base,
         } => run_task_run(&branch, &command, base.as_deref()).await,
-        CliCommand::TaskList => run_task_list().await,
+        CliCommand::TaskList { json } => run_task_list(json).await,
         CliCommand::TaskLogs { branch, follow } => run_task_logs(&branch, follow).await,
         CliCommand::TaskWait { branch } => run_task_wait(&branch).await,
         CliCommand::TaskStop { branch } => run_task_stop(&branch).await,
@@ -541,7 +548,7 @@ Usage: cella task <subcommand>
 
 Subcommands:
   run <branch> [--base ref] -- <cmd...>   Run a background task
-  list                                    List active tasks
+  list [--json]                           List active tasks
   logs [-f|--follow] <branch>             Show task output
   wait <branch>                           Wait for task completion
   stop <branch>                           Stop a running task"
@@ -1195,7 +1202,7 @@ async fn run_task_run(
     }
 }
 
-async fn run_task_list() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+async fn run_task_list(json: bool) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut client = connect_daemon().await?;
 
     let id = request_id();
@@ -1207,7 +1214,9 @@ async fn run_task_list() -> Result<(), Box<dyn std::error::Error + Send + Sync>>
     loop {
         let resp = recv_timeout(&mut client, TIMEOUT_FAST).await?;
         if let DaemonMessage::TaskListResult { tasks, .. } = resp {
-            if tasks.is_empty() {
+            if json {
+                println!("{}", serde_json::to_string_pretty(&tasks)?);
+            } else if tasks.is_empty() {
                 eprintln!("No active tasks.");
             } else {
                 const HEADER: &str = "BRANCH               STATUS     TIME     COMMAND";
@@ -1716,7 +1725,7 @@ mod tests {
             .map(ToString::to_string)
             .collect();
         let cmd = parse_cli_args(&args);
-        assert!(matches!(cmd, CliCommand::TaskList));
+        assert!(matches!(cmd, CliCommand::TaskList { json: false }));
     }
 
     #[test]
@@ -1726,7 +1735,17 @@ mod tests {
             .map(ToString::to_string)
             .collect();
         let cmd = parse_cli_args(&args);
-        assert!(matches!(cmd, CliCommand::TaskList));
+        assert!(matches!(cmd, CliCommand::TaskList { json: false }));
+    }
+
+    #[test]
+    fn parse_task_list_json() {
+        let args: Vec<String> = ["cella", "task", "list", "--json"]
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+        let cmd = parse_cli_args(&args);
+        assert!(matches!(cmd, CliCommand::TaskList { json: true }));
     }
 
     #[test]
@@ -1939,6 +1958,8 @@ mod tests {
                 is_main: true,
                 container_name: Some("project-main".to_string()),
                 container_state: Some("running".to_string()),
+                container_id: None,
+                labels: None,
             },
             cella_protocol::WorktreeEntry {
                 branch: Some("feat/auth".to_string()),
@@ -1946,6 +1967,8 @@ mod tests {
                 is_main: false,
                 container_name: None,
                 container_state: None,
+                container_id: None,
+                labels: None,
             },
             cella_protocol::WorktreeEntry {
                 branch: None,
@@ -1953,6 +1976,8 @@ mod tests {
                 is_main: false,
                 container_name: Some("detached-ctr".to_string()),
                 container_state: Some("exited".to_string()),
+                container_id: None,
+                labels: None,
             },
         ];
         print_worktree_table(&worktrees);
@@ -2238,7 +2263,7 @@ mod tests {
             .map(ToString::to_string)
             .collect();
         let cmd = parse_cli_args(&args);
-        assert!(matches!(cmd, CliCommand::Help));
+        assert!(matches!(cmd, CliCommand::CommandHelp));
     }
 
     #[test]
@@ -2248,7 +2273,7 @@ mod tests {
             .map(ToString::to_string)
             .collect();
         let cmd = parse_cli_args(&args);
-        assert!(matches!(cmd, CliCommand::Help));
+        assert!(matches!(cmd, CliCommand::CommandHelp));
     }
 
     // --- branch name validation ---

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -1194,8 +1194,26 @@ async fn handle_list_request<W: AsyncWriteExt + Unpin>(
         {
             wt.container_name = Some(c.name.clone());
             wt.container_state = Some(c.state.clone());
+            wt.container_id = Some(c.container_id.clone());
             if let Some(ref label) = c.branch_label {
                 wt.branch = Some(label.clone());
+            }
+        }
+    }
+
+    // Batch-inspect matched containers for labels (uses `docker inspect`
+    // with proper JSON output instead of the ambiguous comma-separated format).
+    let matched_ids: Vec<&str> = worktrees
+        .iter()
+        .filter_map(|wt| wt.container_id.as_deref())
+        .collect();
+    if !matched_ids.is_empty() {
+        let label_map = batch_inspect_labels(&matched_ids).await;
+        for wt in &mut worktrees {
+            if let Some(ref id) = wt.container_id
+                && let Some(labels) = label_map.get(id.as_str())
+            {
+                wt.labels = Some(labels.clone());
             }
         }
     }
@@ -1251,6 +1269,8 @@ fn parse_worktree_porcelain(output: &str) -> Vec<cella_protocol::WorktreeEntry> 
                     is_main: is_first && !is_bare,
                     container_name: None,
                     container_state: None,
+                    container_id: None,
+                    labels: None,
                 });
                 is_first = false;
                 is_bare = false;
@@ -1274,6 +1294,8 @@ fn parse_worktree_porcelain(output: &str) -> Vec<cella_protocol::WorktreeEntry> 
             is_main: is_first && !is_bare,
             container_name: None,
             container_state: None,
+            container_id: None,
+            labels: None,
         });
     }
 
@@ -1286,6 +1308,7 @@ struct CellaContainer {
     state: String,
     workspace_path: Option<String>,
     branch_label: Option<String>,
+    container_id: String,
 }
 
 /// List all cella-managed containers with their workspace paths.
@@ -1295,10 +1318,11 @@ async fn list_cella_containers() -> Vec<CellaContainer> {
         .args([
             "ps",
             "-a",
+            "--no-trunc",
             "--filter",
             "label=dev.cella.tool=cella",
             "--format",
-            "{{.Names}}\t{{.State}}\t{{.Label \"dev.cella.workspace_path\"}}\t{{.Label \"dev.cella.branch\"}}",
+            "{{.Names}}\t{{.State}}\t{{.Label \"dev.cella.workspace_path\"}}\t{{.Label \"dev.cella.branch\"}}\t{{.ID}}",
         ])
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())
@@ -1317,7 +1341,7 @@ async fn list_cella_containers() -> Vec<CellaContainer> {
         .lines()
         .filter(|line| !line.is_empty())
         .filter_map(|line| {
-            let mut parts = line.splitn(4, '\t');
+            let mut parts = line.splitn(5, '\t');
             let name = parts.next()?.to_string();
             let state = parts.next()?.to_string();
             let ws = parts
@@ -1328,12 +1352,47 @@ async fn list_cella_containers() -> Vec<CellaContainer> {
                 .next()
                 .map(ToString::to_string)
                 .filter(|s| !s.is_empty());
+            let container_id = parts.next().unwrap_or_default().to_string();
             Some(CellaContainer {
                 name,
                 state,
                 workspace_path: ws,
                 branch_label: branch,
+                container_id,
             })
+        })
+        .collect()
+}
+
+/// Batch-inspect containers by ID to get their labels as proper JSON maps.
+async fn batch_inspect_labels(ids: &[&str]) -> HashMap<String, HashMap<String, String>> {
+    if ids.is_empty() {
+        return HashMap::new();
+    }
+
+    let mut cmd = tokio::process::Command::new("docker");
+    cmd.args(["inspect", "--format", "{{.Id}}\t{{json .Config.Labels}}"]);
+    for id in ids {
+        cmd.arg(id);
+    }
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::null());
+
+    let Ok(output) = cmd.output().await else {
+        return HashMap::new();
+    };
+    if !output.status.success() {
+        return HashMap::new();
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout
+        .lines()
+        .filter(|line| !line.is_empty())
+        .filter_map(|line| {
+            let (id, json) = line.split_once('\t')?;
+            let labels: HashMap<String, String> = serde_json::from_str(json).ok()?;
+            Some((id.to_string(), labels))
         })
         .collect()
 }

--- a/crates/cella-docker/src/exec.rs
+++ b/crates/cella-docker/src/exec.rs
@@ -334,17 +334,20 @@ fn spawn_io_tasks(
 
     let output_handle = tokio::spawn(async move {
         let mut stdout = tokio::io::stdout();
+        let mut stderr = tokio::io::stderr();
         while let Some(chunk) = output.next().await {
             match chunk {
-                Ok(
-                    LogOutput::StdOut { message }
-                    | LogOutput::StdErr { message }
-                    | LogOutput::Console { message },
-                ) => {
+                Ok(LogOutput::StdOut { message } | LogOutput::Console { message }) => {
                     if stdout.write_all(&message).await.is_err() {
                         break;
                     }
                     let _ = stdout.flush().await;
+                }
+                Ok(LogOutput::StdErr { message }) => {
+                    if stderr.write_all(&message).await.is_err() {
+                        break;
+                    }
+                    let _ = stderr.flush().await;
                 }
                 Err(_) | Ok(_) => break,
             }

--- a/crates/cella-protocol/src/lib.rs
+++ b/crates/cella-protocol/src/lib.rs
@@ -686,6 +686,12 @@ pub struct WorktreeEntry {
     pub container_name: Option<String>,
     /// Container state (running, exited, etc.), if a container exists.
     pub container_state: Option<String>,
+    /// Docker container ID.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub container_id: Option<String>,
+    /// Container labels (all labels, including cella-managed ones).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub labels: Option<std::collections::HashMap<String, String>>,
 }
 
 #[cfg(test)]
@@ -1393,6 +1399,8 @@ mod tests {
                     is_main: true,
                     container_name: Some("cella-proj-main".to_string()),
                     container_state: Some("running".to_string()),
+                    container_id: None,
+                    labels: None,
                 },
                 WorktreeEntry {
                     branch: Some("feat/auth".to_string()),
@@ -1400,6 +1408,8 @@ mod tests {
                     is_main: false,
                     container_name: None,
                     container_state: None,
+                    container_id: None,
+                    labels: None,
                 },
             ],
         };
@@ -1408,6 +1418,55 @@ mod tests {
         assert!(
             matches!(decoded, DaemonMessage::ListResult { worktrees, .. } if worktrees.len() == 2)
         );
+    }
+
+    #[test]
+    fn worktree_entry_backward_compat_missing_new_fields() {
+        let json = r#"{"branch":"main","worktree_path":"/repo","is_main":true,"container_name":"ctr","container_state":"running"}"#;
+        let entry: WorktreeEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.branch.as_deref(), Some("main"));
+        assert!(entry.container_id.is_none());
+        assert!(entry.labels.is_none());
+    }
+
+    #[test]
+    fn worktree_entry_new_fields_roundtrip() {
+        let mut labels = std::collections::HashMap::new();
+        labels.insert("team".to_string(), "backend".to_string());
+        let entry = WorktreeEntry {
+            branch: Some("feat/x".to_string()),
+            worktree_path: "/repo".to_string(),
+            is_main: false,
+            container_name: Some("ctr".to_string()),
+            container_state: Some("running".to_string()),
+            container_id: Some("abc123def456".to_string()),
+            labels: Some(labels),
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(json.contains("\"container_id\":\"abc123def456\""));
+        assert!(json.contains("\"team\":\"backend\""));
+        let decoded: WorktreeEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.container_id.as_deref(), Some("abc123def456"));
+        assert_eq!(
+            decoded.labels.as_ref().unwrap().get("team").unwrap(),
+            "backend"
+        );
+    }
+
+    #[test]
+    fn worktree_entry_none_fields_omitted_in_json() {
+        let entry = WorktreeEntry {
+            branch: None,
+            worktree_path: "/repo".to_string(),
+            is_main: false,
+            container_name: None,
+            container_state: None,
+            container_id: None,
+            labels: None,
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(!json.contains("container_id"));
+        assert!(!json.contains("labels"));
     }
 
     // -- Phase 2 protocol tests --------------------------------------------


### PR DESCRIPTION
## Summary

- Fix `exec --json` always returning empty `stderr` — `spawn_io_tasks` was merging stderr into stdout
- Add `--json` flag to `cella task list` for structured output
- Fix per-command `--help` printing both command help and global help
- Enrich `list --json` with `container_id` and `labels` fields on `WorktreeEntry`

## Details

**stderr fix**: `spawn_io_tasks` pattern-matched `StdOut | StdErr | Console` together, routing everything to stdout. Now routes `StdErr` to `tokio::io::stderr()` separately.

**task list --json**: Serializes `TaskEntry` directly via serde. Added `--json` to help text and parser tests.

**double help**: New `CommandHelp` variant returned from per-command help parsing, handled as a no-op in `run()` so it doesn't fall through to `print_help()`.

**list enrichment**: `WorktreeEntry` gains `container_id: Option<String>` and `labels: Option<HashMap<String, String>>` with `serde(default)` for backward compat. Labels fetched via `docker inspect --format '{{json .Config.Labels}}'` (batch call) — avoids the ambiguous comma-separated format from `docker ps`.

## Test plan

- [x] `cargo fmt/clippy/test` all pass
- [x] `cella exec <branch> --json -- sh -c "echo out; echo err >&2"` returns populated `stderr` field
- [x] `cella task list --json` outputs JSON array
- [x] `cella branch --help` shows only branch help, no global help
- [x] `cella list --json` includes `container_id` and `labels` for containers with worktrees
- [x] `WorktreeEntry` backward compat: old JSON without new fields deserializes cleanly