### PR TITLE
fix: workspace overhaul — bug fixes, skills, and agent integration

### DIFF
--- a/.claude/commands/cella-agent-integration.md
+++ b/.claude/commands/cella-agent-integration.md
@@ -1,0 +1,105 @@
+# Cella Agent Integration
+
+Use this skill when running AI coding agents (Claude Code, Codex, or others) inside cella containers. Covers how cella's container isolation complements native agent features like teams, subagents, and worktrees.
+
+## Positioning
+
+Cella is the **container isolation layer under native agent features**. Native tools handle orchestration (spawning agents, coordinating work, merging results). Cella provides:
+- Isolated environments (packages, dependencies, system state)
+- Port de-confliction across parallel agents
+- Docker sandboxing for untrusted agent operations
+- Unified lifecycle management (start, stop, prune)
+
+## Claude Code inside cella containers
+
+### Subagents (Agent tool)
+
+Claude Code subagents with `isolation: "worktree"` create worktrees **inside** the container's filesystem. These are separate from cella's host-level worktrees:
+
+- Cella worktrees: host-side git worktrees, each with its own container
+- Claude worktrees: in-container directory copies for parallel file editing
+
+Both can coexist. Use cella worktrees for full environment isolation; use Claude worktrees for lightweight file-edit parallelism within a single environment.
+
+### Agent Teams (experimental)
+
+Claude Code agent teams (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`) work inside cella containers. The team lead spawns teammates as independent instances communicating via shared files.
+
+Requirements for teams inside cella:
+- The shared git repo is accessible (mounted via cella's bind mount)
+- File-based coordination (markdown task lists, inbox messaging) works because the workspace is shared
+- Each teammate runs in the same container — they share packages/deps
+
+To run teams across multiple containers, dispatch each agent via `cella task run` in separate worktree containers instead.
+
+### Native worktrees (`claude --worktree`)
+
+`claude --worktree <name>` creates directories under `.claude/worktrees/` inside the container. This is independent of cella's host worktree system and works normally within containers.
+
+## Codex inside cella containers
+
+### `codex exec` for non-interactive dispatch
+
+```sh
+cella task run <branch> --timeout 300 -- codex exec "your prompt here"
+```
+
+Notes:
+- Use `--skip-git-repo-check` if Codex doesn't recognize the worktree directory as a git repo
+- Custom agents: place TOML files in `.codex/agents/` within the workspace
+- Per-workspace instructions: use `AGENTS.md` at the repo root
+
+### Codex subagents
+
+Codex's native subagent system (capped at 6 threads) works inside cella containers. Switch between them with `/agent` in the Codex CLI.
+
+### Codex as MCP server
+
+When using Codex orchestrated via Agents SDK, the two MCP tools (`codex()` and `codex-reply()`) work inside containers as long as the MCP server process can reach the Codex binary.
+
+## Bridge pattern
+
+```
+┌─────────────────────────────────────────────────┐
+│  Native orchestration layer                      │
+│  (Claude Code teams/subagents, Codex threads)    │
+└───────────────────────┬─────────────────────────┘
+                        │ spawns/coordinates
+┌───────────────────────▼─────────────────────────┐
+│  Cella container isolation layer                 │
+│  (per-branch containers, port allocation,        │
+│   env isolation, lifecycle management)           │
+└─────────────────────────────────────────────────┘
+```
+
+- **In-session parallelism**: Use native subagents (Agent tool, Codex threads) within a single container
+- **Cross-environment parallelism**: Use `cella task run` to dispatch agents in separate containers
+- **Hybrid**: Native orchestration decides what to do; cella provides where to do it
+
+## Best practices
+
+- **3-4 parallel containers** is the sweet spot for most repos and machines
+- **Always use `--timeout`** on `cella task run` dispatches to prevent runaway agents
+- **Use `isolation: "worktree"` on every code-writing Claude subagent** — prevents file conflicts between parallel agents in the same container
+- **File-based coordination works across containers** because the git repo is shared via bind mount
+- **Don't reinvent messaging** — use native team/subagent communication; cella handles isolation only
+- **Monitor with `cella task list --json`** for programmatic status checking
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Codex doesn't recognize git repo in worktree | Add `--skip-git-repo-check` flag |
+| Claude Code can't find tools/packages | Packages are per-container; install in each branch's container or use a shared base image |
+| Agent can't reach API endpoints | Check container network config; cella containers share the host network by default |
+| Port conflict between agents | Cella auto-allocates ports per container; check `cella list` for port mappings |
+| Agent teams can't communicate | Ensure all teammates run in the same container (not across containers) |
+| Task shows "timed_out" | Increase `--timeout` or break the task into smaller pieces |
+
+## When to use
+
+- Running Claude Code or Codex inside cella dev containers
+- Setting up parallel AI agent workflows across multiple branches
+- Debugging why an agent feature doesn't work inside a container
+- Choosing between native parallelism (subagents) vs cella parallelism (separate containers)
+- Configuring agent coordination patterns within the cella ecosystem

--- a/.claude/commands/cella-parallel-dev.md
+++ b/.claude/commands/cella-parallel-dev.md
@@ -23,40 +23,55 @@ Break the task into independent units of work. Each unit should:
 ### 2. Dispatch with `cella task run`
 
 ```sh
-cella task run <branch> [--base <ref>] -- <command...>
+cella task run <branch> [--base <ref>] [--timeout <secs>] -- <command...>
 ```
 
-Creates the branch + container (if needed) and runs the command in the background. The command typically invokes an AI agent (Claude Code, Codex, etc.).
+Creates the branch + container (if needed) and runs the command in the background. The `--timeout` flag kills the task after the specified duration (status becomes `timed_out` instead of `failed`).
 
 Examples:
 ```sh
-# Dispatch three parallel tasks
-cella task run feat/auth -- claude -p "Implement OAuth2 authentication in src/auth/"
-cella task run feat/api -- claude -p "Build the REST API endpoints in src/api/"
+# Dispatch Claude Code
+cella task run feat/auth --timeout 300 -- claude -p "Implement OAuth2 authentication in src/auth/"
+
+# Dispatch Codex
+cella task run feat/api --timeout 300 -- codex exec "Build the REST API endpoints in src/api/"
+
+# Dispatch any CLI agent
 cella task run feat/tests -- claude -p "Write integration tests for the auth module"
 ```
+
+Task environment parity: tasks get the same user, PATH, working directory, and environment variables (AI keys, SSH agent, terminal vars) as interactive `cella exec`.
 
 ### 3. Monitor with `cella task list`
 
 ```sh
-cella task list
+cella task list [--json]
 ```
 
 Shows all active tasks with status, elapsed time, and command:
 ```
 BRANCH               STATUS     TIME     COMMAND
 feat/auth            running    2m       claude -p "Implement OAuth2..."
-feat/api             running    2m       claude -p "Build REST API..."
+feat/api             timed_out  5m       codex exec "Build REST API..."
 feat/tests           done       5m       claude -p "Write integration..."
 ```
+
+Statuses: `running`, `done`, `failed`, `timed_out`
+
+With `--json`, outputs structured data for programmatic monitoring:
+```sh
+cella task list --json | jq '.[] | select(.status == "running")'
+```
+
+Elapsed time freezes at completion — a task that ran for 45s will always show 45s, not the time since it started.
 
 ### 4. Check output with `cella task logs`
 
 ```sh
-cella task logs <branch>
+cella task logs <branch> [--follow]
 ```
 
-Shows captured stdout/stderr from the task.
+Shows captured stdout/stderr from the task. With `--follow`, streams live output.
 
 ### 5. Wait for completion
 
@@ -72,32 +87,48 @@ Blocks until the task finishes. Returns the exit code.
 cella task stop <branch>
 ```
 
-Aborts a running task.
+Aborts a running task (sends SIGTERM to the process tree).
 
-## Additional commands for manual work
+## Agent dispatch patterns
 
-After tasks complete, you may want to inspect results:
+### Claude Code
 
 ```sh
-# Run a specific command in a task's container
-cella exec feat/auth -- cargo test
-
-# Check test results
-cella exec feat/api -- cat test-results.xml
-
-# View the diff
-cella exec feat/auth -- git diff
+cella task run <branch> --timeout 300 -- claude -p "your prompt here"
 ```
+
+### Codex
+
+```sh
+cella task run <branch> --timeout 300 -- codex exec "your prompt here"
+```
+
+Note: `--skip-git-repo-check` may be needed if the worktree directory isn't recognized as a git repo by Codex.
+
+### Polling for completion
+
+```sh
+# Poll until all tasks complete
+while cella task list --json | jq -e '.[] | select(.status == "running")' > /dev/null 2>&1; do
+  sleep 10
+done
+echo "All tasks complete"
+```
+
+## Failure handling
+
+- One task's failure does NOT affect other running tasks
+- Timed-out tasks exit with code 124 and status `timed_out`
+- Stopped tasks exit with code 130
+- After failure: inspect logs, fix the issue, re-run the task (previous entry is replaced)
 
 ## Example: Full parallel workflow
 
 ```sh
-# User: "Add authentication, rate limiting, and logging to the API"
-
-# 1. Dispatch
-cella task run feat/auth -- claude -p "Add JWT authentication middleware to src/middleware/auth.rs"
-cella task run feat/rate-limit -- claude -p "Add rate limiting middleware to src/middleware/rate_limit.rs"
-cella task run feat/logging -- claude -p "Add structured logging with tracing to all API handlers"
+# 1. Dispatch with timeouts
+cella task run feat/auth --timeout 300 -- claude -p "Add JWT auth middleware"
+cella task run feat/rate-limit --timeout 300 -- claude -p "Add rate limiting"
+cella task run feat/logging --timeout 300 -- claude -p "Add structured logging"
 
 # 2. Monitor
 cella task list
@@ -117,30 +148,28 @@ cella exec feat/logging -- cargo test
 
 ## Lifecycle management
 
-After tasks complete, you can manage the branch containers:
-
 ```sh
 # Stop a branch's container to free resources
 cella down feat/auth
 
-# Restart a stopped branch's container
+# Restart a stopped container
 cella up feat/auth
 
 # Stop and remove container + worktree
 cella down feat/auth --rm
 
-# Clean up all worktrees (including unmerged)
-cella prune --all
+# Clean up all worktrees older than a week
+cella prune --older-than 7d
 
-# Clean up only merged worktrees
-cella prune
+# Clean up all worktrees
+cella prune --all
 ```
 
-## Important notes
+## Best practices
 
-- Each branch gets its own container with the full dev environment
-- Tasks run independently — one failure doesn't affect others
-- The host filesystem is shared, so git operations are coordinated
-- Use `cella down <branch>` to stop individual branches and free resources
-- Use `cella up <branch>` to restart stopped branches (e.g., after reboot)
-- Use `cella prune` to clean up merged branches, `cella prune --all` for all branches
+- 3-4 parallel agents is the sweet spot for most repos
+- Use `--timeout` on all agent dispatches to prevent runaway tasks
+- Use `cella task list --json` for programmatic monitoring
+- Use `cella exec` for quick verification commands after tasks complete
+- Containers persist until explicitly removed with `cella down --rm` or `cella prune`
+- The host filesystem is shared — git operations are coordinated through the worktree mechanism

--- a/.claude/commands/cella-worktree.md
+++ b/.claude/commands/cella-worktree.md
@@ -14,23 +14,40 @@ You are inside a cella container if:
 ### Create a new branch
 
 ```sh
-cella branch <name> [--base <ref>]
+cella branch <name> [--base <ref>] [--label key=value]...
 ```
 
-Creates a git worktree for `<name>` on the host, builds and starts a new container for it. The `--base` flag specifies which commit/branch to branch from (defaults to HEAD).
+Creates a git worktree for `<name>` on the host, builds and starts a new container for it. The `--base` flag specifies which commit/branch to branch from (defaults to HEAD). `--label` adds custom metadata labels to the container.
 
 Example:
 ```sh
 cella branch feat/auth --base main
+cella branch feat/api --label team=backend --label priority=high
 ```
 
 ### List branches
 
 ```sh
-cella list
+cella list [--json]
 ```
 
-Shows all worktree branches with their container name and state (running/exited).
+Shows all worktree branches with their container name and state (running/exited). The current container is marked with `*`. Use `--json` for programmatic output.
+
+### Run a command in another branch's container
+
+```sh
+cella exec <branch> -- <command...>
+cella exec <branch> --json -- <command...>
+```
+
+Runs a command in the specified branch's container and streams output. The exit code is propagated. Works bidirectionally — worktree containers can exec to main and vice versa. With `--json`, outputs structured `{"exit_code": N, "stdout": "...", "stderr": "..."}`.
+
+Examples:
+```sh
+cella exec feat/auth -- cargo test
+cella exec main -- echo "hello from main"
+cella exec feat/auth --json -- cat src/auth.rs
+```
 
 ### Switch to another branch's container
 
@@ -38,21 +55,7 @@ Shows all worktree branches with their container name and state (running/exited)
 cella switch <branch>
 ```
 
-Opens a shell session in the target branch's container. Use this for quick checks; for running specific commands, prefer `cella exec`.
-
-### Run a command in another branch's container
-
-```sh
-cella exec <branch> -- <command...>
-```
-
-Runs a command in the specified branch's container and streams output. The exit code is propagated.
-
-Examples:
-```sh
-cella exec feat/auth -- cargo test
-cella exec feat/auth -- cat src/auth.rs
-```
+Opens an interactive shell session in the target branch's container. Use this for exploratory work; for running specific commands, prefer `cella exec`.
 
 ### Stop a branch's container
 
@@ -62,40 +65,44 @@ cella down <branch> [--rm] [--volumes] [--force]
 
 Stops the container for the specified branch. With `--rm`, also removes the container and worktree directory. With `--volumes`, removes associated volumes (requires `--rm`). With `--force`, overrides shutdownAction="none".
 
-Example:
-```sh
-cella down feat/auth          # Stop the container
-cella down feat/auth --rm     # Stop, remove container + worktree
-```
-
 ### Start/restart a branch's container
 
 ```sh
 cella up <branch> [--rebuild]
 ```
 
-Starts or restarts the container for the specified branch. If the container exists but is stopped, it restarts it. If the worktree exists but the container was removed, it creates a new container. With `--rebuild`, rebuilds from scratch.
-
-Example:
-```sh
-cella up feat/auth            # Restart stopped container
-cella up feat/auth --rebuild  # Rebuild from scratch
-```
+Starts or restarts the container for the specified branch. If the container exists but is stopped, it restarts it. With `--rebuild`, rebuilds from scratch.
 
 ### Clean up worktrees
 
 ```sh
-cella prune [--all] [--dry-run]
+cella prune [--all] [--dry-run] [--older-than <duration>] [--missing-worktree] [--label key=value]...
 ```
 
-Removes worktrees and their containers. By default, only removes worktrees whose branches have been merged. With `--all`, removes all linked worktrees including unmerged ones. Use `--dry-run` to preview what would be removed.
+Removes worktrees and their containers. Options:
+- `--all` — removes all linked worktrees including unmerged
+- `--dry-run` — preview what would be removed
+- `--older-than 7d` — only prune worktrees older than duration
+- `--missing-worktree` — prune entries whose worktree directory no longer exists
+- `--label key=value` — only prune worktrees matching these labels
 
-Examples:
+### Diagnostics
+
 ```sh
-cella prune                   # Remove merged worktrees
-cella prune --all             # Remove ALL worktrees
-cella prune --all --dry-run   # Preview what would be removed
+cella doctor [--json]
 ```
+
+Checks connectivity to the host daemon, protocol version match, agent version, and credential helper status. Exits 1 if any check fails. With `--json`, outputs structured diagnostics.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| "No daemon connection info" | Run `cella up` on the host to start the daemon |
+| "Failed to connect to host daemon" | Check `cella doctor` output; restart with `cella up` on host |
+| Exec to main fails | Fixed in v0.0.48+ — main container lookup uses workspace_path fallback |
+| `*` marker shows wrong branch | Fixed in v0.0.48+ — uses CELLA_CONTAINER_NAME matching |
+| JSON in human output | Fixed in v0.0.48+ — daemon JSON responses are filtered |
 
 ## When to use
 

--- a/crates/cella-agent/src/cli.rs
+++ b/crates/cella-agent/src/cli.rs
@@ -1242,6 +1242,7 @@ async fn run_task_list(json: bool) -> Result<(), Box<dyn std::error::Error + Sen
                         cella_protocol::TaskStatus::Running => "running",
                         cella_protocol::TaskStatus::Done => "done",
                         cella_protocol::TaskStatus::Failed => "failed",
+                        cella_protocol::TaskStatus::TimedOut => "timed_out",
                     };
                     let time = format!("{}s", t.elapsed_secs);
                     let cmd = t.command.join(" ");

--- a/crates/cella-agent/src/cli.rs
+++ b/crates/cella-agent/src/cli.rs
@@ -639,6 +639,8 @@ async fn run_doctor() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let agent_version = env!("CARGO_PKG_VERSION");
     eprintln!("cella doctor (in-container, agent v{agent_version})\n");
 
+    let mut has_failures = false;
+
     // 1. .daemon_addr file
     let daemon_addr_exists = std::path::Path::new("/cella/.daemon_addr").exists();
     if daemon_addr_exists {
@@ -646,6 +648,7 @@ async fn run_doctor() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     } else {
         eprintln!("  \u{2717} daemon address file not found (/cella/.daemon_addr)");
         eprintln!("    Run `cella up` on the host to fix");
+        has_failures = true;
     }
 
     // 2. Resolve connection info (file is authoritative, env vars are fallback)
@@ -659,7 +662,7 @@ async fn run_doctor() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     } else {
         eprintln!("  \u{2717} no connection info available");
         eprintln!("    Set CELLA_DAEMON_ADDR or ensure .daemon_addr exists");
-        return Ok(());
+        std::process::exit(1);
     };
 
     // 3. Daemon connectivity
@@ -685,6 +688,7 @@ async fn run_doctor() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         }
         Err(e) => {
             eprintln!("  \u{2717} daemon unreachable at {addr}: {e}");
+            has_failures = true;
         }
     }
 
@@ -700,11 +704,25 @@ async fn run_doctor() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     }
 
     eprintln!();
+    if has_failures {
+        std::process::exit(1);
+    }
     Ok(())
 }
 
 async fn run_doctor_json() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let mut client = connect_daemon().await?;
+    let mut client = match connect_daemon().await {
+        Ok(c) => c,
+        Err(e) => {
+            let error = serde_json::json!({
+                "ok": false,
+                "error": e.to_string(),
+                "agent_version": env!("CARGO_PKG_VERSION"),
+            });
+            println!("{}", serde_json::to_string_pretty(&error)?);
+            std::process::exit(1);
+        }
+    };
     let id = request_id();
     client
         .send(&AgentMessage::DoctorRequest {

--- a/crates/cella-agent/src/cli.rs
+++ b/crates/cella-agent/src/cli.rs
@@ -919,6 +919,8 @@ async fn run_list(json: bool) -> Result<(), Box<dyn std::error::Error + Send + S
     };
     client.send(&msg).await?;
 
+    let current_container = std::env::var("CELLA_CONTAINER_NAME").ok();
+
     loop {
         let resp = recv_timeout(&mut client, TIMEOUT_FAST).await?;
         if let DaemonMessage::ListResult { worktrees, .. } = resp {
@@ -927,7 +929,7 @@ async fn run_list(json: bool) -> Result<(), Box<dyn std::error::Error + Send + S
             } else if worktrees.is_empty() {
                 eprintln!("No worktree branches found.");
             } else {
-                print_worktree_table(&worktrees);
+                print_worktree_table(&worktrees, current_container.as_deref());
             }
             return Ok(());
         }
@@ -1447,14 +1449,23 @@ fn restore_terminal(termios: &nix::sys::termios::Termios) {
     let _ = t::tcsetattr(&stdin, t::SetArg::TCSANOW, termios);
 }
 
-fn print_worktree_table(worktrees: &[cella_protocol::WorktreeEntry]) {
+fn print_worktree_table(
+    worktrees: &[cella_protocol::WorktreeEntry],
+    current_container: Option<&str>,
+) {
     const HEADER: &str = "BRANCH               STATE      CONTAINER                      PATH";
     println!("{HEADER}");
     for wt in worktrees {
         let branch = wt.branch.as_deref().unwrap_or("(detached)");
         let state = wt.container_state.as_deref().unwrap_or("-");
         let container = wt.container_name.as_deref().unwrap_or("-");
-        let marker = if wt.is_main { " *" } else { "" };
+        let marker = if current_container.is_some_and(|c| wt.container_name.as_deref() == Some(c)) {
+            " *"
+        } else if current_container.is_none() && wt.is_main {
+            " *"
+        } else {
+            ""
+        };
         println!(
             "{:<20} {:<10} {:<30} {}",
             format!("{branch}{marker}"),
@@ -2064,7 +2075,7 @@ mod tests {
                 labels: None,
             },
         ];
-        print_worktree_table(&worktrees);
+        print_worktree_table(&worktrees, Some("project-main"));
     }
 
     #[test]
@@ -2303,7 +2314,7 @@ mod tests {
     #[test]
     fn print_worktree_table_empty() {
         // Should not panic on empty slice.
-        print_worktree_table(&[]);
+        print_worktree_table(&[], None);
     }
 
     // --- JSON flag parsing ---

--- a/crates/cella-agent/src/cli.rs
+++ b/crates/cella-agent/src/cli.rs
@@ -1485,13 +1485,9 @@ fn print_worktree_table(
         let branch = wt.branch.as_deref().unwrap_or("(detached)");
         let state = wt.container_state.as_deref().unwrap_or("-");
         let container = wt.container_name.as_deref().unwrap_or("-");
-        let marker = if current_container.is_some_and(|c| wt.container_name.as_deref() == Some(c)) {
-            " *"
-        } else if current_container.is_none() && wt.is_main {
-            " *"
-        } else {
-            ""
-        };
+        let is_current = current_container.is_some_and(|c| wt.container_name.as_deref() == Some(c))
+            || (current_container.is_none() && wt.is_main);
+        let marker = if is_current { " *" } else { "" };
         println!(
             "{:<20} {:<10} {:<30} {}",
             format!("{branch}{marker}"),

--- a/crates/cella-agent/src/cli.rs
+++ b/crates/cella-agent/src/cli.rs
@@ -622,7 +622,15 @@ async fn connect_daemon() -> Result<ControlClient, Box<dyn std::error::Error + S
 
     let (client, _hello) = ControlClient::connect(&addr, &container_name, &token)
         .await
-        .map_err(|e| format!("Failed to connect to host daemon: {e}"))?;
+        .map_err(|e| {
+            format!(
+                "Failed to connect to host daemon: {e}\n\n\
+                 Possible fixes:\n  \
+                 - Run `cella up` on the host to restart the daemon\n  \
+                 - Check if the host daemon is running with `cella doctor`\n  \
+                 - Verify network connectivity to {addr}"
+            )
+        })?;
 
     Ok(client)
 }

--- a/crates/cella-agent/src/cli.rs
+++ b/crates/cella-agent/src/cli.rs
@@ -1052,7 +1052,11 @@ async fn run_down(
                 eprintln!("\u{25cf} {step}: {message}");
             }
             DaemonMessage::OperationOutput { stream, data, .. } => match stream {
-                OutputStream::Stdout => print!("{data}"),
+                OutputStream::Stdout => {
+                    if !is_json_line(&data) {
+                        print!("{data}");
+                    }
+                }
                 OutputStream::Stderr => eprint!("{data}"),
             },
             DaemonMessage::DownResult { result, .. } => match result {
@@ -1101,7 +1105,11 @@ async fn run_up(
                 eprintln!("\u{25cf} {step}: {message}");
             }
             DaemonMessage::OperationOutput { stream, data, .. } => match stream {
-                OutputStream::Stdout => print!("{data}"),
+                OutputStream::Stdout => {
+                    if !is_json_line(&data) {
+                        print!("{data}");
+                    }
+                }
                 OutputStream::Stderr => eprint!("{data}"),
             },
             DaemonMessage::UpResult { result, .. } => match result {
@@ -1149,7 +1157,11 @@ async fn run_prune(
         let resp = recv_timeout(&mut client, TIMEOUT_MEDIUM).await?;
         match resp {
             DaemonMessage::OperationOutput { stream, data, .. } => match stream {
-                OutputStream::Stdout => print!("{data}"),
+                OutputStream::Stdout => {
+                    if !is_json_line(&data) {
+                        print!("{data}");
+                    }
+                }
                 OutputStream::Stderr => eprint!("{data}"),
             },
             DaemonMessage::PruneResult { pruned, errors, .. } => {
@@ -1451,6 +1463,11 @@ fn print_worktree_table(worktrees: &[cella_protocol::WorktreeEntry]) {
             wt.worktree_path,
         );
     }
+}
+
+fn is_json_line(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed.starts_with('{') && trimmed.ends_with('}')
 }
 
 #[cfg(test)]

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -2096,6 +2096,8 @@ async fn handle_task_list<W: AsyncWriteExt + Unpin>(
                 status: if t.is_done {
                     if t.exit_code == Some(0) {
                         cella_protocol::TaskStatus::Done
+                    } else if t.exit_code == Some(124) {
+                        cella_protocol::TaskStatus::TimedOut
                     } else {
                         cella_protocol::TaskStatus::Failed
                     }

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -213,6 +213,8 @@ struct HandshakeResult {
     agent_state: Arc<AgentConnectionState>,
     /// Host-side workspace path from container labels.
     workspace_path: Option<String>,
+    /// Host-side parent repo root (set for worktree containers).
+    parent_repo: Option<String>,
 }
 
 /// Validate an already-parsed `AgentHello`, look up container, send `DaemonHello`.
@@ -300,6 +302,7 @@ async fn validate_agent_hello<W: AsyncWriteExt + Unpin>(
         .store(current_time_secs(), Ordering::Relaxed);
 
     let workspace_path = hello.workspace_path.clone();
+    let parent_repo = hello.parent_repo.clone();
 
     Ok(Some(HandshakeResult {
         container_name,
@@ -307,6 +310,7 @@ async fn validate_agent_hello<W: AsyncWriteExt + Unpin>(
         container_ip,
         agent_state,
         workspace_path,
+        parent_repo,
     }))
 }
 
@@ -378,6 +382,7 @@ async fn handle_agent_connection_after_hello(
                         msg,
                         WorktreeHandlerCtx {
                             workspace_path: hs.workspace_path.as_deref(),
+                            parent_repo: hs.parent_repo.as_deref(),
                             cella_bin: &ctx.cella_bin,
                             task_mgr: &ctx.task_manager,
                             container_handles: &ctx.container_handles,
@@ -831,6 +836,8 @@ async fn lookup_container_labels(
 /// Shared context for worktree operation handlers.
 struct WorktreeHandlerCtx<'a> {
     workspace_path: Option<&'a str>,
+    /// Parent repo root (set for worktree containers, `None` for main).
+    parent_repo: Option<&'a str>,
     cella_bin: &'a std::path::Path,
     task_mgr: &'a crate::task_manager::SharedTaskManager,
     container_handles: &'a Arc<Mutex<HashMap<String, ContainerHandle>>>,
@@ -2518,6 +2525,10 @@ fn snapshot_binary(source: &std::path::Path) -> Option<std::path::PathBuf> {
 ///
 /// Uses the calling container's backend metadata to determine which CLI binary
 /// to invoke (`docker` or `container`), avoiding hardcoded Docker assumptions.
+///
+/// When targeting "main" from a worktree container, the main container won't have
+/// a `dev.cella.branch` label. Falls back to finding the parent repo's container
+/// by `dev.cella.workspace_path` without the worktree filter.
 async fn find_container_for_branch(branch: &str, wt: &WorktreeHandlerCtx<'_>) -> Option<String> {
     let (cmd_name, docker_host) = resolve_backend_cli_and_host(wt).await;
 
@@ -2539,12 +2550,49 @@ async fn find_container_for_branch(branch: &str, wt: &WorktreeHandlerCtx<'_>) ->
 
     let output = cmd.output().await.ok()?;
 
-    if !output.status.success() {
-        return None;
+    if output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if let Some(name) = stdout.lines().next().map(ToString::to_string) {
+            return Some(name);
+        }
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    stdout.lines().next().map(ToString::to_string)
+    // Fallback: when requesting "main" from a worktree, the main container lacks
+    // the branch/worktree labels. Look it up by workspace_path instead.
+    if let Some(parent) = wt.parent_repo {
+        let mut cmd = tokio::process::Command::new(&cmd_name);
+        if let Some(ref host) = docker_host {
+            cmd.arg("-H").arg(host);
+        }
+        cmd.args([
+            "ps",
+            "--filter",
+            &format!("label=dev.cella.workspace_path={parent}"),
+            "--filter",
+            "label=dev.cella.tool=cella",
+            "--format",
+            "{{.Names}}\t{{.Label \"dev.cella.worktree\"}}",
+        ]);
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::null());
+
+        if let Ok(output) = cmd.output().await {
+            if output.status.success() {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                for line in stdout.lines() {
+                    let (name, worktree_label) = line.split_once('\t').unwrap_or((line, ""));
+                    if worktree_label != "true" {
+                        return Some(name.to_string());
+                    }
+                }
+            }
+        }
+    } else {
+        // Caller IS the main container — resolve to self.
+        return Some(wt.container_name.to_string());
+    }
+
+    None
 }
 
 /// Append `--backend` and `--docker-host` flags from the calling container's handle.

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -2576,14 +2576,14 @@ async fn find_container_for_branch(branch: &str, wt: &WorktreeHandlerCtx<'_>) ->
         cmd.stdout(std::process::Stdio::piped());
         cmd.stderr(std::process::Stdio::null());
 
-        if let Ok(output) = cmd.output().await {
-            if output.status.success() {
-                let stdout = String::from_utf8_lossy(&output.stdout);
-                for line in stdout.lines() {
-                    let (name, worktree_label) = line.split_once('\t').unwrap_or((line, ""));
-                    if worktree_label != "true" {
-                        return Some(name.to_string());
-                    }
+        if let Ok(output) = cmd.output().await
+            && output.status.success()
+        {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            for line in stdout.lines() {
+                let (name, worktree_label) = line.split_once('\t').unwrap_or((line, ""));
+                if worktree_label != "true" {
+                    return Some(name.to_string());
                 }
             }
         }

--- a/crates/cella-daemon/src/task_manager.rs
+++ b/crates/cella-daemon/src/task_manager.rs
@@ -80,6 +80,8 @@ struct TaskState {
     output: Arc<Mutex<TaskOutput>>,
     /// `EXIT_RUNNING` (-1) while task is active; real exit code once done.
     exit_code: Arc<AtomicI32>,
+    /// Frozen elapsed seconds at completion (`u64::MAX` = still running).
+    completed_elapsed_secs: Arc<AtomicU64>,
     /// PID of the child `docker exec` process (0 = not yet known).
     child_pid: Arc<AtomicU32>,
     /// Handle to abort the task.
@@ -138,13 +140,17 @@ impl TaskManager {
         let task_id = branch.to_string();
         let output = Arc::new(Mutex::new(TaskOutput::new(MAX_OUTPUT_BYTES)));
         let exit_code = Arc::new(AtomicI32::new(EXIT_RUNNING));
+        let completed_elapsed_secs = Arc::new(AtomicU64::new(u64::MAX));
         let child_pid = Arc::new(AtomicU32::new(0));
+        let started_at = std::time::Instant::now();
         let (output_tx, _) = tokio::sync::broadcast::channel(1024);
         let (exit_watch, _) = tokio::sync::watch::channel(None);
 
         let handles = TaskHandles {
             output: output.clone(),
             exit_code: exit_code.clone(),
+            completed_elapsed_secs: completed_elapsed_secs.clone(),
+            started_at,
             child_pid: child_pid.clone(),
             output_tx: output_tx.clone(),
             exit_watch: exit_watch.clone(),
@@ -168,9 +174,10 @@ impl TaskManager {
             branch: branch.to_string(),
             container_name,
             command,
-            started_at: std::time::Instant::now(),
+            started_at,
             output,
             exit_code,
+            completed_elapsed_secs,
             child_pid,
             abort_handle: handle.abort_handle(),
             output_tx,
@@ -188,12 +195,18 @@ impl TaskManager {
         for (id, state) in &self.tasks {
             let code = state.exit_code.load(Ordering::Acquire);
             let done = code != EXIT_RUNNING;
+            let stored = state.completed_elapsed_secs.load(Ordering::Acquire);
+            let elapsed = if stored == u64::MAX {
+                state.started_at.elapsed().as_secs()
+            } else {
+                stored
+            };
             infos.push(TaskInfo {
                 task_id: id.clone(),
                 branch: state.branch.clone(),
                 container_name: state.container_name.clone(),
                 command: state.command.clone(),
-                elapsed_secs: state.started_at.elapsed().as_secs(),
+                elapsed_secs: elapsed,
                 is_done: done,
                 exit_code: if done { Some(code) } else { None },
             });
@@ -271,6 +284,8 @@ impl TaskManager {
 struct TaskHandles {
     output: Arc<Mutex<TaskOutput>>,
     exit_code: Arc<AtomicI32>,
+    completed_elapsed_secs: Arc<AtomicU64>,
+    started_at: std::time::Instant,
     child_pid: Arc<AtomicU32>,
     output_tx: tokio::sync::broadcast::Sender<String>,
     exit_watch: tokio::sync::watch::Sender<Option<i32>>,
@@ -415,6 +430,11 @@ async fn run_task_process(
     if let Some(ref pf) = pid_file {
         cleanup_pid_file(container_name, pf).await;
     }
+
+    // Freeze elapsed time at completion.
+    handles
+        .completed_elapsed_secs
+        .store(handles.started_at.elapsed().as_secs(), Ordering::Release);
 
     // Only set if still running — stop_task may have already set 130.
     let _ =

--- a/crates/cella-protocol/src/lib.rs
+++ b/crates/cella-protocol/src/lib.rs
@@ -673,6 +673,7 @@ pub enum TaskStatus {
     Running,
     Done,
     Failed,
+    TimedOut,
 }
 
 /// A worktree entry for list responses.


### PR DESCRIPTION
## Summary

- **6 bug fixes** for the worktree/task system: exec-to-main fallback, JSON output leak, list marker, task elapsed freezing + timed_out status, doctor exit code, connection error hints
- **2 revised skills** (`cella-worktree`, `cella-parallel-dev`) updated with all new flags and patterns
- **1 new skill** (`cella-agent-integration`) documenting how cella bridges native agent features

## Bug fixes

- Worktree containers can now exec back to main (workspace_path fallback when branch label is missing)
- Human output no longer leaks daemon JSON responses in `up`/`down`/`prune`
- `cella list` marks the current container with `*` instead of always marking main
- Task elapsed time freezes at completion; timed-out tasks show `timed_out` (not `failed`)
- `cella doctor` exits 1 on failures; `--json` mode outputs error envelope on connection failure
- Daemon connection errors include actionable recovery hints

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings -D clippy::all` passes
- [x] `cargo test --workspace` passes (3,390+ tests)
- [x] `cargo build --workspace --all-features` succeeds
- [x] Manual: `cella exec <worktree> -- cella exec main -- echo works`
- [x] Manual: `cella task run <branch> --timeout 5 -- sleep 30` → timed_out status

🤖 Generated with [Claude Code](https://claude.com/claude-code)