### PR TITLE
feat: --default-user-env-probe CLI flag + probe robustness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,7 +563,6 @@ dependencies = [
  "cella-network",
  "clap",
  "miette",
- "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,7 +561,9 @@ name = "cella-env"
 version = "0.2.0"
 dependencies = [
  "cella-network",
+ "clap",
  "miette",
+ "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",

--- a/crates/cella-cli/Cargo.toml
+++ b/crates/cella-cli/Cargo.toml
@@ -19,7 +19,7 @@ cella-daemon-client.workspace = true
 cella-doctor.workspace = true
 cella-docker.workspace = true
 cella-orchestrator.workspace = true
-cella-env.workspace = true
+cella-env = { workspace = true, features = ["cli"] }
 cella-templates.workspace = true
 cella-network.workspace = true
 cella-git.workspace = true

--- a/crates/cella-cli/src/commands/branch.rs
+++ b/crates/cella-cli/src/commands/branch.rs
@@ -38,6 +38,10 @@ pub struct BranchArgs {
     /// Output format.
     #[arg(long, value_enum, default_value = "text")]
     output: OutputFormat,
+
+    /// Default value for userEnvProbe when devcontainer.json doesn't specify one.
+    #[arg(long, value_enum, default_value_t = cella_env::user_env_probe::UserEnvProbe::LoginInteractiveShell)]
+    default_user_env_probe: cella_env::user_env_probe::UserEnvProbe,
 }
 
 impl BranchArgs {
@@ -136,7 +140,7 @@ impl BranchArgs {
             extra_labels,
             progress.clone(),
             self.output.clone(),
-            cella_env::user_env_probe::UserEnvProbe::default(),
+            self.default_user_env_probe,
         )
         .await?;
         let _title_guard = crate::title::push_for_workspace(

--- a/crates/cella-cli/src/commands/branch.rs
+++ b/crates/cella-cli/src/commands/branch.rs
@@ -136,6 +136,7 @@ impl BranchArgs {
             extra_labels,
             progress.clone(),
             self.output.clone(),
+            cella_env::user_env_probe::UserEnvProbe::default(),
         )
         .await?;
         let _title_guard = crate::title::push_for_workspace(

--- a/crates/cella-cli/src/commands/compose_up.rs
+++ b/crates/cella-cli/src/commands/compose_up.rs
@@ -36,6 +36,7 @@ pub async fn compose_ensure_up(
         env_files: ctx.compose_env_files.clone(),
         pull_policy: ctx.compose_pull_policy.clone(),
         network_rule_policy: ctx.network_rules,
+        user_env_probe: ctx.probe_type(),
     };
 
     let (sender, renderer) = crate::progress::bridge(&ctx.progress);

--- a/crates/cella-cli/src/commands/exec.rs
+++ b/crates/cella-cli/src/commands/exec.rs
@@ -14,7 +14,7 @@ use crate::title::push_for_container;
 /// Execute a command inside the running dev container.
 #[derive(Args)]
 pub struct ExecArgs {
-    /// Default value for userEnvProbe when reading the probe cache.
+    /// Default userEnvProbe type when the container has no probe label.
     #[arg(long, value_enum, default_value_t = cella_env::user_env_probe::UserEnvProbe::LoginInteractiveShell)]
     default_user_env_probe: cella_env::user_env_probe::UserEnvProbe,
 

--- a/crates/cella-cli/src/commands/exec.rs
+++ b/crates/cella-cli/src/commands/exec.rs
@@ -14,6 +14,10 @@ use crate::title::push_for_container;
 /// Execute a command inside the running dev container.
 #[derive(Args)]
 pub struct ExecArgs {
+    /// Default value for userEnvProbe when reading the probe cache.
+    #[arg(long, value_enum, default_value_t = cella_env::user_env_probe::UserEnvProbe::LoginInteractiveShell)]
+    default_user_env_probe: cella_env::user_env_probe::UserEnvProbe,
+
     /// Explicit workspace folder path (defaults to current directory).
     #[arg(long)]
     workspace_folder: Option<PathBuf>,
@@ -73,6 +77,7 @@ impl ExecArgs {
         let service = self.service;
         let detach = self.detach;
         let output = self.output;
+        let default_user_env_probe = self.default_user_env_probe;
 
         let target = ContainerTarget {
             container_id: self.container_id,
@@ -114,6 +119,7 @@ impl ExecArgs {
             workdir_opt,
             remote_env,
             &command,
+            default_user_env_probe,
         )
         .await?;
 
@@ -140,6 +146,7 @@ async fn resolve_exec_context(
     workdir_opt: Option<String>,
     remote_env: Vec<String>,
     command: &[String],
+    default_user_env_probe: cella_env::user_env_probe::UserEnvProbe,
 ) -> Result<
     (String, Option<String>, Vec<String>, Vec<String>),
     Box<dyn std::error::Error + Send + Sync>,
@@ -163,7 +170,7 @@ async fn resolve_exec_context(
 
     let working_dir = workdir_opt.or(label_workdir);
 
-    let mut env = build_exec_env(client, container, &user, label_env).await;
+    let mut env = build_exec_env(client, container, &user, label_env, default_user_env_probe).await;
     env.extend(remote_env);
 
     let preferred = crate::commands::load_shell_preferred(&container.labels);
@@ -276,8 +283,13 @@ async fn build_exec_env(
     container: &cella_backend::ContainerInfo,
     user: &str,
     label_env: Vec<String>,
+    default_user_env_probe: cella_env::user_env_probe::UserEnvProbe,
 ) -> Vec<String> {
-    let base_env = if let Some(probed) = read_probed_env_cache(client, &container.id, user).await {
+    let probe_type =
+        super::resolve_probe_type_from_labels(&container.labels, default_user_env_probe);
+    let base_env = if let Some(probed) =
+        read_probed_env_cache(client, &container.id, user, probe_type).await
+    {
         cella_env::user_env_probe::merge_env(&probed, &label_env)
     } else {
         label_env

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -321,6 +321,17 @@ pub fn load_shell_preferred(labels: &std::collections::HashMap<String, String>) 
     settings.shell.preferred
 }
 
+/// Resolve the `userEnvProbe` type from container labels, falling back to the given default.
+pub fn resolve_probe_type_from_labels(
+    labels: &std::collections::HashMap<String, String>,
+    default: cella_env::user_env_probe::UserEnvProbe,
+) -> cella_env::user_env_probe::UserEnvProbe {
+    labels
+        .get("dev.cella.user_env_probe")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(default)
+}
+
 /// Append AI provider API keys from the host environment into `env`.
 ///
 /// Loads settings from the workspace path label on the container,

--- a/crates/cella-cli/src/commands/shell.rs
+++ b/crates/cella-cli/src/commands/shell.rs
@@ -98,10 +98,15 @@ impl ShellArgs {
         debug!("Using shell: {}", resolution.shell);
 
         // Build environment: probed env (merged with label env) + terminal env
+        let probe_type = super::resolve_probe_type_from_labels(
+            &container.labels,
+            cella_env::user_env_probe::UserEnvProbe::default(),
+        );
         let base_env = if let Some(probed) = cella_orchestrator::env_cache::read_probed_env_cache(
             client.as_ref(),
             &container.id,
             &user,
+            probe_type,
         )
         .await
         {

--- a/crates/cella-cli/src/commands/switch.rs
+++ b/crates/cella-cli/src/commands/switch.rs
@@ -82,10 +82,15 @@ impl SwitchArgs {
         debug!("Using shell: {shell}");
 
         // Build environment: probed env (merged with label env) + terminal env
+        let probe_type = super::resolve_probe_type_from_labels(
+            &container.labels,
+            cella_env::user_env_probe::UserEnvProbe::default(),
+        );
         let base_env = if let Some(probed) = cella_orchestrator::env_cache::read_probed_env_cache(
             client.as_ref(),
             &container.id,
             &user,
+            probe_type,
         )
         .await
         {

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -119,6 +119,10 @@ pub struct UpArgs {
 
     #[command(flatten)]
     pub(crate) mounts: UpMountArgs,
+
+    /// Default value for userEnvProbe when devcontainer.json doesn't specify one.
+    #[arg(long, value_enum, default_value_t = cella_env::user_env_probe::UserEnvProbe::LoginInteractiveShell)]
+    pub(crate) default_user_env_probe: cella_env::user_env_probe::UserEnvProbe,
 }
 
 impl UpArgs {
@@ -285,6 +289,8 @@ pub struct UpContext {
     /// Extra Docker networks to connect after container start (before lifecycle hooks).
     pub(crate) extra_networks: Vec<String>,
     mount_config: ResolvedMountConfig,
+    /// Resolved user env probe type (config value or CLI default).
+    default_user_env_probe: cella_env::user_env_probe::UserEnvProbe,
 }
 
 impl UpContext {
@@ -390,6 +396,7 @@ impl UpContext {
                 mount_workspace_git_root: args.mounts.mount_workspace_git_root,
                 mount_git_worktree_common_dir: args.mounts.mount_git_worktree_common_dir,
             },
+            default_user_env_probe: args.default_user_env_probe,
         })
     }
 
@@ -463,6 +470,7 @@ impl UpContext {
                 mount_workspace_git_root: true,
                 mount_git_worktree_common_dir: false,
             },
+            default_user_env_probe: cella_env::user_env_probe::UserEnvProbe::default(),
         })
     }
 
@@ -478,11 +486,12 @@ impl UpContext {
         self.workspace_folder_from_config.as_deref()
     }
 
-    pub(crate) fn probe_type(&self) -> &str {
+    pub(crate) fn probe_type(&self) -> cella_env::user_env_probe::UserEnvProbe {
         self.config()
             .get("userEnvProbe")
             .and_then(|v| v.as_str())
-            .unwrap_or("loginInteractiveShell")
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(self.default_user_env_probe)
     }
 
     /// Register the container with the daemon for port management.
@@ -860,6 +869,7 @@ impl UpContext {
                 mount_git_worktree_common_dir: self.mount_config.mount_git_worktree_common_dir,
             },
             lifecycle_secrets: &self.lifecycle_secrets,
+            user_env_probe: self.probe_type(),
         };
 
         let result =

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -411,6 +411,7 @@ impl UpContext {
         extra_labels: std::collections::HashMap<String, String>,
         progress: crate::progress::Progress,
         output: OutputFormat,
+        default_user_env_probe: cella_env::user_env_probe::UserEnvProbe,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let cwd = workspace_path
             .canonicalize()
@@ -470,7 +471,7 @@ impl UpContext {
                 mount_workspace_git_root: true,
                 mount_git_worktree_common_dir: false,
             },
-            default_user_env_probe: cella_env::user_env_probe::UserEnvProbe::default(),
+            default_user_env_probe,
         })
     }
 
@@ -923,6 +924,7 @@ impl UpArgs {
             extra_labels,
             progress,
             self.output.clone(),
+            self.default_user_env_probe,
         )
         .await?;
         let _title_guard = crate::title::push_for_workspace(
@@ -948,7 +950,6 @@ impl UpArgs {
         } else {
             NetworkRulePolicy::Enforce
         };
-        ctx.default_user_env_probe = self.default_user_env_probe;
 
         let result = if ctx.is_compose() {
             let progress = ctx.progress.clone();

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -577,6 +577,7 @@ impl UpContext {
 
         // Probe user environment first so tool installs can use feature-provided PATH
         // (e.g., nvm adds /usr/local/share/nvm/current/bin via login shell profiles)
+        let probe_type = self.probe_type();
         let probed_env = self
             .progress
             .run_step(
@@ -585,7 +586,7 @@ impl UpContext {
                     self.client.as_ref(),
                     container_id,
                     remote_user,
-                    self.probe_type(),
+                    probe_type,
                     &shell,
                 ),
             )
@@ -639,7 +640,7 @@ impl UpContext {
                         self.client.as_ref(),
                         container_id,
                         remote_user,
-                        self.probe_type(),
+                        probe_type,
                         &shell,
                     ),
                 )

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -948,6 +948,7 @@ impl UpArgs {
         } else {
             NetworkRulePolicy::Enforce
         };
+        ctx.default_user_env_probe = self.default_user_env_probe;
 
         let result = if ctx.is_compose() {
             let progress = ctx.progress.clone();

--- a/crates/cella-compose/src/orchestrate.rs
+++ b/crates/cella-compose/src/orchestrate.rs
@@ -57,6 +57,8 @@ pub struct ComposeUpConfig<'a> {
     pub pull_policy: Option<String>,
     /// Network rule enforcement policy.
     pub network_rule_policy: cella_network::NetworkRulePolicy,
+    /// Resolved userEnvProbe type (from config or CLI default).
+    pub user_env_probe: cella_env::user_env_probe::UserEnvProbe,
 }
 
 // ---------------------------------------------------------------------------
@@ -1071,6 +1073,10 @@ fn build_compose_labels(
         "dev.cella.docker_runtime".to_string(),
         cella_env::platform::detect_runtime().as_label().to_string(),
     );
+    labels.insert(
+        "dev.cella.user_env_probe".to_string(),
+        cfg.user_env_probe.to_string(),
+    );
 
     // Spec-standard labels for VS Code / tooling interop.
     labels.insert("devcontainer.local_folder".to_string(), workspace_str);
@@ -1416,6 +1422,7 @@ mod tests {
             env_files: vec![],
             pull_policy: None,
             network_rule_policy: cella_network::NetworkRulePolicy::Enforce,
+            user_env_probe: cella_env::user_env_probe::UserEnvProbe::default(),
         };
         let project = ComposeProject {
             project_name: "cella-test".to_string(),
@@ -1439,6 +1446,10 @@ mod tests {
             .get("dev.cella.version")
             .expect("compose labels must include dev.cella.version");
         assert_eq!(version, env!("CARGO_PKG_VERSION"));
+        assert_eq!(
+            labels.get("dev.cella.user_env_probe").map(String::as_str),
+            Some("loginInteractiveShell")
+        );
     }
 
     #[test]
@@ -1471,6 +1482,7 @@ mod tests {
             env_files: vec![],
             pull_policy: None,
             network_rule_policy: cella_network::NetworkRulePolicy::Enforce,
+            user_env_probe: cella_env::user_env_probe::UserEnvProbe::default(),
         };
         let project = ComposeProject {
             project_name: "cella-test-project".to_string(),

--- a/crates/cella-env/Cargo.toml
+++ b/crates/cella-env/Cargo.toml
@@ -11,7 +11,6 @@ cli = ["dep:clap"]
 cella-network.workspace = true
 clap = { workspace = true, optional = true }
 miette.workspace = true
-serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/cella-env/Cargo.toml
+++ b/crates/cella-env/Cargo.toml
@@ -4,9 +4,14 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+cli = ["dep:clap"]
+
 [dependencies]
 cella-network.workspace = true
+clap = { workspace = true, optional = true }
 miette.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/cella-env/src/user_env_probe.rs
+++ b/crates/cella-env/src/user_env_probe.rs
@@ -9,15 +9,12 @@ use std::str::FromStr;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
+#[cfg_attr(feature = "cli", clap(rename_all = "camelCase"))]
 pub enum UserEnvProbe {
-    #[cfg_attr(feature = "cli", value(name = "none"))]
     None,
-    #[cfg_attr(feature = "cli", value(name = "loginShell"))]
     LoginShell,
-    #[cfg_attr(feature = "cli", value(name = "interactiveShell"))]
     InteractiveShell,
     #[default]
-    #[cfg_attr(feature = "cli", value(name = "loginInteractiveShell"))]
     LoginInteractiveShell,
 }
 

--- a/crates/cella-env/src/user_env_probe.rs
+++ b/crates/cella-env/src/user_env_probe.rs
@@ -7,14 +7,17 @@ use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
-#[serde(rename_all = "camelCase")]
 pub enum UserEnvProbe {
+    #[cfg_attr(feature = "cli", value(name = "none"))]
     None,
+    #[cfg_attr(feature = "cli", value(name = "loginShell"))]
     LoginShell,
+    #[cfg_attr(feature = "cli", value(name = "interactiveShell"))]
     InteractiveShell,
     #[default]
+    #[cfg_attr(feature = "cli", value(name = "loginInteractiveShell"))]
     LoginInteractiveShell,
 }
 
@@ -45,7 +48,7 @@ impl fmt::Display for UserEnvProbe {
 }
 
 impl FromStr for UserEnvProbe {
-    type Err = String;
+    type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
@@ -53,7 +56,7 @@ impl FromStr for UserEnvProbe {
             "loginShell" => Ok(Self::LoginShell),
             "interactiveShell" => Ok(Self::InteractiveShell),
             "loginInteractiveShell" => Ok(Self::LoginInteractiveShell),
-            other => Err(format!("unknown userEnvProbe value: {other}")),
+            _ => Err(()),
         }
     }
 }

--- a/crates/cella-env/src/user_env_probe.rs
+++ b/crates/cella-env/src/user_env_probe.rs
@@ -4,23 +4,65 @@
 //! and parses the null-delimited output.
 
 use std::collections::HashMap;
+use std::fmt;
+use std::str::FromStr;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
+#[serde(rename_all = "camelCase")]
+pub enum UserEnvProbe {
+    None,
+    LoginShell,
+    InteractiveShell,
+    #[default]
+    LoginInteractiveShell,
+}
+
+impl UserEnvProbe {
+    pub const fn shell_flags(self) -> Option<&'static str> {
+        match self {
+            Self::None => None,
+            Self::LoginShell => Some("-l"),
+            Self::InteractiveShell => Some("-i"),
+            Self::LoginInteractiveShell => Some("-li"),
+        }
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::LoginShell => "loginShell",
+            Self::InteractiveShell => "interactiveShell",
+            Self::LoginInteractiveShell => "loginInteractiveShell",
+        }
+    }
+}
+
+impl fmt::Display for UserEnvProbe {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for UserEnvProbe {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "none" => Ok(Self::None),
+            "loginShell" => Ok(Self::LoginShell),
+            "interactiveShell" => Ok(Self::InteractiveShell),
+            "loginInteractiveShell" => Ok(Self::LoginInteractiveShell),
+            other => Err(format!("unknown userEnvProbe value: {other}")),
+        }
+    }
+}
 
 /// Generate the shell command to probe the user's environment.
 ///
-/// Returns `None` if `probe_type` is `"none"`.
-///
-/// # Arguments
-/// * `probe_type` - The `userEnvProbe` config value
-/// * `shell` - The user's shell (e.g., "/bin/bash")
-pub fn probe_command(probe_type: &str, shell: &str) -> Option<Vec<String>> {
-    let flags = match probe_type {
-        "none" => return None,
-        "loginShell" => "-l",
-        "interactiveShell" => "-i",
-        // Default per spec (loginInteractiveShell, empty, or unknown)
-        _ => "-li",
-    };
-
+/// Returns `None` if `probe_type` is `None`.
+pub fn probe_command(probe_type: UserEnvProbe, shell: &str) -> Option<Vec<String>> {
+    let flags = probe_type.shell_flags()?;
     Some(vec![
         shell.to_string(),
         flags.to_string(),
@@ -30,12 +72,18 @@ pub fn probe_command(probe_type: &str, shell: &str) -> Option<Vec<String>> {
 }
 
 /// Parse null-delimited environment output into a map.
+///
+/// Filters out `PWD` — the probed working directory is meaningless
+/// (it's the probe command's cwd) and can interfere with exec sessions.
 pub fn parse_probed_env(output: &str) -> HashMap<String, String> {
     output
         .split('\0')
         .filter(|s| !s.is_empty())
         .filter_map(|entry| {
             let (key, value) = entry.split_once('=')?;
+            if key == "PWD" {
+                return None;
+            }
             Some((key.to_string(), value.to_string()))
         })
         .collect()
@@ -69,30 +117,24 @@ mod tests {
 
     #[test]
     fn probe_command_none() {
-        assert!(probe_command("none", "/bin/bash").is_none());
+        assert!(probe_command(UserEnvProbe::None, "/bin/bash").is_none());
     }
 
     #[test]
     fn probe_command_login_shell() {
-        let cmd = probe_command("loginShell", "/bin/bash").unwrap();
+        let cmd = probe_command(UserEnvProbe::LoginShell, "/bin/bash").unwrap();
         assert_eq!(cmd, vec!["/bin/bash", "-l", "-c", "env -0"]);
     }
 
     #[test]
     fn probe_command_interactive_shell() {
-        let cmd = probe_command("interactiveShell", "/bin/zsh").unwrap();
+        let cmd = probe_command(UserEnvProbe::InteractiveShell, "/bin/zsh").unwrap();
         assert_eq!(cmd, vec!["/bin/zsh", "-i", "-c", "env -0"]);
     }
 
     #[test]
     fn probe_command_default() {
-        let cmd = probe_command("loginInteractiveShell", "/bin/bash").unwrap();
-        assert_eq!(cmd, vec!["/bin/bash", "-li", "-c", "env -0"]);
-    }
-
-    #[test]
-    fn probe_command_empty_defaults() {
-        let cmd = probe_command("", "/bin/bash").unwrap();
+        let cmd = probe_command(UserEnvProbe::LoginInteractiveShell, "/bin/bash").unwrap();
         assert_eq!(cmd, vec!["/bin/bash", "-li", "-c", "env -0"]);
     }
 
@@ -114,12 +156,42 @@ mod tests {
 
     #[test]
     fn parse_entry_without_equals() {
-        // Malformed entries should be skipped
         let output = "GOOD=value\0BADENTRY\0ALSO_GOOD=val2\0";
         let env = parse_probed_env(output);
         assert_eq!(env.len(), 2);
         assert!(env.contains_key("GOOD"));
         assert!(env.contains_key("ALSO_GOOD"));
+    }
+
+    #[test]
+    fn parse_env_filters_pwd() {
+        let output = "HOME=/home/user\0PWD=/tmp\0SHELL=/bin/bash\0";
+        let env = parse_probed_env(output);
+        assert_eq!(env.len(), 2);
+        assert!(!env.contains_key("PWD"));
+        assert_eq!(env.get("HOME"), Some(&"/home/user".to_string()));
+    }
+
+    #[test]
+    fn from_str_roundtrip() {
+        for variant in [
+            UserEnvProbe::None,
+            UserEnvProbe::LoginShell,
+            UserEnvProbe::InteractiveShell,
+            UserEnvProbe::LoginInteractiveShell,
+        ] {
+            assert_eq!(UserEnvProbe::from_str(variant.as_str()).unwrap(), variant);
+        }
+    }
+
+    #[test]
+    fn from_str_invalid() {
+        assert!(UserEnvProbe::from_str("bogus").is_err());
+    }
+
+    #[test]
+    fn default_is_login_interactive() {
+        assert_eq!(UserEnvProbe::default(), UserEnvProbe::LoginInteractiveShell);
     }
 
     #[test]

--- a/crates/cella-orchestrator/src/config.rs
+++ b/crates/cella-orchestrator/src/config.rs
@@ -55,6 +55,8 @@ pub struct UpConfig<'a> {
     /// Secrets injected into lifecycle commands as environment variables.
     /// Runtime-only — must NOT be stored in labels or image layers.
     pub lifecycle_secrets: &'a [String],
+    /// Resolved `userEnvProbe` type (config value or CLI default).
+    pub user_env_probe: cella_env::user_env_probe::UserEnvProbe,
 }
 
 /// How the up pipeline should handle the container image.

--- a/crates/cella-orchestrator/src/env_cache.rs
+++ b/crates/cella-orchestrator/src/env_cache.rs
@@ -88,15 +88,14 @@ async fn run_env_probe(
     };
     let exec_future = client.exec_command(container_id, &exec_opts);
 
-    let result = match tokio::time::timeout(Duration::from_secs(10), exec_future).await {
-        Ok(r) => r.ok()?,
-        Err(_) => {
-            warn!(
-                "userEnvProbe timed out after 10s \
-                 — avoid waiting for user input in shell startup scripts"
-            );
-            return None;
-        }
+    let result = if let Ok(r) = tokio::time::timeout(Duration::from_secs(10), exec_future).await {
+        r.ok()?
+    } else {
+        warn!(
+            "userEnvProbe timed out after 10s \
+             — avoid waiting for user input in shell startup scripts"
+        );
+        return None;
     };
 
     if result.exit_code != 0 {

--- a/crates/cella-orchestrator/src/env_cache.rs
+++ b/crates/cella-orchestrator/src/env_cache.rs
@@ -1,17 +1,19 @@
 use std::collections::HashMap;
+use std::time::Duration;
 
-use tracing::debug;
+use tracing::{debug, warn};
 
 use cella_backend::{ContainerBackend, ExecOptions, FileToUpload};
 use cella_env::platform::DockerRuntime;
+use cella_env::user_env_probe::UserEnvProbe;
 
-/// Compute the per-user cache path for the probed environment.
+/// Compute the per-user, per-probe-type cache path for the probed environment.
 ///
-/// Stores under `$HOME/.cella/probed-env.json` so it survives container
-/// restarts (unlike `/tmp` which can be cleared).
-fn cache_path(user: &str) -> String {
+/// Stores under `$HOME/.cella/env-{probeType}.json` so different probe types
+/// don't serve stale results from a previous probe configuration.
+fn cache_path(user: &str, probe_type: UserEnvProbe) -> String {
     let home = cella_env::claude_code::container_home(user);
-    format!("{home}/.cella/probed-env.json")
+    format!("{home}/.cella/env-{probe_type}.json")
 }
 
 /// Read the cached probed environment from a running container.
@@ -22,8 +24,9 @@ pub async fn read_probed_env_cache(
     client: &dyn ContainerBackend,
     container_id: &str,
     user: &str,
+    probe_type: UserEnvProbe,
 ) -> Option<HashMap<String, String>> {
-    let path = cache_path(user);
+    let path = cache_path(user, probe_type);
     let result = client
         .exec_command(
             container_id,
@@ -54,38 +57,47 @@ pub async fn probe_and_cache_user_env(
     client: &dyn ContainerBackend,
     container_id: &str,
     user: &str,
-    probe_type: &str,
+    probe_type: UserEnvProbe,
     shell: &str,
 ) -> Option<HashMap<String, String>> {
     let env = run_env_probe(client, container_id, user, probe_type, shell).await?;
-    write_env_cache(client, container_id, user, &env).await;
+    write_env_cache(client, container_id, user, probe_type, &env).await;
     Some(env)
 }
 
 /// Execute the environment probe command and parse the output.
+///
+/// Applies a 10-second timeout to prevent indefinite hangs from shell
+/// startup scripts that wait for user input.
 async fn run_env_probe(
     client: &dyn ContainerBackend,
     container_id: &str,
     user: &str,
-    probe_type: &str,
+    probe_type: UserEnvProbe,
     shell: &str,
 ) -> Option<HashMap<String, String>> {
     let probe_cmd = cella_env::user_env_probe::probe_command(probe_type, shell)?;
 
     debug!("Running userEnvProbe ({probe_type}) with {shell}: {probe_cmd:?}");
 
-    let result = client
-        .exec_command(
-            container_id,
-            &ExecOptions {
-                cmd: probe_cmd,
-                user: Some(user.to_string()),
-                env: None,
-                working_dir: None,
-            },
-        )
-        .await
-        .ok()?;
+    let exec_opts = ExecOptions {
+        cmd: probe_cmd,
+        user: Some(user.to_string()),
+        env: None,
+        working_dir: None,
+    };
+    let exec_future = client.exec_command(container_id, &exec_opts);
+
+    let result = match tokio::time::timeout(Duration::from_secs(10), exec_future).await {
+        Ok(r) => r.ok()?,
+        Err(_) => {
+            warn!(
+                "userEnvProbe timed out after 10s \
+                 — avoid waiting for user input in shell startup scripts"
+            );
+            return None;
+        }
+    };
 
     if result.exit_code != 0 {
         debug!(
@@ -107,13 +119,14 @@ async fn write_env_cache(
     client: &dyn ContainerBackend,
     container_id: &str,
     user: &str,
+    probe_type: UserEnvProbe,
     env: &HashMap<String, String>,
 ) {
     let Some(json) = serde_json::to_string(env).ok() else {
         return;
     };
 
-    let path = cache_path(user);
+    let path = cache_path(user, probe_type);
 
     let home = cella_env::claude_code::container_home(user);
     let dir_path = format!("{home}/.cella");
@@ -193,23 +206,28 @@ mod tests {
     use super::*;
 
     #[test]
-    fn cache_path_root_user() {
-        let path = cache_path("root");
-        assert!(path.contains("root"));
-        assert!(path.ends_with("/.cella/probed-env.json"));
-    }
-
-    #[test]
-    fn cache_path_regular_user() {
-        let path = cache_path("vscode");
+    fn cache_path_includes_probe_type() {
+        let path = cache_path("vscode", UserEnvProbe::LoginInteractiveShell);
         assert!(path.contains("vscode"));
-        assert!(path.ends_with("/.cella/probed-env.json"));
+        assert!(path.ends_with("/.cella/env-loginInteractiveShell.json"));
     }
 
     #[test]
-    fn cache_path_custom_user() {
-        let path = cache_path("devuser");
-        assert!(path.contains("devuser"));
-        assert!(path.ends_with("probed-env.json"));
+    fn cache_path_none_probe() {
+        let path = cache_path("vscode", UserEnvProbe::None);
+        assert!(path.ends_with("/.cella/env-none.json"));
+    }
+
+    #[test]
+    fn cache_path_root_user() {
+        let path = cache_path("root", UserEnvProbe::LoginShell);
+        assert!(path.contains("root"));
+        assert!(path.ends_with("/.cella/env-loginShell.json"));
+    }
+
+    #[test]
+    fn cache_path_interactive_shell() {
+        let path = cache_path("devuser", UserEnvProbe::InteractiveShell);
+        assert!(path.ends_with("/.cella/env-interactiveShell.json"));
     }
 }

--- a/crates/cella-orchestrator/src/env_cache.rs
+++ b/crates/cella-orchestrator/src/env_cache.rs
@@ -26,6 +26,9 @@ pub async fn read_probed_env_cache(
     user: &str,
     probe_type: UserEnvProbe,
 ) -> Option<HashMap<String, String>> {
+    if probe_type == UserEnvProbe::None {
+        return None;
+    }
     let path = cache_path(user, probe_type);
     let result = client
         .exec_command(

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -178,13 +178,6 @@ impl EnsureUpContext<'_> {
             .unwrap_or(self.config.default_workspace_folder)
     }
 
-    fn probe_type(&self) -> &str {
-        self.config_json()
-            .get("userEnvProbe")
-            .and_then(|v| v.as_str())
-            .unwrap_or("loginInteractiveShell")
-    }
-
     fn build_lifecycle_ctx<'b>(
         &'b self,
         container_id: &'b str,
@@ -289,7 +282,7 @@ impl EnsureUpContext<'_> {
                     self.client,
                     container_id,
                     remote_user,
-                    self.probe_type(),
+                    self.config.user_env_probe,
                     &shell,
                 )
                 .await,
@@ -335,7 +328,7 @@ impl EnsureUpContext<'_> {
                         self.client,
                         container_id,
                         remote_user,
-                        self.probe_type(),
+                        self.config.user_env_probe,
                         &shell,
                     )
                     .await
@@ -846,6 +839,10 @@ impl EnsureUpContext<'_> {
             "dev.cella.workspace_folder".to_string(),
             self.workspace_folder_str().to_string(),
         );
+        labels.insert(
+            "dev.cella.user_env_probe".to_string(),
+            self.config.user_env_probe.to_string(),
+        );
 
         let mut label_remote_env = self.config.remote_env.to_vec();
         for e in &env_fwd.env {
@@ -1155,7 +1152,7 @@ impl EnsureUpContext<'_> {
                     self.client,
                     container_id,
                     remote_user,
-                    self.probe_type(),
+                    self.config.user_env_probe,
                     &shell,
                 )
                 .await,
@@ -1237,7 +1234,7 @@ impl EnsureUpContext<'_> {
                         self.client,
                         container_id,
                         remote_user,
-                        self.probe_type(),
+                        self.config.user_env_probe,
                         shell,
                     )
                     .await

--- a/docs/dev/spec-compliance.md
+++ b/docs/dev/spec-compliance.md
@@ -66,7 +66,7 @@ Date: 2026-05-26 (updated from 2026-04-29)
 | `--log-level` | `info` | Has as `--verbose` (boolean) | PARTIAL |
 | `--log-format` | `text` | Has as `--output` (`text`, `json`) | PARTIAL (name differs) |
 | `--terminal-columns/rows` | - | Not implemented | MISSING |
-| `--default-user-env-probe` | `loginInteractiveShell` | Not implemented | MISSING |
+| `--default-user-env-probe` | `loginInteractiveShell` | Has it (on `up` and `exec`) | PASS |
 | `--update-remote-user-uid-default` | `on` | Not implemented | MISSING |
 | `--remove-existing-container` | `false` | Has as `--remove-existing-container` | PASS |
 | `--build-no-cache` | `false` | Has as `--build-no-cache` | PASS |


### PR DESCRIPTION
## Summary

- Add `--default-user-env-probe` CLI flag to `up` and `exec` commands with typed `UserEnvProbe` enum (`none`, `loginShell`, `interactiveShell`, `loginInteractiveShell`)
- Add 10s timeout around env probe execution to prevent indefinite hangs from interactive shell startup scripts
- Filter `PWD` from probed environment to prevent interference with exec working directories
- Switch to per-probe-type cache files (`env-{type}.json`) so changing the probe type doesn't serve stale results
- Store probe type in `dev.cella.user_env_probe` container label so exec/shell/switch resolve the correct cache file
- Remove duplicate `probe_type()` method from orchestrator — reads from `UpConfig` directly

## Design

`UserEnvProbe` enum lives in `cella-env` with feature-gated `clap::ValueEnum` (behind `cli` feature) to keep tier boundaries clean. The CLI resolves `config.userEnvProbe ?? args.default_user_env_probe` once and threads the result through `UpConfig`.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings -D clippy::all` clean
- [x] `cargo test --workspace` passes (1 pre-existing failure in cella-compose unrelated to this change)
- [x] `cella up --help` shows `--default-user-env-probe` flag with enum values
- [x] `cella exec --help` shows `--default-user-env-probe` flag with enum values
- [x] No `#[allow(clippy::...)]` annotations, no `_`-prefixed unused vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)