### PR TITLE
feat: clipboard image paste support in containers

### DIFF
--- a/crates/cella-agent/src/clipboard.rs
+++ b/crates/cella-agent/src/clipboard.rs
@@ -45,7 +45,7 @@ pub fn parse_xclip_args(args: &[String]) -> ClipboardOp {
         match args[i].as_str() {
             "-i" | "-in" => mode = Some("input"),
             "-o" | "-out" => mode = Some("output"),
-            "-target" => {
+            "-target" | "-t" => {
                 i += 1;
                 if let Some(t) = args.get(i) {
                     mime_type.clone_from(t);
@@ -255,5 +255,23 @@ mod tests {
         assert!(args.iter().any(|a| a == "-f" || a == "-filter"));
         let args2 = ["-filter".to_string()];
         assert!(args2.iter().any(|a| a == "-f" || a == "-filter"));
+    }
+
+    #[test]
+    fn parse_xclip_short_target_flag() {
+        let op = parse_xclip_args(&["-t".to_string(), "image/png".to_string(), "-o".to_string()]);
+        assert!(matches!(op, ClipboardOp::Paste { mime_type } if mime_type == "image/png"));
+    }
+
+    #[test]
+    fn parse_xclip_short_target_with_targets() {
+        let op = parse_xclip_args(&[
+            "-selection".to_string(),
+            "clipboard".to_string(),
+            "-t".to_string(),
+            "TARGETS".to_string(),
+            "-o".to_string(),
+        ]);
+        assert!(matches!(op, ClipboardOp::Paste { mime_type } if mime_type == "TARGETS"));
     }
 }

--- a/crates/cella-agent/src/clipboard.rs
+++ b/crates/cella-agent/src/clipboard.rs
@@ -90,14 +90,14 @@ pub fn parse_wl_paste_args(args: &[String]) -> WlPasteOptions {
     while i < args.len() {
         match args[i].as_str() {
             "--list-types" | "-l" => list_types = true,
+            "-n" | "--no-newline" => no_newline = true,
             "--type" | "-t" => {
                 i += 1;
                 if let Some(t) = args.get(i) {
                     mime_type.clone_from(t);
                 }
             }
-            "-n" | "--no-newline" => no_newline = true,
-            "--primary" | "--seat" => {
+            "--seat" => {
                 i += 1;
             }
             _ => {}
@@ -123,7 +123,7 @@ pub fn parse_wl_copy_args(args: &[String]) -> ClipboardOp {
                     mime_type.clone_from(t);
                 }
             }
-            "--primary" | "--seat" | "--foreground" | "--paste-once" => {
+            "--seat" => {
                 i += 1;
             }
             _ => {}

--- a/crates/cella-agent/src/clipboard.rs
+++ b/crates/cella-agent/src/clipboard.rs
@@ -75,6 +75,89 @@ pub async fn handle_xclip(args: &[String]) -> Result<(), CellaPortError> {
     execute_clipboard_op(op, filter).await
 }
 
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+pub struct WlPasteOptions {
+    pub mime_type: String,
+    pub list_types: bool,
+    pub no_newline: bool,
+}
+
+pub fn parse_wl_paste_args(args: &[String]) -> WlPasteOptions {
+    let mut mime_type = DEFAULT_MIME_TYPE.to_string();
+    let mut list_types = false;
+    let mut no_newline = false;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--list-types" | "-l" => list_types = true,
+            "--type" | "-t" => {
+                i += 1;
+                if let Some(t) = args.get(i) {
+                    mime_type.clone_from(t);
+                }
+            }
+            "-n" | "--no-newline" => no_newline = true,
+            "--primary" | "--seat" => {
+                i += 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    WlPasteOptions {
+        mime_type,
+        list_types,
+        no_newline,
+    }
+}
+
+pub fn parse_wl_copy_args(args: &[String]) -> ClipboardOp {
+    let mut mime_type = DEFAULT_MIME_TYPE.to_string();
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--clear" | "-c" => return ClipboardOp::Clear,
+            "--type" | "-t" => {
+                i += 1;
+                if let Some(t) = args.get(i) {
+                    mime_type.clone_from(t);
+                }
+            }
+            "--primary" | "--seat" | "--foreground" | "--paste-once" => {
+                i += 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    ClipboardOp::Copy { mime_type }
+}
+
+pub async fn handle_wl_paste(args: &[String]) -> Result<(), CellaPortError> {
+    let opts = parse_wl_paste_args(args);
+    let mime = if opts.list_types {
+        "TARGETS".to_string()
+    } else {
+        opts.mime_type
+    };
+    let data = request_clipboard_paste(&mime).await?;
+    let output = if opts.no_newline {
+        data.strip_suffix(b"\n").unwrap_or(&data).to_vec()
+    } else {
+        data
+    };
+    std::io::stdout()
+        .write_all(&output)
+        .map_err(|e| CellaPortError::ControlSocket {
+            message: format!("failed to write stdout: {e}"),
+        })
+}
+
+pub async fn handle_wl_copy(args: &[String]) -> Result<(), CellaPortError> {
+    let op = parse_wl_copy_args(args);
+    execute_clipboard_op(op, false).await
+}
+
 async fn execute_clipboard_op(op: ClipboardOp, filter: bool) -> Result<(), CellaPortError> {
     match op {
         ClipboardOp::Copy { mime_type } => {
@@ -273,5 +356,68 @@ mod tests {
             "-o".to_string(),
         ]);
         assert!(matches!(op, ClipboardOp::Paste { mime_type } if mime_type == "TARGETS"));
+    }
+
+    #[test]
+    fn parse_wl_paste_list_types() {
+        let opts = parse_wl_paste_args(&["--list-types".to_string()]);
+        assert!(opts.list_types);
+    }
+
+    #[test]
+    fn parse_wl_paste_type_flag() {
+        let opts = parse_wl_paste_args(&["--type".to_string(), "image/png".to_string()]);
+        assert_eq!(opts.mime_type, "image/png");
+        assert!(!opts.list_types);
+    }
+
+    #[test]
+    fn parse_wl_paste_short_type_flag() {
+        let opts = parse_wl_paste_args(&["-t".to_string(), "image/jpeg".to_string()]);
+        assert_eq!(opts.mime_type, "image/jpeg");
+    }
+
+    #[test]
+    fn parse_wl_paste_short_list_flag() {
+        let opts = parse_wl_paste_args(&["-l".to_string()]);
+        assert!(opts.list_types);
+    }
+
+    #[test]
+    fn parse_wl_paste_no_newline_flag() {
+        let opts = parse_wl_paste_args(&["-n".to_string()]);
+        assert!(opts.no_newline);
+    }
+
+    #[test]
+    fn parse_wl_paste_defaults() {
+        let opts = parse_wl_paste_args(&[]);
+        assert_eq!(opts.mime_type, "text/plain");
+        assert!(!opts.list_types);
+        assert!(!opts.no_newline);
+    }
+
+    #[test]
+    fn parse_wl_copy_defaults_to_copy() {
+        let op = parse_wl_copy_args(&[]);
+        assert!(matches!(op, ClipboardOp::Copy { mime_type } if mime_type == "text/plain"));
+    }
+
+    #[test]
+    fn parse_wl_copy_type_flag() {
+        let op = parse_wl_copy_args(&["--type".to_string(), "image/png".to_string()]);
+        assert!(matches!(op, ClipboardOp::Copy { mime_type } if mime_type == "image/png"));
+    }
+
+    #[test]
+    fn parse_wl_copy_clear_flag() {
+        assert!(matches!(
+            parse_wl_copy_args(&["--clear".to_string()]),
+            ClipboardOp::Clear
+        ));
+        assert!(matches!(
+            parse_wl_copy_args(&["-c".to_string()]),
+            ClipboardOp::Clear
+        ));
     }
 }

--- a/crates/cella-agent/src/main.rs
+++ b/crates/cella-agent/src/main.rs
@@ -52,6 +52,10 @@ enum AgentCommand {
     Xsel { args: Vec<String> },
     /// Handle xclip-compatible clipboard command.
     Xclip { args: Vec<String> },
+    /// Handle wl-paste-compatible clipboard command.
+    WlPaste { args: Vec<String> },
+    /// Handle wl-copy-compatible clipboard command.
+    WlCopy { args: Vec<String> },
 }
 
 fn parse_args() -> Result<AgentArgs, String> {
@@ -119,6 +123,16 @@ fn parse_args_from(args: &[String]) -> Result<AgentArgs, String> {
         }),
         "xclip" => Ok(AgentArgs {
             command: AgentCommand::Xclip {
+                args: args[2..].to_vec(),
+            },
+        }),
+        "wl-paste" => Ok(AgentArgs {
+            command: AgentCommand::WlPaste {
+                args: args[2..].to_vec(),
+            },
+        }),
+        "wl-copy" => Ok(AgentArgs {
+            command: AgentCommand::WlCopy {
                 args: args[2..].to_vec(),
             },
         }),
@@ -211,6 +225,18 @@ async fn main() {
         AgentCommand::Xclip { args } => {
             if let Err(e) = clipboard::handle_xclip(&args).await {
                 error!("Clipboard (xclip) error: {e}");
+                std::process::exit(1);
+            }
+        }
+        AgentCommand::WlPaste { args } => {
+            if let Err(e) = clipboard::handle_wl_paste(&args).await {
+                error!("Clipboard (wl-paste) error: {e}");
+                std::process::exit(1);
+            }
+        }
+        AgentCommand::WlCopy { args } => {
+            if let Err(e) = clipboard::handle_wl_copy(&args).await {
+                error!("Clipboard (wl-copy) error: {e}");
                 std::process::exit(1);
             }
         }
@@ -526,6 +552,26 @@ mod tests {
         ]))
         .unwrap();
         assert!(matches!(a.command, AgentCommand::Xclip { args } if args.len() == 5));
+    }
+
+    #[test]
+    fn parse_wl_paste_command() {
+        let a = parse_args_from(&args(&["cella-agent", "wl-paste", "--list-types"])).unwrap();
+        assert!(
+            matches!(a.command, AgentCommand::WlPaste { args } if args == vec!["--list-types"])
+        );
+    }
+
+    #[test]
+    fn parse_wl_paste_no_args() {
+        let a = parse_args_from(&args(&["cella-agent", "wl-paste"])).unwrap();
+        assert!(matches!(a.command, AgentCommand::WlPaste { args } if args.is_empty()));
+    }
+
+    #[test]
+    fn parse_wl_copy_command() {
+        let a = parse_args_from(&args(&["cella-agent", "wl-copy", "-t", "image/png"])).unwrap();
+        assert!(matches!(a.command, AgentCommand::WlCopy { args } if args.len() == 2));
     }
 
     #[test]

--- a/crates/cella-daemon/src/clipboard.rs
+++ b/crates/cella-daemon/src/clipboard.rs
@@ -117,7 +117,7 @@ const JXA_TARGETS: &str = r"ObjC.import('AppKit');
 var pb=$.NSPasteboard.generalPasteboard;
 var types=pb.types;
 var m=['TARGETS','text/plain'];
-var map={'public.png':'image/png','public.tiff':'image/png','public.jpeg':'image/jpeg'};
+var map={'public.png':'image/png','public.tiff':'image/png'};
 for(var i=0;i<types.count;i++){var t=types.objectAtIndex(i).js;if(map[t]&&m.indexOf(map[t])===-1)m.push(map[t]);}
 m.join('\n');";
 
@@ -166,7 +166,7 @@ impl ClipboardBackend for PbcopyBackend {
 
     fn copy(&self, data: &[u8], mime_type: &str) -> Result<(), String> {
         #[cfg(target_os = "macos")]
-        if mime_type.starts_with("image/") {
+        if mime_type == "image/png" {
             use base64::Engine;
             let encoded = base64::engine::general_purpose::STANDARD.encode(data);
             let script = format!(

--- a/crates/cella-daemon/src/clipboard.rs
+++ b/crates/cella-daemon/src/clipboard.rs
@@ -113,16 +113,16 @@ impl ClipboardBackend for NullBackend {
 struct PbcopyBackend;
 
 #[cfg(target_os = "macos")]
-const JXA_TARGETS: &str = r#"ObjC.import('AppKit');
+const JXA_TARGETS: &str = r"ObjC.import('AppKit');
 var pb=$.NSPasteboard.generalPasteboard;
 var types=pb.types;
 var m=['TARGETS','text/plain'];
 var map={'public.png':'image/png','public.tiff':'image/png','public.jpeg':'image/jpeg'};
 for(var i=0;i<types.count;i++){var t=types.objectAtIndex(i).js;if(map[t]&&m.indexOf(map[t])===-1)m.push(map[t]);}
-m.join('\n');"#;
+m.join('\n');";
 
 #[cfg(target_os = "macos")]
-const JXA_IMAGE_PASTE: &str = r#"ObjC.import('AppKit');ObjC.import('Foundation');
+const JXA_IMAGE_PASTE: &str = r"ObjC.import('AppKit');ObjC.import('Foundation');
 var pb=$.NSPasteboard.generalPasteboard;
 var types=['public.png','public.tiff','public.jpeg'];
 var data=null;
@@ -130,7 +130,7 @@ for(var i=0;i<types.length;i++){data=pb.dataForType(types[i]);if(data&&!data.isN
 if(!data||data.isNil())'';
 else{var rep=$.NSBitmapImageRep.imageRepWithData(data);
 var png=rep.representationUsingTypeProperties($.NSBitmapImageFileTypePNG,$.NSDictionary.dictionary);
-png.base64EncodedStringWithOptions(0).js;}"#;
+png.base64EncodedStringWithOptions(0).js;}";
 
 #[cfg(target_os = "macos")]
 fn run_jxa(script: &str) -> Result<Vec<u8>, String> {
@@ -171,10 +171,9 @@ impl ClipboardBackend for PbcopyBackend {
             let encoded = base64::engine::general_purpose::STANDARD.encode(data);
             let script = format!(
                 "ObjC.import('AppKit');ObjC.import('Foundation');\
-                 var data=$.NSData.alloc.initWithBase64EncodedStringOptions($('{}'),0);\
+                 var data=$.NSData.alloc.initWithBase64EncodedStringOptions($('{encoded}'),0);\
                  var pb=$.NSPasteboard.generalPasteboard;pb.clearContents;\
-                 pb.setDataForType(data,$.NSPasteboardTypePNG);'ok';",
-                encoded
+                 pb.setDataForType(data,$.NSPasteboardTypePNG);'ok';"
             );
             return run_jxa(&script).map(|_| ());
         }
@@ -190,13 +189,13 @@ impl ClipboardBackend for PbcopyBackend {
                 return Ok((output, "text/plain".to_string()));
             }
             if mime_type.starts_with("image/") {
+                use base64::Engine;
                 let output = run_jxa(JXA_IMAGE_PASTE)?;
                 let text = String::from_utf8_lossy(&output);
                 let trimmed = text.trim();
                 if trimmed.is_empty() {
                     return Ok((Vec::new(), mime_type.to_string()));
                 }
-                use base64::Engine;
                 let bytes = base64::engine::general_purpose::STANDARD
                     .decode(trimmed)
                     .map_err(|e| format!("jxa base64 decode: {e}"))?;

--- a/crates/cella-daemon/src/clipboard.rs
+++ b/crates/cella-daemon/src/clipboard.rs
@@ -103,22 +103,106 @@ impl ClipboardBackend for NullBackend {
     }
 
     fn paste(&self, mime_type: &str) -> Result<(Vec<u8>, String), String> {
+        if mime_type == "TARGETS" {
+            return Ok((b"TARGETS\ntext/plain\n".to_vec(), "text/plain".to_string()));
+        }
         Ok((Vec::new(), mime_type.to_string()))
     }
 }
 
 struct PbcopyBackend;
 
+#[cfg(target_os = "macos")]
+const JXA_TARGETS: &str = r#"ObjC.import('AppKit');
+var pb=$.NSPasteboard.generalPasteboard;
+var types=pb.types;
+var m=['TARGETS','text/plain'];
+var map={'public.png':'image/png','public.tiff':'image/png','public.jpeg':'image/jpeg'};
+for(var i=0;i<types.count;i++){var t=types.objectAtIndex(i).js;if(map[t]&&m.indexOf(map[t])===-1)m.push(map[t]);}
+m.join('\n');"#;
+
+#[cfg(target_os = "macos")]
+const JXA_IMAGE_PASTE: &str = r#"ObjC.import('AppKit');ObjC.import('Foundation');
+var pb=$.NSPasteboard.generalPasteboard;
+var types=['public.png','public.tiff','public.jpeg'];
+var data=null;
+for(var i=0;i<types.length;i++){data=pb.dataForType(types[i]);if(data&&!data.isNil()&&data.length>0)break;data=null;}
+if(!data||data.isNil())'';
+else{var rep=$.NSBitmapImageRep.imageRepWithData(data);
+var png=rep.representationUsingTypeProperties($.NSBitmapImageFileTypePNG,$.NSDictionary.dictionary);
+png.base64EncodedStringWithOptions(0).js;}"#;
+
+#[cfg(target_os = "macos")]
+fn run_jxa(script: &str) -> Result<Vec<u8>, String> {
+    use std::io::Write;
+    let mut child = std::process::Command::new("osascript")
+        .args(["-l", "JavaScript", "-"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("osascript: {e}"))?;
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(script.as_bytes())
+        .map_err(|e| format!("osascript stdin: {e}"))?;
+    let output = child
+        .wait_with_output()
+        .map_err(|e| format!("osascript wait: {e}"))?;
+    if output.status.success() {
+        Ok(output.stdout)
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(format!("osascript exited with {}: {stderr}", output.status))
+    }
+}
+
 impl ClipboardBackend for PbcopyBackend {
     fn name(&self) -> &'static str {
         "pbcopy"
     }
 
-    fn copy(&self, data: &[u8], _mime_type: &str) -> Result<(), String> {
+    fn copy(&self, data: &[u8], mime_type: &str) -> Result<(), String> {
+        #[cfg(target_os = "macos")]
+        if mime_type.starts_with("image/") {
+            use base64::Engine;
+            let encoded = base64::engine::general_purpose::STANDARD.encode(data);
+            let script = format!(
+                "ObjC.import('AppKit');ObjC.import('Foundation');\
+                 var data=$.NSData.alloc.initWithBase64EncodedStringOptions($('{}'),0);\
+                 var pb=$.NSPasteboard.generalPasteboard;pb.clearContents;\
+                 pb.setDataForType(data,$.NSPasteboardTypePNG);'ok';",
+                encoded
+            );
+            return run_jxa(&script).map(|_| ());
+        }
+        let _ = mime_type;
         pipe_to_command("pbcopy", &[], data)
     }
 
     fn paste(&self, mime_type: &str) -> Result<(Vec<u8>, String), String> {
+        #[cfg(target_os = "macos")]
+        {
+            if mime_type == "TARGETS" {
+                let output = run_jxa(JXA_TARGETS)?;
+                return Ok((output, "text/plain".to_string()));
+            }
+            if mime_type.starts_with("image/") {
+                let output = run_jxa(JXA_IMAGE_PASTE)?;
+                let text = String::from_utf8_lossy(&output);
+                let trimmed = text.trim();
+                if trimmed.is_empty() {
+                    return Ok((Vec::new(), mime_type.to_string()));
+                }
+                use base64::Engine;
+                let bytes = base64::engine::general_purpose::STANDARD
+                    .decode(trimmed)
+                    .map_err(|e| format!("jxa base64 decode: {e}"))?;
+                return Ok((bytes, "image/png".to_string()));
+            }
+        }
         let output = run_command("pbpaste", &[])?;
         Ok((output, mime_type.to_string()))
     }
@@ -136,6 +220,10 @@ impl ClipboardBackend for WlClipboardBackend {
     }
 
     fn paste(&self, mime_type: &str) -> Result<(Vec<u8>, String), String> {
+        if mime_type == "TARGETS" {
+            let output = run_command("wl-paste", &["--list-types"])?;
+            return Ok((output, "text/plain".to_string()));
+        }
         let output = run_command("wl-paste", &["--type", mime_type])?;
         Ok((output, mime_type.to_string()))
     }
@@ -153,6 +241,9 @@ impl ClipboardBackend for XselBackend {
     }
 
     fn paste(&self, mime_type: &str) -> Result<(Vec<u8>, String), String> {
+        if mime_type == "TARGETS" {
+            return Ok((b"TARGETS\ntext/plain\n".to_vec(), "text/plain".to_string()));
+        }
         let output = run_command("xsel", &["--clipboard", "--output"])?;
         Ok((output, mime_type.to_string()))
     }
@@ -202,6 +293,9 @@ impl ClipboardBackend for Osc52Backend {
     }
 
     fn paste(&self, mime_type: &str) -> Result<(Vec<u8>, String), String> {
+        if mime_type == "TARGETS" {
+            return Ok((b"TARGETS\ntext/plain\n".to_vec(), "text/plain".to_string()));
+        }
         debug!("OSC 52 paste not supported, returning empty");
         Ok((Vec::new(), mime_type.to_string()))
     }
@@ -284,5 +378,15 @@ mod tests {
         let handler = ClipboardHandler::null();
         let (_, mime) = handler.paste("image/png").await.unwrap();
         assert_eq!(mime, "image/png");
+    }
+
+    #[tokio::test]
+    async fn null_backend_targets_returns_text_plain() {
+        let handler = ClipboardHandler::null();
+        let (data, mime) = handler.paste("TARGETS").await.unwrap();
+        let text = String::from_utf8_lossy(&data);
+        assert!(text.contains("text/plain"));
+        assert!(text.contains("TARGETS"));
+        assert_eq!(mime, "text/plain");
     }
 }

--- a/crates/cella-docker/src/volume.rs
+++ b/crates/cella-docker/src/volume.rs
@@ -208,6 +208,34 @@ exec "{agent_path}" xclip "$@"
     .into_bytes()
 }
 
+/// Generate the wl-paste shim script content.
+///
+/// Placed at `/cella/bin/wl-paste` to shadow the real wl-paste binary.
+/// Forwards all arguments to the agent's clipboard handler.
+pub fn wl_paste_helper_script() -> Vec<u8> {
+    let agent_path = agent_symlink_path();
+    format!(
+        r#"#!/bin/sh
+exec "{agent_path}" wl-paste "$@"
+"#
+    )
+    .into_bytes()
+}
+
+/// Generate the wl-copy shim script content.
+///
+/// Placed at `/cella/bin/wl-copy` to shadow the real wl-copy binary.
+/// Forwards all arguments to the agent's clipboard handler.
+pub fn wl_copy_helper_script() -> Vec<u8> {
+    let agent_path = agent_symlink_path();
+    format!(
+        r#"#!/bin/sh
+exec "{agent_path}" wl-copy "$@"
+"#
+    )
+    .into_bytes()
+}
+
 /// Version marker file path inside the volume.
 pub const fn version_marker_path() -> &'static str {
     "/cella/.version"
@@ -308,6 +336,8 @@ async fn populate_volume(
         browser: &browser_helper_script(),
         xsel: &xsel_helper_script(),
         xclip: &xclip_helper_script(),
+        wl_paste: &wl_paste_helper_script(),
+        wl_copy: &wl_copy_helper_script(),
     };
 
     upload_to_volume(
@@ -930,6 +960,25 @@ struct VolumeTarScripts<'a> {
     browser: &'a [u8],
     xsel: &'a [u8],
     xclip: &'a [u8],
+    wl_paste: &'a [u8],
+    wl_copy: &'a [u8],
+}
+
+fn tar_append_file(
+    archive: &mut tar::Builder<&mut Vec<u8>>,
+    path: &str,
+    data: &[u8],
+    mode: u32,
+) -> Result<(), CellaDockerError> {
+    let mut header = tar::Header::new_gnu();
+    header.set_size(data.len() as u64);
+    header.set_mode(mode);
+    header.set_cksum();
+    archive
+        .append_data(&mut header, path, data)
+        .map_err(|e| CellaDockerError::AgentVolume {
+            message: format!("tar append {path}: {e}"),
+        })
 }
 
 fn build_volume_tar(
@@ -939,57 +988,22 @@ fn build_volume_tar(
     scripts: &VolumeTarScripts<'_>,
     version_marker: &str,
 ) -> Result<Vec<u8>, CellaDockerError> {
-    let browser_script = scripts.browser;
-    let xsel_script = scripts.xsel;
-    let xclip_script = scripts.xclip;
     let mut buf = Vec::new();
     {
         let mut archive = tar::Builder::new(&mut buf);
 
-        // Agent binary: /cella/v{version}/{arch}/cella-agent
         let agent_path = format!("cella/v{version}/{arch}/cella-agent");
-        let mut header = tar::Header::new_gnu();
-        header.set_size(agent_bytes.len() as u64);
-        header.set_mode(0o755);
-        header.set_cksum();
-        archive
-            .append_data(&mut header, &agent_path, agent_bytes)
-            .map_err(|e| CellaDockerError::AgentVolume {
-                message: format!("tar append agent: {e}"),
-            })?;
-
-        // Browser helper: /cella/bin/cella-browser
-        let mut header = tar::Header::new_gnu();
-        header.set_size(browser_script.len() as u64);
-        header.set_mode(0o755);
-        header.set_cksum();
-        archive
-            .append_data(&mut header, "cella/bin/cella-browser", browser_script)
-            .map_err(|e| CellaDockerError::AgentVolume {
-                message: format!("tar append browser: {e}"),
-            })?;
-
-        // xsel shim: /cella/bin/xsel
-        let mut header = tar::Header::new_gnu();
-        header.set_size(xsel_script.len() as u64);
-        header.set_mode(0o755);
-        header.set_cksum();
-        archive
-            .append_data(&mut header, "cella/bin/xsel", xsel_script)
-            .map_err(|e| CellaDockerError::AgentVolume {
-                message: format!("tar append xsel: {e}"),
-            })?;
-
-        // xclip shim: /cella/bin/xclip
-        let mut header = tar::Header::new_gnu();
-        header.set_size(xclip_script.len() as u64);
-        header.set_mode(0o755);
-        header.set_cksum();
-        archive
-            .append_data(&mut header, "cella/bin/xclip", xclip_script)
-            .map_err(|e| CellaDockerError::AgentVolume {
-                message: format!("tar append xclip: {e}"),
-            })?;
+        tar_append_file(&mut archive, &agent_path, agent_bytes, 0o755)?;
+        tar_append_file(
+            &mut archive,
+            "cella/bin/cella-browser",
+            scripts.browser,
+            0o755,
+        )?;
+        tar_append_file(&mut archive, "cella/bin/xsel", scripts.xsel, 0o755)?;
+        tar_append_file(&mut archive, "cella/bin/xclip", scripts.xclip, 0o755)?;
+        tar_append_file(&mut archive, "cella/bin/wl-paste", scripts.wl_paste, 0o755)?;
+        tar_append_file(&mut archive, "cella/bin/wl-copy", scripts.wl_copy, 0o755)?;
 
         // Stable agent symlink: /cella/bin/cella-agent -> versioned binary
         // Survives version upgrades so CMD paths and credential helpers keep working.
@@ -1018,17 +1032,12 @@ fn build_volume_tar(
                 message: format!("tar append cella symlink: {e}"),
             })?;
 
-        // Version marker: /cella/.version
-        let marker_bytes = version_marker.as_bytes();
-        let mut header = tar::Header::new_gnu();
-        header.set_size(marker_bytes.len() as u64);
-        header.set_mode(0o644);
-        header.set_cksum();
-        archive
-            .append_data(&mut header, "cella/.version", marker_bytes)
-            .map_err(|e| CellaDockerError::AgentVolume {
-                message: format!("tar append version: {e}"),
-            })?;
+        tar_append_file(
+            &mut archive,
+            "cella/.version",
+            version_marker.as_bytes(),
+            0o644,
+        )?;
 
         archive
             .finish()
@@ -1432,6 +1441,8 @@ mod tests {
                 browser: browser_bytes,
                 xsel: b"s",
                 xclip: b"s",
+                wl_paste: b"s",
+                wl_copy: b"s",
             },
             marker,
         )
@@ -1459,6 +1470,14 @@ mod tests {
         assert!(
             entries.iter().any(|e| e == "cella/bin/xclip"),
             "tar must contain xclip shim"
+        );
+        assert!(
+            entries.iter().any(|e| e == "cella/bin/wl-paste"),
+            "tar must contain wl-paste shim"
+        );
+        assert!(
+            entries.iter().any(|e| e == "cella/bin/wl-copy"),
+            "tar must contain wl-copy shim"
         );
     }
 
@@ -1489,6 +1508,8 @@ mod tests {
                 browser: browser_bytes,
                 xsel: b"s",
                 xclip: b"s",
+                wl_paste: b"s",
+                wl_copy: b"s",
             },
             marker,
         )
@@ -1534,6 +1555,8 @@ mod tests {
                 browser: browser_bytes,
                 xsel: b"s",
                 xclip: b"s",
+                wl_paste: b"s",
+                wl_copy: b"s",
             },
             marker,
         )
@@ -1712,6 +1735,34 @@ mod tests {
     }
 
     #[test]
+    fn wl_paste_helper_script_starts_with_shebang() {
+        let bytes = wl_paste_helper_script();
+        assert!(String::from_utf8_lossy(&bytes).starts_with("#!/bin/sh"));
+    }
+
+    #[test]
+    fn wl_paste_helper_script_execs_agent() {
+        let bytes = wl_paste_helper_script();
+        let script = String::from_utf8_lossy(&bytes);
+        assert!(script.contains("wl-paste"));
+        assert!(script.contains("cella-agent"));
+    }
+
+    #[test]
+    fn wl_copy_helper_script_starts_with_shebang() {
+        let bytes = wl_copy_helper_script();
+        assert!(String::from_utf8_lossy(&bytes).starts_with("#!/bin/sh"));
+    }
+
+    #[test]
+    fn wl_copy_helper_script_execs_agent() {
+        let bytes = wl_copy_helper_script();
+        let script = String::from_utf8_lossy(&bytes);
+        assert!(script.contains("wl-copy"));
+        assert!(script.contains("cella-agent"));
+    }
+
+    #[test]
     fn version_marker_path_is_under_cella() {
         let path = version_marker_path();
         assert_eq!(path, "/cella/.version");
@@ -1823,6 +1874,8 @@ abc333  artifact-c
                 browser: browser_bytes,
                 xsel: b"s",
                 xclip: b"s",
+                wl_paste: b"s",
+                wl_copy: b"s",
             },
             marker,
         )
@@ -1852,6 +1905,8 @@ abc333  artifact-c
                 browser: b"#!/bin/sh",
                 xsel: b"s",
                 xclip: b"s",
+                wl_paste: b"s",
+                wl_copy: b"s",
             },
             "m",
         )
@@ -1905,7 +1960,7 @@ abc333  artifact-c
     // -----------------------------------------------------------------------
 
     #[test]
-    fn build_volume_tar_contains_exactly_seven_entries() {
+    fn build_volume_tar_contains_exactly_nine_entries() {
         let tar_bytes = build_volume_tar(
             "2.0.0",
             "aarch64",
@@ -1914,6 +1969,8 @@ abc333  artifact-c
                 browser: b"#!/bin/sh",
                 xsel: b"s",
                 xclip: b"s",
+                wl_paste: b"s",
+                wl_copy: b"s",
             },
             "2.0.0/aarch64\n",
         )
@@ -1929,11 +1986,11 @@ abc333  artifact-c
             })
             .collect();
 
-        // agent binary, browser script, xsel shim, xclip shim, agent symlink, cella symlink, .version
+        // agent binary, browser script, xsel shim, xclip shim, wl-paste shim, wl-copy shim, agent symlink, cella symlink, .version
         assert_eq!(
             entries.len(),
-            7,
-            "expected 7 entries in volume tar, got {}: {entries:?}",
+            9,
+            "expected 9 entries in volume tar, got {}: {entries:?}",
             entries.len()
         );
     }
@@ -1949,6 +2006,8 @@ abc333  artifact-c
                 browser: b"script",
                 xsel: b"s",
                 xclip: b"s",
+                wl_paste: b"s",
+                wl_copy: b"s",
             },
             "marker",
         )
@@ -1979,6 +2038,8 @@ abc333  artifact-c
                 browser: browser_content,
                 xsel: b"s",
                 xclip: b"s",
+                wl_paste: b"s",
+                wl_copy: b"s",
             },
             "marker",
         )
@@ -2008,6 +2069,8 @@ abc333  artifact-c
                 browser: b"script",
                 xsel: b"s",
                 xclip: b"s",
+                wl_paste: b"s",
+                wl_copy: b"s",
             },
             "1.0.0/x86_64\n",
         )
@@ -2040,6 +2103,8 @@ abc333  artifact-c
                 browser: b"script",
                 xsel: b"s",
                 xclip: b"s",
+                wl_paste: b"s",
+                wl_copy: b"s",
             },
             "marker",
         )
@@ -2054,7 +2119,7 @@ abc333  artifact-c
                     .and_then(|entry| entry.path().ok().map(|p| p.to_string_lossy().to_string()))
             })
             .collect();
-        assert_eq!(entries.len(), 7);
+        assert_eq!(entries.len(), 9);
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fix xclip `-t` short flag parsing — Claude Code uses `xclip -t TARGETS -o` but the parser only matched `-target`
- Add macOS `PbcopyBackend` image clipboard support via JXA/osascript (TIFF→PNG conversion, base64 transport)
- Add TARGETS query handling to all daemon clipboard backends
- Add `wl-paste`/`wl-copy` argument parsers, handlers, CLI commands, and volume shims

## Test plan

- [x] `cargo test --workspace` passes (867 tests across modified crates)
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings -D clippy::all` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Manual: copy screenshot on macOS host, run `xclip -selection clipboard -t TARGETS -o` in container → lists `image/png`
- [x] Manual: `wl-paste -l` in container → lists available MIME types
- [x] Manual: Ctrl+V in Claude Code inside container → image attaches to prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)