### PR TITLE
fix: home directory ownership clobbered at runtime by tar upload

### DIFF
--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -1261,6 +1261,24 @@ impl EnsureUpContext<'_> {
             )
             .await;
 
+        // Ensure home directory ownership survives file uploads that include
+        // root-owned tar directory entries (e.g. seed_tool_config_files).
+        if remote_user != "root" {
+            let home = format!("/home/{remote_user}");
+            let _ = self
+                .client
+                .exec_command(
+                    container_id,
+                    &ExecOptions {
+                        cmd: vec!["chown".into(), format!("{remote_user}:{remote_user}"), home],
+                        user: Some("root".to_string()),
+                        env: None,
+                        working_dir: None,
+                    },
+                )
+                .await;
+        }
+
         self.install_tools_and_probe_env(
             container_id,
             remote_user,

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -856,6 +856,13 @@ impl EnsureUpContext<'_> {
                         )
                         .await;
                     let _ = self.client.upload_files(container_id, &files).await;
+                    crate::container_setup::chown_in_container(
+                        self.client,
+                        container_id,
+                        remote_user,
+                        &config_dir,
+                    )
+                    .await;
                     tracing::debug!("Seeded phantom gh credentials into container");
                 }
             } else {

--- a/crates/cella-tool-install/src/lib.rs
+++ b/crates/cella-tool-install/src/lib.rs
@@ -1138,31 +1138,40 @@ pub async fn seed_tool_config_files(
 
     match client.upload_files(container_id, &to_upload).await {
         Ok(()) => {
-            // Tar extraction runs as root, so the files land root-owned; chown
-            // each to the remote user or `claude`/tmux can't read its own config.
-            for file in &to_upload {
-                chown_in_container(client, container_id, remote_user, &file.path).await;
-            }
-
-            // Also chown parent directories — create_tar_archive includes
-            // directory entries with root ownership that clobber the
-            // UID-remapped home directory.
-            let mut parents: Vec<&str> = to_upload
-                .iter()
-                .filter_map(|f| std::path::Path::new(&f.path).parent()?.to_str())
-                .collect();
-            parents.sort_unstable();
-            parents.dedup();
-            for parent in parents {
-                chown_in_container(client, container_id, remote_user, parent).await;
-            }
-
+            chown_uploaded_files_and_parents(client, container_id, remote_user, &to_upload).await;
             debug!(
                 "Seeded {} tool config file(s) into container",
                 to_upload.len()
             );
         }
         Err(e) => warn!("Failed to seed tool config files: {e}"),
+    }
+}
+
+/// Chown each uploaded file and its parent directories back to `remote_user`.
+///
+/// Tar extraction runs as root, so files land root-owned. Additionally,
+/// `create_tar_archive` includes directory entries with root ownership that
+/// clobber the UID-remapped home directory. This chowns both files and their
+/// unique parent directories.
+async fn chown_uploaded_files_and_parents(
+    client: &dyn ContainerBackend,
+    container_id: &str,
+    remote_user: &str,
+    files: &[FileToUpload],
+) {
+    for file in files {
+        chown_in_container(client, container_id, remote_user, &file.path).await;
+    }
+
+    let mut parents: Vec<&str> = files
+        .iter()
+        .filter_map(|f| std::path::Path::new(&f.path).parent()?.to_str())
+        .collect();
+    parents.sort_unstable();
+    parents.dedup();
+    for parent in parents {
+        chown_in_container(client, container_id, remote_user, parent).await;
     }
 }
 
@@ -3079,5 +3088,110 @@ mod tests {
             install_cmd.contains("bubblewrap"),
             "should install bubblewrap"
         );
+    }
+
+    // ── chown_uploaded_files_and_parents — parent directory chown regression ──
+
+    #[tokio::test]
+    async fn chown_after_upload_includes_deduped_parent_dirs() {
+        let files = vec![
+            FileToUpload {
+                path: "/home/dev/.claude.json".to_string(),
+                content: b"{}".to_vec(),
+                mode: 0o600,
+            },
+            FileToUpload {
+                path: "/home/dev/.tmux.conf".to_string(),
+                content: b"set -g mouse on".to_vec(),
+                mode: 0o600,
+            },
+        ];
+
+        // 2 per-file chowns + 1 deduped parent chown = 3 exec calls
+        let backend = MockBackend::new(vec![
+            Ok(ok_exit(0)), // chown .claude.json
+            Ok(ok_exit(0)), // chown .tmux.conf
+            Ok(ok_exit(0)), // chown /home/dev (parent)
+        ]);
+
+        chown_uploaded_files_and_parents(&backend, "ctr", "dev", &files).await;
+
+        let calls = backend.calls();
+        assert_eq!(calls.len(), 3, "2 file chowns + 1 parent chown");
+
+        assert_eq!(
+            calls[0].cmd,
+            vec!["chown", "-R", "dev:dev", "/home/dev/.claude.json"],
+        );
+        assert_eq!(
+            calls[1].cmd,
+            vec!["chown", "-R", "dev:dev", "/home/dev/.tmux.conf"],
+        );
+        assert_eq!(calls[2].cmd, vec!["chown", "-R", "dev:dev", "/home/dev"],);
+        assert_eq!(calls[2].user.as_deref(), Some("root"));
+    }
+
+    #[tokio::test]
+    async fn chown_after_upload_deduplicates_shared_parent() {
+        let files = vec![
+            FileToUpload {
+                path: "/home/dev/.config/tmux/tmux.conf".to_string(),
+                content: vec![],
+                mode: 0o600,
+            },
+            FileToUpload {
+                path: "/home/dev/.config/tmux/plugins.conf".to_string(),
+                content: vec![],
+                mode: 0o600,
+            },
+            FileToUpload {
+                path: "/home/dev/.claude.json".to_string(),
+                content: vec![],
+                mode: 0o600,
+            },
+        ];
+
+        // 3 file chowns + 2 unique parents (/home/dev/.config/tmux, /home/dev)
+        let backend = MockBackend::new(vec![
+            Ok(ok_exit(0)),
+            Ok(ok_exit(0)),
+            Ok(ok_exit(0)),
+            Ok(ok_exit(0)),
+            Ok(ok_exit(0)),
+        ]);
+
+        chown_uploaded_files_and_parents(&backend, "ctr", "dev", &files).await;
+
+        let calls = backend.calls();
+        assert_eq!(calls.len(), 5, "3 file chowns + 2 unique parent chowns");
+
+        let parent_chowns: Vec<&str> = calls[3..].iter().map(|c| c.cmd[3].as_str()).collect();
+        assert!(parent_chowns.contains(&"/home/dev"));
+        assert!(parent_chowns.contains(&"/home/dev/.config/tmux"));
+    }
+
+    #[tokio::test]
+    async fn chown_after_upload_handles_single_file() {
+        let files = vec![FileToUpload {
+            path: "/home/dev/.claude.json".to_string(),
+            content: b"{}".to_vec(),
+            mode: 0o600,
+        }];
+
+        // 1 file chown + 1 parent chown
+        let backend = MockBackend::new(vec![Ok(ok_exit(0)), Ok(ok_exit(0))]);
+
+        chown_uploaded_files_and_parents(&backend, "ctr", "dev", &files).await;
+
+        let calls = backend.calls();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[1].cmd[3], "/home/dev");
+    }
+
+    #[tokio::test]
+    async fn chown_after_upload_empty_is_noop() {
+        let backend = MockBackend::new(vec![]);
+        chown_uploaded_files_and_parents(&backend, "ctr", "dev", &[]).await;
+        assert!(backend.calls().is_empty());
     }
 }

--- a/crates/cella-tool-install/src/lib.rs
+++ b/crates/cella-tool-install/src/lib.rs
@@ -1143,6 +1143,20 @@ pub async fn seed_tool_config_files(
             for file in &to_upload {
                 chown_in_container(client, container_id, remote_user, &file.path).await;
             }
+
+            // Also chown parent directories — create_tar_archive includes
+            // directory entries with root ownership that clobber the
+            // UID-remapped home directory.
+            let mut parents: Vec<&str> = to_upload
+                .iter()
+                .filter_map(|f| std::path::Path::new(&f.path).parent()?.to_str())
+                .collect();
+            parents.sort_unstable();
+            parents.dedup();
+            for parent in parents {
+                chown_in_container(client, container_id, remote_user, parent).await;
+            }
+
             debug!(
                 "Seeded {} tool config file(s) into container",
                 to_upload.len()


### PR DESCRIPTION
## Summary

- **Root cause fix:** `seed_tool_config_files` now chowns unique parent directories of uploaded files — `create_tar_archive` includes directory entries with uid=0:gid=0 that overwrite the UID-remapped home directory ownership on extraction
- **Phantom gh creds:** `setup_credential_protection` chowns the config directory after uploading phantom gh credentials, same root cause
- **Safety net:** `post_create_setup` does a non-recursive chown of `/home/<remote_user>` after all file uploads but before tool installation, catching any future upload that might clobber ownership

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings -D clippy::all` passes
- [x] `cargo test --workspace` passes (no new failures)
- [x] Manual: `cella up --rebuild` on a devcontainer with non-root remoteUser → `ls -lan /home` shows remapped UID, not 0:0
- [x] Manual: `touch ~/test-write` succeeds in shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)