### PR TITLE
fix: WezTerm tab title recovery after sub-process exit

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,6 +9,7 @@
       "nvmVersion": "latest"
     }
   },
+  "postCreateCommand": "cargo install cargo-insta",
   "postStartCommand": "npm install -g @openai/codex @google/gemini-cli",
   "customizations": {
     "vscode": {

--- a/crates/cella-backend/src/container_setup.rs
+++ b/crates/cella-backend/src/container_setup.rs
@@ -424,7 +424,7 @@ pub async fn inject_cella_path(
         format!("/home/{remote_user}")
     };
 
-    for (guard, snippet) in PATH_SNIPPETS {
+    for (guard, snippet) in PATH_SNIPPETS.iter().chain(TITLE_SNIPPETS) {
         for profile in &[".bashrc", ".zshrc", ".profile"] {
             let path = format!("{home}/{profile}");
             let cmd = format!(
@@ -474,6 +474,22 @@ fi
 "#,
     ),
 ];
+
+const TITLE_SNIPPETS: &[(&str, &str)] = &[(
+    "# cella terminal title",
+    r#"
+# cella terminal title (re-set title after each command for WezTerm compat)
+if [ -n "$CELLA_TITLE" ]; then
+    if [ -n "$BASH" ]; then
+        __cella_title() { printf '\033]0;%s\007' "$CELLA_TITLE"; }
+        PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND;}__cella_title"
+    elif [ -n "$ZSH_VERSION" ]; then
+        __cella_title() { printf '\033]0;%s\007' "$CELLA_TITLE" }
+        precmd_functions+=(__cella_title)
+    fi
+fi
+"#,
+)];
 
 /// Seed gh CLI credentials into a container.
 ///
@@ -808,5 +824,33 @@ mod tests {
         let cmd = json!({"step": 42});
         let result = run_host_command("test", &cmd);
         assert!(result.is_ok());
+    }
+
+    // ── TITLE_SNIPPETS ──────────────────────────────────────────────
+
+    #[test]
+    fn title_snippet_contains_prompt_command_for_bash() {
+        let (_, snippet) = TITLE_SNIPPETS[0];
+        assert!(snippet.contains("PROMPT_COMMAND"));
+        assert!(snippet.contains("CELLA_TITLE"));
+    }
+
+    #[test]
+    fn title_snippet_contains_precmd_for_zsh() {
+        let (_, snippet) = TITLE_SNIPPETS[0];
+        assert!(snippet.contains("precmd_functions"));
+        assert!(snippet.contains("ZSH_VERSION"));
+    }
+
+    #[test]
+    fn title_snippet_guard_is_idempotent_marker() {
+        let (guard, _) = TITLE_SNIPPETS[0];
+        assert!(guard.starts_with("# cella"));
+    }
+
+    #[test]
+    fn title_snippet_only_activates_when_cella_title_set() {
+        let (_, snippet) = TITLE_SNIPPETS[0];
+        assert!(snippet.contains(r#"if [ -n "$CELLA_TITLE" ]"#));
     }
 }

--- a/crates/cella-backend/src/container_setup.rs
+++ b/crates/cella-backend/src/container_setup.rs
@@ -413,19 +413,15 @@ async fn apply_git_config(
 /// Each block has its own idempotency guard so the function is safe to
 /// re-run and also patches containers that were created before the
 /// `~/.local/bin` block existed.
-pub async fn inject_cella_path(
+async fn inject_snippets(
     client: &dyn ContainerBackend,
     container_id: &str,
-    remote_user: &str,
+    home: &str,
+    snippets: &[(&str, &str)],
+    profiles: &[&str],
 ) {
-    let home = if remote_user == "root" {
-        "/root".to_string()
-    } else {
-        format!("/home/{remote_user}")
-    };
-
-    for (guard, snippet) in PATH_SNIPPETS.iter().chain(TITLE_SNIPPETS) {
-        for profile in &[".bashrc", ".zshrc", ".profile"] {
+    for (guard, snippet) in snippets {
+        for profile in profiles {
             let path = format!("{home}/{profile}");
             let cmd = format!(
                 "if [ -f '{path}' ] && ! grep -q '{guard}' '{path}'; then printf '%s\\n' '{escaped}' >> '{path}'; fi",
@@ -446,6 +442,38 @@ pub async fn inject_cella_path(
                 .await;
         }
     }
+}
+
+pub async fn inject_cella_path(
+    client: &dyn ContainerBackend,
+    container_id: &str,
+    remote_user: &str,
+) {
+    let home = if remote_user == "root" {
+        "/root".to_string()
+    } else {
+        format!("/home/{remote_user}")
+    };
+
+    // PATH_SNIPPETS are POSIX-safe → all profiles including .profile.
+    inject_snippets(
+        client,
+        container_id,
+        &home,
+        PATH_SNIPPETS,
+        &[".bashrc", ".zshrc", ".profile"],
+    )
+    .await;
+    // TITLE_SNIPPETS contain zsh-specific syntax (precmd_functions+=) that
+    // dash cannot parse even inside a dead branch → .bashrc/.zshrc only.
+    inject_snippets(
+        client,
+        container_id,
+        &home,
+        TITLE_SNIPPETS,
+        &[".bashrc", ".zshrc"],
+    )
+    .await;
 }
 
 const PATH_SNIPPETS: &[(&str, &str)] = &[

--- a/crates/cella-cli/src/commands/exec.rs
+++ b/crates/cella-cli/src/commands/exec.rs
@@ -224,6 +224,11 @@ async fn run_exec(
         }
     } else {
         let title_guard = push_for_container(container, service, "exec");
+        let mut env = env;
+        env.push(format!(
+            "CELLA_TITLE={}",
+            crate::title::title_for_container(container, service, "exec")
+        ));
         let exit_code = client
             .exec_interactive(
                 &container.id,

--- a/crates/cella-cli/src/commands/shell.rs
+++ b/crates/cella-cli/src/commands/shell.rs
@@ -69,6 +69,8 @@ impl ShellArgs {
             super::resolve_service_container(client.as_ref(), container, self.service.as_deref())
                 .await?;
 
+        let cella_title =
+            crate::title::title_for_container(&container, self.service.as_deref(), "shell");
         let title_guard =
             crate::title::push_for_container(&container, self.service.as_deref(), "shell");
 
@@ -131,6 +133,8 @@ impl ShellArgs {
                 env.push(format!("{var}={val}"));
             }
         }
+
+        env.push(format!("CELLA_TITLE={cella_title}"));
 
         let exit_code = client
             .as_ref()

--- a/crates/cella-cli/src/commands/switch.rs
+++ b/crates/cella-cli/src/commands/switch.rs
@@ -50,6 +50,7 @@ impl SwitchArgs {
         };
 
         let container = target.resolve(client.as_ref(), true).await?;
+        let cella_title = crate::title::title_for_container(&container, None, "switch");
         let title_guard = crate::title::push_for_container(&container, None, "switch");
 
         super::ensure_cella_daemon().await;
@@ -108,6 +109,8 @@ impl SwitchArgs {
                 env.push(format!("{var}={val}"));
             }
         }
+
+        env.push(format!("CELLA_TITLE={cella_title}"));
 
         let exit_code = client
             .as_ref()

--- a/crates/cella-cli/src/title.rs
+++ b/crates/cella-cli/src/title.rs
@@ -105,6 +105,19 @@ impl TitleGuard {
     }
 }
 
+fn content_for_container(
+    container: &cella_backend::ContainerInfo,
+    service: Option<&str>,
+    subcommand: &'static str,
+) -> TitleContent {
+    TitleContent {
+        name: title_name(base_name(container)).to_string(),
+        service: service.map(str::to_string),
+        branch: container.labels.get("dev.cella.branch").cloned(),
+        subcommand,
+    }
+}
+
 /// Convenience: build a guard from a resolved container. Pulls `branch` from
 /// the `dev.cella.branch` label when present, and `service` from the caller's
 /// explicit flag. For compose containers, prefers the `com.docker.compose.project`
@@ -115,12 +128,7 @@ pub fn push_for_container(
     service: Option<&str>,
     subcommand: &'static str,
 ) -> Option<TitleGuard> {
-    TitleGuard::push(&TitleContent {
-        name: title_name(base_name(container)).to_string(),
-        service: service.map(str::to_string),
-        branch: container.labels.get("dev.cella.branch").cloned(),
-        subcommand,
-    })
+    TitleGuard::push(&content_for_container(container, service, subcommand))
 }
 
 /// Format the title string for a container without emitting any escape
@@ -130,13 +138,7 @@ pub fn title_for_container(
     service: Option<&str>,
     subcommand: &'static str,
 ) -> String {
-    TitleContent {
-        name: title_name(base_name(container)).to_string(),
-        service: service.map(str::to_string),
-        branch: container.labels.get("dev.cella.branch").cloned(),
-        subcommand,
-    }
-    .format()
+    content_for_container(container, service, subcommand).format()
 }
 
 /// Look up the existing container for `workspace_root` and derive a guard from

--- a/crates/cella-cli/src/title.rs
+++ b/crates/cella-cli/src/title.rs
@@ -19,9 +19,12 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 static TITLE_ACTIVE: AtomicBool = AtomicBool::new(false);
 static NEEDS_TMUX_WRAP: AtomicBool = AtomicBool::new(false);
+static IS_WEZTERM: AtomicBool = AtomicBool::new(false);
 
 const RESTORE_PLAIN: &[u8] = b"\x1b[23;0t";
 const RESTORE_TMUX: &[u8] = b"\x1bPtmux;\x1b\x1b[23;0t\x1b\\";
+const WEZTERM_RESET_PLAIN: &[u8] = b"\x1b]0;wezterm\x07";
+const WEZTERM_RESET_TMUX: &[u8] = b"\x1bPtmux;\x1b\x1b]0;wezterm\x07\x1b\\";
 
 /// Strip the `"cella-"` prefix so the title doesn't repeat the brand already
 /// present in the `" \u{2014} cella <subcommand>"` suffix. No-op if the prefix
@@ -96,6 +99,7 @@ impl TitleGuard {
         let _ = emit_set(&mut stderr, &content.format(), tmux);
         let _ = stderr.flush();
         NEEDS_TMUX_WRAP.store(tmux, Ordering::Release);
+        IS_WEZTERM.store(is_wezterm(), Ordering::Release);
         TITLE_ACTIVE.store(true, Ordering::Release);
         Some(Self(()))
     }
@@ -117,6 +121,22 @@ pub fn push_for_container(
         branch: container.labels.get("dev.cella.branch").cloned(),
         subcommand,
     })
+}
+
+/// Format the title string for a container without emitting any escape
+/// sequences. Used to set the `CELLA_TITLE` env var.
+pub fn title_for_container(
+    container: &cella_backend::ContainerInfo,
+    service: Option<&str>,
+    subcommand: &'static str,
+) -> String {
+    TitleContent {
+        name: title_name(base_name(container)).to_string(),
+        service: service.map(str::to_string),
+        branch: container.labels.get("dev.cella.branch").cloned(),
+        subcommand,
+    }
+    .format()
 }
 
 /// Look up the existing container for `workspace_root` and derive a guard from
@@ -201,10 +221,27 @@ fn emit_set(w: &mut impl Write, title: &str, in_tmux: bool) -> io::Result<()> {
     }
 }
 
-// Pop the title stack. Terminals with stack support (xterm, kitty, iTerm2)
-// restore the prior title; terminals without (WezTerm) silently ignore the
-// pop and leave the cella title until the shell prompt overwrites it.
+fn is_wezterm() -> bool {
+    std::env::var("TERM_PROGRAM").is_ok_and(|v| v == "WezTerm")
+}
+
+fn emit_wezterm_reset(w: &mut impl Write, in_tmux: bool) -> io::Result<()> {
+    let bytes: &[u8] = b"\x1b]0;wezterm\x07";
+    if in_tmux {
+        w.write_all(&tmux_wrap(bytes))
+    } else {
+        w.write_all(bytes)
+    }
+}
+
 fn emit_restore(w: &mut impl Write, in_tmux: bool) -> io::Result<()> {
+    emit_restore_impl(w, in_tmux, IS_WEZTERM.load(Ordering::Acquire))
+}
+
+fn emit_restore_impl(w: &mut impl Write, in_tmux: bool, wezterm: bool) -> io::Result<()> {
+    if wezterm {
+        emit_wezterm_reset(w, in_tmux)?;
+    }
     emit_pop(w, in_tmux)
 }
 
@@ -259,11 +296,23 @@ pub fn install_signal_handlers() {
 
 extern "C" fn restore_title_on_signal(sig: nix::libc::c_int) {
     if TITLE_ACTIVE.load(Ordering::Acquire) {
-        let bytes = if NEEDS_TMUX_WRAP.load(Ordering::Acquire) {
-            RESTORE_TMUX
-        } else {
-            RESTORE_PLAIN
-        };
+        let tmux = NEEDS_TMUX_WRAP.load(Ordering::Acquire);
+
+        if IS_WEZTERM.load(Ordering::Acquire) {
+            let bytes = if tmux {
+                WEZTERM_RESET_TMUX
+            } else {
+                WEZTERM_RESET_PLAIN
+            };
+            #[allow(unsafe_code)]
+            // SAFETY: libc::write on STDERR_FILENO is async-signal-safe.
+            unsafe {
+                let _ =
+                    nix::libc::write(nix::libc::STDERR_FILENO, bytes.as_ptr().cast(), bytes.len());
+            }
+        }
+
+        let bytes = if tmux { RESTORE_TMUX } else { RESTORE_PLAIN };
         #[allow(unsafe_code)]
         // SAFETY: libc::write on STDERR_FILENO is async-signal-safe.
         unsafe {
@@ -622,6 +671,102 @@ mod tests {
         ]
         .concat();
         assert_eq!(out, expected);
+    }
+
+    // ── emit_restore_impl (WezTerm) ────────────────────────────────
+
+    #[test]
+    fn emit_restore_wezterm_plain_emits_reset_then_pop() {
+        let mut out = Vec::new();
+        emit_restore_impl(&mut out, false, true).unwrap();
+        let expected = [b"\x1b]0;wezterm\x07".as_slice(), b"\x1b[23;0t".as_slice()].concat();
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn emit_restore_wezterm_tmux_emits_wrapped_reset_then_pop() {
+        let mut out = Vec::new();
+        emit_restore_impl(&mut out, true, true).unwrap();
+        let expected = [
+            tmux_wrap(b"\x1b]0;wezterm\x07").as_slice(),
+            tmux_wrap(b"\x1b[23;0t").as_slice(),
+        ]
+        .concat();
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn emit_restore_non_wezterm_unchanged() {
+        let mut out = Vec::new();
+        emit_restore_impl(&mut out, false, false).unwrap();
+        assert_eq!(out, b"\x1b[23;0t");
+    }
+
+    // ── emit_wezterm_reset constants ──────────────────────────────
+
+    #[test]
+    fn wezterm_reset_plain_matches_emit_output() {
+        let mut out = Vec::new();
+        emit_wezterm_reset(&mut out, false).unwrap();
+        assert_eq!(out.as_slice(), WEZTERM_RESET_PLAIN);
+    }
+
+    #[test]
+    fn wezterm_reset_tmux_matches_emit_output() {
+        let mut out = Vec::new();
+        emit_wezterm_reset(&mut out, true).unwrap();
+        assert_eq!(out.as_slice(), WEZTERM_RESET_TMUX);
+    }
+
+    // ── full lifecycle (WezTerm) ────────────────────────────────────
+
+    #[test]
+    fn full_push_set_restore_lifecycle_wezterm_plain() {
+        let mut out = Vec::new();
+        emit_push(&mut out, false).unwrap();
+        emit_set(&mut out, "x \u{2014} cella exec", false).unwrap();
+        emit_restore_impl(&mut out, false, true).unwrap();
+
+        let expected = [
+            b"\x1b[22;0t".as_slice(),
+            b"\x1b]0;x \xe2\x80\x94 cella exec\x07".as_slice(),
+            b"\x1b]0;wezterm\x07".as_slice(),
+            b"\x1b[23;0t".as_slice(),
+        ]
+        .concat();
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn full_push_set_restore_lifecycle_wezterm_tmux() {
+        let mut out = Vec::new();
+        emit_push(&mut out, true).unwrap();
+        emit_set(&mut out, "x", true).unwrap();
+        emit_restore_impl(&mut out, true, true).unwrap();
+
+        let expected = [
+            tmux_wrap(b"\x1b[22;0t").as_slice(),
+            tmux_wrap(b"\x1b]0;x\x07").as_slice(),
+            tmux_wrap(b"\x1b]0;wezterm\x07").as_slice(),
+            tmux_wrap(b"\x1b[23;0t").as_slice(),
+        ]
+        .concat();
+        assert_eq!(out, expected);
+    }
+
+    // ── title_for_container ─────────────────────────────────────────
+
+    #[test]
+    fn title_for_container_matches_push_format() {
+        let c = container_with_labels("cella-myrepo-a1b2c3d4", &[]);
+        let title = title_for_container(&c, Some("api"), "shell");
+        let content = TitleContent {
+            name: title_name(base_name(&c)).to_string(),
+            service: Some("api".to_string()),
+            branch: None,
+            subcommand: "shell",
+        };
+        assert_eq!(title, content.format());
     }
 
     // ── public API reachability ──────────────────────────────────────

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.95.0"
-components = ["clippy", "rustfmt", "llvm-tools-preview"]
+components = ["clippy", "rustfmt", "llvm-tools-preview", "rust-analyzer"]


### PR DESCRIPTION
## Summary

- Detect WezTerm via `TERM_PROGRAM` and emit `OSC 0;wezterm` before the title pop to re-enable dynamic process-name guessing (WezTerm silently ignores the xterm title stack)
- Set `CELLA_TITLE` env var in `shell`, `exec`, and `switch` interactive sessions
- Inject a shell hook into `.bashrc`/`.zshrc` that re-emits the title via `PROMPT_COMMAND` (bash) / `precmd_functions` (zsh) after every command, recovering from sub-processes that clobber the title

## Test plan

- [x] WezTerm: run `cella exec -- bash -c 'printf "\033]0;\007"'` — title should recover after exit
- [x] WezTerm: `cella shell` → `printf '\033]0;\007'` → next prompt restores title
- [x] Non-WezTerm (kitty/iTerm2): existing push/pop behavior unchanged
- [x] Debian/Ubuntu containers: `.profile` not broken by zsh-specific syntax (dash-safe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)