### PR TITLE
fix: render CLI errors with proper formatting + miette diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,6 +392,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "terminal_size",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/cella-cli/Cargo.toml
+++ b/crates/cella-cli/Cargo.toml
@@ -38,6 +38,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 indicatif.workspace = true
 jsonc-parser.workspace = true
+thiserror.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cella-container.workspace = true

--- a/crates/cella-cli/src/commands/code.rs
+++ b/crates/cella-cli/src/commands/code.rs
@@ -607,4 +607,19 @@ mod tests {
         let err = CodeError::NonDockerBackend;
         assert!(err.help().is_none());
     }
+
+    #[test]
+    fn code_error_renders_help_on_separate_line() {
+        let report: miette::Report = CodeError::EditorNotInPath {
+            name: "code".into(),
+            help_text: "add it to PATH".into(),
+        }
+        .into();
+        let mut rendered = String::new();
+        miette::GraphicalReportHandler::new()
+            .render_report(&mut rendered, report.as_ref())
+            .unwrap();
+        assert!(rendered.contains("help:"), "missing help section");
+        assert!(!rendered.contains("\\n"), "literal \\n in output");
+    }
 }

--- a/crates/cella-cli/src/commands/code.rs
+++ b/crates/cella-cli/src/commands/code.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use clap::{Args, ValueEnum};
@@ -22,6 +22,40 @@ pub enum EditorChoice {
 }
 
 use crate::picker;
+
+#[derive(Debug, thiserror::Error, miette::Diagnostic)]
+pub enum CodeError {
+    #[error("`{name}` not found in PATH")]
+    #[diagnostic(code(cella::code::editor_not_in_path), help("{help_text}"))]
+    EditorNotInPath { name: String, help_text: String },
+
+    #[error("editor binary not found: {path}")]
+    #[diagnostic(code(cella::code::editor_binary_not_found))]
+    EditorBinaryNotFound { path: String },
+
+    #[error("failed to launch `{name}`: {reason}")]
+    #[diagnostic(
+        code(cella::code::editor_launch_failed),
+        help("Ensure `{name}` is properly installed and can be launched from the terminal.")
+    )]
+    EditorLaunchFailed { name: String, reason: String },
+
+    #[error("`cella code` requires a local Docker host")]
+    #[diagnostic(
+        code(cella::code::remote_docker_host),
+        help(
+            "DOCKER_HOST points to a remote {protocol} host. For remote containers:\n\
+             \x20 1. SSH into the remote host\n\
+             \x20 2. Run `cella code` there, or\n\
+             \x20 3. Use VS Code Remote-SSH + forward Docker socket"
+        )
+    )]
+    RemoteDockerHost { protocol: String },
+
+    #[error("`cella code` requires the Docker backend (VS Code attach is Docker-specific)")]
+    #[diagnostic(code(cella::code::non_docker_backend))]
+    NonDockerBackend,
+}
 
 /// Open VS Code connected to the dev container.
 ///
@@ -50,10 +84,7 @@ impl CodeArgs {
         self.up.is_text_output()
     }
 
-    pub async fn execute(
-        self,
-        progress: crate::progress::Progress,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn execute(self, progress: crate::progress::Progress) -> miette::Result<()> {
         // 1. Check for remote Docker (unsupported)
         check_local_docker()?;
 
@@ -67,7 +98,9 @@ impl CodeArgs {
         let output_format = self.up.output.resolve();
         let mut up = self.up;
         picker::resolve_up_workspace(&mut up).await;
-        let ctx = UpContext::new(&up, progress).await?;
+        let ctx = UpContext::new(&up, progress)
+            .await
+            .map_err(|e| miette::Report::msg(e.to_string()))?;
         let _title_guard = crate::title::push_for_workspace(
             ctx.client.as_ref(),
             &ctx.resolved.workspace_root,
@@ -80,25 +113,32 @@ impl CodeArgs {
 
         // Reject non-Docker backends — VS Code attach URI is Docker-specific
         if ctx.client.kind() != cella_backend::BackendKind::Docker {
-            return Err(
-                "cella code requires the Docker backend (VS Code attach is Docker-specific)".into(),
-            );
+            return Err(CodeError::NonDockerBackend.into());
         }
         let result = if ctx.is_compose() {
-            super::compose_up::compose_ensure_up(&ctx).await?
+            super::compose_up::compose_ensure_up(&ctx)
+                .await
+                .map_err(|e| miette::Report::msg(e.to_string()))?
         } else {
-            ctx.ensure_up(build_no_cache, &strict).await?
+            ctx.ensure_up(build_no_cache, &strict)
+                .await
+                .map_err(|e| miette::Report::msg(e.to_string()))?
         };
 
         // 4. Resolve compose service if needed
         let container_id = if self.service.is_some() {
-            let container = ctx.client.inspect_container(&result.container_id).await?;
+            let container = ctx
+                .client
+                .inspect_container(&result.container_id)
+                .await
+                .map_err(|e| miette::Report::msg(e.to_string()))?;
             let resolved = super::resolve_service_container(
                 ctx.client.as_ref(),
                 container,
                 self.service.as_deref(),
             )
-            .await?;
+            .await
+            .map_err(|e| miette::Report::msg(e.to_string()))?;
             resolved.id
         } else {
             result.container_id.clone()
@@ -119,11 +159,15 @@ impl CodeArgs {
             Ok(_child) => step.finish(),
             Err(e) => {
                 step.fail("failed to launch");
-                return Err(format!(
-                    "Failed to launch `{}`: {e}\n\n{}",
-                    editor.display(),
-                    editor_install_hint(&editor)
-                )
+                let name = editor
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("editor")
+                    .to_string();
+                return Err(CodeError::EditorLaunchFailed {
+                    name,
+                    reason: e.to_string(),
+                }
                 .into());
             }
         }
@@ -213,21 +257,19 @@ fn build_vscode_uri(container_id: &str, workspace_folder: &str) -> String {
 }
 
 /// Resolve which editor binary to use.
-///
-/// Returns the path to the editor binary. If the binary is not found, returns
-/// an error with platform-specific installation instructions.
 fn resolve_editor_binary(
     editor: &EditorChoice,
     binary: Option<&str>,
-) -> Result<PathBuf, Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<PathBuf, CodeError> {
     let name = if let Some(b) = binary {
-        // If it contains a path separator, treat as path
         if b.contains('/') {
             let path = PathBuf::from(b);
             if path.exists() {
                 return Ok(path);
             }
-            return Err(format!("Editor binary not found: {b}").into());
+            return Err(CodeError::EditorBinaryNotFound {
+                path: b.to_string(),
+            });
         }
         b.to_string()
     } else {
@@ -242,7 +284,7 @@ fn resolve_editor_binary(
 }
 
 /// Look up a binary name in PATH.
-fn which_binary(name: &str) -> Result<PathBuf, Box<dyn std::error::Error + Send + Sync>> {
+fn which_binary(name: &str) -> Result<PathBuf, CodeError> {
     if let Ok(path_var) = std::env::var("PATH") {
         for dir in std::env::split_paths(&path_var) {
             let candidate = dir.join(name);
@@ -251,62 +293,43 @@ fn which_binary(name: &str) -> Result<PathBuf, Box<dyn std::error::Error + Send 
             }
         }
     }
-    Err(format!(
-        "`{name}` not found in PATH.\n\n{}",
-        editor_not_found_help(name)
-    )
-    .into())
+    Err(CodeError::EditorNotInPath {
+        name: name.to_string(),
+        help_text: editor_not_found_help(name),
+    })
 }
 
-/// Platform-specific help text when an editor binary is not found.
+/// Platform-specific help text for the `EditorNotInPath` diagnostic.
 fn editor_not_found_help(name: &str) -> String {
     match name {
         "code" | "code-insiders" => {
             if cfg!(target_os = "macos") {
                 format!(
-                    "To fix:\n  \
-                     Open VS Code \u{2192} Cmd+Shift+P \u{2192} \
+                    "Open VS Code \u{2192} Cmd+Shift+P \u{2192} \
                      \"Shell Command: Install '{name}' command in PATH\""
                 )
             } else {
-                format!("To fix:\n  Install the `{name}` package or add it to your PATH")
+                format!("Install the `{name}` package or add it to your PATH")
             }
         }
-        "cursor" => {
-            "To fix:\n  Install Cursor from https://cursor.com and add it to your PATH".to_string()
-        }
+        "cursor" => "Install Cursor from https://cursor.com and add it to your PATH".to_string(),
         _ => format!("Ensure `{name}` is installed and available in your PATH"),
     }
 }
 
-/// Help text when editor launch fails (binary exists but spawn fails).
-fn editor_install_hint(editor: &Path) -> String {
-    let name = editor
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("editor");
-    format!("Ensure `{name}` is properly installed and can be launched from the terminal.")
-}
-
 /// Check that Docker is local (not a remote host via SSH or TCP).
-fn check_local_docker() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+fn check_local_docker() -> Result<(), CodeError> {
     let docker_host = std::env::var("DOCKER_HOST").ok();
     if let Some(ref host) = docker_host {
         if host.starts_with("ssh://") {
-            return Err("`cella code` requires a local Docker host.\n\n\
-                 DOCKER_HOST is set to an SSH remote. For remote containers:\n  \
-                 1. SSH into the remote host\n  \
-                 2. Run `cella code` there, or\n  \
-                 3. Use VS Code Remote-SSH + forward Docker socket"
-                .into());
+            return Err(CodeError::RemoteDockerHost {
+                protocol: "SSH".to_string(),
+            });
         }
         if host.starts_with("tcp://") && !is_localhost_tcp(host) {
-            return Err("`cella code` requires a local Docker host.\n\n\
-                 DOCKER_HOST points to a remote TCP host. For remote containers:\n  \
-                 1. SSH into the remote host\n  \
-                 2. Run `cella code` there, or\n  \
-                 3. Use VS Code Remote-SSH + forward Docker socket"
-                .into());
+            return Err(CodeError::RemoteDockerHost {
+                protocol: "TCP".to_string(),
+            });
         }
     }
     Ok(())
@@ -474,17 +497,37 @@ mod tests {
     }
 
     #[test]
-    fn editor_install_hint_with_name() {
-        let path = PathBuf::from("/usr/local/bin/code");
-        let hint = editor_install_hint(&path);
-        assert!(hint.contains("code"));
+    fn code_error_editor_not_in_path_has_help() {
+        use miette::Diagnostic;
+        let err = CodeError::EditorNotInPath {
+            name: "code".into(),
+            help_text: "Install code".into(),
+        };
+        let help = err.help().expect("should have help text");
+        assert!(help.to_string().contains("Install code"));
     }
 
     #[test]
-    fn editor_install_hint_no_file_name() {
-        let path = PathBuf::from("/");
-        let hint = editor_install_hint(&path);
-        assert!(hint.contains("editor"));
+    fn code_error_editor_launch_failed_has_help() {
+        use miette::Diagnostic;
+        let err = CodeError::EditorLaunchFailed {
+            name: "code".into(),
+            reason: "not found".into(),
+        };
+        let help = err.help().expect("should have help text");
+        assert!(help.to_string().contains("code"));
+        assert!(help.to_string().contains("terminal"));
+    }
+
+    #[test]
+    fn code_error_remote_docker_has_help() {
+        use miette::Diagnostic;
+        let err = CodeError::RemoteDockerHost {
+            protocol: "SSH".into(),
+        };
+        let help = err.help().expect("should have help text");
+        assert!(help.to_string().contains("SSH"));
+        assert!(help.to_string().contains("Remote-SSH"));
     }
 
     #[test]
@@ -558,13 +601,10 @@ mod tests {
         assert!(uri.ends_with("/workspaces/project/sub/dir"));
     }
 
-    // ── editor_install_hint ────────────────────────────────────────
-
     #[test]
-    fn editor_install_hint_with_nested_path() {
-        let path = PathBuf::from("/usr/local/bin/my-editor");
-        let hint = editor_install_hint(&path);
-        assert!(hint.contains("my-editor"));
-        assert!(hint.contains("terminal"));
+    fn code_error_non_docker_has_no_help() {
+        use miette::Diagnostic;
+        let err = CodeError::NonDockerBackend;
+        assert!(err.help().is_none());
     }
 }

--- a/crates/cella-cli/src/commands/code.rs
+++ b/crates/cella-cli/src/commands/code.rs
@@ -40,14 +40,13 @@ pub enum CodeError {
     )]
     EditorLaunchFailed { name: String, reason: String },
 
-    #[error("`cella code` requires a local Docker host")]
+    #[error(
+        "DOCKER_HOST points to a remote {protocol} host, but `cella code` requires a local Docker host"
+    )]
     #[diagnostic(
         code(cella::code::remote_docker_host),
         help(
-            "DOCKER_HOST points to a remote {protocol} host. For remote containers:\n\
-             \x20 1. SSH into the remote host\n\
-             \x20 2. Run `cella code` there, or\n\
-             \x20 3. Use VS Code Remote-SSH + forward Docker socket"
+            "For remote containers:\n  1. SSH into the remote host\n  2. Run `cella code` there, or\n  3. Use VS Code Remote-SSH + forward Docker socket"
         )
     )]
     RemoteDockerHost { protocol: String },
@@ -100,7 +99,7 @@ impl CodeArgs {
         picker::resolve_up_workspace(&mut up).await;
         let ctx = UpContext::new(&up, progress)
             .await
-            .map_err(|e| miette::Report::msg(e.to_string()))?;
+            .map_err(super::boxed_err_to_report)?;
         let _title_guard = crate::title::push_for_workspace(
             ctx.client.as_ref(),
             &ctx.resolved.workspace_root,
@@ -118,27 +117,23 @@ impl CodeArgs {
         let result = if ctx.is_compose() {
             super::compose_up::compose_ensure_up(&ctx)
                 .await
-                .map_err(|e| miette::Report::msg(e.to_string()))?
+                .map_err(super::boxed_err_to_report)?
         } else {
             ctx.ensure_up(build_no_cache, &strict)
                 .await
-                .map_err(|e| miette::Report::msg(e.to_string()))?
+                .map_err(super::boxed_err_to_report)?
         };
 
         // 4. Resolve compose service if needed
         let container_id = if self.service.is_some() {
-            let container = ctx
-                .client
-                .inspect_container(&result.container_id)
-                .await
-                .map_err(|e| miette::Report::msg(e.to_string()))?;
+            let container = ctx.client.inspect_container(&result.container_id).await?;
             let resolved = super::resolve_service_container(
                 ctx.client.as_ref(),
                 container,
                 self.service.as_deref(),
             )
             .await
-            .map_err(|e| miette::Report::msg(e.to_string()))?;
+            .map_err(super::boxed_err_to_report)?;
             resolved.id
         } else {
             result.container_id.clone()
@@ -523,10 +518,13 @@ mod tests {
     fn code_error_remote_docker_has_help() {
         use miette::Diagnostic;
         let err = CodeError::RemoteDockerHost {
-            protocol: "SSH".into(),
+            protocol: "TCP".into(),
         };
+        assert!(
+            err.to_string().contains("TCP"),
+            "protocol should appear in error body"
+        );
         let help = err.help().expect("should have help text");
-        assert!(help.to_string().contains("SSH"));
         assert!(help.to_string().contains("Remote-SSH"));
     }
 
@@ -606,6 +604,21 @@ mod tests {
         use miette::Diagnostic;
         let err = CodeError::NonDockerBackend;
         assert!(err.help().is_none());
+    }
+
+    #[test]
+    fn code_error_remote_docker_renders_multiline_help() {
+        let report: miette::Report = CodeError::RemoteDockerHost {
+            protocol: "SSH".into(),
+        }
+        .into();
+        let mut rendered = String::new();
+        miette::GraphicalReportHandler::new()
+            .render_report(&mut rendered, report.as_ref())
+            .unwrap();
+        assert!(rendered.contains("help:"), "missing help section");
+        assert!(rendered.contains("1."), "missing numbered list");
+        assert!(rendered.contains("Remote-SSH"), "missing VS Code hint");
     }
 
     #[test]

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -351,39 +351,70 @@ impl Command {
     }
 
     pub async fn execute(self, progress: Progress) -> miette::Result<()> {
-        let map = |e: Box<dyn std::error::Error + Send + Sync>| miette::Report::msg(e.to_string());
         match self {
             Self::Code(args) => args.execute(progress).await,
-            Self::Up(args) => args.execute(progress).await.map_err(map),
-            Self::Down(args) => args.execute().await.map_err(map),
-            Self::Shell(args) => args.execute().await.map_err(map),
-            Self::Exec(args) => args.execute().await.map_err(map),
-            Self::Install(args) => args.execute().await.map_err(map),
-            Self::Build(args) => args.execute(progress).await.map_err(map),
-            Self::List(args) => args.execute().await.map_err(map),
-            Self::Logs(args) => args.execute().await.map_err(map),
-            Self::Doctor(args) => args.execute().await.map_err(map),
-            Self::Branch(args) => args.execute(progress).await.map_err(map),
-            Self::Switch(args) => args.execute().await.map_err(map),
-            Self::Prune(args) => args.execute().await.map_err(map),
-            Self::ReadConfiguration(args) => args.execute().await.map_err(map),
-            Self::RunUserCommands(args) => args.execute(progress).await.map_err(map),
-            Self::Config(args) => args.execute().map_err(map),
-            Self::Template(args) => args.execute().map_err(map),
-            Self::Features(args) => args.execute(progress).await.map_err(map),
-            Self::Outdated(args) => args.execute().await.map_err(map),
-            Self::Init(args) => args.execute(progress).await.map_err(map),
+            Self::Up(args) => args.execute(progress).await.map_err(boxed_err_to_report),
+            Self::Down(args) => args.execute().await.map_err(boxed_err_to_report),
+            Self::Shell(args) => args.execute().await.map_err(boxed_err_to_report),
+            Self::Exec(args) => args.execute().await.map_err(boxed_err_to_report),
+            Self::Install(args) => args.execute().await.map_err(boxed_err_to_report),
+            Self::Build(args) => args.execute(progress).await.map_err(boxed_err_to_report),
+            Self::List(args) => args.execute().await.map_err(boxed_err_to_report),
+            Self::Logs(args) => args.execute().await.map_err(boxed_err_to_report),
+            Self::Doctor(args) => args.execute().await.map_err(boxed_err_to_report),
+            Self::Branch(args) => args.execute(progress).await.map_err(boxed_err_to_report),
+            Self::Switch(args) => args.execute().await.map_err(boxed_err_to_report),
+            Self::Prune(args) => args.execute().await.map_err(boxed_err_to_report),
+            Self::ReadConfiguration(args) => args.execute().await.map_err(boxed_err_to_report),
+            Self::RunUserCommands(args) => {
+                args.execute(progress).await.map_err(boxed_err_to_report)
+            }
+            Self::Config(args) => args.execute().map_err(boxed_err_to_report),
+            Self::Template(args) => args.execute().map_err(boxed_err_to_report),
+            Self::Features(args) => args.execute(progress).await.map_err(boxed_err_to_report),
+            Self::Outdated(args) => args.execute().await.map_err(boxed_err_to_report),
+            Self::Init(args) => args.execute(progress).await.map_err(boxed_err_to_report),
             Self::Completion(args) => {
                 args.execute();
                 Ok(())
             }
-            Self::Credential(args) => args.execute().await.map_err(map),
-            Self::Network(args) => args.execute().map_err(map),
-            Self::Ports(args) => args.execute().await.map_err(map),
-            Self::Status(args) => args.execute().await.map_err(map),
-            Self::Daemon(args) => args.execute().await.map_err(map),
+            Self::Credential(args) => args.execute().await.map_err(boxed_err_to_report),
+            Self::Network(args) => args.execute().map_err(boxed_err_to_report),
+            Self::Ports(args) => args.execute().await.map_err(boxed_err_to_report),
+            Self::Status(args) => args.execute().await.map_err(boxed_err_to_report),
+            Self::Daemon(args) => args.execute().await.map_err(boxed_err_to_report),
         }
     }
+}
+
+/// Convert a `Box<dyn Error>` into a `miette::Report`, preserving the error source chain.
+///
+/// Miette's `IntoDiagnostic` requires `E: Error`, which `Box<dyn Error + Send + Sync>`
+/// doesn't satisfy. This adapter bridges the gap until commands return `miette::Result` natively.
+pub fn boxed_err_to_report(err: Box<dyn std::error::Error + Send + Sync>) -> miette::Report {
+    struct Adapter(Box<dyn std::error::Error + Send + Sync>);
+
+    impl std::fmt::Display for Adapter {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            std::fmt::Display::fmt(&self.0, f)
+        }
+    }
+
+    impl std::fmt::Debug for Adapter {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            std::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+
+    impl std::error::Error for Adapter {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            self.0.source()
+        }
+    }
+
+    impl miette::Diagnostic for Adapter {}
+
+    miette::Report::new(Adapter(err))
 }
 
 /// Emit a warning if a container lacks the `dev.cella.backend` label.

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -350,40 +350,38 @@ impl Command {
         }
     }
 
-    pub async fn execute(
-        self,
-        progress: Progress,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn execute(self, progress: Progress) -> miette::Result<()> {
+        let map = |e: Box<dyn std::error::Error + Send + Sync>| miette::Report::msg(e.to_string());
         match self {
-            Self::Up(args) => args.execute(progress).await,
             Self::Code(args) => args.execute(progress).await,
-            Self::Down(args) => args.execute().await,
-            Self::Shell(args) => args.execute().await,
-            Self::Exec(args) => args.execute().await,
-            Self::Install(args) => args.execute().await,
-            Self::Build(args) => args.execute(progress).await,
-            Self::List(args) => args.execute().await,
-            Self::Logs(args) => args.execute().await,
-            Self::Doctor(args) => args.execute().await,
-            Self::Branch(args) => args.execute(progress).await,
-            Self::Switch(args) => args.execute().await,
-            Self::Prune(args) => args.execute().await,
-            Self::ReadConfiguration(args) => args.execute().await,
-            Self::RunUserCommands(args) => args.execute(progress).await,
-            Self::Config(args) => args.execute(),
-            Self::Template(args) => args.execute(),
-            Self::Features(args) => args.execute(progress).await,
-            Self::Outdated(args) => args.execute().await,
-            Self::Init(args) => args.execute(progress).await,
+            Self::Up(args) => args.execute(progress).await.map_err(map),
+            Self::Down(args) => args.execute().await.map_err(map),
+            Self::Shell(args) => args.execute().await.map_err(map),
+            Self::Exec(args) => args.execute().await.map_err(map),
+            Self::Install(args) => args.execute().await.map_err(map),
+            Self::Build(args) => args.execute(progress).await.map_err(map),
+            Self::List(args) => args.execute().await.map_err(map),
+            Self::Logs(args) => args.execute().await.map_err(map),
+            Self::Doctor(args) => args.execute().await.map_err(map),
+            Self::Branch(args) => args.execute(progress).await.map_err(map),
+            Self::Switch(args) => args.execute().await.map_err(map),
+            Self::Prune(args) => args.execute().await.map_err(map),
+            Self::ReadConfiguration(args) => args.execute().await.map_err(map),
+            Self::RunUserCommands(args) => args.execute(progress).await.map_err(map),
+            Self::Config(args) => args.execute().map_err(map),
+            Self::Template(args) => args.execute().map_err(map),
+            Self::Features(args) => args.execute(progress).await.map_err(map),
+            Self::Outdated(args) => args.execute().await.map_err(map),
+            Self::Init(args) => args.execute(progress).await.map_err(map),
             Self::Completion(args) => {
                 args.execute();
                 Ok(())
             }
-            Self::Credential(args) => args.execute().await,
-            Self::Network(args) => args.execute(),
-            Self::Ports(args) => args.execute().await,
-            Self::Status(args) => args.execute().await,
-            Self::Daemon(args) => args.execute().await,
+            Self::Credential(args) => args.execute().await.map_err(map),
+            Self::Network(args) => args.execute().map_err(map),
+            Self::Ports(args) => args.execute().await.map_err(map),
+            Self::Status(args) => args.execute().await.map_err(map),
+            Self::Daemon(args) => args.execute().await.map_err(map),
         }
     }
 }

--- a/crates/cella-cli/src/main.rs
+++ b/crates/cella-cli/src/main.rs
@@ -74,7 +74,7 @@ struct Cli {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+async fn main() {
     title::install_signal_handlers();
 
     // Install miette's graphical error handler for pretty diagnostics
@@ -138,7 +138,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     // The `up` argument surface is large (full devcontainer-CLI flag parity),
     // so box the dispatch future to keep it off the stack.
-    Box::pin(cli.command.execute(progress)).await
+    if let Err(e) = Box::pin(cli.command.execute(progress)).await {
+        eprintln!("Error: {e}");
+        std::process::exit(1);
+    }
 }
 
 #[cfg(test)]

--- a/crates/cella-cli/src/main.rs
+++ b/crates/cella-cli/src/main.rs
@@ -139,7 +139,8 @@ async fn main() {
     // The `up` argument surface is large (full devcontainer-CLI flag parity),
     // so box the dispatch future to keep it off the stack.
     if let Err(e) = Box::pin(cli.command.execute(progress)).await {
-        eprintln!("Error: {e}");
+        let report = miette::Report::msg(e.to_string());
+        eprintln!("{report:?}");
         std::process::exit(1);
     }
 }

--- a/crates/cella-cli/src/main.rs
+++ b/crates/cella-cli/src/main.rs
@@ -138,8 +138,7 @@ async fn main() {
 
     // The `up` argument surface is large (full devcontainer-CLI flag parity),
     // so box the dispatch future to keep it off the stack.
-    if let Err(e) = Box::pin(cli.command.execute(progress)).await {
-        let report = miette::Report::msg(e.to_string());
+    if let Err(report) = Box::pin(cli.command.execute(progress)).await {
         eprintln!("{report:?}");
         std::process::exit(1);
     }


### PR DESCRIPTION
## Summary

- Fix CLI error formatting: `main()` returned `Result<(), Box<dyn Error>>` which Rust prints via `Debug`, escaping `\n` and quoting strings. Now catches errors explicitly and renders through miette's graphical handler.
- Add `CodeError` diagnostic enum for the `code` command, separating error messages from help text as distinct miette sections.
- Thread `miette::Result` through `Command::execute()` so diagnostic metadata (help text, error codes) is preserved all the way to the render point.

Before:
```
Error: "`code` not found in PATH.\n\nTo fix:\n  Open VS Code → ..."
```

After:
```
cella::code::editor_not_in_path

  × `code` not found in PATH
  help: Open VS Code → Cmd+Shift+P → "Shell Command: Install 'code' command in PATH"
```

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings -D clippy::all` clean
- [x] `cargo test -p cella-cli` — 590 tests pass
- [x] Manual verification: `cella code --binary zzz-nonexistent-editor` renders help on separate line with no escaped `\n`
- [x] Render test asserts full `CodeError → Report → GraphicalReportHandler` pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)