### PR TITLE
feat: add cella outdated command

### DIFF
--- a/.claude/skills/cella-ops/SKILL.md
+++ b/.claude/skills/cella-ops/SKILL.md
@@ -204,7 +204,7 @@ Shows captured stdout/stderr from the task. With `--follow`, streams live output
 cella task wait <branch>
 ```
 
-Blocks until the task finishes. The process exit code (`$?`) matches the task's exit code (see table below). Prints a summary line to stdout (`Task <branch> exited with code N`) when it observes the exit — if the task already completed before `wait` is called, it may return silently with just the exit code.
+Blocks until the task finishes. The process exit code (`$?`) matches the task's exit code (see table below). Always prints a status message to **stderr**: `Task '<branch>' exited with code N` (non-zero) or `Task '<branch>' completed successfully.` (zero). Stdout is never written to, so scripts can safely capture it.
 
 ### Stop a Task
 

--- a/crates/cella-cli/src/commands/features/update.rs
+++ b/crates/cella-cli/src/commands/features/update.rs
@@ -30,17 +30,17 @@ pub struct UpdateArgs {
 
 /// A feature with an available update.
 #[derive(Debug, Clone)]
-struct UpdateCandidate {
+pub struct UpdateCandidate {
     /// Current full OCI reference (e.g. `ghcr.io/.../node:1`).
-    current_ref: String,
+    pub current_ref: String,
     /// Display name of the feature.
-    name: String,
+    pub name: String,
     /// Current tag.
-    current_tag: String,
+    pub current_tag: String,
     /// Latest available version from the collection.
-    latest_version: String,
+    pub latest_version: String,
     /// Updated full reference.
-    updated_ref: String,
+    pub updated_ref: String,
 }
 
 impl UpdateArgs {
@@ -222,7 +222,7 @@ fn apply_updates(
 }
 
 /// Check if a configured feature has an update available in the collection.
-async fn check_for_update(
+pub async fn check_for_update(
     reference: &str,
     collection: &cella_templates::types::FeatureCollectionIndex,
     cache: &TemplateCache,

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -15,6 +15,7 @@ mod install;
 mod list;
 mod logs;
 mod network;
+mod outdated;
 mod ports;
 mod prune;
 mod read_configuration;
@@ -143,6 +144,8 @@ pub enum Command {
     Template(template::TemplateArgs),
     /// Manage devcontainer features.
     Features(features::FeaturesArgs),
+    /// Show current and available versions.
+    Outdated(outdated::OutdatedArgs),
     /// Initialize cella in the current repository.
     Init(init::InitArgs),
     /// Open VS Code connected to the dev container.
@@ -223,6 +226,7 @@ impl Command {
             Self::Config(args) => args.execute(),
             Self::Template(args) => args.execute(),
             Self::Features(args) => args.execute(progress).await,
+            Self::Outdated(args) => args.execute().await,
             Self::Init(args) => args.execute(progress).await,
             Self::Completion(args) => {
                 args.execute();

--- a/crates/cella-cli/src/commands/outdated.rs
+++ b/crates/cella-cli/src/commands/outdated.rs
@@ -7,7 +7,7 @@ use serde_json::json;
 
 use crate::commands::OutputFormat;
 use crate::commands::features::resolve::{self, CommonFeatureFlags};
-use crate::commands::features::update::{self, UpdateCandidate};
+use crate::commands::features::update;
 use crate::table::{Column, Table};
 
 /// Show current and available versions.
@@ -66,23 +66,36 @@ impl OutdatedArgs {
         let collection =
             cella_templates::collection::fetch_feature_collection(registry, &cache, false).await?;
 
-        let mut candidates: Vec<OutdatedEntry> = Vec::new();
+        let mut entries: Vec<FeatureStatus> = Vec::new();
         for (reference, _) in &features {
             if let Some(candidate) = update::check_for_update(reference, &collection, &cache).await
             {
-                candidates.push(OutdatedEntry {
+                entries.push(FeatureStatus {
+                    name: candidate.name.clone(),
                     reference: reference.clone(),
-                    candidate,
+                    current: candidate.current_tag.clone(),
+                    latest: candidate.latest_version.clone(),
+                    outdated: true,
+                });
+            } else {
+                let current_tag = reference.rsplit_once(':').map_or("latest", |(_, tag)| tag);
+                let name = resolve::resolve_feature_name(reference, &cache).await;
+                entries.push(FeatureStatus {
+                    name,
+                    reference: reference.clone(),
+                    current: current_tag.to_owned(),
+                    latest: current_tag.to_owned(),
+                    outdated: false,
                 });
             }
         }
 
         match self.output {
-            OutputFormat::Text => print_table(&candidates),
-            OutputFormat::Json => print_json(&candidates)?,
+            OutputFormat::Text => print_table(&entries),
+            OutputFormat::Json => print_json(&entries)?,
         }
 
-        if self.check && !candidates.is_empty() {
+        if self.check && entries.iter().any(|e| e.outdated) {
             std::process::exit(1);
         }
 
@@ -90,12 +103,15 @@ impl OutdatedArgs {
     }
 }
 
-struct OutdatedEntry {
+struct FeatureStatus {
+    name: String,
     reference: String,
-    candidate: UpdateCandidate,
+    current: String,
+    latest: String,
+    outdated: bool,
 }
 
-fn print_table(entries: &[OutdatedEntry]) {
+fn print_table(entries: &[FeatureStatus]) {
     if entries.is_empty() {
         eprintln!("All features are up to date.");
         return;
@@ -104,31 +120,36 @@ fn print_table(entries: &[OutdatedEntry]) {
     let mut table = Table::new(vec![
         Column::shrinkable("FEATURE"),
         Column::fixed("CURRENT"),
-        Column::fixed("WANTED"),
         Column::fixed("LATEST"),
+        Column::fixed("STATUS"),
     ]);
 
     for entry in entries {
+        let status = if entry.outdated {
+            "outdated"
+        } else {
+            "up to date"
+        };
         table.add_row(vec![
-            entry.candidate.name.clone(),
-            entry.candidate.current_tag.clone(),
-            entry.candidate.latest_version.clone(),
-            entry.candidate.latest_version.clone(),
+            entry.name.clone(),
+            entry.current.clone(),
+            entry.latest.clone(),
+            status.to_owned(),
         ]);
     }
 
     table.eprint();
 }
 
-fn print_json(entries: &[OutdatedEntry]) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+fn print_json(entries: &[FeatureStatus]) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let mut features = serde_json::Map::new();
     for entry in entries {
         features.insert(
             entry.reference.clone(),
             json!({
-                "current": entry.candidate.current_tag,
-                "wanted": entry.candidate.latest_version,
-                "latest": entry.candidate.latest_version,
+                "current": entry.current,
+                "latest": entry.latest,
+                "updateAvailable": entry.outdated,
             }),
         );
     }
@@ -203,22 +224,19 @@ mod tests {
 
     #[test]
     fn print_json_empty_produces_valid_json() {
-        let entries: Vec<OutdatedEntry> = vec![];
+        let entries: Vec<FeatureStatus> = vec![];
         let result = print_json(&entries);
         assert!(result.is_ok());
     }
 
     #[test]
     fn print_json_with_entries_produces_valid_structure() {
-        let entries = vec![OutdatedEntry {
+        let entries = vec![FeatureStatus {
+            name: "Node.js".to_owned(),
             reference: "ghcr.io/devcontainers/features/node:1".to_owned(),
-            candidate: UpdateCandidate {
-                current_ref: "ghcr.io/devcontainers/features/node:1".to_owned(),
-                name: "Node.js".to_owned(),
-                current_tag: "1".to_owned(),
-                latest_version: "2.0.0".to_owned(),
-                updated_ref: "ghcr.io/devcontainers/features/node:2.0.0".to_owned(),
-            },
+            current: "1".to_owned(),
+            latest: "2.0.0".to_owned(),
+            outdated: true,
         }];
         let result = print_json(&entries);
         assert!(result.is_ok());
@@ -226,15 +244,12 @@ mod tests {
 
     #[test]
     fn print_table_with_entries_does_not_panic() {
-        let entries = vec![OutdatedEntry {
+        let entries = vec![FeatureStatus {
+            name: "Node.js".to_owned(),
             reference: "ghcr.io/devcontainers/features/node:1".to_owned(),
-            candidate: UpdateCandidate {
-                current_ref: "ghcr.io/devcontainers/features/node:1".to_owned(),
-                name: "Node.js".to_owned(),
-                current_tag: "1".to_owned(),
-                latest_version: "2.0.0".to_owned(),
-                updated_ref: "ghcr.io/devcontainers/features/node:2.0.0".to_owned(),
-            },
+            current: "1".to_owned(),
+            latest: "2.0.0".to_owned(),
+            outdated: true,
         }];
         print_table(&entries);
     }

--- a/crates/cella-cli/src/commands/outdated.rs
+++ b/crates/cella-cli/src/commands/outdated.rs
@@ -1,0 +1,241 @@
+//! `cella outdated` — show current and available versions for configured features.
+
+use std::path::PathBuf;
+
+use clap::Args;
+use serde_json::json;
+
+use crate::commands::OutputFormat;
+use crate::commands::features::resolve::{self, CommonFeatureFlags};
+use crate::commands::features::update::{self, UpdateCandidate};
+use crate::table::{Column, Table};
+
+/// Show current and available versions.
+#[derive(Args)]
+pub struct OutdatedArgs {
+    #[command(flatten)]
+    pub common: CommonFeatureFlags,
+
+    /// Output format.
+    #[arg(long, value_enum, default_value = "text")]
+    pub output: OutputFormat,
+
+    /// Exit with code 1 if any feature is outdated.
+    #[arg(long)]
+    pub check: bool,
+
+    #[arg(long, hide = true)]
+    pub terminal_columns: Option<u16>,
+
+    #[arg(long, hide = true)]
+    pub terminal_rows: Option<u16>,
+
+    #[arg(long, hide = true)]
+    pub user_data_folder: Option<PathBuf>,
+
+    #[arg(long, hide = true)]
+    pub log_level: Option<String>,
+
+    #[arg(long, hide = true)]
+    pub log_format: Option<String>,
+}
+
+impl OutdatedArgs {
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let config_path = resolve::discover_config(&self.common)?;
+        let raw = resolve::read_raw_config(&config_path)?;
+        let stripped = cella_jsonc::strip(&raw)?;
+        let config: serde_json::Value = serde_json::from_str(&stripped)?;
+        let features = resolve::extract_features(&config);
+
+        if features.is_empty() {
+            if matches!(self.output, OutputFormat::Json) {
+                println!("{{\"features\":{{}}}}");
+            } else {
+                eprintln!("No features configured.");
+            }
+            return Ok(());
+        }
+
+        let registry = self
+            .common
+            .registry
+            .as_deref()
+            .unwrap_or(cella_templates::collection::DEFAULT_FEATURE_COLLECTION);
+        let cache = cella_templates::cache::TemplateCache::new();
+        let collection =
+            cella_templates::collection::fetch_feature_collection(registry, &cache, false).await?;
+
+        let mut candidates: Vec<OutdatedEntry> = Vec::new();
+        for (reference, _) in &features {
+            if let Some(candidate) = update::check_for_update(reference, &collection, &cache).await
+            {
+                candidates.push(OutdatedEntry {
+                    reference: reference.clone(),
+                    candidate,
+                });
+            }
+        }
+
+        match self.output {
+            OutputFormat::Text => print_table(&candidates),
+            OutputFormat::Json => print_json(&candidates)?,
+        }
+
+        if self.check && !candidates.is_empty() {
+            std::process::exit(1);
+        }
+
+        Ok(())
+    }
+}
+
+struct OutdatedEntry {
+    reference: String,
+    candidate: UpdateCandidate,
+}
+
+fn print_table(entries: &[OutdatedEntry]) {
+    if entries.is_empty() {
+        eprintln!("All features are up to date.");
+        return;
+    }
+
+    let mut table = Table::new(vec![
+        Column::shrinkable("FEATURE"),
+        Column::fixed("CURRENT"),
+        Column::fixed("WANTED"),
+        Column::fixed("LATEST"),
+    ]);
+
+    for entry in entries {
+        table.add_row(vec![
+            entry.candidate.name.clone(),
+            entry.candidate.current_tag.clone(),
+            entry.candidate.latest_version.clone(),
+            entry.candidate.latest_version.clone(),
+        ]);
+    }
+
+    table.eprint();
+}
+
+fn print_json(entries: &[OutdatedEntry]) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let mut features = serde_json::Map::new();
+    for entry in entries {
+        features.insert(
+            entry.reference.clone(),
+            json!({
+                "current": entry.candidate.current_tag,
+                "wanted": entry.candidate.latest_version,
+                "latest": entry.candidate.latest_version,
+            }),
+        );
+    }
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&json!({ "features": features }))?
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use cella_templates::cache::TemplateCache;
+    use cella_templates::types::{FeatureCollectionIndex, FeatureSummary};
+
+    use super::*;
+
+    fn make_collection(features: Vec<FeatureSummary>) -> FeatureCollectionIndex {
+        FeatureCollectionIndex {
+            features,
+            source_information: None,
+        }
+    }
+
+    #[test]
+    fn outdated_entry_from_update_candidate() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let cache = TemplateCache::with_root(std::env::temp_dir().join("cella-test-outdated-1"));
+        let collection = make_collection(vec![FeatureSummary {
+            id: "node".to_owned(),
+            version: "2.0.0".to_owned(),
+            name: Some("Node.js".to_owned()),
+            description: None,
+            keywords: vec![],
+        }]);
+
+        let candidate = rt.block_on(update::check_for_update(
+            "ghcr.io/devcontainers/features/node:1",
+            &collection,
+            &cache,
+        ));
+        assert!(candidate.is_some());
+        let c = candidate.unwrap();
+        assert_eq!(c.current_tag, "1");
+        assert_eq!(c.latest_version, "2.0.0");
+    }
+
+    #[test]
+    fn outdated_entry_up_to_date_returns_none() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let cache = TemplateCache::with_root(std::env::temp_dir().join("cella-test-outdated-2"));
+        let collection = make_collection(vec![FeatureSummary {
+            id: "node".to_owned(),
+            version: "1".to_owned(),
+            name: Some("Node.js".to_owned()),
+            description: None,
+            keywords: vec![],
+        }]);
+
+        let candidate = rt.block_on(update::check_for_update(
+            "ghcr.io/devcontainers/features/node:1",
+            &collection,
+            &cache,
+        ));
+        assert!(candidate.is_none());
+    }
+
+    #[test]
+    fn print_table_empty_shows_up_to_date() {
+        print_table(&[]);
+    }
+
+    #[test]
+    fn print_json_empty_produces_valid_json() {
+        let entries: Vec<OutdatedEntry> = vec![];
+        let result = print_json(&entries);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn print_json_with_entries_produces_valid_structure() {
+        let entries = vec![OutdatedEntry {
+            reference: "ghcr.io/devcontainers/features/node:1".to_owned(),
+            candidate: UpdateCandidate {
+                current_ref: "ghcr.io/devcontainers/features/node:1".to_owned(),
+                name: "Node.js".to_owned(),
+                current_tag: "1".to_owned(),
+                latest_version: "2.0.0".to_owned(),
+                updated_ref: "ghcr.io/devcontainers/features/node:2.0.0".to_owned(),
+            },
+        }];
+        let result = print_json(&entries);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn print_table_with_entries_does_not_panic() {
+        let entries = vec![OutdatedEntry {
+            reference: "ghcr.io/devcontainers/features/node:1".to_owned(),
+            candidate: UpdateCandidate {
+                current_ref: "ghcr.io/devcontainers/features/node:1".to_owned(),
+                name: "Node.js".to_owned(),
+                current_tag: "1".to_owned(),
+                latest_version: "2.0.0".to_owned(),
+                updated_ref: "ghcr.io/devcontainers/features/node:2.0.0".to_owned(),
+            },
+        }];
+        print_table(&entries);
+    }
+}


### PR DESCRIPTION
## Summary

- Add top-level `cella outdated` command showing current vs available feature versions
- Reuse `check_for_update` from features/update (exposed as pub)
- Table and JSON output formats, `--check` flag for CI (exits 1 if outdated)
- 6 unit tests with mock collections

## Test plan

- [x] 6 unit tests passing
- [x] `cargo clippy --workspace` clean
- [x] `cargo test --workspace` passes

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)