### PR TITLE
fix: add missing semicolon in zsh function body for bash compat

### DIFF
--- a/crates/cella-backend/src/container_setup.rs
+++ b/crates/cella-backend/src/container_setup.rs
@@ -512,7 +512,7 @@ if [ -n "$CELLA_TITLE" ]; then
         __cella_title() { printf '\033]0;%s\007' "$CELLA_TITLE"; }
         PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND;}__cella_title"
     elif [ -n "$ZSH_VERSION" ]; then
-        __cella_title() { printf '\033]0;%s\007' "$CELLA_TITLE" }
+        __cella_title() { printf '\033]0;%s\007' "$CELLA_TITLE"; }
         precmd_functions+=(__cella_title)
     fi
 fi
@@ -664,6 +664,22 @@ mod tests {
         let guards: Vec<&str> = PATH_SNIPPETS.iter().map(|(g, _)| *g).collect();
         let unique: std::collections::HashSet<&str> = guards.iter().copied().collect();
         assert_eq!(guards.len(), unique.len());
+    }
+
+    // ── TITLE_SNIPPETS ────────────────────────────────────────────────────
+
+    #[test]
+    fn title_snippet_is_valid_bash() {
+        let (_, snippet) = TITLE_SNIPPETS[0];
+        let output = std::process::Command::new("bash")
+            .args(["-n", "-c", snippet])
+            .output()
+            .expect("bash should be available");
+        assert!(
+            output.status.success(),
+            "TITLE_SNIPPETS must be valid bash syntax: {}",
+            String::from_utf8_lossy(&output.stderr),
+        );
     }
 
     // ── map_env_object ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Fix bash syntax error in `TITLE_SNIPPETS` where the zsh branch's `__cella_title()` function omitted a semicolon before `}` — valid zsh but invalid bash, causing `.bashrc` parse failures
- Add `bash -n` regression test to catch shell syntax errors in the snippet

Introduced in #111.

## Test plan

- [x] `cargo test -p cella-backend title_snippet_is_valid_bash` passes
- [x] `cargo clippy` clean
- [x] `cella shell` into a container — no `.bashrc` syntax error

🤖 Generated with [Claude Code](https://claude.com/claude-code)