### PR TITLE
feat: add runtime_test macro for integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,9 +111,12 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Run tests with coverage
-        run: cargo llvm-cov --no-report --workspace
+        run: >
+          cargo llvm-cov --no-report --workspace
+          --exclude cella-docker
+          --exclude cella-compose
 
-      - name: Run Docker integration tests serialized
+      - name: Run Docker and Compose tests serialized
         run: >
           cargo llvm-cov --no-report
           -p cella-docker

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,38 +110,15 @@ jobs:
       - name: Log in to ghcr.io
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
-      - name: Run unit tests with coverage
+      - name: Run tests with coverage
         run: cargo llvm-cov --no-report --workspace
 
-      - name: Run integration tests with coverage
-        run: >
-          cargo llvm-cov --no-report
-          -p cella-features
-          -p cella-daemon
-          -p cella-compose
-          -p cella-agent
-          -p cella-env
-          --features integration-tests
-
-      - name: Run Docker integration tests with coverage
+      - name: Run Docker integration tests serialized
         run: >
           cargo llvm-cov --no-report
           -p cella-docker
-          --features integration-tests
-          -- --ignored --test-threads=1
-
-      - name: Run Compose integration tests with coverage
-        run: >
-          cargo llvm-cov --no-report
           -p cella-compose
-          --features integration-tests
-          -- --ignored --test-threads=1
-
-      - name: Run template registry integration tests with coverage
-        run: >
-          cargo llvm-cov --no-report
-          -p cella-templates
-          --features integration-tests
+          -- --test-threads=1
 
       - name: Generate combined coverage report
         run: cargo llvm-cov report > coverage-report.txt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,10 @@ jobs:
           tool: cargo-insta
 
       - name: Validate snapshots
-        run: cargo insta test --workspace --check --unreferenced=reject
+        run: cargo insta test --workspace --exclude cella-docker --exclude cella-compose --check --unreferenced=reject
+
+      - name: Validate Docker and Compose snapshots serialized
+        run: cargo insta test -p cella-docker -p cella-compose --check --unreferenced=reject -- --test-threads=1
 
   integration-test:
     name: Integration Test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,10 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
 
       - name: Run tests
-        run: cargo test --workspace
+        run: cargo test --workspace --exclude cella-docker --exclude cella-compose
+
+      - name: Run Docker and Compose tests serialized
+        run: cargo test -p cella-docker -p cella-compose -- --test-threads=1
 
   insta:
     name: Snapshots

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,10 +65,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
 
       - name: Run tests
-        run: cargo test --workspace --exclude cella-docker --exclude cella-compose
-
-      - name: Run Docker and Compose tests serialized
-        run: cargo test -p cella-docker -p cella-compose -- --test-threads=1
+        run: cargo test --workspace
 
   insta:
     name: Snapshots
@@ -88,10 +85,7 @@ jobs:
           tool: cargo-insta
 
       - name: Validate snapshots
-        run: cargo insta test --workspace --exclude cella-docker --exclude cella-compose --check --unreferenced=reject
-
-      - name: Validate Docker and Compose snapshots serialized
-        run: cargo insta test -p cella-docker -p cella-compose --check --unreferenced=reject -- --test-threads=1
+        run: cargo insta test --workspace --check --unreferenced=reject
 
   integration-test:
     name: Integration Test
@@ -117,17 +111,7 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Run tests with coverage
-        run: >
-          cargo llvm-cov --no-report --workspace
-          --exclude cella-docker
-          --exclude cella-compose
-
-      - name: Run Docker and Compose tests serialized
-        run: >
-          cargo llvm-cov --no-report
-          -p cella-docker
-          -p cella-compose
-          -- --test-threads=1
+        run: cargo llvm-cov --no-report --workspace
 
       - name: Generate combined coverage report
         run: cargo llvm-cov report > coverage-report.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,15 +7,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ```sh
 cargo fmt --all -- --check                                            # format check
 cargo clippy --workspace --all-features --all-targets -- -D warnings -D clippy::all  # lint (all warnings are errors)
-cargo test --workspace                                                # unit tests
+cargo test --workspace                                                # all tests (integration tests skip if runtime unavailable)
 cargo insta test --workspace --check --unreferenced=reject            # snapshot tests
 ```
 
-Integration tests require Docker and are feature-gated:
-
-```sh
-cargo test -p cella-features -p cella-daemon -p cella-compose --features integration-tests
-```
+Integration tests use `#[runtime_test]` from `cella-testing` for runtime detection. They always compile and skip gracefully when the required runtime (Docker, compose, network, etc.) is unavailable. No special flags needed — `cargo test --workspace` runs everything.
 
 Update snapshots with `cargo insta review`.
 
@@ -55,11 +51,12 @@ Always research before suggesting changes or asking the user questions. Use `/sp
 
 ## Architecture
 
-Rust workspace (edition 2024, MSRV 1.95.0) with 19 crates in `crates/`. Three-tier structure:
+Rust workspace (edition 2024, MSRV 1.95.0) with crates in `crates/`. Three-tier structure:
 
 - **Tier 1 (CLI):** cella-cli — binary entry point, delegates to library crates
 - **Tier 2 (Domain):** cella-docker, cella-compose, cella-orchestrator, cella-config, cella-features, cella-git, cella-daemon, cella-agent, cella-env, cella-doctor, cella-container, cella-templates
 - **Tier 3 (Foundation):** cella-backend, cella-port, cella-codegen, cella-network, cella-protocol, cella-jsonc
+- **Testing:** cella-testing (runtime detection + `#[runtime_test]` macro), cella-test-macros (proc macro)
 
 Backend-agnostic design: cella-backend defines traits, cella-docker and cella-container implement them. Hooks pattern (PruneHooks, ComposeUpHooks, UpHooks) bridges CLI-owned operations into the orchestrator without circular dependencies.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,6 +412,7 @@ dependencies = [
  "cella-features",
  "cella-git",
  "cella-network",
+ "cella-testing",
  "cella-tool-install",
  "hex",
  "insta",
@@ -453,6 +454,7 @@ name = "cella-container"
 version = "0.0.51"
 dependencies = [
  "cella-backend",
+ "cella-testing",
  "serde",
  "serde_json",
  "tempfile",
@@ -469,6 +471,7 @@ dependencies = [
  "cella-port",
  "cella-protocol",
  "cella-proxy",
+ "cella-testing",
  "hex",
  "miette",
  "nix 0.31.2",
@@ -501,6 +504,7 @@ version = "0.0.51"
 dependencies = [
  "bollard",
  "cella-backend",
+ "cella-testing",
  "chrono",
  "crossterm",
  "futures-util",
@@ -549,6 +553,7 @@ name = "cella-features"
 version = "0.0.51"
 dependencies = [
  "cella-oci",
+ "cella-testing",
  "dirs",
  "flate2",
  "futures-util",
@@ -681,6 +686,7 @@ version = "0.0.51"
 dependencies = [
  "cella-jsonc",
  "cella-oci",
+ "cella-testing",
  "dirs",
  "filetime",
  "flate2",
@@ -697,6 +703,24 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "cella-test-macros"
+version = "0.0.51"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cella-testing"
+version = "0.0.51"
+dependencies = [
+ "bollard",
+ "cella-test-macros",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,6 +721,7 @@ dependencies = [
  "bollard",
  "cella-test-macros",
  "tokio",
+ "trybuild",
 ]
 
 [[package]]
@@ -3158,6 +3159,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3168,6 +3175,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -3496,6 +3512,21 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trybuild"
+version = "1.0.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml",
+]
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ members = [
     "crates/cella-network",
     "crates/cella-oci",
     "crates/cella-orchestrator",
+    "crates/cella-test-macros",
+    "crates/cella-testing",
     "crates/cella-tool-install",
     "crates/cella-protocol",
     "crates/cella-proxy",
@@ -146,6 +148,11 @@ nix = { version = "=0.31.2", default-features = false, features = ["signal", "te
 # PTY
 portable-pty = "=0.9.0"
 
+# Proc macros
+syn = { version = "=2.0.117", features = ["full"] }
+quote = "=1.0.45"
+proc-macro2 = "=1.0.106"
+
 # Testing
 tempfile = "=3.27.0"
 filetime = "=0.2.27"
@@ -174,6 +181,8 @@ cella-port = { path = "crates/cella-port" }
 cella-protocol = { path = "crates/cella-protocol" }
 cella-proxy = { path = "crates/cella-proxy" }
 cella-templates = { path = "crates/cella-templates" }
+cella-test-macros = { path = "crates/cella-test-macros" }
+cella-testing = { path = "crates/cella-testing" }
 
 [profile.release]
 strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,6 +157,7 @@ proc-macro2 = "=1.0.106"
 tempfile = "=3.27.0"
 filetime = "=0.2.27"
 insta = { version = "=1.47.2", features = ["json", "yaml", "redactions"] }
+trybuild = "=1.0.116"
 
 # Internal crates
 cella-backend = { path = "crates/cella-backend" }

--- a/crates/cella-agent/Cargo.toml
+++ b/crates/cella-agent/Cargo.toml
@@ -34,8 +34,5 @@ tracing-subscriber.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 
-[features]
-integration-tests = []
-
 [lints]
 workspace = true

--- a/crates/cella-agent/src/main.rs
+++ b/crates/cella-agent/src/main.rs
@@ -15,7 +15,7 @@ mod clipboard;
 mod control;
 mod credential;
 mod forward_proxy;
-#[cfg(all(test, feature = "integration-tests"))]
+#[cfg(test)]
 mod integration_tests;
 mod mitm;
 mod plugin_sync;

--- a/crates/cella-codegen/Cargo.toml
+++ b/crates/cella-codegen/Cargo.toml
@@ -8,9 +8,9 @@ license.workspace = true
 miette.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-syn = { version = "=2.0.117", features = ["full"] }
-quote = "=1.0.45"
-proc-macro2 = "=1.0.106"
+syn.workspace = true
+quote.workspace = true
+proc-macro2.workspace = true
 prettyplease = "=0.2.37"
 heck = "=0.5.0"
 indexmap = { version = "=2.14.0", features = ["serde"] }

--- a/crates/cella-compose/Cargo.toml
+++ b/crates/cella-compose/Cargo.toml
@@ -24,11 +24,9 @@ tokio.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+cella-testing.workspace = true
 insta.workspace = true
 tempfile.workspace = true
-
-[features]
-integration-tests = []
 
 [lints]
 workspace = true

--- a/crates/cella-compose/src/combined_dockerfile_build.rs
+++ b/crates/cella-compose/src/combined_dockerfile_build.rs
@@ -385,8 +385,8 @@ mod tests {
     //! Regression tests for compose + features user resolution.
     //!
     //! Pure-function tests; the `resolve_build_image_user` paths that call
-    //! `inspect_image_details` are covered by integration tests gated on the
-    //! `integration-tests` feature of `cella-compose`.
+    //! `inspect_image_details` are covered by integration tests using
+    //! `#[runtime_test(docker, compose)]`.
 
     use crate::{FEATURES_TARGET_STAGE, find_stage_base_image, find_user_statement};
     use cella_features::dockerfile::generate_dockerfile;

--- a/crates/cella-compose/src/integration_tests/smoke_tests.rs
+++ b/crates/cella-compose/src/integration_tests/smoke_tests.rs
@@ -1,7 +1,4 @@
 //! Smoke tests: full compose lifecycle with Docker.
-//!
-//! These tests are `#[ignore = "requires Docker daemon"]`-d by default because they require a running
-//! Docker daemon. Run them with `cargo test --features integration-tests -- --ignored`.
 
 use std::collections::BTreeMap;
 
@@ -30,8 +27,7 @@ fn plain_override(service: &str) -> OverrideConfig {
 }
 
 /// Plain compose: write override -> build -> up -> ps -> down.
-#[tokio::test]
-#[ignore = "requires Docker daemon"]
+#[cella_testing::runtime_test(docker, compose)]
 async fn plain_compose_lifecycle() {
     let ctx = ComposeTestContext::new("plain-compose");
     let config = load_fixture_config(&ctx.fixture_dir);
@@ -87,8 +83,7 @@ async fn plain_compose_lifecycle() {
 /// for an image-only service that would normally get features injected.
 /// It does not perform actual feature resolution (that requires cella-features),
 /// but confirms the override structure is accepted by Docker Compose.
-#[tokio::test]
-#[ignore = "requires Docker daemon"]
+#[cella_testing::runtime_test(docker, compose)]
 async fn image_only_features_lifecycle() {
     let ctx = ComposeTestContext::new("image-only-features");
     let config = load_fixture_config(&ctx.fixture_dir);
@@ -131,8 +126,7 @@ async fn image_only_features_lifecycle() {
 }
 
 /// Multi-service compose: verify that runServices are started and others are not.
-#[tokio::test]
-#[ignore = "requires Docker daemon"]
+#[cella_testing::runtime_test(docker, compose)]
 async fn multi_service_lifecycle() {
     let ctx = ComposeTestContext::new("multi-service");
     let config = load_fixture_config(&ctx.fixture_dir);

--- a/crates/cella-compose/src/lib.rs
+++ b/crates/cella-compose/src/lib.rs
@@ -31,5 +31,5 @@ pub use error::CellaComposeError;
 pub use override_file::{ComposeSecret, OverrideConfig};
 pub use project::{ComposeProject, ShutdownAction};
 
-#[cfg(all(test, feature = "integration-tests"))]
+#[cfg(test)]
 mod integration_tests;

--- a/crates/cella-container/Cargo.toml
+++ b/crates/cella-container/Cargo.toml
@@ -12,11 +12,9 @@ tokio.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+cella-testing.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-
-[features]
-integration-tests = []
 
 [lints]
 workspace = true

--- a/crates/cella-container/README.md
+++ b/crates/cella-container/README.md
@@ -55,7 +55,7 @@ The backend discovers the `container` binary via `CELLA_CONTAINER_PATH` or `PATH
 cargo test -p cella-container
 ```
 
-Unit tests cover CLI argument assembly, JSON output parsing, and container state mapping. Integration tests require macOS 26 with the Apple Container CLI installed and are gated behind the `integration-tests` feature.
+Unit tests cover CLI argument assembly, JSON output parsing, and container state mapping. Integration tests require macOS 26 with the Apple Container CLI installed and use `#[runtime_test(apple_container)]` for runtime detection — they skip gracefully on other platforms.
 
 ## Development
 

--- a/crates/cella-container/src/integration_tests.rs
+++ b/crates/cella-container/src/integration_tests.rs
@@ -1,8 +1,8 @@
 //! Integration tests for the Apple Container backend.
 //!
 //! These tests require a real Apple Container CLI installed and running on
-//! macOS. They are gated behind the `integration-tests` feature and
-//! `target_os = "macos"`.
+//! macOS. They are gated behind `target_os = "macos"` and use
+//! `#[runtime_test(apple_container)]` for runtime detection.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -90,7 +90,7 @@ fn minimal_create_opts(name: &str) -> CreateContainerOptions {
 // Tests
 // ---------------------------------------------------------------------------
 
-#[tokio::test(flavor = "multi_thread")]
+#[cella_testing::runtime_test(apple_container, flavor = "multi_thread")]
 async fn test_full_lifecycle() {
     let (backend, cli_path) = setup_backend();
     let name = test_container_name("lifecycle");
@@ -131,7 +131,7 @@ async fn test_full_lifecycle() {
     guard.container_id = None; // already removed
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[cella_testing::runtime_test(apple_container, flavor = "multi_thread")]
 async fn test_exec_with_env_and_workdir() {
     let (backend, cli_path) = setup_backend();
     let name = test_container_name("execenv");
@@ -166,7 +166,7 @@ async fn test_exec_with_env_and_workdir() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[cella_testing::runtime_test(apple_container, flavor = "multi_thread")]
 async fn test_exec_exit_code() {
     let (backend, cli_path) = setup_backend();
     let name = test_container_name("exitcode");
@@ -191,7 +191,7 @@ async fn test_exec_exit_code() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[cella_testing::runtime_test(apple_container, flavor = "multi_thread")]
 async fn test_env_vars_in_container() {
     let (backend, cli_path) = setup_backend();
     let name = test_container_name("envvars");
@@ -225,7 +225,7 @@ async fn test_env_vars_in_container() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[cella_testing::runtime_test(apple_container, flavor = "multi_thread")]
 async fn test_labels_roundtrip() {
     let (backend, cli_path) = setup_backend();
     let name = test_container_name("labels");
@@ -255,7 +255,7 @@ async fn test_labels_roundtrip() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[cella_testing::runtime_test(apple_container, flavor = "multi_thread")]
 async fn test_list_cella_containers() {
     let (backend, cli_path) = setup_backend();
     let name = test_container_name("list");
@@ -293,7 +293,7 @@ async fn test_list_cella_containers() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[cella_testing::runtime_test(apple_container, flavor = "multi_thread")]
 async fn test_file_upload() {
     let (backend, cli_path) = setup_backend();
     let name = test_container_name("upload");
@@ -325,7 +325,7 @@ async fn test_file_upload() {
     assert_eq!(result.stdout.trim(), "hello from integration test");
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[cella_testing::runtime_test(apple_container, flavor = "multi_thread")]
 async fn test_find_container_by_workspace_path() {
     let (backend, cli_path) = setup_backend();
     let name = test_container_name("findws");
@@ -361,7 +361,7 @@ async fn test_find_container_by_workspace_path() {
     let _ = tokio::fs::remove_dir_all(&workspace_path).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[cella_testing::runtime_test(apple_container, flavor = "multi_thread")]
 async fn test_inspect_image_details() {
     let (backend, _cli_path) = setup_backend();
 
@@ -378,7 +378,7 @@ async fn test_inspect_image_details() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[cella_testing::runtime_test(apple_container, flavor = "multi_thread")]
 async fn test_privileged_warns_not_errors() {
     let (backend, cli_path) = setup_backend();
     let name = test_container_name("priv");
@@ -393,7 +393,7 @@ async fn test_privileged_warns_not_errors() {
     assert!(!id.is_empty());
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[cella_testing::runtime_test(apple_container, flavor = "multi_thread")]
 async fn test_cap_add_warns_not_errors() {
     let (backend, cli_path) = setup_backend();
     let name = test_container_name("capadd");
@@ -407,7 +407,7 @@ async fn test_cap_add_warns_not_errors() {
     assert!(!id.is_empty());
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[cella_testing::runtime_test(apple_container, flavor = "multi_thread")]
 async fn test_security_opt_warns_not_errors() {
     let (backend, cli_path) = setup_backend();
     let name = test_container_name("secopt");
@@ -421,7 +421,7 @@ async fn test_security_opt_warns_not_errors() {
     assert!(!id.is_empty());
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[cella_testing::runtime_test(apple_container, flavor = "multi_thread")]
 async fn test_gpu_request_warns_not_errors() {
     let (backend, cli_path) = setup_backend();
     let name = test_container_name("gpu");
@@ -435,7 +435,7 @@ async fn test_gpu_request_warns_not_errors() {
     assert!(!id.is_empty());
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[cella_testing::runtime_test(apple_container, flavor = "multi_thread")]
 async fn test_container_restart() {
     let (backend, cli_path) = setup_backend();
     let name = test_container_name("restart");
@@ -462,7 +462,7 @@ async fn test_container_restart() {
     assert!(result.stdout.contains("after-restart"));
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[cella_testing::runtime_test(apple_container, flavor = "multi_thread")]
 async fn test_exec_stderr_capture() {
     let (backend, cli_path) = setup_backend();
     let name = test_container_name("stderr");
@@ -492,7 +492,7 @@ async fn test_exec_stderr_capture() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[cella_testing::runtime_test(apple_container, flavor = "multi_thread")]
 async fn test_multiple_file_uploads() {
     let (backend, cli_path) = setup_backend();
     let name = test_container_name("multiup");
@@ -535,7 +535,7 @@ async fn test_multiple_file_uploads() {
     }
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[cella_testing::runtime_test(apple_container, flavor = "multi_thread")]
 async fn test_remove_nonexistent_container() {
     let (backend, _cli_path) = setup_backend();
 
@@ -548,7 +548,7 @@ async fn test_remove_nonexistent_container() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[cella_testing::runtime_test(apple_container, flavor = "multi_thread")]
 async fn test_workspace_folder_label_set() {
     let (backend, cli_path) = setup_backend();
     let name = test_container_name("wslabel");

--- a/crates/cella-container/src/lib.rs
+++ b/crates/cella-container/src/lib.rs
@@ -10,5 +10,5 @@ pub mod sdk;
 
 pub use backend::AppleContainerBackend;
 
-#[cfg(all(test, feature = "integration-tests", target_os = "macos"))]
+#[cfg(all(test, target_os = "macos"))]
 mod integration_tests;

--- a/crates/cella-daemon/Cargo.toml
+++ b/crates/cella-daemon/Cargo.toml
@@ -21,11 +21,9 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [dev-dependencies]
+cella-testing.workspace = true
 cella-daemon-client.workspace = true
 tempfile.workspace = true
-
-[features]
-integration-tests = []
 
 [lints]
 workspace = true

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -2967,7 +2967,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "integration-tests")]
     #[tokio::test]
     async fn control_server_marks_connected_via_real_tcp_handshake() {
         use tokio::io::AsyncWriteExt;

--- a/crates/cella-daemon/src/management.rs
+++ b/crates/cella-daemon/src/management.rs
@@ -1002,7 +1002,6 @@ mod tests {
         server.abort();
     }
 
-    #[cfg(feature = "integration-tests")]
     #[tokio::test]
     async fn query_status_reports_connected_after_bare_handshake() {
         use tokio::io::AsyncWriteExt;

--- a/crates/cella-daemon/src/shared.rs
+++ b/crates/cella-daemon/src/shared.rs
@@ -204,8 +204,7 @@ mod tests {
         cleanup_files(&[&dir.path().join("nonexistent")]);
     }
 
-    #[test]
-    #[cfg(feature = "integration-tests")]
+    #[cella_testing::runtime_test(docker)]
     fn container_count_with_no_containers() {
         assert_eq!(running_cella_container_count(), 0);
     }

--- a/crates/cella-docker/Cargo.toml
+++ b/crates/cella-docker/Cargo.toml
@@ -20,8 +20,8 @@ thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 
-[features]
-integration-tests = []
+[dev-dependencies]
+cella-testing.workspace = true
 
 [lints]
 workspace = true

--- a/crates/cella-docker/src/integration_tests/mod.rs
+++ b/crates/cella-docker/src/integration_tests/mod.rs
@@ -1,10 +1,6 @@
-//! Integration tests gated on `--features integration-tests`.
+//! Integration tests using `#[runtime_test]` for runtime detection.
 //!
-//! These tests require a reachable Docker daemon and are marked
-//! `#[ignore = "requires Docker daemon"]` so they don't run by default.
-//! Execute with:
-//! ```sh
-//! cargo test -p cella-docker --features integration-tests -- --ignored
-//! ```
+//! Tests that need Docker use `#[runtime_test(docker)]` and skip
+//! gracefully when Docker is unavailable.
 
 mod network_tests;

--- a/crates/cella-docker/src/integration_tests/network_tests.rs
+++ b/crates/cella-docker/src/integration_tests/network_tests.rs
@@ -9,24 +9,6 @@ use crate::network::{
     list_managed_networks, remove_network_if_orphan, repo_network_name, workspace_network_name,
 };
 
-/// Connect to Docker using local defaults. Skip the test if unreachable
-/// so a failed daemon doesn't look like a cella regression.
-async fn docker_or_skip(test_name: &str) -> Option<Docker> {
-    match Docker::connect_with_local_defaults() {
-        Ok(docker) => match docker.ping().await {
-            Ok(_) => Some(docker),
-            Err(e) => {
-                eprintln!("{test_name}: Docker ping failed ({e}); skipping");
-                None
-            }
-        },
-        Err(e) => {
-            eprintln!("{test_name}: Docker unreachable ({e}); skipping");
-            None
-        }
-    }
-}
-
 /// Create a bridge network with the given labels. Returns the network name.
 async fn create_test_network(
     docker: &Docker,
@@ -49,14 +31,9 @@ async fn force_remove(docker: &Docker, name: &str) {
 }
 
 /// A managed orphan (no endpoints, `dev.cella.managed=true`) is removed.
-#[tokio::test]
-#[ignore = "requires Docker daemon"]
+#[cella_testing::runtime_test(docker)]
 async fn remove_network_if_orphan_removes_managed_empty_network() {
-    let Some(docker) =
-        docker_or_skip("remove_network_if_orphan_removes_managed_empty_network").await
-    else {
-        return;
-    };
+    let docker = Docker::connect_with_local_defaults().unwrap();
     let name = "cella-integration-orphan-managed-empty";
 
     force_remove(&docker, name).await;
@@ -90,14 +67,9 @@ async fn remove_network_if_orphan_removes_managed_empty_network() {
 /// A network missing the `dev.cella.managed` label is never touched,
 /// even if it has zero endpoints — we must not remove user-owned
 /// networks that happen to be idle.
-#[tokio::test]
-#[ignore = "requires Docker daemon"]
+#[cella_testing::runtime_test(docker)]
 async fn remove_network_if_orphan_skips_unlabeled_empty_network() {
-    let Some(docker) =
-        docker_or_skip("remove_network_if_orphan_skips_unlabeled_empty_network").await
-    else {
-        return;
-    };
+    let docker = Docker::connect_with_local_defaults().unwrap();
     let name = "cella-integration-unlabeled-empty";
 
     force_remove(&docker, name).await;
@@ -124,13 +96,9 @@ async fn remove_network_if_orphan_skips_unlabeled_empty_network() {
 }
 
 /// A missing network reports `NotFound` (idempotent success for callers).
-#[tokio::test]
-#[ignore = "requires Docker daemon"]
+#[cella_testing::runtime_test(docker)]
 async fn remove_network_if_orphan_not_found_is_idempotent() {
-    let Some(docker) = docker_or_skip("remove_network_if_orphan_not_found_is_idempotent").await
-    else {
-        return;
-    };
+    let docker = Docker::connect_with_local_defaults().unwrap();
     let name = "cella-integration-does-not-exist-xyz-123";
     force_remove(&docker, name).await; // extra safety
 
@@ -142,12 +110,9 @@ async fn remove_network_if_orphan_not_found_is_idempotent() {
 
 /// `list_managed_networks` reports only labeled networks and omits
 /// unlabeled ones.
-#[tokio::test]
-#[ignore = "requires Docker daemon"]
+#[cella_testing::runtime_test(docker)]
 async fn list_managed_networks_filters_by_label() {
-    let Some(docker) = docker_or_skip("list_managed_networks_filters_by_label").await else {
-        return;
-    };
+    let docker = Docker::connect_with_local_defaults().unwrap();
     let managed = "cella-integration-list-managed-xyz";
     let unlabeled = "cella-integration-list-unlabeled-xyz";
 
@@ -197,7 +162,6 @@ async fn list_managed_networks_filters_by_label() {
 /// canonicalized path — the contract `cella down --rm` relies on to
 /// find the network it's trying to remove.
 #[tokio::test]
-#[ignore = "requires Docker daemon"]
 async fn workspace_network_name_matches_repo_network_name_for_real_path() {
     let tmpdir =
         std::env::temp_dir().join(format!("cella-integration-wsroot-{}", std::process::id()));

--- a/crates/cella-docker/src/integration_tests/network_tests.rs
+++ b/crates/cella-docker/src/integration_tests/network_tests.rs
@@ -25,6 +25,10 @@ async fn create_test_network(
     Ok(())
 }
 
+fn test_network_name(base: &str) -> String {
+    format!("{base}-{}", std::process::id())
+}
+
 /// Best-effort teardown. Used in `Drop`-style cleanup at end of each test.
 async fn force_remove(docker: &Docker, name: &str) {
     let _ = docker.remove_network(name).await;
@@ -34,24 +38,24 @@ async fn force_remove(docker: &Docker, name: &str) {
 #[cella_testing::runtime_test(docker)]
 async fn remove_network_if_orphan_removes_managed_empty_network() {
     let docker = Docker::connect_with_local_defaults().unwrap();
-    let name = "cella-integration-orphan-managed-empty";
+    let name = test_network_name("cella-it-orphan-managed");
 
-    force_remove(&docker, name).await;
+    force_remove(&docker, &name).await;
     create_test_network(
         &docker,
-        name,
+        &name,
         HashMap::from([("dev.cella.managed".to_string(), "true".to_string())]),
     )
     .await
     .expect("create test network");
 
-    let outcome = remove_network_if_orphan(&docker, name)
+    let outcome = remove_network_if_orphan(&docker, &name)
         .await
         .expect("remove_network_if_orphan");
     assert_eq!(outcome, RemovalOutcome::Removed);
 
     // Confirm it's actually gone.
-    let err = docker.inspect_network(name, None).await;
+    let err = docker.inspect_network(&name, None).await;
     assert!(
         matches!(
             err,
@@ -70,14 +74,14 @@ async fn remove_network_if_orphan_removes_managed_empty_network() {
 #[cella_testing::runtime_test(docker)]
 async fn remove_network_if_orphan_skips_unlabeled_empty_network() {
     let docker = Docker::connect_with_local_defaults().unwrap();
-    let name = "cella-integration-unlabeled-empty";
+    let name = test_network_name("cella-it-unlabeled");
 
-    force_remove(&docker, name).await;
-    create_test_network(&docker, name, HashMap::new())
+    force_remove(&docker, &name).await;
+    create_test_network(&docker, &name, HashMap::new())
         .await
         .expect("create test network");
 
-    let outcome = remove_network_if_orphan(&docker, name)
+    let outcome = remove_network_if_orphan(&docker, &name)
         .await
         .expect("remove_network_if_orphan");
     assert_eq!(
@@ -86,23 +90,23 @@ async fn remove_network_if_orphan_skips_unlabeled_empty_network() {
         "unlabeled network must not be removed"
     );
     // Confirm it still exists.
-    let inspect = docker.inspect_network(name, None).await;
+    let inspect = docker.inspect_network(&name, None).await;
     assert!(
         inspect.is_ok(),
         "network should still exist after skip, got {inspect:?}"
     );
 
-    force_remove(&docker, name).await;
+    force_remove(&docker, &name).await;
 }
 
 /// A missing network reports `NotFound` (idempotent success for callers).
 #[cella_testing::runtime_test(docker)]
 async fn remove_network_if_orphan_not_found_is_idempotent() {
     let docker = Docker::connect_with_local_defaults().unwrap();
-    let name = "cella-integration-does-not-exist-xyz-123";
-    force_remove(&docker, name).await; // extra safety
+    let name = test_network_name("cella-it-nonexistent");
+    force_remove(&docker, &name).await;
 
-    let outcome = remove_network_if_orphan(&docker, name)
+    let outcome = remove_network_if_orphan(&docker, &name)
         .await
         .expect("remove_network_if_orphan");
     assert_eq!(outcome, RemovalOutcome::NotFound);
@@ -113,14 +117,14 @@ async fn remove_network_if_orphan_not_found_is_idempotent() {
 #[cella_testing::runtime_test(docker)]
 async fn list_managed_networks_filters_by_label() {
     let docker = Docker::connect_with_local_defaults().unwrap();
-    let managed = "cella-integration-list-managed-xyz";
-    let unlabeled = "cella-integration-list-unlabeled-xyz";
+    let managed = test_network_name("cella-it-list-managed");
+    let unlabeled = test_network_name("cella-it-list-unlabeled");
 
-    force_remove(&docker, managed).await;
-    force_remove(&docker, unlabeled).await;
+    force_remove(&docker, &managed).await;
+    force_remove(&docker, &unlabeled).await;
     create_test_network(
         &docker,
-        managed,
+        &managed,
         HashMap::from([
             ("dev.cella.managed".to_string(), "true".to_string()),
             (
@@ -131,7 +135,7 @@ async fn list_managed_networks_filters_by_label() {
     )
     .await
     .expect("create managed network");
-    create_test_network(&docker, unlabeled, HashMap::new())
+    create_test_network(&docker, &unlabeled, HashMap::new())
         .await
         .expect("create unlabeled network");
 
@@ -141,11 +145,11 @@ async fn list_managed_networks_filters_by_label() {
     let names: Vec<&str> = listed.iter().map(|n| n.name.as_str()).collect();
 
     assert!(
-        names.contains(&managed),
+        names.contains(&managed.as_str()),
         "managed network should be listed: {names:?}"
     );
     assert!(
-        !names.contains(&unlabeled),
+        !names.contains(&unlabeled.as_str()),
         "unlabeled network must not be listed: {names:?}"
     );
 
@@ -154,8 +158,8 @@ async fn list_managed_networks_filters_by_label() {
     assert_eq!(entry.container_count, 0);
     assert_eq!(entry.repo_path.as_deref(), Some("/tmp/integration-test"));
 
-    force_remove(&docker, managed).await;
-    force_remove(&docker, unlabeled).await;
+    force_remove(&docker, &managed).await;
+    force_remove(&docker, &unlabeled).await;
 }
 
 /// `workspace_network_name` matches `repo_network_name` for the same

--- a/crates/cella-docker/src/lib.rs
+++ b/crates/cella-docker/src/lib.rs
@@ -14,5 +14,5 @@ pub use client::DockerClient;
 pub use config_map::to_bollard_config;
 pub use error::CellaDockerError;
 
-#[cfg(all(test, feature = "integration-tests"))]
+#[cfg(test)]
 mod integration_tests;

--- a/crates/cella-env/Cargo.toml
+++ b/crates/cella-env/Cargo.toml
@@ -11,9 +11,6 @@ serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
-[features]
-integration-tests = []
-
 [dev-dependencies]
 tempfile.workspace = true
 

--- a/crates/cella-env/src/git_ignore.rs
+++ b/crates/cella-env/src/git_ignore.rs
@@ -263,7 +263,6 @@ mod tests {
         assert_eq!(content, "# --- forwarded from host ---\n*.log\n");
     }
 
-    #[cfg(feature = "integration-tests")]
     #[test]
     fn resolve_from_real_git_config() {
         // If git reports an excludesFile, the resolved path must exist.

--- a/crates/cella-env/tests/ssh_agent_retry.rs
+++ b/crates/cella-env/tests/ssh_agent_retry.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "integration-tests")]
-
 use cella_env::platform::DockerRuntime;
 use cella_env::ssh_agent::{is_ssh_mount_error, ssh_skip_warning};
 

--- a/crates/cella-features/Cargo.toml
+++ b/crates/cella-features/Cargo.toml
@@ -22,11 +22,9 @@ tokio.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+cella-testing.workspace = true
 insta.workspace = true
 tempfile.workspace = true
-
-[features]
-integration-tests = []
 
 [lints]
 workspace = true

--- a/crates/cella-features/src/lib.rs
+++ b/crates/cella-features/src/lib.rs
@@ -636,7 +636,6 @@ mod tests {
 
     use super::*;
 
-    #[cfg(feature = "integration-tests")]
     use crate::test_utils::test_platform;
 
     // -----------------------------------------------------------------------
@@ -1120,8 +1119,7 @@ mod tests {
     // End-to-end: OCI feature resolution (requires Docker + network)
     // -----------------------------------------------------------------------
 
-    #[tokio::test]
-    #[cfg(feature = "integration-tests")]
+    #[cella_testing::runtime_test(network)]
     async fn e2e_resolve_node_feature() {
         let config = json!({
             "image": "mcr.microsoft.com/devcontainers/base:ubuntu",

--- a/crates/cella-features/src/oci.rs
+++ b/crates/cella-features/src/oci.rs
@@ -290,7 +290,6 @@ use cella_oci::{build_registry_auth, extract_layer, is_extractable_layer};
 mod tests {
     use super::*;
 
-    #[cfg(feature = "integration-tests")]
     use crate::test_utils::test_platform;
 
     #[test]
@@ -316,8 +315,7 @@ mod tests {
     // Integration test -- requires network access
     // -----------------------------------------------------------------------
 
-    #[tokio::test]
-    #[cfg(feature = "integration-tests")]
+    #[cella_testing::runtime_test(network)]
     async fn fetch_node_feature_from_ghcr() {
         let fetcher = OciFetcher::new();
         let cache_dir = tempfile::tempdir().unwrap();
@@ -350,8 +348,7 @@ mod tests {
         assert_eq!(path, path2, "second fetch should return cached path");
     }
 
-    #[tokio::test]
-    #[cfg(feature = "integration-tests")]
+    #[cella_testing::runtime_test(network)]
     async fn fetch_github_cli_feature_from_ghcr() {
         let fetcher = OciFetcher::new();
         let cache_dir = tempfile::tempdir().unwrap();

--- a/crates/cella-features/src/test_utils.rs
+++ b/crates/cella-features/src/test_utils.rs
@@ -1,11 +1,9 @@
 //! Shared test utilities for the cella-features crate.
 
-#[cfg(feature = "integration-tests")]
 use crate::types::Platform;
 
 /// Build a [`Platform`] matching the current host — used by integration tests
 /// that pull real OCI images from ghcr.io.
-#[cfg(feature = "integration-tests")]
 pub fn test_platform() -> Platform {
     let architecture = match std::env::consts::ARCH {
         "x86_64" => "amd64",

--- a/crates/cella-templates/Cargo.toml
+++ b/crates/cella-templates/Cargo.toml
@@ -24,11 +24,9 @@ tracing.workspace = true
 cella-oci.workspace = true
 
 [dev-dependencies]
+cella-testing.workspace = true
 filetime.workspace = true
 tempfile.workspace = true
-
-[features]
-integration-tests = []
 
 [lints]
 workspace = true

--- a/crates/cella-templates/src/collection.rs
+++ b/crates/cella-templates/src/collection.rs
@@ -245,8 +245,7 @@ mod tests {
         assert_eq!(cached.features[2].id, "rust");
     }
 
-    #[tokio::test]
-    #[cfg(feature = "integration-tests")]
+    #[cella_testing::runtime_test(network)]
     async fn fetch_official_template_collection() {
         let cache_dir = tempfile::tempdir().unwrap();
         let cache = TemplateCache::with_root(cache_dir.path());
@@ -266,8 +265,7 @@ mod tests {
         assert!(ids.contains(&"debian"), "should contain debian template");
     }
 
-    #[tokio::test]
-    #[cfg(feature = "integration-tests")]
+    #[cella_testing::runtime_test(network)]
     async fn fetch_official_feature_collection() {
         let cache_dir = tempfile::tempdir().unwrap();
         let cache = TemplateCache::with_root(cache_dir.path());

--- a/crates/cella-templates/src/fetcher.rs
+++ b/crates/cella-templates/src/fetcher.rs
@@ -303,8 +303,7 @@ mod tests {
         assert!(read_template_metadata(dir.path()).is_err());
     }
 
-    #[tokio::test]
-    #[cfg(feature = "integration-tests")]
+    #[cella_testing::runtime_test(network)]
     async fn fetch_rust_template() {
         let cache_dir = tempfile::tempdir().unwrap();
         let cache = TemplateCache::with_root(cache_dir.path());

--- a/crates/cella-test-macros/Cargo.toml
+++ b/crates/cella-test-macros/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "cella-test-macros"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn.workspace = true
+quote.workspace = true
+proc-macro2.workspace = true
+
+[lints]
+workspace = true

--- a/crates/cella-test-macros/src/lib.rs
+++ b/crates/cella-test-macros/src/lib.rs
@@ -1,0 +1,223 @@
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::parse::{Parse, ParseStream};
+use syn::{ItemFn, LitStr, Token, punctuated::Punctuated};
+
+const KNOWN_RUNTIMES: &[&str] = &[
+    "docker",
+    "compose",
+    "buildx",
+    "podman",
+    "apple_container",
+    "orbstack",
+    "colima",
+    "lima",
+    "network",
+    "container_runtime",
+];
+
+struct RuntimeRequirement {
+    negated: bool,
+    name: String,
+}
+
+struct RuntimeTestArgs {
+    requirements: Vec<RuntimeRequirement>,
+    flavor: Option<String>,
+}
+
+impl Parse for RuntimeTestArgs {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let mut requirements = Vec::new();
+        let mut flavor = None;
+
+        if input.is_empty() {
+            return Ok(Self {
+                requirements,
+                flavor,
+            });
+        }
+
+        let items = Punctuated::<RuntimeArg, Token![,]>::parse_terminated(input)?;
+        for item in items {
+            match item {
+                RuntimeArg::Runtime(req) => requirements.push(req),
+                RuntimeArg::Flavor(f) => flavor = Some(f),
+            }
+        }
+
+        Ok(Self {
+            requirements,
+            flavor,
+        })
+    }
+}
+
+enum RuntimeArg {
+    Runtime(RuntimeRequirement),
+    Flavor(String),
+}
+
+impl Parse for RuntimeArg {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        if input.peek(syn::Ident) {
+            let ident: syn::Ident = input.parse()?;
+            if ident == "flavor" {
+                let _: Token![=] = input.parse()?;
+                let value: LitStr = input.parse()?;
+                return Ok(Self::Flavor(value.value()));
+            }
+            if !KNOWN_RUNTIMES.contains(&ident.to_string().as_str()) {
+                return Err(syn::Error::new(
+                    ident.span(),
+                    format!(
+                        "unknown runtime `{ident}`. Expected one of: {}",
+                        KNOWN_RUNTIMES.join(", ")
+                    ),
+                ));
+            }
+            Ok(Self::Runtime(RuntimeRequirement {
+                negated: false,
+                name: ident.to_string(),
+            }))
+        } else if input.peek(Token![!]) {
+            let _: Token![!] = input.parse()?;
+            let ident: syn::Ident = input.parse()?;
+            if !KNOWN_RUNTIMES.contains(&ident.to_string().as_str()) {
+                return Err(syn::Error::new(
+                    ident.span(),
+                    format!(
+                        "unknown runtime `{ident}`. Expected one of: {}",
+                        KNOWN_RUNTIMES.join(", ")
+                    ),
+                ));
+            }
+            Ok(Self::Runtime(RuntimeRequirement {
+                negated: true,
+                name: ident.to_string(),
+            }))
+        } else {
+            Err(input.error("expected runtime name or `!runtime_name`"))
+        }
+    }
+}
+
+#[proc_macro_attribute]
+pub fn runtime_test(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let args = syn::parse_macro_input!(attr as RuntimeTestArgs);
+    let input = syn::parse_macro_input!(item as ItemFn);
+
+    match expand_runtime_test(&args, &input) {
+        Ok(tokens) => tokens.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+fn expand_runtime_test(
+    args: &RuntimeTestArgs,
+    input: &ItemFn,
+) -> syn::Result<proc_macro2::TokenStream> {
+    let is_async = input.sig.asyncness.is_some();
+    let fn_name = &input.sig.ident;
+    let fn_name_str = fn_name.to_string();
+    let vis = &input.vis;
+    let attrs = &input.attrs;
+    let sig = &input.sig;
+    let body = &input.block;
+
+    let preamble = build_preamble(args, &fn_name_str, is_async)?;
+
+    let test_attr = if is_async {
+        args.flavor.as_ref().map_or_else(
+            || quote! { #[tokio::test] },
+            |flavor| quote! { #[tokio::test(flavor = #flavor)] },
+        )
+    } else {
+        if args.flavor.is_some() {
+            return Err(syn::Error::new_spanned(
+                fn_name,
+                "flavor can only be used with async test functions",
+            ));
+        }
+        quote! { #[test] }
+    };
+
+    Ok(quote! {
+        #(#attrs)*
+        #test_attr
+        #vis #sig {
+            #preamble
+            #body
+        }
+    })
+}
+
+fn build_preamble(
+    args: &RuntimeTestArgs,
+    fn_name: &str,
+    is_async: bool,
+) -> syn::Result<proc_macro2::TokenStream> {
+    if args.requirements.is_empty() {
+        let check = if is_async {
+            quote! { cella_testing::detect::container_runtime_available().await }
+        } else {
+            quote! { cella_testing::detect::container_runtime_available_sync() }
+        };
+        return Ok(quote! {
+            if !#check {
+                println!("skipping {}: no container runtime available", #fn_name);
+                return;
+            }
+        });
+    }
+
+    let has_negated = args.requirements.iter().any(|r| r.negated);
+    let has_positive = args.requirements.iter().any(|r| !r.negated);
+
+    if has_negated && has_positive {
+        return Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "cannot mix negated (!) and positive runtime requirements",
+        ));
+    }
+
+    if has_negated {
+        let excluded: Vec<&str> = args.requirements.iter().map(|r| r.name.as_str()).collect();
+        let check = if is_async {
+            quote! { cella_testing::detect::container_runtime_available_except(&[#(#excluded),*]).await }
+        } else {
+            quote! { cella_testing::detect::container_runtime_available_except_sync(&[#(#excluded),*]) }
+        };
+        return Ok(quote! {
+            if !#check {
+                println!("skipping {}: no container runtime available (excluding {})", #fn_name, [#(#excluded),*].join(", "));
+                return;
+            }
+        });
+    }
+
+    let mut checks = proc_macro2::TokenStream::new();
+    for req in &args.requirements {
+        let fn_async = format_ident!("{}_available", req.name);
+        let fn_sync = format_ident!("{}_available_sync", req.name);
+        let name = &req.name;
+        let check = if is_async {
+            quote! {
+                if !cella_testing::detect::#fn_async().await {
+                    println!("skipping {}: {} not available", #fn_name, #name);
+                    return;
+                }
+            }
+        } else {
+            quote! {
+                if !cella_testing::detect::#fn_sync() {
+                    println!("skipping {}: {} not available", #fn_name, #name);
+                    return;
+                }
+            }
+        };
+        checks.extend(check);
+    }
+
+    Ok(checks)
+}

--- a/crates/cella-testing/Cargo.toml
+++ b/crates/cella-testing/Cargo.toml
@@ -9,5 +9,9 @@ cella-test-macros.workspace = true
 tokio.workspace = true
 bollard.workspace = true
 
+[dev-dependencies]
+bollard.workspace = true
+trybuild.workspace = true
+
 [lints]
 workspace = true

--- a/crates/cella-testing/Cargo.toml
+++ b/crates/cella-testing/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "cella-testing"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+cella-test-macros.workspace = true
+tokio.workspace = true
+bollard.workspace = true
+
+[lints]
+workspace = true

--- a/crates/cella-testing/src/detect.rs
+++ b/crates/cella-testing/src/detect.rs
@@ -1,0 +1,153 @@
+use std::sync::OnceLock;
+use std::time::Duration;
+use tokio::sync::OnceCell;
+
+const TIMEOUT: Duration = Duration::from_secs(5);
+
+macro_rules! detect_fn {
+    ($async_name:ident, $sync_name:ident, $cell_async:ident, $cell_sync:ident, $check:expr) => {
+        static $cell_async: OnceCell<bool> = OnceCell::const_new();
+        static $cell_sync: OnceLock<bool> = OnceLock::new();
+
+        pub async fn $async_name() -> bool {
+            *$cell_async
+                .get_or_init(|| async {
+                    tokio::time::timeout(TIMEOUT, async { $check.await })
+                        .await
+                        .unwrap_or(false)
+                })
+                .await
+        }
+
+        pub fn $sync_name() -> bool {
+            *$cell_sync.get_or_init(|| {
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("failed to build tokio runtime for sync detection")
+                    .block_on($async_name())
+            })
+        }
+    };
+}
+
+async fn check_docker() -> bool {
+    let Ok(docker) = bollard::Docker::connect_with_local_defaults() else {
+        return false;
+    };
+    docker.ping().await.is_ok()
+}
+
+async fn check_command(cmd: &str, args: &[&str]) -> bool {
+    tokio::process::Command::new(cmd)
+        .args(args)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .await
+        .is_ok_and(|s| s.success())
+}
+
+async fn check_network() -> bool {
+    tokio::net::TcpStream::connect("ghcr.io:443").await.is_ok()
+}
+
+detect_fn!(
+    docker_available,
+    docker_available_sync,
+    DOCKER_ASYNC,
+    DOCKER_SYNC,
+    check_docker()
+);
+detect_fn!(
+    compose_available,
+    compose_available_sync,
+    COMPOSE_ASYNC,
+    COMPOSE_SYNC,
+    check_command("docker", &["compose", "version"])
+);
+detect_fn!(
+    buildx_available,
+    buildx_available_sync,
+    BUILDX_ASYNC,
+    BUILDX_SYNC,
+    check_command("docker", &["buildx", "version"])
+);
+detect_fn!(
+    podman_available,
+    podman_available_sync,
+    PODMAN_ASYNC,
+    PODMAN_SYNC,
+    check_command("podman", &["version"])
+);
+detect_fn!(
+    apple_container_available,
+    apple_container_available_sync,
+    APPLE_CONTAINER_ASYNC,
+    APPLE_CONTAINER_SYNC,
+    check_command("container", &["--version"])
+);
+detect_fn!(
+    orbstack_available,
+    orbstack_available_sync,
+    ORBSTACK_ASYNC,
+    ORBSTACK_SYNC,
+    check_command("orbctl", &["version"])
+);
+detect_fn!(
+    colima_available,
+    colima_available_sync,
+    COLIMA_ASYNC,
+    COLIMA_SYNC,
+    check_command("colima", &["status"])
+);
+detect_fn!(
+    lima_available,
+    lima_available_sync,
+    LIMA_ASYNC,
+    LIMA_SYNC,
+    check_command("limactl", &["list", "--quiet"])
+);
+detect_fn!(
+    network_available,
+    network_available_sync,
+    NETWORK_ASYNC,
+    NETWORK_SYNC,
+    check_network()
+);
+
+pub async fn container_runtime_available() -> bool {
+    docker_available().await
+        || podman_available().await
+        || apple_container_available().await
+        || orbstack_available().await
+        || colima_available().await
+        || lima_available().await
+}
+
+pub fn container_runtime_available_sync() -> bool {
+    docker_available_sync()
+        || podman_available_sync()
+        || apple_container_available_sync()
+        || orbstack_available_sync()
+        || colima_available_sync()
+        || lima_available_sync()
+}
+
+pub async fn container_runtime_available_except(exclude: &[&str]) -> bool {
+    (!exclude.contains(&"docker") && docker_available().await)
+        || (!exclude.contains(&"podman") && podman_available().await)
+        || (!exclude.contains(&"apple_container") && apple_container_available().await)
+        || (!exclude.contains(&"orbstack") && orbstack_available().await)
+        || (!exclude.contains(&"colima") && colima_available().await)
+        || (!exclude.contains(&"lima") && lima_available().await)
+}
+
+pub fn container_runtime_available_except_sync(exclude: &[&str]) -> bool {
+    (!exclude.contains(&"docker") && docker_available_sync())
+        || (!exclude.contains(&"podman") && podman_available_sync())
+        || (!exclude.contains(&"apple_container") && apple_container_available_sync())
+        || (!exclude.contains(&"orbstack") && orbstack_available_sync())
+        || (!exclude.contains(&"colima") && colima_available_sync())
+        || (!exclude.contains(&"lima") && lima_available_sync())
+}

--- a/crates/cella-testing/src/lib.rs
+++ b/crates/cella-testing/src/lib.rs
@@ -1,0 +1,3 @@
+pub use cella_test_macros::runtime_test;
+
+pub mod detect;

--- a/crates/cella-testing/tests/compile_tests.rs
+++ b/crates/cella-testing/tests/compile_tests.rs
@@ -1,0 +1,6 @@
+#[test]
+fn compile_tests() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/ui/pass_*.rs");
+    t.compile_fail("tests/ui/fail_*.rs");
+}

--- a/crates/cella-testing/tests/live_tests.rs
+++ b/crates/cella-testing/tests/live_tests.rs
@@ -1,0 +1,15 @@
+use cella_testing::runtime_test;
+
+#[runtime_test(docker)]
+async fn macro_works_with_docker() {
+    let docker = bollard::Docker::connect_with_local_defaults().unwrap();
+    docker.ping().await.unwrap();
+}
+
+#[runtime_test]
+async fn macro_works_any_runtime() {}
+
+#[runtime_test(network)]
+async fn macro_works_with_network() {
+    let _stream = tokio::net::TcpStream::connect("ghcr.io:443").await.unwrap();
+}

--- a/crates/cella-testing/tests/live_tests.rs
+++ b/crates/cella-testing/tests/live_tests.rs
@@ -13,3 +13,13 @@ async fn macro_works_any_runtime() {}
 async fn macro_works_with_network() {
     let _stream = tokio::net::TcpStream::connect("ghcr.io:443").await.unwrap();
 }
+
+#[runtime_test(podman)]
+async fn macro_works_with_podman() {
+    let status = tokio::process::Command::new("podman")
+        .args(["version", "--format", "{{.Client.Version}}"])
+        .status()
+        .await
+        .unwrap();
+    assert!(status.success());
+}

--- a/crates/cella-testing/tests/ui/fail_not_function.rs
+++ b/crates/cella-testing/tests/ui/fail_not_function.rs
@@ -1,0 +1,6 @@
+use cella_testing::runtime_test;
+
+#[runtime_test(docker)]
+struct Foo;
+
+fn main() {}

--- a/crates/cella-testing/tests/ui/fail_not_function.stderr
+++ b/crates/cella-testing/tests/ui/fail_not_function.stderr
@@ -1,0 +1,5 @@
+error: expected `fn`
+ --> tests/ui/fail_not_function.rs:4:1
+  |
+4 | struct Foo;
+  | ^^^^^^

--- a/crates/cella-testing/tests/ui/fail_unknown_runtime.rs
+++ b/crates/cella-testing/tests/ui/fail_unknown_runtime.rs
@@ -1,0 +1,6 @@
+use cella_testing::runtime_test;
+
+#[runtime_test(foobar)]
+async fn test_unknown() {}
+
+fn main() {}

--- a/crates/cella-testing/tests/ui/fail_unknown_runtime.stderr
+++ b/crates/cella-testing/tests/ui/fail_unknown_runtime.stderr
@@ -1,0 +1,5 @@
+error: unknown runtime `foobar`. Expected one of: docker, compose, buildx, podman, apple_container, orbstack, colima, lima, network, container_runtime
+ --> tests/ui/fail_unknown_runtime.rs:3:16
+  |
+3 | #[runtime_test(foobar)]
+  |                ^^^^^^

--- a/crates/cella-testing/tests/ui/pass_async_docker.rs
+++ b/crates/cella-testing/tests/ui/pass_async_docker.rs
@@ -1,0 +1,6 @@
+use cella_testing::runtime_test;
+
+#[runtime_test(docker)]
+async fn test_docker() {}
+
+fn main() {}

--- a/crates/cella-testing/tests/ui/pass_bare.rs
+++ b/crates/cella-testing/tests/ui/pass_bare.rs
@@ -1,0 +1,6 @@
+use cella_testing::runtime_test;
+
+#[runtime_test]
+async fn test_bare() {}
+
+fn main() {}

--- a/crates/cella-testing/tests/ui/pass_exclude.rs
+++ b/crates/cella-testing/tests/ui/pass_exclude.rs
@@ -1,0 +1,6 @@
+use cella_testing::runtime_test;
+
+#[runtime_test(!apple_container)]
+async fn test_exclude() {}
+
+fn main() {}

--- a/crates/cella-testing/tests/ui/pass_flavor.rs
+++ b/crates/cella-testing/tests/ui/pass_flavor.rs
@@ -1,0 +1,6 @@
+use cella_testing::runtime_test;
+
+#[runtime_test(docker, flavor = "multi_thread")]
+async fn test_flavor() {}
+
+fn main() {}

--- a/crates/cella-testing/tests/ui/pass_multi_runtime.rs
+++ b/crates/cella-testing/tests/ui/pass_multi_runtime.rs
@@ -1,0 +1,6 @@
+use cella_testing::runtime_test;
+
+#[runtime_test(docker, compose)]
+async fn test_multi() {}
+
+fn main() {}

--- a/crates/cella-testing/tests/ui/pass_network.rs
+++ b/crates/cella-testing/tests/ui/pass_network.rs
@@ -1,0 +1,6 @@
+use cella_testing::runtime_test;
+
+#[runtime_test(network)]
+async fn test_network() {}
+
+fn main() {}

--- a/crates/cella-testing/tests/ui/pass_sync_docker.rs
+++ b/crates/cella-testing/tests/ui/pass_sync_docker.rs
@@ -1,0 +1,6 @@
+use cella_testing::runtime_test;
+
+#[runtime_test(docker)]
+fn test_docker_sync() {}
+
+fn main() {}

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -19,11 +19,7 @@ Unit tests (no external dependencies):
 cargo test --workspace
 ```
 
-Integration tests (requires Docker, feature-gated):
-
-```sh
-cargo test -p cella-features -p cella-daemon -p cella-compose --features integration-tests
-```
+Integration tests skip gracefully when the runtime (Docker, network) is unavailable — no special flags needed.
 
 Snapshot tests (insta):
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -6,7 +6,7 @@ cella uses a layered testing approach:
 
 - **Unit tests** — fast, inline with the code, no external dependencies
 - **Snapshot tests** — schema codegen and feature resolution, via [insta](https://insta.rs/)
-- **Integration tests** — feature-gated, require Docker and network access
+- **Integration tests** — use `#[runtime_test]` for runtime detection, skip gracefully when unavailable
 
 ## Unit Tests
 
@@ -24,7 +24,7 @@ mod tests {
 }
 ```
 
-Run all unit tests:
+Run all tests (unit + integration):
 
 ```sh
 cargo test --workspace
@@ -50,20 +50,32 @@ If `cargo-insta` is not installed in a dev container, run `cargo test` to verify
 
 ## Integration Tests
 
-Tests that require Docker or network access (OCI registry fetches, container lifecycle) are gated behind a Cargo feature flag:
+Tests that require Docker, compose, or network access use the `#[runtime_test]` proc macro from `cella-testing`. Tests always compile and skip gracefully at runtime when the required runtime is unavailable:
 
 ```rust
-#[cfg(feature = "integration-tests")]
-#[tokio::test]
+#[cella_testing::runtime_test(docker)]
+async fn network_lifecycle() {
+    let docker = Docker::connect_with_local_defaults().unwrap();
+    // ...
+}
+
+#[cella_testing::runtime_test(network)]
 async fn fetch_from_ghcr() {
+    // ...
+}
+
+#[cella_testing::runtime_test(docker, compose)]
+async fn compose_lifecycle() {
     // ...
 }
 ```
 
-Run integration tests locally (requires Docker):
+Available runtime requirements: `docker`, `compose`, `buildx`, `podman`, `apple_container`, `orbstack`, `colima`, `lima`, `network`, `container_runtime`.
+
+Run all tests — integration tests skip if the runtime is unavailable:
 
 ```sh
-cargo test -p cella-features -p cella-daemon -p cella-compose --features integration-tests
+cargo test --workspace
 ```
 
 These tests run automatically in CI via the **Integration Test** job, which authenticates to `ghcr.io` and produces a combined coverage report via `cargo llvm-cov`.
@@ -104,8 +116,8 @@ impl ContainerRuntime for MockRuntime {
 ## Adding New Tests
 
 1. **Unit test**: add a `#[cfg(test)]` module in the same file as the code under test.
-2. **Integration test**: wrap the test in `#[cfg(feature = "integration-tests")]`. Add the feature flag to the crate's `Cargo.toml` if not already present.
-3. **Async tests**: use `#[tokio::test]` for async test functions.
+2. **Integration test**: add `cella-testing` to `[dev-dependencies]` and use `#[cella_testing::runtime_test(docker)]` (or other runtime).
+3. **Async tests**: `#[runtime_test]` handles async/sync detection automatically. For tests without runtime deps, use `#[tokio::test]`.
 4. **Snapshots**: use `insta::assert_snapshot!` / `insta::assert_json_snapshot!`; run `cargo insta review` to accept.
 5. **Architecture**: use `test_platform()` instead of hardcoding `"amd64"` in OCI or image-architecture tests.
 6. **Regression tests**: every bugfix should land with a failing test from the bug and the fix in the same commit (or split as the fix + the test, but the test should precede or accompany the code).


### PR DESCRIPTION
## Summary

- Add `cella-test-macros` and `cella-testing` crates that provide a `#[runtime_test]` proc macro for integration tests — tests compile everywhere and skip gracefully when Docker/Compose/network/Podman isn't available
- Migrate all existing integration tests from the old `#[cfg_attr(not(...), ignore)]` pattern to `#[runtime_test]`
- Simplify CI from separate parallel/integration steps down to a single `cargo test --workspace`

## Test plan

- [x] Compile tests and UI tests for the proc macro (`trybuild`)
- [x] Live runtime detection tests in `cella-testing`
- [x] All existing integration tests migrated and passing
- [x] CI workflow updated and green