### PR TITLE
fix: prevent agent_tx clobber on transient connections (OAuth callback fix)

### DIFF
--- a/crates/cella-agent/src/browser.rs
+++ b/crates/cella-agent/src/browser.rs
@@ -17,7 +17,7 @@ pub async fn send_browser_open(url: &str) -> Result<(), CellaPortError> {
     let (addr, token) = crate::control::resolve_daemon_connection()?;
     let name = std::env::var("CELLA_CONTAINER_NAME").unwrap_or_default();
 
-    let (mut client, _hello) = ControlClient::connect(&addr, &name, &token).await?;
+    let (mut client, _hello) = ControlClient::connect(&addr, &name, &token, true).await?;
     let msg = AgentMessage::BrowserOpen {
         url: url.to_string(),
     };

--- a/crates/cella-agent/src/cli.rs
+++ b/crates/cella-agent/src/cli.rs
@@ -620,7 +620,7 @@ async fn connect_daemon() -> Result<ControlClient, Box<dyn std::error::Error + S
     };
     let container_name = std::env::var("CELLA_CONTAINER_NAME").unwrap_or_default();
 
-    let (client, _hello) = ControlClient::connect(&addr, &container_name, &token)
+    let (client, _hello) = ControlClient::connect(&addr, &container_name, &token, true)
         .await
         .map_err(|e| {
             format!(
@@ -675,7 +675,7 @@ async fn run_doctor() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     // 3. Daemon connectivity
     let container_name = std::env::var("CELLA_CONTAINER_NAME").unwrap_or_default();
-    match ControlClient::connect(&addr, &container_name, &token).await {
+    match ControlClient::connect(&addr, &container_name, &token, true).await {
         Ok((_client, hello)) => {
             eprintln!("  \u{2713} daemon reachable at {addr}");
             eprintln!(

--- a/crates/cella-agent/src/clipboard.rs
+++ b/crates/cella-agent/src/clipboard.rs
@@ -199,7 +199,7 @@ async fn execute_clipboard_op(op: ClipboardOp, filter: bool) -> Result<(), Cella
 async fn send_clipboard_copy(data: &[u8], mime_type: &str) -> Result<(), CellaPortError> {
     let (addr, token) = crate::control::resolve_daemon_connection()?;
     let name = std::env::var("CELLA_CONTAINER_NAME").unwrap_or_default();
-    let (mut client, _hello) = ControlClient::connect(&addr, &name, &token).await?;
+    let (mut client, _hello) = ControlClient::connect(&addr, &name, &token, true).await?;
     let encoded = base64::engine::general_purpose::STANDARD.encode(data);
     let msg = AgentMessage::ClipboardCopy {
         data: encoded,
@@ -211,7 +211,7 @@ async fn send_clipboard_copy(data: &[u8], mime_type: &str) -> Result<(), CellaPo
 async fn request_clipboard_paste(mime_type: &str) -> Result<Vec<u8>, CellaPortError> {
     let (addr, token) = crate::control::resolve_daemon_connection()?;
     let name = std::env::var("CELLA_CONTAINER_NAME").unwrap_or_default();
-    let (mut client, _hello) = ControlClient::connect(&addr, &name, &token).await?;
+    let (mut client, _hello) = ControlClient::connect(&addr, &name, &token, true).await?;
     let msg = AgentMessage::ClipboardPaste {
         mime_type: Some(mime_type.to_string()),
     };

--- a/crates/cella-agent/src/control.rs
+++ b/crates/cella-agent/src/control.rs
@@ -28,6 +28,7 @@ impl ControlClient {
         addr: &str,
         container_name: &str,
         auth_token: &str,
+        transient: bool,
     ) -> Result<(Self, DaemonHello), CellaPortError> {
         let stream = TcpStream::connect(addr)
             .await
@@ -51,6 +52,7 @@ impl ControlClient {
             container_name: container_name.to_string(),
             auth_token: auth_token.to_string(),
             claude_config_sync: crate::claude_config_sync::sync_enabled(),
+            transient,
         };
         let mut json = serde_json::to_string(&hello)?;
         json.push('\n');
@@ -297,7 +299,7 @@ mod tests {
 
     #[tokio::test]
     async fn connect_fails_on_unreachable_address() {
-        let result = ControlClient::connect("127.0.0.1:1", "test-container", "token").await;
+        let result = ControlClient::connect("127.0.0.1:1", "test-container", "token", false).await;
         let Err(err) = result else {
             panic!("expected error on unreachable address");
         };
@@ -315,7 +317,8 @@ mod tests {
             drop(stream);
         });
 
-        let result = ControlClient::connect(&addr.to_string(), "test-container", "token").await;
+        let result =
+            ControlClient::connect(&addr.to_string(), "test-container", "token", false).await;
         assert!(
             result.is_err(),
             "expected error when server closes connection immediately"
@@ -334,7 +337,8 @@ mod tests {
             stream.write_all(b"not-json\n").await.unwrap();
         });
 
-        let result = ControlClient::connect(&addr.to_string(), "test-container", "token").await;
+        let result =
+            ControlClient::connect(&addr.to_string(), "test-container", "token", false).await;
         let Err(err) = result else {
             panic!("expected error on invalid JSON");
         };
@@ -364,7 +368,8 @@ mod tests {
             stream.write_all(json.as_bytes()).await.unwrap();
         });
 
-        let result = ControlClient::connect(&addr.to_string(), "test-container", "bad-token").await;
+        let result =
+            ControlClient::connect(&addr.to_string(), "test-container", "bad-token", false).await;
         let Err(err) = result else {
             panic!("expected error when daemon rejects");
         };
@@ -397,7 +402,8 @@ mod tests {
             stream.write_all(json.as_bytes()).await.unwrap();
         });
 
-        let result = ControlClient::connect(&addr.to_string(), "test-container", "token").await;
+        let result =
+            ControlClient::connect(&addr.to_string(), "test-container", "token", false).await;
         assert!(result.is_ok());
         let (_client, hello) = result.unwrap();
         assert_eq!(hello.daemon_version, "0.1.0");
@@ -441,7 +447,7 @@ mod tests {
         });
 
         let (mut client, _hello) =
-            ControlClient::connect(&addr.to_string(), "test-container", "token")
+            ControlClient::connect(&addr.to_string(), "test-container", "token", false)
                 .await
                 .unwrap();
         client.start_reader(None, None);
@@ -485,7 +491,7 @@ mod tests {
         });
 
         let (mut client, _hello) =
-            ControlClient::connect(&addr.to_string(), "test-container", "token")
+            ControlClient::connect(&addr.to_string(), "test-container", "token", false)
                 .await
                 .unwrap();
         client.start_reader(None, None);
@@ -529,7 +535,7 @@ mod tests {
         });
 
         let (mut client, _hello) =
-            ControlClient::connect(&addr.to_string(), "test-container", "token")
+            ControlClient::connect(&addr.to_string(), "test-container", "token", false)
                 .await
                 .unwrap();
 

--- a/crates/cella-agent/src/credential.rs
+++ b/crates/cella-agent/src/credential.rs
@@ -41,7 +41,7 @@ pub async fn handle_credential(operation: &str) -> Result<(), CellaPortError> {
     let (addr, token) = crate::control::resolve_daemon_connection()?;
     let name = std::env::var("CELLA_CONTAINER_NAME").unwrap_or_default();
 
-    let (mut client, _hello) = ControlClient::connect(&addr, &name, &token).await?;
+    let (mut client, _hello) = ControlClient::connect(&addr, &name, &token, true).await?;
 
     let msg = AgentMessage::CredentialRequest {
         id: request_id.clone(),

--- a/crates/cella-agent/src/reconnecting_client.rs
+++ b/crates/cella-agent/src/reconnecting_client.rs
@@ -95,7 +95,7 @@ impl ReconnectingClient {
             .flatten();
 
         loop {
-            match ControlClient::connect(&addr, container_name, &token).await {
+            match ControlClient::connect(&addr, container_name, &token, false).await {
                 Ok((mut client, hello)) => {
                     info!("Connected to daemon at {addr}");
                     let tunnel_config = Some(crate::tunnel::TunnelConfig {
@@ -247,7 +247,9 @@ impl ReconnectingClient {
     /// updates on every `cella up` and daemon restart).
     async fn try_reconnect(&mut self) -> Result<(), CellaPortError> {
         // 1. Try the current address
-        match ControlClient::connect(&self.addr, &self.container_name, &self.auth_token).await {
+        match ControlClient::connect(&self.addr, &self.container_name, &self.auth_token, false)
+            .await
+        {
             Ok((mut client, hello)) => {
                 info!("Reconnected to daemon at {}", self.addr);
                 let tunnel_config = Some(crate::tunnel::TunnelConfig {
@@ -275,7 +277,8 @@ impl ReconnectingClient {
                 "Daemon address changed ({} -> {}), trying new address",
                 self.addr, info.addr
             );
-            match ControlClient::connect(&info.addr, &self.container_name, &info.token).await {
+            match ControlClient::connect(&info.addr, &self.container_name, &info.token, false).await
+            {
                 Ok((mut client, hello)) => {
                     info!("Reconnected to daemon at {} (from .daemon_addr)", info.addr);
                     let tunnel_config = Some(crate::tunnel::TunnelConfig {
@@ -367,7 +370,7 @@ pub fn spawn_background_reconnect(
                 (initial_addr.clone(), initial_token.clone())
             };
 
-            match ControlClient::connect(&addr, &container_name, &token).await {
+            match ControlClient::connect(&addr, &container_name, &token, false).await {
                 Ok((client, hello)) => {
                     info!("Background reconnection succeeded (addr: {addr})");
                     control

--- a/crates/cella-daemon/src/claude_config_sync.rs
+++ b/crates/cella-daemon/src/claude_config_sync.rs
@@ -270,6 +270,7 @@ mod tests {
             docker_host: None,
             agent_tx: Some(tx),
             claude_config_sync: true,
+            agent_tx_generation: 0,
         };
         handles
             .try_lock()

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -376,7 +376,9 @@ async fn validate_agent_hello<W: AsyncWriteExt + Unpin>(
         pm.container_ip(&container_id).map(String::from)
     };
 
-    if let Ok(mut v) = agent_state.agent_version.lock() {
+    if !agent_hello.transient
+        && let Ok(mut v) = agent_state.agent_version.lock()
+    {
         *v = Some(agent_hello.agent_version.clone());
     }
 
@@ -413,7 +415,9 @@ async fn validate_agent_hello<W: AsyncWriteExt + Unpin>(
         message: format!("hello flush error: {e}"),
     })?;
 
-    agent_state.connected.store(true, Ordering::Relaxed);
+    if !agent_hello.transient {
+        agent_state.connected.store(true, Ordering::Relaxed);
+    }
     agent_state
         .last_seen_secs
         .store(current_time_secs(), Ordering::Relaxed);
@@ -593,11 +597,11 @@ async fn handle_agent_connection_after_hello(
         {
             handle.agent_tx = None;
             handle.claude_config_sync = false;
-        }
-        drop(handles);
-        hs.agent_state.connected.store(false, Ordering::Relaxed);
-        if let Ok(mut v) = hs.agent_state.agent_version.lock() {
-            *v = None;
+            drop(handles);
+            hs.agent_state.connected.store(false, Ordering::Relaxed);
+            if let Ok(mut v) = hs.agent_state.agent_version.lock() {
+                *v = None;
+            }
         }
     }
     info!("Agent disconnected for container {}", hs.container_name);

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -71,6 +71,12 @@ impl Default for AgentConnectionState {
     }
 }
 
+/// Monotonic counter for `agent_tx` ownership. Each persistent connection
+/// bumps this and stores its value; on disconnect it only clears `agent_tx`
+/// if its generation still matches, preventing stale cleanup from clobbering
+/// a newer persistent connection that reconnected during the race window.
+static AGENT_TX_GENERATION: AtomicU64 = AtomicU64::new(0);
+
 /// Handle for a registered container (no per-container server task).
 pub struct ContainerHandle {
     pub container_id: String,
@@ -85,6 +91,7 @@ pub struct ContainerHandle {
     /// (advertised via `AgentHello.claude_config_sync`). The daemon only
     /// broadcasts config updates to handles where this is true.
     pub claude_config_sync: bool,
+    pub(crate) agent_tx_generation: u64,
 }
 
 /// Spawn a handler task for a new TCP connection (agent or tunnel).
@@ -324,6 +331,7 @@ struct HandshakeResult {
     /// `ClaudeConfigChanged`, so a non-opted-in container cannot write the host
     /// config or poison peers.
     claude_config_sync: bool,
+    transient: bool,
 }
 
 /// Validate an already-parsed `AgentHello`, look up container, send `DaemonHello`.
@@ -421,6 +429,7 @@ async fn validate_agent_hello<W: AsyncWriteExt + Unpin>(
         workspace_path,
         parent_repo,
         claude_config_sync: agent_hello.claude_config_sync,
+        transient: agent_hello.transient,
     }))
 }
 
@@ -524,13 +533,19 @@ async fn handle_agent_connection_after_hello(
 
     let (daemon_tx, mut daemon_rx) = tokio::sync::mpsc::channel::<DaemonMessage>(32);
 
-    {
+    let my_generation = if hs.transient {
+        0
+    } else {
+        let generation = AGENT_TX_GENERATION.fetch_add(1, Ordering::Relaxed) + 1;
         let mut handles = ctx.container_handles.lock().await;
         if let Some(handle) = handles.get_mut(&hs.container_name) {
             handle.agent_tx = Some(daemon_tx.clone());
+            handle.agent_tx_generation = generation;
             handle.claude_config_sync = hs.claude_config_sync;
         }
-    }
+        drop(handles);
+        generation
+    };
 
     // The agent re-announces its current `~/.claude.json` on (re)connect (before
     // its reader starts), so the daemon merges its state and pushes back whatever
@@ -571,16 +586,19 @@ async fn handle_agent_connection_after_hello(
 
     // Connection closed — clear live state so status queries don't report
     // stale version/connectivity info for this container.
-    {
+    if !hs.transient {
         let mut handles = ctx.container_handles.lock().await;
-        if let Some(handle) = handles.get_mut(&hs.container_name) {
+        if let Some(handle) = handles.get_mut(&hs.container_name)
+            && handle.agent_tx_generation == my_generation
+        {
             handle.agent_tx = None;
             handle.claude_config_sync = false;
         }
-    }
-    hs.agent_state.connected.store(false, Ordering::Relaxed);
-    if let Ok(mut v) = hs.agent_state.agent_version.lock() {
-        *v = None;
+        drop(handles);
+        hs.agent_state.connected.store(false, Ordering::Relaxed);
+        if let Ok(mut v) = hs.agent_state.agent_version.lock() {
+            *v = None;
+        }
     }
     info!("Agent disconnected for container {}", hs.container_name);
 
@@ -3151,6 +3169,7 @@ mod tests {
             docker_host: None,
             agent_tx: None,
             claude_config_sync: false,
+            agent_tx_generation: 0,
         };
         assert_eq!(handle.container_id, "abc123");
         assert!(!handle.agent_state.connected.load(Ordering::Relaxed));
@@ -3199,6 +3218,7 @@ mod tests {
                     docker_host: None,
                     agent_tx: None,
                     claude_config_sync: false,
+                    agent_tx_generation: 0,
                 },
             );
             Arc::new(Mutex::new(map))
@@ -3211,6 +3231,7 @@ mod tests {
             container_name: "test-container".to_string(),
             auth_token: "test-token".to_string(),
             claude_config_sync: false,
+            transient: false,
         };
 
         assert!(
@@ -3260,6 +3281,7 @@ mod tests {
                     docker_host: None,
                     agent_tx: None,
                     claude_config_sync: false,
+                    agent_tx_generation: 0,
                 },
             );
             Arc::new(Mutex::new(map))
@@ -3283,6 +3305,7 @@ mod tests {
             container_name: "int-test-container".to_string(),
             auth_token: "int-test-token".to_string(),
             claude_config_sync: false,
+            transient: false,
         };
         let mut json = serde_json::to_string(&hello).unwrap();
         json.push('\n');
@@ -3336,6 +3359,7 @@ mod tests {
             container_name: "not-registered".to_string(),
             auth_token: "test-token".to_string(),
             claude_config_sync: false,
+            transient: false,
         };
 
         let (_daemon_side, agent_side) = tokio::io::duplex(4096);
@@ -3358,6 +3382,7 @@ mod tests {
             workspace_path: None,
             parent_repo: None,
             claude_config_sync,
+            transient: false,
         }
     }
 
@@ -3447,6 +3472,7 @@ mod tests {
                 docker_host: None,
                 agent_tx: Some(tx),
                 claude_config_sync: true,
+                agent_tx_generation: 0,
             },
         );
         let handles = Arc::new(Mutex::new(map));

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -4800,6 +4800,207 @@ branch refs/heads/feat-b
     }
 
     // ---------------------------------------------------------------
+    // agent_tx ownership / transient connection regression tests
+    // ---------------------------------------------------------------
+
+    struct TestServer {
+        handles: Arc<Mutex<HashMap<String, ContainerHandle>>>,
+        addr: std::net::SocketAddr,
+        shutdown_tx: tokio::sync::watch::Sender<bool>,
+    }
+
+    async fn start_ownership_test_server(
+        agent_tx: Option<tokio::sync::mpsc::Sender<DaemonMessage>>,
+        initial_generation: u64,
+    ) -> TestServer {
+        let handles = {
+            let mut map = HashMap::new();
+            map.insert(
+                "test-container".to_string(),
+                ContainerHandle {
+                    container_id: "cid".to_string(),
+                    agent_state: Arc::new(AgentConnectionState::new()),
+                    backend_kind: None,
+                    docker_host: None,
+                    agent_tx,
+                    claude_config_sync: false,
+                    agent_tx_generation: initial_generation,
+                },
+            );
+            Arc::new(Mutex::new(map))
+        };
+        let ctx = test_control_context(handles.clone(), "test-token");
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let la = Arc::new(AtomicU64::new(0));
+        tokio::spawn(async move {
+            run_control_server(listener, ctx, la, shutdown_rx).await;
+        });
+        TestServer {
+            handles,
+            addr,
+            shutdown_tx,
+        }
+    }
+
+    async fn agent_handshake(addr: std::net::SocketAddr, transient: bool) -> tokio::net::TcpStream {
+        use tokio::io::AsyncWriteExt;
+        let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let hello = AgentHello {
+            protocol_version: PROTOCOL_VERSION,
+            agent_version: "0.0.28".to_string(),
+            container_name: "test-container".to_string(),
+            auth_token: "test-token".to_string(),
+            claude_config_sync: false,
+            transient,
+        };
+        let mut json = serde_json::to_string(&hello).unwrap();
+        json.push('\n');
+        stream.write_all(json.as_bytes()).await.unwrap();
+        stream.flush().await.unwrap();
+        let mut buf = String::new();
+        BufReader::new(&mut stream)
+            .read_line(&mut buf)
+            .await
+            .unwrap();
+        stream
+    }
+
+    fn get_handle_state(guard: &HashMap<String, ContainerHandle>) -> (bool, u64) {
+        let h = guard.get("test-container").unwrap();
+        (h.agent_tx.is_some(), h.agent_tx_generation)
+    }
+
+    #[tokio::test]
+    async fn transient_connect_does_not_set_agent_tx() {
+        use tokio::io::AsyncWriteExt;
+        let (existing_tx, _existing_rx) = tokio::sync::mpsc::channel::<DaemonMessage>(8);
+        let srv = start_ownership_test_server(Some(existing_tx), 42).await;
+
+        let mut stream = agent_handshake(srv.addr, true).await;
+        let msg = AgentMessage::BrowserOpen {
+            url: "http://example.com".to_string(),
+        };
+        let mut msg_json = serde_json::to_string(&msg).unwrap();
+        msg_json.push('\n');
+        stream.write_all(msg_json.as_bytes()).await.unwrap();
+        stream.flush().await.unwrap();
+        drop(stream);
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let (has_tx, generation) = get_handle_state(&*srv.handles.lock().await);
+        assert!(has_tx, "transient disconnect must not clear agent_tx");
+        assert_eq!(generation, 42, "transient must not change generation");
+        let _ = srv.shutdown_tx.send(true);
+    }
+
+    #[tokio::test]
+    async fn persistent_connect_sets_and_clears_agent_tx() {
+        let srv = start_ownership_test_server(None, 0).await;
+        let stream = agent_handshake(srv.addr, false).await;
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        let (has_tx, generation) = get_handle_state(&*srv.handles.lock().await);
+        assert!(has_tx, "persistent connect must set agent_tx");
+        assert!(generation > 0, "persistent connect must bump generation");
+
+        drop(stream);
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let (has_tx, _) = get_handle_state(&*srv.handles.lock().await);
+        assert!(!has_tx, "persistent disconnect must clear agent_tx");
+        let _ = srv.shutdown_tx.send(true);
+    }
+
+    #[tokio::test]
+    async fn generation_counter_prevents_stale_persistent_cleanup() {
+        let srv = start_ownership_test_server(None, 0).await;
+
+        let stream1 = agent_handshake(srv.addr, false).await;
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        let gen1 = get_handle_state(&*srv.handles.lock().await).1;
+
+        let stream2 = agent_handshake(srv.addr, false).await;
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        let gen2 = get_handle_state(&*srv.handles.lock().await).1;
+        assert!(gen2 > gen1, "second connect must bump generation");
+
+        // Disconnect #1 — stale cleanup must NOT clear #2's agent_tx.
+        drop(stream1);
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let (has_tx, g) = get_handle_state(&*srv.handles.lock().await);
+        assert!(has_tx, "stale disconnect must not clear newer agent_tx");
+        assert_eq!(g, gen2, "generation must still be from connection #2");
+
+        // Disconnect #2 — owning cleanup should clear.
+        drop(stream2);
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let (has_tx, _) = get_handle_state(&*srv.handles.lock().await);
+        assert!(!has_tx, "owning disconnect must clear agent_tx");
+        let _ = srv.shutdown_tx.send(true);
+    }
+
+    #[tokio::test]
+    async fn transient_lifecycle_preserves_persistent_tunnel_channel() {
+        use tokio::io::AsyncWriteExt;
+        // Regression: the exact sequence that broke OAuth on Colima.
+        let srv = start_ownership_test_server(None, 0).await;
+
+        // Persistent agent connects.
+        let persistent = agent_handshake(srv.addr, false).await;
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        assert!(
+            get_handle_state(&*srv.handles.lock().await).0,
+            "persistent must set agent_tx"
+        );
+
+        // Transient browser-open connects, sends, disconnects.
+        let mut transient = agent_handshake(srv.addr, true).await;
+        let msg = AgentMessage::BrowserOpen {
+            url: "http://oauth.example.com/callback".to_string(),
+        };
+        let mut json = serde_json::to_string(&msg).unwrap();
+        json.push('\n');
+        transient.write_all(json.as_bytes()).await.unwrap();
+        transient.flush().await.unwrap();
+        drop(transient);
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // Persistent agent_tx must survive.
+        assert!(
+            get_handle_state(&*srv.handles.lock().await).0,
+            "REGRESSION: transient disconnect must not clear persistent agent_tx"
+        );
+
+        // agent_tx must still be functional (tunnel would work).
+        let tx = srv
+            .handles
+            .lock()
+            .await
+            .get("test-container")
+            .unwrap()
+            .agent_tx
+            .as_ref()
+            .unwrap()
+            .clone();
+        assert!(
+            tx.send(DaemonMessage::TunnelRequest {
+                connection_id: 1,
+                target_port: 45973,
+            })
+            .await
+            .is_ok(),
+            "agent_tx must still be functional after transient lifecycle"
+        );
+
+        drop(persistent);
+        let _ = srv.shutdown_tx.send(true);
+    }
+
+    // ---------------------------------------------------------------
     // snapshot_binary
     // ---------------------------------------------------------------
 

--- a/crates/cella-daemon/src/management.rs
+++ b/crates/cella-daemon/src/management.rs
@@ -414,6 +414,7 @@ async fn handle_register(
             docker_host: reg.docker_host,
             agent_tx: None,
             claude_config_sync: false,
+            agent_tx_generation: 0,
         },
     );
 
@@ -1097,6 +1098,7 @@ mod tests {
             container_name: "hs-container".to_string(),
             auth_token: "test-token".to_string(),
             claude_config_sync: false,
+            transient: false,
         };
         let mut json = serde_json::to_string(&hello).unwrap();
         json.push('\n');

--- a/crates/cella-protocol/src/lib.rs
+++ b/crates/cella-protocol/src/lib.rs
@@ -1193,6 +1193,30 @@ mod tests {
     }
 
     #[test]
+    fn agent_hello_transient_flag_roundtrip() {
+        let hello = AgentHello {
+            protocol_version: PROTOCOL_VERSION,
+            agent_version: "0.1.0".to_string(),
+            container_name: "test".to_string(),
+            auth_token: "token".to_string(),
+            claude_config_sync: false,
+            transient: true,
+        };
+        let json = serde_json::to_string(&hello).unwrap();
+        assert!(json.contains("\"transient\":true"));
+        let decoded: AgentHello = serde_json::from_str(&json).unwrap();
+        assert!(decoded.transient);
+    }
+
+    #[test]
+    fn agent_hello_backward_compat_missing_transient() {
+        // Old agents won't send transient; it must default to false.
+        let json = r#"{"protocol_version":1,"agent_version":"0.1.0","container_name":"c","auth_token":"t"}"#;
+        let decoded: AgentHello = serde_json::from_str(json).unwrap();
+        assert!(!decoded.transient);
+    }
+
+    #[test]
     fn roundtrip_agent_hello() {
         let hello = AgentHello {
             protocol_version: PROTOCOL_VERSION,

--- a/crates/cella-protocol/src/lib.rs
+++ b/crates/cella-protocol/src/lib.rs
@@ -69,6 +69,10 @@ pub struct AgentHello {
     /// agents that don't send the field.
     #[serde(default)]
     pub claude_config_sync: bool,
+    /// One-shot connections (browser-open, credential, clipboard) set this so
+    /// the daemon skips `agent_tx` and connection-state management.
+    #[serde(default)]
+    pub transient: bool,
 }
 
 /// Sent by the daemon in response to `AgentHello`.
@@ -967,6 +971,7 @@ mod tests {
             container_name: "test".to_string(),
             auth_token: "token".to_string(),
             claude_config_sync: false,
+            transient: false,
         };
         let json = serde_json::to_string(&hello).unwrap();
         let result = serde_json::from_str::<TunnelHandshake>(&json);
@@ -1171,6 +1176,7 @@ mod tests {
             container_name: "test".to_string(),
             auth_token: "token".to_string(),
             claude_config_sync: true,
+            transient: false,
         };
         let json = serde_json::to_string(&hello).unwrap();
         assert!(json.contains("\"claude_config_sync\":true"));
@@ -1194,6 +1200,7 @@ mod tests {
             container_name: "test-container".to_string(),
             auth_token: "token123".to_string(),
             claude_config_sync: false,
+            transient: false,
         };
         let json = serde_json::to_string(&hello).unwrap();
         let decoded: AgentHello = serde_json::from_str(&json).unwrap();


### PR DESCRIPTION
## Summary

- Transient agent connections (browser-open, credential, clipboard, CLI) no longer overwrite or clear the persistent connection's `agent_tx` channel. This fixes the OAuth callback failure on Colima where a transient browser-open connection would clobber the tunnel channel, causing all subsequent `TunnelRequest`s to fail with "agent not connected".
- Persistent connections now use a monotonic generation counter so stale cleanup from a dropped connection can't clobber a newer reconnected connection's channel.

## Changes

- **Protocol**: Added `transient: bool` field to `AgentHello` with `#[serde(default)]` for backward compatibility
- **Agent**: `ControlClient::connect` takes a `transient` parameter; all one-shot callers pass `true`, the `ReconnectingClient` passes `false`
- **Daemon**: Connect block skips `agent_tx` management for transient connections; disconnect block checks generation ownership before clearing

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings -D clippy::all` passes
- [x] `cargo test --workspace` passes (1 pre-existing env-dependent failure in `cella-env` unrelated to this change)
- [x] Protocol backward compat: old agents without `transient` field default to `false`
- [x] Regression test: transient browser-open lifecycle preserves persistent tunnel channel (exact OAuth failure sequence)
- [x] Generation counter prevents stale persistent cleanup from clobbering newer connection
- [x] Manual Colima test: `claude login` inside a cella dev container completes OAuth flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)