### PR TITLE
feat: add missing flags and fix merged configuration in read-configuration

### DIFF
--- a/.claude/skills/cella-ops/SKILL.md
+++ b/.claude/skills/cella-ops/SKILL.md
@@ -204,7 +204,7 @@ Shows captured stdout/stderr from the task. With `--follow`, streams live output
 cella task wait <branch>
 ```
 
-Blocks until the task finishes. The process exit code (`$?`) matches the task's exit code (see table below). Prints a summary line to stdout (`Task <branch> exited with code N`) when it observes the exit — if the task already completed before `wait` is called, it may return silently with just the exit code.
+Blocks until the task finishes. The process exit code (`$?`) matches the task's exit code (see table below). Always prints a status message to **stderr**: `Task '<branch>' exited with code N` (non-zero) or `Task '<branch>' completed successfully.` (zero). Stdout is never written to, so scripts can safely capture it.
 
 ### Stop a Task
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,6 +360,7 @@ dependencies = [
  "cella-docker",
  "cella-doctor",
  "cella-env",
+ "cella-features",
  "cella-git",
  "cella-jsonc",
  "cella-network",

--- a/crates/cella-cli/Cargo.toml
+++ b/crates/cella-cli/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 cella-backend.workspace = true
 cella-compose.workspace = true
 cella-config.workspace = true
+cella-features.workspace = true
 cella-jsonc.workspace = true
 cella-daemon.workspace = true
 cella-daemon-client.workspace = true

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -219,7 +219,7 @@ impl Command {
             Self::Branch(args) => args.execute(progress).await,
             Self::Switch(args) => args.execute().await,
             Self::Prune(args) => args.execute().await,
-            Self::ReadConfiguration(args) => args.execute(),
+            Self::ReadConfiguration(args) => args.execute().await,
             Self::Config(args) => args.execute(),
             Self::Template(args) => args.execute(),
             Self::Features(args) => args.execute(progress).await,

--- a/crates/cella-cli/src/commands/read_configuration.rs
+++ b/crates/cella-cli/src/commands/read_configuration.rs
@@ -5,6 +5,7 @@ use serde_json::json;
 
 use cella_backend::ContainerTarget;
 use cella_config::devcontainer::resolve;
+use cella_features::types::FeatureContainerConfig;
 
 use crate::backend::BackendArgs;
 
@@ -137,10 +138,85 @@ impl ReadConfigurationArgs {
         });
 
         if self.include_merged_configuration {
-            output["mergedConfiguration"] = output["configuration"].clone();
+            output["mergedConfiguration"] =
+                resolve_merged_config(&resolved.config, &resolved.config_path).await?;
         }
 
         println!("{}", serde_json::to_string_pretty(&output)?);
         Ok(())
+    }
+}
+
+async fn resolve_merged_config(
+    config: &serde_json::Value,
+    config_path: &std::path::Path,
+) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
+    let features = super::features::resolve::extract_features(config);
+    if features.is_empty() {
+        return Ok(config.clone());
+    }
+
+    let platform =
+        cella_features::oci::detect_platform(std::env::consts::OS, std::env::consts::ARCH);
+    let cache = cella_features::cache::FeatureCache::new();
+    let base_image = config.get("image").and_then(|v| v.as_str()).unwrap_or("");
+    let base_ctx = cella_features::BaseImageContext {
+        base_image,
+        image_user: "root",
+        metadata: None,
+    };
+    let rf =
+        cella_features::resolve_features(config, config_path, &platform, &cache, &base_ctx, false)
+            .await?;
+
+    let mut merged = config.clone();
+    apply_feature_config(&mut merged, &rf.container_config);
+    Ok(merged)
+}
+
+fn apply_feature_config(config: &mut serde_json::Value, fc: &FeatureContainerConfig) {
+    if !fc.mounts.is_empty() {
+        config["mounts"] = json!(fc.mounts);
+    }
+    if !fc.cap_add.is_empty() {
+        config["capAdd"] = json!(fc.cap_add);
+    }
+    if !fc.security_opt.is_empty() {
+        config["securityOpt"] = json!(fc.security_opt);
+    }
+    if fc.privileged {
+        config["privileged"] = json!(true);
+    }
+    if fc.init {
+        config["init"] = json!(true);
+    }
+    if !fc.container_env.is_empty() {
+        config["containerEnv"] = json!(fc.container_env);
+    }
+    if !fc.customizations.is_null() {
+        config["customizations"] = fc.customizations.clone();
+    }
+    apply_lifecycle_field(config, "onCreateCommand", &fc.lifecycle.on_create);
+    apply_lifecycle_field(config, "updateContentCommand", &fc.lifecycle.update_content);
+    apply_lifecycle_field(config, "postCreateCommand", &fc.lifecycle.post_create);
+    apply_lifecycle_field(config, "postStartCommand", &fc.lifecycle.post_start);
+    apply_lifecycle_field(config, "postAttachCommand", &fc.lifecycle.post_attach);
+}
+
+fn apply_lifecycle_field(
+    config: &mut serde_json::Value,
+    key: &str,
+    entries: &[cella_features::types::LifecycleEntry],
+) {
+    match entries.len() {
+        0 => {}
+        1 => config[key] = entries[0].command.clone(),
+        _ => {
+            let obj: serde_json::Map<String, serde_json::Value> = entries
+                .iter()
+                .map(|e| (e.origin.clone(), e.command.clone()))
+                .collect();
+            config[key] = serde_json::Value::Object(obj);
+        }
     }
 }

--- a/crates/cella-cli/src/commands/read_configuration.rs
+++ b/crates/cella-cli/src/commands/read_configuration.rs
@@ -51,6 +51,8 @@ impl ReadConfigurationArgs {
     pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let has_container_target = self.id_label.is_some() || self.container_id.is_some();
 
+        let config_path = self.override_config.as_deref().or(self.config.as_deref());
+
         let (resolved, cwd) = if has_container_target {
             let client = self.backend.resolve_client().await?;
             let target = ContainerTarget {
@@ -66,11 +68,11 @@ impl ReadConfigurationArgs {
                 .get("dev.cella.workspace_path")
                 .ok_or("container has no dev.cella.workspace_path label")?;
             let ws = PathBuf::from(workspace_path);
-            let res = resolve::config(&ws, self.config.as_deref())?;
+            let res = resolve::config(&ws, config_path)?;
             (res, ws)
         } else {
             let ws = super::resolve_workspace_folder(self.workspace_folder.as_deref())?;
-            let res = resolve::config(&ws, self.config.as_deref())?;
+            let res = resolve::config(&ws, config_path)?;
             (res, ws)
         };
 

--- a/crates/cella-cli/src/commands/read_configuration.rs
+++ b/crates/cella-cli/src/commands/read_configuration.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use clap::Args;
 use serde_json::json;
 
+use cella_backend::ContainerTarget;
 use cella_config::devcontainer::resolve;
 
 use crate::backend::BackendArgs;
@@ -47,12 +48,32 @@ pub struct ReadConfigurationArgs {
 }
 
 impl ReadConfigurationArgs {
-    pub fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let cwd = super::resolve_workspace_folder(self.workspace_folder.as_deref())?;
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let has_container_target = self.id_label.is_some() || self.container_id.is_some();
 
-        let resolved = resolve::config(&cwd, self.config.as_deref())?;
+        let (resolved, cwd) = if has_container_target {
+            let client = self.backend.resolve_client().await?;
+            let target = ContainerTarget {
+                container_id: self.container_id.clone(),
+                container_name: None,
+                id_label: self.id_label.clone(),
+                workspace_folder: self.workspace_folder.clone(),
+            };
+            let container = target.resolve(&*client, false).await?;
 
-        // Determine deviceContainerType
+            let workspace_path = container
+                .labels
+                .get("dev.cella.workspace_path")
+                .ok_or("container has no dev.cella.workspace_path label")?;
+            let ws = PathBuf::from(workspace_path);
+            let res = resolve::config(&ws, self.config.as_deref())?;
+            (res, ws)
+        } else {
+            let ws = super::resolve_workspace_folder(self.workspace_folder.as_deref())?;
+            let res = resolve::config(&ws, self.config.as_deref())?;
+            (res, ws)
+        };
+
         let device_type = if resolved.config.get("dockerComposeFile").is_some() {
             "dockerCompose"
         } else if resolved.config.get("build").is_some()
@@ -63,7 +84,6 @@ impl ReadConfigurationArgs {
             "image"
         };
 
-        // Compute workspace folder
         let workspace_basename = cwd.file_name().map_or_else(
             || "workspace".to_string(),
             |n| n.to_string_lossy().to_string(),
@@ -94,11 +114,8 @@ impl ReadConfigurationArgs {
             }
         });
 
-        // Include merged configuration if requested.
-        // Full feature resolution requires Docker and network access;
-        // for now output the resolved configuration itself.
         if self.include_merged_configuration {
-            output["mergeConfiguration"] = output["configuration"].clone();
+            output["mergedConfiguration"] = output["configuration"].clone();
         }
 
         println!("{}", serde_json::to_string_pretty(&output)?);

--- a/crates/cella-cli/src/commands/read_configuration.rs
+++ b/crates/cella-cli/src/commands/read_configuration.rs
@@ -220,3 +220,294 @@ fn apply_lifecycle_field(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use cella_features::types::{FeatureContainerConfig, FeatureLifecycle, LifecycleEntry};
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn apply_feature_config_sets_mounts() {
+        let mut config = json!({"image": "ubuntu"});
+        let fc = FeatureContainerConfig {
+            mounts: vec!["type=volume,src=v,dst=/v".to_string()],
+            ..Default::default()
+        };
+        apply_feature_config(&mut config, &fc);
+        assert_eq!(config["mounts"], json!(["type=volume,src=v,dst=/v"]));
+    }
+
+    #[test]
+    fn apply_feature_config_sets_capabilities() {
+        let mut config = json!({});
+        let fc = FeatureContainerConfig {
+            cap_add: vec!["SYS_PTRACE".to_string()],
+            security_opt: vec!["seccomp=unconfined".to_string()],
+            ..Default::default()
+        };
+        apply_feature_config(&mut config, &fc);
+        assert_eq!(config["capAdd"], json!(["SYS_PTRACE"]));
+        assert_eq!(config["securityOpt"], json!(["seccomp=unconfined"]));
+    }
+
+    #[test]
+    fn apply_feature_config_sets_privileged_and_init() {
+        let mut config = json!({});
+        let fc = FeatureContainerConfig {
+            privileged: true,
+            init: true,
+            ..Default::default()
+        };
+        apply_feature_config(&mut config, &fc);
+        assert_eq!(config["privileged"], json!(true));
+        assert_eq!(config["init"], json!(true));
+    }
+
+    #[test]
+    fn apply_feature_config_skips_false_bools() {
+        let mut config = json!({});
+        let fc = FeatureContainerConfig::default();
+        apply_feature_config(&mut config, &fc);
+        assert!(config.get("privileged").is_none());
+        assert!(config.get("init").is_none());
+    }
+
+    #[test]
+    fn apply_feature_config_sets_container_env() {
+        let mut config = json!({});
+        let fc = FeatureContainerConfig {
+            container_env: HashMap::from([("KEY".to_string(), "val".to_string())]),
+            ..Default::default()
+        };
+        apply_feature_config(&mut config, &fc);
+        assert_eq!(config["containerEnv"]["KEY"], json!("val"));
+    }
+
+    #[test]
+    fn apply_feature_config_sets_customizations() {
+        let mut config = json!({});
+        let fc = FeatureContainerConfig {
+            customizations: json!({"vscode": {"settings": {}}}),
+            ..Default::default()
+        };
+        apply_feature_config(&mut config, &fc);
+        assert_eq!(
+            config["customizations"],
+            json!({"vscode": {"settings": {}}})
+        );
+    }
+
+    #[test]
+    fn apply_feature_config_skips_empty_fields() {
+        let mut config = json!({"image": "ubuntu"});
+        let fc = FeatureContainerConfig::default();
+        apply_feature_config(&mut config, &fc);
+        assert!(config.get("mounts").is_none());
+        assert!(config.get("capAdd").is_none());
+        assert!(config.get("containerEnv").is_none());
+    }
+
+    #[test]
+    fn apply_lifecycle_empty_entries_no_change() {
+        let mut config = json!({});
+        apply_lifecycle_field(&mut config, "onCreateCommand", &[]);
+        assert!(config.get("onCreateCommand").is_none());
+    }
+
+    #[test]
+    fn apply_lifecycle_single_entry_uses_command_directly() {
+        let mut config = json!({});
+        let entries = vec![LifecycleEntry {
+            origin: "devcontainer.json".to_string(),
+            command: json!("echo hello"),
+        }];
+        apply_lifecycle_field(&mut config, "onCreateCommand", &entries);
+        assert_eq!(config["onCreateCommand"], json!("echo hello"));
+    }
+
+    #[test]
+    fn apply_lifecycle_multiple_entries_uses_object() {
+        let mut config = json!({});
+        let entries = vec![
+            LifecycleEntry {
+                origin: "feature-a".to_string(),
+                command: json!("echo a"),
+            },
+            LifecycleEntry {
+                origin: "devcontainer.json".to_string(),
+                command: json!("echo b"),
+            },
+        ];
+        apply_lifecycle_field(&mut config, "postCreateCommand", &entries);
+        assert_eq!(
+            config["postCreateCommand"],
+            json!({"feature-a": "echo a", "devcontainer.json": "echo b"})
+        );
+    }
+
+    #[test]
+    fn apply_feature_config_lifecycle_integration() {
+        let mut config = json!({});
+        let fc = FeatureContainerConfig {
+            lifecycle: FeatureLifecycle {
+                on_create: vec![LifecycleEntry {
+                    origin: "feat".to_string(),
+                    command: json!("setup"),
+                }],
+                post_create: vec![
+                    LifecycleEntry {
+                        origin: "feat".to_string(),
+                        command: json!("init"),
+                    },
+                    LifecycleEntry {
+                        origin: "devcontainer.json".to_string(),
+                        command: json!("start"),
+                    },
+                ],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        apply_feature_config(&mut config, &fc);
+        assert_eq!(config["onCreateCommand"], json!("setup"));
+        assert_eq!(
+            config["postCreateCommand"],
+            json!({"feat": "init", "devcontainer.json": "start"})
+        );
+        assert!(config.get("postStartCommand").is_none());
+    }
+
+    fn make_temp_workspace(config_content: &str) -> PathBuf {
+        let workspace = std::env::temp_dir().join(format!(
+            "cella-read-cfg-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        let dc_dir = workspace.join(".devcontainer");
+        std::fs::create_dir_all(&dc_dir).expect("create .devcontainer dir");
+        std::fs::write(dc_dir.join("devcontainer.json"), config_content)
+            .expect("write devcontainer.json");
+        workspace
+    }
+
+    #[tokio::test]
+    async fn execute_basic_read_succeeds() {
+        let workspace = make_temp_workspace(r#"{"image": "ubuntu:22.04"}"#);
+        let args = ReadConfigurationArgs {
+            backend: BackendArgs::default(),
+            workspace_folder: Some(workspace.clone()),
+            config: None,
+            include_merged_configuration: false,
+            include_features_configuration: false,
+            override_config: None,
+            id_label: None,
+            container_id: None,
+            additional_features: None,
+        };
+        args.execute().await.unwrap();
+        let _ = std::fs::remove_dir_all(&workspace);
+    }
+
+    #[tokio::test]
+    async fn execute_override_config_uses_override_file() {
+        let workspace = make_temp_workspace(r#"{"image": "ubuntu:22.04"}"#);
+        let override_path = workspace.join("override.json");
+        std::fs::write(&override_path, r#"{"image": "alpine:3.18"}"#).unwrap();
+
+        let args = ReadConfigurationArgs {
+            backend: BackendArgs::default(),
+            workspace_folder: Some(workspace.clone()),
+            config: None,
+            include_merged_configuration: false,
+            include_features_configuration: false,
+            override_config: Some(override_path),
+            id_label: None,
+            container_id: None,
+            additional_features: None,
+        };
+        args.execute().await.unwrap();
+        let _ = std::fs::remove_dir_all(&workspace);
+    }
+
+    #[tokio::test]
+    async fn execute_additional_features_valid_json() {
+        let workspace = make_temp_workspace(r#"{"image": "ubuntu:22.04"}"#);
+        let args = ReadConfigurationArgs {
+            backend: BackendArgs::default(),
+            workspace_folder: Some(workspace.clone()),
+            config: None,
+            include_merged_configuration: false,
+            include_features_configuration: false,
+            override_config: None,
+            id_label: None,
+            container_id: None,
+            additional_features: Some(
+                r#"{"ghcr.io/devcontainers/features/git:1": {}}"#.to_string(),
+            ),
+        };
+        args.execute().await.unwrap();
+        let _ = std::fs::remove_dir_all(&workspace);
+    }
+
+    #[tokio::test]
+    async fn execute_additional_features_invalid_json_returns_error() {
+        let workspace = make_temp_workspace(r#"{"image": "ubuntu:22.04"}"#);
+        let args = ReadConfigurationArgs {
+            backend: BackendArgs::default(),
+            workspace_folder: Some(workspace.clone()),
+            config: None,
+            include_merged_configuration: false,
+            include_features_configuration: false,
+            override_config: None,
+            id_label: None,
+            container_id: None,
+            additional_features: Some("not valid json".to_string()),
+        };
+        let err = args.execute().await.unwrap_err();
+        assert!(err.to_string().contains("invalid JSON"));
+        let _ = std::fs::remove_dir_all(&workspace);
+    }
+
+    #[tokio::test]
+    async fn execute_additional_features_non_object_returns_error() {
+        let workspace = make_temp_workspace(r#"{"image": "ubuntu:22.04"}"#);
+        let args = ReadConfigurationArgs {
+            backend: BackendArgs::default(),
+            workspace_folder: Some(workspace.clone()),
+            config: None,
+            include_merged_configuration: false,
+            include_features_configuration: false,
+            override_config: None,
+            id_label: None,
+            container_id: None,
+            additional_features: Some(r#"["not", "an", "object"]"#.to_string()),
+        };
+        let err = args.execute().await.unwrap_err();
+        assert!(err.to_string().contains("must be a JSON object"));
+        let _ = std::fs::remove_dir_all(&workspace);
+    }
+
+    #[tokio::test]
+    async fn execute_include_merged_configuration_no_features() {
+        let workspace = make_temp_workspace(r#"{"image": "ubuntu:22.04"}"#);
+        let args = ReadConfigurationArgs {
+            backend: BackendArgs::default(),
+            workspace_folder: Some(workspace.clone()),
+            config: None,
+            include_merged_configuration: true,
+            include_features_configuration: false,
+            override_config: None,
+            id_label: None,
+            container_id: None,
+            additional_features: None,
+        };
+        args.execute().await.unwrap();
+        let _ = std::fs::remove_dir_all(&workspace);
+    }
+}

--- a/crates/cella-cli/src/commands/read_configuration.rs
+++ b/crates/cella-cli/src/commands/read_configuration.rs
@@ -53,7 +53,7 @@ impl ReadConfigurationArgs {
 
         let config_path = self.override_config.as_deref().or(self.config.as_deref());
 
-        let (resolved, cwd) = if has_container_target {
+        let (mut resolved, cwd) = if has_container_target {
             let client = self.backend.resolve_client().await?;
             let target = ContainerTarget {
                 container_id: self.container_id.clone(),
@@ -75,6 +75,26 @@ impl ReadConfigurationArgs {
             let res = resolve::config(&ws, config_path)?;
             (res, ws)
         };
+
+        if let Some(ref additional) = self.additional_features {
+            let extra: serde_json::Value = serde_json::from_str(additional)
+                .map_err(|e| format!("--additional-features: invalid JSON: {e}"))?;
+            let obj = extra
+                .as_object()
+                .ok_or("--additional-features must be a JSON object")?;
+            let features = resolved
+                .config
+                .as_object_mut()
+                .expect("config is always an object")
+                .entry("features")
+                .or_insert_with(|| json!({}));
+            let features_obj = features
+                .as_object_mut()
+                .ok_or("existing features field is not an object")?;
+            for (k, v) in obj {
+                features_obj.insert(k.clone(), v.clone());
+            }
+        }
 
         let device_type = if resolved.config.get("dockerComposeFile").is_some() {
             "dockerCompose"

--- a/crates/cella-cli/src/commands/read_configuration.rs
+++ b/crates/cella-cli/src/commands/read_configuration.rs
@@ -5,9 +5,14 @@ use serde_json::json;
 
 use cella_config::devcontainer::resolve;
 
+use crate::backend::BackendArgs;
+
 /// Read and output the resolved devcontainer configuration.
 #[derive(Args)]
 pub struct ReadConfigurationArgs {
+    #[command(flatten)]
+    backend: BackendArgs,
+
     /// Workspace folder path (defaults to current directory).
     #[arg(long)]
     workspace_folder: Option<PathBuf>,
@@ -23,6 +28,22 @@ pub struct ReadConfigurationArgs {
     /// Include features configuration details.
     #[arg(long)]
     include_features_configuration: bool,
+
+    /// Path to a devcontainer.json that replaces the discovered config entirely.
+    #[arg(long = "override-config")]
+    override_config: Option<PathBuf>,
+
+    /// Target container by label.
+    #[arg(long = "id-label")]
+    id_label: Option<String>,
+
+    /// Target container by ID.
+    #[arg(long = "container-id")]
+    container_id: Option<String>,
+
+    /// Additional features as JSON string.
+    #[arg(long = "additional-features")]
+    additional_features: Option<String>,
 }
 
 impl ReadConfigurationArgs {


### PR DESCRIPTION
## Summary

- Add 4 missing flags: `--override-config`, `--additional-features`, `--id-label`, `--container-id`
- Fix `--include-merged-configuration` to resolve features instead of shallow-cloning
- Fix output key typo: `mergeConfiguration` → `mergedConfiguration`
- Make `execute()` async with `BackendArgs` for Docker client access

## Test plan

- [x] 19 unit tests passing for read-configuration
- [x] `cargo clippy --workspace` clean
- [x] `cargo test --workspace` passes

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)