### PR TITLE
feat: configurable shell preference

### DIFF
--- a/crates/cella-cli/src/commands/exec.rs
+++ b/crates/cella-cli/src/commands/exec.rs
@@ -5,7 +5,7 @@ use tracing::warn;
 
 use cella_backend::{ContainerTarget, ExecOptions, InteractiveExecOptions};
 use cella_orchestrator::env_cache::{ensure_ssh_auth_sock, read_probed_env_cache};
-use cella_orchestrator::shell_detect::{detect_shell, wrap_in_login_shell};
+use cella_orchestrator::shell_detect::{ShellSource, resolve_shell, wrap_in_login_shell};
 use cella_orchestrator::tool_install::ToolName;
 
 use crate::picker;
@@ -166,8 +166,22 @@ async fn resolve_exec_context(
     let mut env = build_exec_env(client, container, &user, label_env).await;
     env.extend(remote_env);
 
-    let shell = detect_shell(client, &container.id, &user).await;
-    let cmd = wrap_in_login_shell(&shell, command);
+    let preferred = crate::commands::load_shell_preferred(&container.labels);
+    let resolution = resolve_shell(client, &container.id, &user, &preferred).await;
+
+    if !preferred.is_empty()
+        && !matches!(
+            resolution.source,
+            ShellSource::Preferred | ShellSource::CliFlag
+        )
+    {
+        warn!(
+            "Preferred shells not available, falling back to {}",
+            resolution.shell,
+        );
+    }
+
+    let cmd = wrap_in_login_shell(&resolution.shell, command);
 
     Ok((user, working_dir, env, cmd))
 }

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -301,6 +301,26 @@ pub async fn resolve_service_container(
         .ok_or_else(|| format!("Service '{svc}' not found in compose project '{project}'").into())
 }
 
+/// Load shell preferences from cella config.
+///
+/// Uses the container's workspace path label to find project-level config.
+/// Returns an empty list if the workspace label is missing or config is unavailable.
+pub fn load_shell_preferred(labels: &std::collections::HashMap<String, String>) -> Vec<String> {
+    let Some(workspace_path) = labels
+        .get("dev.cella.workspace_path")
+        .filter(|p| !p.trim().is_empty())
+    else {
+        return Vec::new();
+    };
+
+    let workspace = std::path::Path::new(workspace_path);
+    let resolved = cella_config::devcontainer::resolve::config(workspace, None).ok();
+    let Ok(settings) = cella_config::CellaConfig::load(workspace, resolved.as_ref()) else {
+        return Vec::new();
+    };
+    settings.shell.preferred
+}
+
 /// Append AI provider API keys from the host environment into `env`.
 ///
 /// Loads settings from the workspace path label on the container,

--- a/crates/cella-cli/src/commands/shell.rs
+++ b/crates/cella-cli/src/commands/shell.rs
@@ -1,9 +1,10 @@
 use std::path::PathBuf;
 
 use clap::Args;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use cella_backend::{ContainerTarget, InteractiveExecOptions};
+use cella_orchestrator::shell_detect::{ShellResolution, ShellSource};
 
 use crate::picker;
 
@@ -92,15 +93,9 @@ impl ShellArgs {
             .and_then(|v| serde_json::from_str(v).ok())
             .unwrap_or_default();
 
-        // Detect shell
-        let shell = if let Some(s) = self.shell {
-            s
-        } else {
-            cella_orchestrator::shell_detect::detect_shell(client.as_ref(), &container.id, &user)
-                .await
-        };
-
-        debug!("Using shell: {shell}");
+        let resolution =
+            resolve_preferred_shell(client.as_ref(), &container, &user, self.shell).await;
+        debug!("Using shell: {}", resolution.shell);
 
         // Build environment: probed env (merged with label env) + terminal env
         let base_env = if let Some(probed) = cella_orchestrator::env_cache::read_probed_env_cache(
@@ -141,7 +136,7 @@ impl ShellArgs {
             .exec_interactive(
                 &container.id,
                 &InteractiveExecOptions {
-                    cmd: vec![shell, "-l".to_string()],
+                    cmd: vec![resolution.shell, "-l".to_string()],
                     user: Some(user),
                     env: Some(env),
                     working_dir,
@@ -154,4 +149,37 @@ impl ShellArgs {
         drop(title_guard);
         std::process::exit(i32::try_from(exit_code).unwrap_or(125));
     }
+}
+
+async fn resolve_preferred_shell(
+    client: &dyn cella_backend::ContainerBackend,
+    container: &cella_backend::ContainerInfo,
+    user: &str,
+    cli_shell: Option<String>,
+) -> ShellResolution {
+    if let Some(s) = cli_shell {
+        return ShellResolution {
+            shell: s,
+            source: ShellSource::CliFlag,
+        };
+    }
+
+    let preferred = super::load_shell_preferred(&container.labels);
+    let resolution =
+        cella_orchestrator::shell_detect::resolve_shell(client, &container.id, user, &preferred)
+            .await;
+
+    if !preferred.is_empty()
+        && !matches!(
+            resolution.source,
+            ShellSource::Preferred | ShellSource::CliFlag
+        )
+    {
+        warn!(
+            "Preferred shells not available, falling back to {}",
+            resolution.shell,
+        );
+    }
+
+    resolution
 }

--- a/crates/cella-config/src/cella_config/mod.rs
+++ b/crates/cella-config/src/cella_config/mod.rs
@@ -12,7 +12,7 @@ pub use cli::{Cli, CliBuild, OutputFormat, PullPolicy};
 pub use error::CellaConfigError;
 pub use security::{Security, SecurityMode};
 
-use crate::settings::{Credentials, Network, Tools};
+use crate::settings::{Credentials, Network, Shell, Tools};
 
 use self::format::load_layer;
 use self::merge::merge_layers;
@@ -31,6 +31,9 @@ pub struct CellaConfig {
 
     #[serde(default)]
     pub network: Network,
+
+    #[serde(default)]
+    pub shell: Shell,
 
     #[serde(default)]
     pub cli: Cli,
@@ -87,7 +90,19 @@ impl CellaConfig {
             layers.push(val);
         }
 
-        let merged = merge_layers(&layers);
+        let mut merged = merge_layers(&layers);
+
+        // shell.preferred uses replacement semantics: highest-priority layer wins
+        // entirely, instead of the default array-prepend merge behavior.
+        for layer in layers.iter().rev() {
+            if let Some(preferred) = layer.pointer("/shell/preferred")
+                && let Some(obj) = merged.pointer_mut("/shell").and_then(|v| v.as_object_mut())
+            {
+                obj.insert("preferred".to_string(), preferred.clone());
+                break;
+            }
+        }
+
         serde_json::from_value(merged).map_err(|e| CellaConfigError::Deserialization { source: e })
     }
 }
@@ -287,5 +302,48 @@ mod tests {
         assert!(cfg.credentials.ai.enabled);
         assert!(!cfg.credentials.ai.is_provider_enabled("openai"));
         assert!(!cfg.credentials.ai.is_provider_enabled("anthropic"));
+    }
+
+    #[test]
+    fn shell_preferred_replacement_semantics() {
+        let global = TempDir::new().unwrap();
+        let ws = TempDir::new().unwrap();
+        std::fs::write(
+            global.path().join("config.toml"),
+            "[shell]\npreferred = [\"zsh\", \"bash\", \"sh\"]\n",
+        )
+        .unwrap();
+        let devcontainer = ws.path().join(".devcontainer");
+        std::fs::create_dir_all(&devcontainer).unwrap();
+        std::fs::write(
+            devcontainer.join("cella.toml"),
+            "[shell]\npreferred = [\"bash\", \"sh\"]\n",
+        )
+        .unwrap();
+        let cfg = CellaConfig::load_with_global(ws.path(), None, Some(global.path())).unwrap();
+        assert_eq!(cfg.shell.preferred, vec!["bash", "sh"]);
+    }
+
+    #[test]
+    fn shell_preferred_from_customizations() {
+        let ws = TempDir::new().unwrap();
+        let global = TempDir::new().unwrap();
+        let resolved = make_resolved(json!({
+            "customizations": {
+                "cella": {
+                    "shell": {"preferred": ["fish", "zsh", "bash", "sh"]}
+                }
+            }
+        }));
+        let cfg =
+            CellaConfig::load_with_global(ws.path(), Some(&resolved), Some(global.path())).unwrap();
+        assert_eq!(cfg.shell.preferred, vec!["fish", "zsh", "bash", "sh"]);
+    }
+
+    #[test]
+    fn no_shell_config_returns_empty() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = CellaConfig::load_with_global(tmp.path(), None, Some(tmp.path())).unwrap();
+        assert!(cfg.shell.preferred.is_empty());
     }
 }

--- a/crates/cella-config/src/settings/mod.rs
+++ b/crates/cella-config/src/settings/mod.rs
@@ -5,6 +5,7 @@ mod credentials;
 mod gemini;
 pub mod network;
 mod nvim;
+mod shell;
 mod tmux;
 mod tools;
 
@@ -15,5 +16,6 @@ pub use credentials::Credentials;
 pub use gemini::Gemini;
 pub use network::Network;
 pub use nvim::Nvim;
+pub use shell::Shell;
 pub use tmux::Tmux;
 pub use tools::Tools;

--- a/crates/cella-config/src/settings/shell.rs
+++ b/crates/cella-config/src/settings/shell.rs
@@ -1,0 +1,44 @@
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct Shell {
+    #[serde(default)]
+    pub preferred: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_has_empty_preferred() {
+        let shell = Shell::default();
+        assert!(shell.preferred.is_empty());
+    }
+
+    #[test]
+    fn deserialize_preferred_list() {
+        let shell: Shell = toml::from_str(r#"preferred = ["zsh", "bash", "sh"]"#).unwrap();
+        assert_eq!(shell.preferred, vec!["zsh", "bash", "sh"]);
+    }
+
+    #[test]
+    fn deserialize_empty_uses_defaults() {
+        let shell: Shell = toml::from_str("").unwrap();
+        assert!(shell.preferred.is_empty());
+    }
+
+    #[test]
+    fn deserialize_full_paths() {
+        let shell: Shell =
+            toml::from_str(r#"preferred = ["/usr/local/bin/fish", "zsh", "bash", "sh"]"#).unwrap();
+        assert_eq!(shell.preferred[0], "/usr/local/bin/fish");
+    }
+
+    #[test]
+    fn unknown_field_rejected() {
+        let result = toml::from_str::<Shell>("unknown = true");
+        assert!(result.is_err());
+    }
+}

--- a/crates/cella-orchestrator/src/shell_detect.rs
+++ b/crates/cella-orchestrator/src/shell_detect.rs
@@ -400,4 +400,295 @@ mod tests {
         assert!(!is_valid_shell_name("sh && echo pwned"));
         assert!(!is_valid_shell_name("zsh\nmalicious"));
     }
+
+    // ── Mock backend for async resolve_shell tests ─────────────────
+
+    use std::collections::VecDeque;
+    use std::path::Path;
+    use std::sync::Mutex;
+
+    use cella_backend::{BackendCapabilities, BackendError, BackendKind, BoxFuture, ExecResult};
+
+    struct MockBackend {
+        responses: Mutex<VecDeque<ExecResult>>,
+    }
+
+    impl MockBackend {
+        fn from_responses(responses: Vec<ExecResult>) -> Self {
+            Self {
+                responses: Mutex::new(VecDeque::from(responses)),
+            }
+        }
+    }
+
+    fn ok_result(stdout: &str) -> ExecResult {
+        ExecResult {
+            exit_code: 0,
+            stdout: stdout.to_string(),
+            stderr: String::new(),
+        }
+    }
+
+    fn fail_result() -> ExecResult {
+        ExecResult {
+            exit_code: 1,
+            stdout: String::new(),
+            stderr: String::new(),
+        }
+    }
+
+    macro_rules! panic_method {
+        ($name:ident, $($arg:ident: $ty:ty),* => $ret:ty) => {
+            fn $name<'a>(&'a self, $(_: $ty),*) -> BoxFuture<'a, $ret> {
+                panic!(concat!(stringify!($name), " should not be called"));
+            }
+        };
+    }
+
+    impl ContainerBackend for MockBackend {
+        fn kind(&self) -> BackendKind {
+            BackendKind::Docker
+        }
+
+        fn capabilities(&self) -> BackendCapabilities {
+            BackendCapabilities {
+                compose: false,
+                managed_agent: false,
+            }
+        }
+
+        fn exec_command<'a>(
+            &'a self,
+            _container_id: &'a str,
+            _opts: &'a ExecOptions,
+        ) -> BoxFuture<'a, Result<ExecResult, BackendError>> {
+            let result = self
+                .responses
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("MockBackend: no exec_command response configured");
+            Box::pin(async move { Ok(result) })
+        }
+
+        panic_method!(find_container, w: &'a Path => Result<Option<cella_backend::ContainerInfo>, BackendError>);
+        panic_method!(create_container, o: &'a cella_backend::CreateContainerOptions => Result<String, BackendError>);
+        panic_method!(start_container, id: &'a str => Result<(), BackendError>);
+        panic_method!(stop_container, id: &'a str => Result<(), BackendError>);
+        fn remove_container<'a>(
+            &'a self,
+            _id: &'a str,
+            _remove_volumes: bool,
+        ) -> BoxFuture<'a, Result<(), BackendError>> {
+            panic!("remove_container should not be called");
+        }
+        panic_method!(inspect_container, id: &'a str => Result<cella_backend::ContainerInfo, BackendError>);
+        fn list_cella_containers(
+            &self,
+            _running_only: bool,
+        ) -> BoxFuture<'_, Result<Vec<cella_backend::ContainerInfo>, BackendError>> {
+            panic!("list_cella_containers should not be called");
+        }
+        fn find_compose_service<'a>(
+            &'a self,
+            _project: &'a str,
+            _service: &'a str,
+        ) -> BoxFuture<'a, Result<Option<cella_backend::ContainerInfo>, BackendError>> {
+            panic!("find_compose_service should not be called");
+        }
+        fn find_container_by_label<'a>(
+            &'a self,
+            _label: &'a str,
+        ) -> BoxFuture<'a, Result<Option<cella_backend::ContainerInfo>, BackendError>> {
+            panic!("find_container_by_label should not be called");
+        }
+        fn container_logs<'a>(
+            &'a self,
+            _id: &'a str,
+            _tail: u32,
+        ) -> BoxFuture<'a, Result<String, BackendError>> {
+            panic!("container_logs should not be called");
+        }
+        fn exec_stream<'a>(
+            &'a self,
+            _container_id: &'a str,
+            _opts: &'a ExecOptions,
+            _stdout: Box<dyn std::io::Write + Send + 'a>,
+            _stderr: Box<dyn std::io::Write + Send + 'a>,
+        ) -> BoxFuture<'a, Result<ExecResult, BackendError>> {
+            panic!("exec_stream should not be called");
+        }
+        fn exec_interactive<'a>(
+            &'a self,
+            _container_id: &'a str,
+            _opts: &'a cella_backend::InteractiveExecOptions,
+        ) -> BoxFuture<'a, Result<i64, BackendError>> {
+            panic!("exec_interactive should not be called");
+        }
+        fn exec_detached<'a>(
+            &'a self,
+            _container_id: &'a str,
+            _opts: &'a ExecOptions,
+        ) -> BoxFuture<'a, Result<String, BackendError>> {
+            panic!("exec_detached should not be called");
+        }
+        panic_method!(pull_image, image: &'a str => Result<(), BackendError>);
+        panic_method!(build_image, opts: &'a cella_backend::BuildOptions => Result<String, BackendError>);
+        panic_method!(image_exists, image: &'a str => Result<bool, BackendError>);
+        panic_method!(inspect_image_details, image: &'a str => Result<cella_backend::ImageDetails, BackendError>);
+        fn upload_files<'a>(
+            &'a self,
+            _container_id: &'a str,
+            _files: &'a [cella_backend::FileToUpload],
+        ) -> BoxFuture<'a, Result<(), BackendError>> {
+            panic!("upload_files should not be called");
+        }
+        fn ping(&self) -> BoxFuture<'_, Result<(), BackendError>> {
+            panic!("ping should not be called");
+        }
+        fn host_gateway(&self) -> &'static str {
+            "host.docker.internal"
+        }
+        fn detect_platform(&self) -> BoxFuture<'_, Result<cella_backend::Platform, BackendError>> {
+            panic!("detect_platform should not be called");
+        }
+        fn detect_container_arch(&self) -> BoxFuture<'_, Result<String, BackendError>> {
+            panic!("detect_container_arch should not be called");
+        }
+        fn inspect_image_env<'a>(
+            &'a self,
+            _image: &'a str,
+        ) -> BoxFuture<'a, Result<Vec<String>, BackendError>> {
+            panic!("inspect_image_env should not be called");
+        }
+        fn inspect_image_user<'a>(
+            &'a self,
+            _image: &'a str,
+        ) -> BoxFuture<'a, Result<String, BackendError>> {
+            panic!("inspect_image_user should not be called");
+        }
+        fn ensure_network(&self) -> BoxFuture<'_, Result<(), BackendError>> {
+            panic!("ensure_network should not be called");
+        }
+        fn ensure_container_network<'a>(
+            &'a self,
+            _container_id: &'a str,
+            _repo_path: &'a Path,
+        ) -> BoxFuture<'a, Result<(), BackendError>> {
+            panic!("ensure_container_network should not be called");
+        }
+        fn get_container_ip<'a>(
+            &'a self,
+            _container_id: &'a str,
+        ) -> BoxFuture<'a, Result<Option<String>, BackendError>> {
+            panic!("get_container_ip should not be called");
+        }
+        fn ensure_agent_provisioned<'a>(
+            &'a self,
+            _version: &'a str,
+            _arch: &'a str,
+            _skip_checksum: bool,
+        ) -> BoxFuture<'a, Result<(), BackendError>> {
+            panic!("ensure_agent_provisioned should not be called");
+        }
+        fn write_agent_addr<'a>(
+            &'a self,
+            _container_id: &'a str,
+            _addr: &'a str,
+            _token: &'a str,
+        ) -> BoxFuture<'a, Result<(), BackendError>> {
+            panic!("write_agent_addr should not be called");
+        }
+        fn agent_volume_mount(&self) -> (String, String, bool) {
+            panic!("agent_volume_mount should not be called");
+        }
+        fn prune_old_agent_versions<'a>(
+            &'a self,
+            _current_version: &'a str,
+        ) -> BoxFuture<'a, Result<(), BackendError>> {
+            panic!("prune_old_agent_versions should not be called");
+        }
+    }
+
+    // ── Async resolve_shell tests ──────────────────────────────────
+
+    #[tokio::test]
+    async fn resolve_picks_first_available_preferred() {
+        let mock = MockBackend::from_responses(vec![
+            ok_result("/usr/bin/fish"), // command -v fish
+        ]);
+        let res = resolve_shell(&mock, "ctr", "user", &["fish".to_string()]).await;
+        assert_eq!(res.shell, "/usr/bin/fish");
+        assert_eq!(res.source, ShellSource::Preferred);
+    }
+
+    #[tokio::test]
+    async fn resolve_skips_unavailable_tries_next() {
+        let mock = MockBackend::from_responses(vec![
+            fail_result(),          // command -v fish
+            fail_result(),          // test -x /bin/fish
+            fail_result(),          // test -x /usr/bin/fish
+            fail_result(),          // test -x /usr/local/bin/fish
+            ok_result("/bin/bash"), // command -v bash
+        ]);
+        let res = resolve_shell(
+            &mock,
+            "ctr",
+            "user",
+            &["fish".to_string(), "bash".to_string()],
+        )
+        .await;
+        assert_eq!(res.shell, "/bin/bash");
+        assert_eq!(res.source, ShellSource::Preferred);
+    }
+
+    #[tokio::test]
+    async fn resolve_falls_through_when_no_preferred_available() {
+        let mock = MockBackend::from_responses(vec![
+            fail_result(),          // command -v nonexistent
+            fail_result(),          // test -x /bin/nonexistent
+            fail_result(),          // test -x /usr/bin/nonexistent
+            fail_result(),          // test -x /usr/local/bin/nonexistent
+            ok_result("/bin/bash"), // detect_shell: echo $SHELL
+        ]);
+        let res = resolve_shell(&mock, "ctr", "user", &["nonexistent".to_string()]).await;
+        assert_eq!(res.shell, "/bin/bash");
+        assert_eq!(res.source, ShellSource::Detected);
+    }
+
+    #[tokio::test]
+    async fn resolve_empty_preferred_uses_detection() {
+        let mock = MockBackend::from_responses(vec![
+            ok_result("/bin/zsh"), // detect_shell: echo $SHELL
+        ]);
+        let res = resolve_shell(&mock, "ctr", "user", &[]).await;
+        assert_eq!(res.shell, "/bin/zsh");
+        assert_eq!(res.source, ShellSource::Detected);
+    }
+
+    #[tokio::test]
+    async fn resolve_full_path_probed_directly() {
+        let mock = MockBackend::from_responses(vec![
+            ok_result(""), // test -x /home/linuxbrew/.linuxbrew/bin/fish
+        ]);
+        let res = resolve_shell(
+            &mock,
+            "ctr",
+            "user",
+            &["/home/linuxbrew/.linuxbrew/bin/fish".to_string()],
+        )
+        .await;
+        assert_eq!(res.shell, "/home/linuxbrew/.linuxbrew/bin/fish");
+        assert_eq!(res.source, ShellSource::Preferred);
+    }
+
+    #[tokio::test]
+    async fn resolve_fallback_when_detection_returns_bin_sh() {
+        let mock = MockBackend::from_responses(vec![
+            ok_result("/bin/sh"), // detect_shell: echo $SHELL
+        ]);
+        let res = resolve_shell(&mock, "ctr", "user", &[]).await;
+        assert_eq!(res.shell, "/bin/sh");
+        assert_eq!(res.source, ShellSource::Fallback);
+    }
 }

--- a/crates/cella-orchestrator/src/shell_detect.rs
+++ b/crates/cella-orchestrator/src/shell_detect.rs
@@ -4,6 +4,47 @@ use tracing::{debug, warn};
 
 use cella_backend::{ContainerBackend, ExecOptions};
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ShellSource {
+    CliFlag,
+    Preferred,
+    Detected,
+    Fallback,
+}
+
+#[derive(Debug, Clone)]
+pub struct ShellResolution {
+    pub shell: String,
+    pub source: ShellSource,
+}
+
+/// Resolve the shell to use, respecting user preferences.
+///
+/// Priority: preference list (probed) -> existing detection -> /bin/sh.
+pub async fn resolve_shell(
+    client: &dyn ContainerBackend,
+    container_id: &str,
+    user: &str,
+    preferred: &[String],
+) -> ShellResolution {
+    if !preferred.is_empty()
+        && let Some(shell) = probe_preferred(client, container_id, user, preferred).await
+    {
+        return ShellResolution {
+            shell,
+            source: ShellSource::Preferred,
+        };
+    }
+
+    let shell = detect_shell(client, container_id, user).await;
+    let source = if shell == "/bin/sh" {
+        ShellSource::Fallback
+    } else {
+        ShellSource::Detected
+    };
+    ShellResolution { shell, source }
+}
+
 /// Detect the best available shell for a user inside a container.
 pub async fn detect_shell(client: &dyn ContainerBackend, container_id: &str, user: &str) -> String {
     if let Some(shell) = detect_shell_from_env(client, container_id, user).await {
@@ -154,6 +195,118 @@ async fn detect_shell_by_probing(
     None
 }
 
+async fn probe_preferred(
+    client: &dyn ContainerBackend,
+    container_id: &str,
+    user: &str,
+    preferred: &[String],
+) -> Option<String> {
+    for candidate in preferred {
+        let resolved = if candidate.contains('/') {
+            probe_full_path(client, container_id, user, candidate).await
+        } else {
+            probe_short_name(client, container_id, user, candidate).await
+        };
+        if let Some(shell) = resolved {
+            debug!("Resolved preferred shell {candidate} -> {shell}");
+            return Some(shell);
+        }
+        debug!("Preferred shell {candidate} not available");
+    }
+    None
+}
+
+fn is_valid_shell_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.bytes().all(|b| {
+            b.is_ascii_alphanumeric()
+                || b == b'_'
+                || b == b'.'
+                || b == b'/'
+                || b == b'-'
+                || b == b'+'
+        })
+}
+
+async fn probe_short_name(
+    client: &dyn ContainerBackend,
+    container_id: &str,
+    user: &str,
+    name: &str,
+) -> Option<String> {
+    if !is_valid_shell_name(name) {
+        warn!("Ignoring invalid shell name in preference: {name:?}");
+        return None;
+    }
+
+    let quoted = shell_quote(&[name.to_string()]);
+    let result = client
+        .exec_command(
+            container_id,
+            &ExecOptions {
+                cmd: vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    format!("command -v {quoted}"),
+                ],
+                user: Some(user.to_string()),
+                env: None,
+                working_dir: None,
+            },
+        )
+        .await
+        .ok()?;
+
+    if result.exit_code == 0 {
+        let path = result.stdout.trim().to_string();
+        if !path.is_empty() {
+            return Some(path);
+        }
+    }
+
+    for prefix in &["/bin/", "/usr/bin/", "/usr/local/bin/"] {
+        let path = format!("{prefix}{name}");
+        if probe_full_path(client, container_id, user, &path)
+            .await
+            .is_some()
+        {
+            return Some(path);
+        }
+    }
+    None
+}
+
+async fn probe_full_path(
+    client: &dyn ContainerBackend,
+    container_id: &str,
+    user: &str,
+    path: &str,
+) -> Option<String> {
+    if !is_valid_shell_name(path) {
+        warn!("Ignoring invalid shell path in preference: {path:?}");
+        return None;
+    }
+
+    let result = client
+        .exec_command(
+            container_id,
+            &ExecOptions {
+                cmd: vec!["test".to_string(), "-x".to_string(), path.to_string()],
+                user: Some(user.to_string()),
+                env: None,
+                working_dir: None,
+            },
+        )
+        .await
+        .ok()?;
+
+    if result.exit_code == 0 {
+        Some(path.to_string())
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -217,5 +370,34 @@ mod tests {
                 "exec 'claude' '--dangerously-skip-permissions'"
             ]
         );
+    }
+
+    #[test]
+    fn shell_resolution_types() {
+        let res = ShellResolution {
+            shell: "/bin/zsh".to_string(),
+            source: ShellSource::Preferred,
+        };
+        assert_eq!(res.source, ShellSource::Preferred);
+    }
+
+    #[test]
+    fn valid_shell_names_accepted() {
+        assert!(is_valid_shell_name("zsh"));
+        assert!(is_valid_shell_name("bash"));
+        assert!(is_valid_shell_name("/bin/zsh"));
+        assert!(is_valid_shell_name("/usr/local/bin/fish"));
+        assert!(is_valid_shell_name("my-shell_v2.0"));
+        assert!(is_valid_shell_name("shell+extra"));
+    }
+
+    #[test]
+    fn injection_shell_names_rejected() {
+        assert!(!is_valid_shell_name(""));
+        assert!(!is_valid_shell_name("zsh; rm -rf /"));
+        assert!(!is_valid_shell_name("$(evil)"));
+        assert!(!is_valid_shell_name("shell`whoami`"));
+        assert!(!is_valid_shell_name("sh && echo pwned"));
+        assert!(!is_valid_shell_name("zsh\nmalicious"));
     }
 }


### PR DESCRIPTION
## Summary

- Add `[shell]` config section with `preferred` field — an ordered list of shell names/paths
- New `resolve_shell()` probes each candidate in the preference list before falling through to existing detection logic
- Both `cella shell` and `cella exec` respect the preference; `--shell` flag still overrides everything
- Input validation rejects command injection in shell names
- Replacement merge semantics: project config fully replaces global preference list (no prepend)

## Example config

```toml
# ~/.cella/config.toml
[shell]
preferred = ["zsh", "bash", "sh"]
```

## Test plan

- [x] Shell settings struct: deserialization, defaults, unknown field rejection
- [x] Config merge: replacement semantics verified (project replaces global)
- [x] Config loading from customizations.cella section
- [x] Shell name validation: accepts normal names, rejects injection attempts
- [x] resolve_shell with mock backend: preference hit, skip-unavailable, fallback to detection, full path probing, /bin/sh fallback
- [x] Format, clippy, and test suite pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)