### PR TITLE
fix: tools from install list not available in worktree containers

### DIFF
--- a/.claude/skills/cella-ops/SKILL.md
+++ b/.claude/skills/cella-ops/SKILL.md
@@ -393,6 +393,7 @@ cella exec feat/auth -- cargo test -p middleware
 | Agent can't reach API endpoints | Cella containers share the host network by default; check DNS/firewall |
 | Agent teams can't communicate | All teammates must run in the same container, not across containers |
 | Task shows "timed_out" | Increase `--timeout` or break the task into smaller pieces |
+| Plan/task files not visible in worktree | Place shared files in `~/.claude/plans/` — this volume is mounted in ALL containers. Don't rely on git-tracked files for cross-worktree sharing |
 
 ## Best Practices
 

--- a/crates/cella-backend/src/container_setup.rs
+++ b/crates/cella-backend/src/container_setup.rs
@@ -401,48 +401,73 @@ async fn apply_git_config(
     }
 }
 
-/// Add `/cella/bin` to PATH in the container's shell profile.
+/// Add `/cella/bin` and `~/.local/bin` to PATH in the container's shell
+/// profile.
 ///
-/// This makes the `cella` CLI (symlinked to the agent binary) discoverable
-/// by users and AI agents running inside the container.
+/// `/cella/bin` makes the cella CLI (symlinked to the agent binary)
+/// discoverable. `~/.local/bin` is the XDG-standard user-local binary
+/// directory used by `curl | bash` installers (Claude Code, uv, rustup,
+/// etc.) — without it, tools installed by `install_tools_and_probe_env`
+/// may not appear on PATH in worktree containers.
+///
+/// Each block has its own idempotency guard so the function is safe to
+/// re-run and also patches containers that were created before the
+/// `~/.local/bin` block existed.
 pub async fn inject_cella_path(
     client: &dyn ContainerBackend,
     container_id: &str,
     remote_user: &str,
 ) {
-    let snippet = r#"
-# cella CLI (in-container worktree commands)
-if [ -d /cella/bin ] && ! echo "$PATH" | grep -q /cella/bin; then
-    export PATH="/cella/bin:$PATH"
-fi
-"#;
-    // Determine home directory
     let home = if remote_user == "root" {
         "/root".to_string()
     } else {
         format!("/home/{remote_user}")
     };
 
-    for profile in &[".bashrc", ".zshrc", ".profile"] {
-        let path = format!("{home}/{profile}");
-        let cmd = format!(
-            "if [ -f '{path}' ] && ! grep -q '/cella/bin' '{path}'; then printf '%s\\n' '{snippet_escaped}' >> '{path}'; fi",
-            path = path,
-            snippet_escaped = snippet.replace('\'', "'\\''"),
-        );
-        let _ = client
-            .exec_command(
-                container_id,
-                &ExecOptions {
-                    cmd: vec!["sh".to_string(), "-c".to_string(), cmd],
-                    user: Some("root".to_string()),
-                    working_dir: None,
-                    env: None,
-                },
-            )
-            .await;
+    for (guard, snippet) in PATH_SNIPPETS {
+        for profile in &[".bashrc", ".zshrc", ".profile"] {
+            let path = format!("{home}/{profile}");
+            let cmd = format!(
+                "if [ -f '{path}' ] && ! grep -q '{guard}' '{path}'; then printf '%s\\n' '{escaped}' >> '{path}'; fi",
+                path = path,
+                guard = guard,
+                escaped = snippet.replace('\'', "'\\''"),
+            );
+            let _ = client
+                .exec_command(
+                    container_id,
+                    &ExecOptions {
+                        cmd: vec!["sh".to_string(), "-c".to_string(), cmd],
+                        user: Some("root".to_string()),
+                        working_dir: None,
+                        env: None,
+                    },
+                )
+                .await;
+        }
     }
 }
+
+const PATH_SNIPPETS: &[(&str, &str)] = &[
+    (
+        "# cella CLI",
+        r#"
+# cella CLI (in-container worktree commands)
+if [ -d /cella/bin ] && ! echo "$PATH" | grep -q /cella/bin; then
+    export PATH="/cella/bin:$PATH"
+fi
+"#,
+    ),
+    (
+        "# cella user-local bin",
+        r#"
+# cella user-local bin (curl|bash installers: claude, uv, rustup, etc.)
+if [ -d "$HOME/.local/bin" ] && ! echo "$PATH" | grep -q "$HOME/.local/bin"; then
+    export PATH="$HOME/.local/bin:$PATH"
+fi
+"#,
+    ),
+];
 
 /// Seed gh CLI credentials into a container.
 ///
@@ -566,6 +591,29 @@ mod tests {
         let config = json!({"remoteUser": 42, "containerUser": true});
         let result = resolve_remote_user(&config, None, "fallback");
         assert_eq!(result, "fallback");
+    }
+
+    // ── PATH_SNIPPETS ────────────────────────────────────────────────────
+
+    #[test]
+    fn path_snippets_include_cella_bin() {
+        let (guard, snippet) = PATH_SNIPPETS[0];
+        assert_eq!(guard, "# cella CLI");
+        assert!(snippet.contains("/cella/bin"));
+    }
+
+    #[test]
+    fn path_snippets_include_user_local_bin() {
+        let (guard, snippet) = PATH_SNIPPETS[1];
+        assert_eq!(guard, "# cella user-local bin");
+        assert!(snippet.contains("$HOME/.local/bin"));
+    }
+
+    #[test]
+    fn path_snippets_have_unique_guards() {
+        let guards: Vec<&str> = PATH_SNIPPETS.iter().map(|(g, _)| *g).collect();
+        let unique: std::collections::HashSet<&str> = guards.iter().copied().collect();
+        assert_eq!(guards.len(), unique.len());
     }
 
     // ── map_env_object ───────────────────────────────────────────────────

--- a/crates/cella-backend/src/container_setup.rs
+++ b/crates/cella-backend/src/container_setup.rs
@@ -453,8 +453,11 @@ const PATH_SNIPPETS: &[(&str, &str)] = &[
         "# cella CLI",
         r#"
 # cella CLI (in-container worktree commands)
-if [ -d /cella/bin ] && ! echo "$PATH" | grep -q /cella/bin; then
-    export PATH="/cella/bin:$PATH"
+if [ -d /cella/bin ]; then
+    case ":$PATH:" in
+        *":/cella/bin:"*) ;;
+        *) export PATH="/cella/bin:$PATH" ;;
+    esac
 fi
 "#,
     ),
@@ -462,8 +465,11 @@ fi
         "# cella user-local bin",
         r#"
 # cella user-local bin (curl|bash installers: claude, uv, rustup, etc.)
-if [ -d "$HOME/.local/bin" ] && ! echo "$PATH" | grep -q "$HOME/.local/bin"; then
-    export PATH="$HOME/.local/bin:$PATH"
+if [ -d "$HOME/.local/bin" ]; then
+    case ":$PATH:" in
+        *":$HOME/.local/bin:"*) ;;
+        *) export PATH="$HOME/.local/bin:$PATH" ;;
+    esac
 fi
 "#,
     ),

--- a/crates/cella-daemon/src/task_manager.rs
+++ b/crates/cella-daemon/src/task_manager.rs
@@ -729,8 +729,13 @@ mod tests {
             .unwrap();
         mgr.start_task("b", "c".into(), vec!["x".into()], None, Vec::new(), None)
             .unwrap();
-        // Let both tasks finish (docker unavailable → exit 1).
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        // Poll until both tasks finish (docker unavailable → exit 1).
+        for _ in 0..50 {
+            if mgr.is_done("a") && mgr.is_done("b") {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
         mgr.cleanup_done();
         assert!(mgr.list_tasks().is_empty());
     }

--- a/crates/cella-tool-install/src/lib.rs
+++ b/crates/cella-tool-install/src/lib.rs
@@ -542,6 +542,7 @@ pub async fn is_claude_code_installed(
             return true;
         }
     }
+    debug!("Claude Code not found or version mismatch, will install");
     false
 }
 
@@ -597,6 +598,7 @@ pub async fn install_claude_code(
     )
     .await
     {
+        debug!("Claude Code install skipped (already at requested version)");
         return None;
     }
 
@@ -1386,6 +1388,10 @@ async fn verified_install_step(
         return false;
     }
 
+    if install_result.is_none() {
+        debug!("{binary}: install was idempotent, verifying reachability");
+    }
+
     let verify = verify_tool_callable(
         ctx.client,
         ctx.container_id,
@@ -1402,6 +1408,7 @@ async fn verified_install_step(
             true
         }
         VerifyOutcome::InstalledElsewhere(path) => {
+            debug!("{binary}: found at {path} but not on login-shell PATH, symlinking");
             match symlink_to_usr_local_bin(ctx.client, ctx.container_id, binary, &path).await {
                 Ok(()) => {
                     let second = verify_tool_callable(


### PR DESCRIPTION
## Summary

- Add `~/.local/bin` to PATH injection so `curl | bash` installers (Claude Code, uv, rustup) are discoverable in worktree containers — uses a separate idempotency guard so existing containers get patched without recreation
- Add debug-level logging to `is_claude_code_installed`, `install_claude_code`, and `verified_install_step` so silent install failures are diagnosable
- Add shared-volume guidance for cross-worktree files in cella-ops skill

Closes #105

## Test plan
- [x] `cargo test --workspace` passes (2,969 tests)
- [x] `cargo clippy --workspace --all-features --all-targets` clean
- [x] Create a worktree container with `tools.install = ["claude-code"]` and verify `which claude` finds the binary
- [x] Verify `echo $PATH` includes `~/.local/bin` in both main and worktree containers
- [x] With `RUST_LOG=debug`, verify install decision logs appear

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>