### PR TITLE
feat: graduate apple/container backend to v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The [Dev Container specification](https://containers.dev/) ([spec repo](https://
 | `waitFor` | Return after specified lifecycle phase | No |
 | Config validation | Source-positioned diagnostics | Basic |
 | Docker Compose | Yes | Yes |
-| Container backends | Docker, Apple Container (experimental), Colima (experimental) | Docker, Podman |
+| Container backends | Docker, Apple Container, Colima (experimental) | Docker, Podman |
 | Podman | Not yet | Yes |
 | Editor requirement | None (any terminal) | VS Code for full feature set |
 
@@ -165,12 +165,9 @@ The [Dev Container specification](https://containers.dev/) ([spec repo](https://
 
 - [x] Docker Engine
 - [x] OrbStack
+- [x] Apple Container (1.0.0+, Apple Silicon — no Compose, no managed agent; networks need macOS 26)
 - [x] Colima / Lima (experimental — reverse tunnel port forwarding)
 - [ ] Podman
-
-### Experimental Backends
-
-- [x] Apple Container (macOS 26+, Apple Silicon only — pre-1.0 CLI, no Compose support)
 
 ### Planned
 

--- a/crates/cella-backend/src/network.rs
+++ b/crates/cella-backend/src/network.rs
@@ -1,6 +1,53 @@
-//! Types describing cella-managed Docker networks.
+//! Types and naming rules for cella-managed container networks.
 
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+/// Label that marks networks created by cella.
+pub const MANAGED_LABEL: &str = "dev.cella.managed";
+/// Label value required on [`MANAGED_LABEL`] for cella-managed networks.
+pub const MANAGED_VALUE: &str = "true";
+/// Label that carries the workspace path on per-repo networks.
+pub const REPO_LABEL: &str = "dev.cella.repo";
+
+/// Shared network name for cella containers (cross-container DNS hub).
+pub const CELLA_NETWORK_NAME: &str = "cella";
+
+/// Derive a per-repository network name from a repo path.
+///
+/// Returns `cella-net-{first 12 hex chars of SHA-256 of repo_path}`.
+#[must_use]
+pub fn repo_network_name(repo_path: &Path) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(repo_path.to_string_lossy().as_bytes());
+    let hash = hasher.finalize();
+    let short = hex::encode(&hash[..6]); // 6 bytes = 12 hex chars
+    format!("cella-net-{short}")
+}
+
+/// Canonicalize a path for network identity, falling back to the
+/// original path if canonicalization fails (e.g. path doesn't exist).
+///
+/// Must be applied consistently at every network-op boundary so that
+/// `cella down --rm` and `cella prune` hash to the same name the
+/// container was created with. `container_labels` already canonicalizes
+/// the `dev.cella.workspace_path` label, so this keeps network names
+/// aligned with that source of truth.
+#[must_use]
+pub fn canonicalize_for_network(repo_path: &Path) -> PathBuf {
+    repo_path
+        .canonicalize()
+        .unwrap_or_else(|_| repo_path.to_path_buf())
+}
+
+/// Derive the workspace network name the same way `cella up` does, so
+/// `cella down --rm` / `cella prune` target the matching network.
+#[must_use]
+pub fn workspace_network_name(workspace_root: &Path) -> String {
+    repo_network_name(&canonicalize_for_network(workspace_root))
+}
 
 /// A cella-managed Docker network, as returned by
 /// [`ContainerBackend::list_managed_networks`](crate::ContainerBackend::list_managed_networks).
@@ -36,4 +83,133 @@ pub enum RemovalOutcome {
     /// The network does not exist (either never existed or was removed
     /// by a concurrent caller).
     NotFound,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cella_network_name_constant() {
+        assert_eq!(CELLA_NETWORK_NAME, "cella");
+    }
+
+    #[test]
+    fn cella_network_name_is_valid_network_name() {
+        // Network names must be lowercase alphanumeric.
+        assert!(
+            CELLA_NETWORK_NAME.chars().all(|c| c.is_ascii_lowercase()),
+            "network name should be all lowercase"
+        );
+    }
+
+    #[test]
+    fn repo_network_name_deterministic() {
+        let path = Path::new("/home/user/my-project");
+        let name1 = repo_network_name(path);
+        let name2 = repo_network_name(path);
+        assert_eq!(name1, name2);
+    }
+
+    #[test]
+    fn repo_network_name_has_prefix() {
+        let name = repo_network_name(Path::new("/any/path"));
+        assert!(
+            name.starts_with("cella-net-"),
+            "name should start with 'cella-net-': {name}"
+        );
+    }
+
+    #[test]
+    fn repo_network_name_has_12_hex_chars() {
+        let name = repo_network_name(Path::new("/some/repo"));
+        let hash_part = name.strip_prefix("cella-net-").unwrap();
+        assert_eq!(
+            hash_part.len(),
+            12,
+            "hash portion should be 12 hex chars: {hash_part}"
+        );
+        assert!(
+            hash_part.chars().all(|c| c.is_ascii_hexdigit()),
+            "hash portion should be hex: {hash_part}"
+        );
+    }
+
+    #[test]
+    fn repo_network_name_different_paths_differ() {
+        let name1 = repo_network_name(Path::new("/project/a"));
+        let name2 = repo_network_name(Path::new("/project/b"));
+        assert_ne!(name1, name2);
+    }
+
+    #[test]
+    fn repo_network_name_empty_path() {
+        // Edge case: empty path should still produce a valid name
+        let name = repo_network_name(Path::new(""));
+        assert!(name.starts_with("cella-net-"));
+        let hash_part = name.strip_prefix("cella-net-").unwrap();
+        assert_eq!(hash_part.len(), 12);
+    }
+
+    #[test]
+    fn repo_network_name_with_unicode_path() {
+        let name = repo_network_name(Path::new("/home/user/proyecto-espanol"));
+        assert!(name.starts_with("cella-net-"));
+        let hash = name.strip_prefix("cella-net-").unwrap();
+        assert_eq!(hash.len(), 12);
+        assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn repo_network_name_with_spaces() {
+        let name = repo_network_name(Path::new("/home/user/my project"));
+        assert!(name.starts_with("cella-net-"));
+        let hash = name.strip_prefix("cella-net-").unwrap();
+        assert_eq!(hash.len(), 12);
+    }
+
+    #[test]
+    fn repo_network_name_with_dots() {
+        let name = repo_network_name(Path::new("/home/user/.hidden-project"));
+        assert!(name.starts_with("cella-net-"));
+    }
+
+    #[test]
+    fn repo_network_name_very_long_path() {
+        let long_path = "/".to_string() + &"a".repeat(1000);
+        let name = repo_network_name(Path::new(&long_path));
+        assert!(name.starts_with("cella-net-"));
+        let hash = name.strip_prefix("cella-net-").unwrap();
+        assert_eq!(
+            hash.len(),
+            12,
+            "hash should always be 12 chars regardless of path length"
+        );
+    }
+
+    #[test]
+    fn repo_network_name_root_path() {
+        let name = repo_network_name(Path::new("/"));
+        assert!(name.starts_with("cella-net-"));
+    }
+
+    #[test]
+    fn repo_network_name_similar_paths_differ() {
+        let name1 = repo_network_name(Path::new("/project/a"));
+        let name2 = repo_network_name(Path::new("/project/A"));
+        assert_ne!(
+            name1, name2,
+            "case-different paths should produce different hashes"
+        );
+    }
+
+    #[test]
+    fn workspace_network_name_canonicalizes_then_hashes() {
+        let tmpdir = std::env::temp_dir();
+        let canonical = canonicalize_for_network(&tmpdir);
+        assert_eq!(
+            workspace_network_name(&tmpdir),
+            repo_network_name(&canonical)
+        );
+    }
 }

--- a/crates/cella-backend/src/types.rs
+++ b/crates/cella-backend/src/types.rs
@@ -63,7 +63,8 @@ impl ContainerState {
     pub fn parse(s: &str) -> Self {
         match s {
             "running" => Self::Running,
-            "exited" | "dead" => Self::Stopped,
+            // Docker reports exited/dead; Apple Container reports stopped.
+            "exited" | "dead" | "stopped" => Self::Stopped,
             "created" => Self::Created,
             "removing" => Self::Removing,
             other => Self::Other(other.to_string()),
@@ -350,6 +351,11 @@ mod tests {
     #[test]
     fn parse_dead() {
         assert_eq!(ContainerState::parse("dead"), ContainerState::Stopped);
+    }
+
+    #[test]
+    fn parse_stopped() {
+        assert_eq!(ContainerState::parse("stopped"), ContainerState::Stopped);
     }
 
     #[test]

--- a/crates/cella-cli/src/backend.rs
+++ b/crates/cella-cli/src/backend.rs
@@ -162,12 +162,6 @@ fn connect_docker_backend(
 fn connect_apple_container_backend()
 -> Result<Box<dyn ContainerBackend>, Box<dyn std::error::Error + Send + Sync>> {
     let cli = cella_container::discovery::discover()?;
-
-    eprintln!(
-        "warning: Apple Container backend is experimental. \
-         Report issues at https://github.com/eve0415/cella/issues"
-    );
-
     Ok(Box::new(cella_container::AppleContainerBackend::new(cli)))
 }
 

--- a/crates/cella-cli/src/backend.rs
+++ b/crates/cella-cli/src/backend.rs
@@ -125,8 +125,22 @@ async fn auto_detect(
 
     // Apple Container is lowest priority fallback (macOS only)
     #[cfg(target_os = "macos")]
-    if let Ok(client) = connect_apple_container_backend() {
-        return Ok(client);
+    match connect_apple_container_backend() {
+        Ok(client) => return Ok(client),
+        Err(e) => {
+            // An installed-but-outdated CLI deserves a visible hint even in
+            // auto-detect, where other fallback failures stay silent.
+            if e.downcast_ref::<cella_container::discovery::DiscoveryError>()
+                .is_some_and(|d| {
+                    matches!(
+                        d,
+                        cella_container::discovery::DiscoveryError::UnsupportedVersion { .. }
+                    )
+                })
+            {
+                eprintln!("warning: {e}");
+            }
+        }
     }
 
     Err(
@@ -147,8 +161,7 @@ fn connect_docker_backend(
 #[cfg(target_os = "macos")]
 fn connect_apple_container_backend()
 -> Result<Box<dyn ContainerBackend>, Box<dyn std::error::Error + Send + Sync>> {
-    let cli = cella_container::discovery::discover()
-        .ok_or("Apple Container CLI not found. Install from https://github.com/apple/container")?;
+    let cli = cella_container::discovery::discover()?;
 
     eprintln!(
         "warning: Apple Container backend is experimental. \

--- a/crates/cella-cli/src/backend.rs
+++ b/crates/cella-cli/src/backend.rs
@@ -128,16 +128,13 @@ async fn auto_detect(
     match connect_apple_container_backend() {
         Ok(client) => return Ok(client),
         Err(e) => {
+            use cella_container::discovery::DiscoveryError;
             // An installed-but-outdated CLI deserves a visible hint even in
             // auto-detect, where other fallback failures stay silent.
-            if e.downcast_ref::<cella_container::discovery::DiscoveryError>()
-                .is_some_and(|d| {
-                    matches!(
-                        d,
-                        cella_container::discovery::DiscoveryError::UnsupportedVersion { .. }
-                    )
-                })
-            {
+            if matches!(
+                e.downcast_ref::<DiscoveryError>(),
+                Some(DiscoveryError::UnsupportedVersion { .. })
+            ) {
                 eprintln!("warning: {e}");
             }
         }

--- a/crates/cella-cli/src/commands/prune.rs
+++ b/crates/cella-cli/src/commands/prune.rs
@@ -239,7 +239,20 @@ impl PruneArgs {
 
     async fn execute_networks_sweep(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let client = self.backend.resolve_client().await?;
-        let all = client.list_managed_networks().await?;
+        let all = match client.list_managed_networks().await {
+            Ok(networks) => networks,
+            // e.g. Apple Container on macOS 15, where the network commands
+            // don't exist — nothing to sweep rather than a hard failure.
+            Err(cella_backend::BackendError::NotSupported { .. }) => {
+                if self.is_json() {
+                    print_networks_json_result(&[], &[], &[]);
+                } else {
+                    eprintln!("Network management is not supported by this backend.");
+                }
+                return Ok(());
+            }
+            Err(e) => return Err(e.into()),
+        };
         let orphans: Vec<ManagedNetwork> =
             all.into_iter().filter(|n| n.container_count == 0).collect();
 

--- a/crates/cella-container/Cargo.toml
+++ b/crates/cella-container/Cargo.toml
@@ -8,12 +8,12 @@ license.workspace = true
 cella-backend.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+tempfile.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
 cella-testing.workspace = true
-tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]

--- a/crates/cella-container/README.md
+++ b/crates/cella-container/README.md
@@ -1,28 +1,36 @@
 # cella-container
 
-> Apple Container backend for cella (experimental).
+> Apple Container backend for cella.
 
 Part of the [cella](../../README.md) workspace.
 
 ## Overview
 
-cella-container implements `cella_backend::ContainerBackend` by driving the Apple `container` CLI binary, part of the [Apple Containerization framework](https://developer.apple.com/documentation/containerization) introduced in macOS 26. This is an **experimental** backend — the CLI output format is pre-1.0 and may change between releases.
+cella-container implements `cella_backend::ContainerBackend` by driving the Apple `container` CLI binary, part of the [Apple Containerization framework](https://developer.apple.com/documentation/containerization). It targets the stable 1.0.0 CLI surface and structured-output shapes.
 
-The backend discovers the `container` binary via `CELLA_CONTAINER_PATH` or `PATH` lookup, validates it by checking version output, and then shells out for all operations. JSON output parsing maps Apple's container metadata to cella's shared types.
+The backend discovers the `container` binary via `CELLA_CONTAINER_PATH` or `PATH` lookup, validates it with `container system version`, and rejects releases older than 1.0.0 (their JSON output is incompatible). All operations shell out to the binary; JSON output parsing maps Apple's container metadata to cella's shared types.
 
 ### Requirements
 
-- macOS 26 (Sequoia) or later
+- Apple Container CLI **1.0.0 or newer**
+- macOS 26 for full functionality (macOS 15 runs with reduced networking)
 - Apple Silicon (arm64)
-- Apple Container CLI installed
+
+### Feature Support
+
+- **Lifecycle, exec, logs, build, pull** — full support
+- **File injection** — native `container cp` plus an exec to normalize ownership/mode
+- **Networks** — the shared `cella` network and per-workspace `cella-net-*` networks are created with the same labels and names as the Docker backend. vmnet fixes attachments at creation, so they are requested on `container create`; post-create `network connect` does not exist. Requires macOS 26 (on macOS 15 the backend degrades to the default network).
+- **runArgs** — `--cap-add`, memory/cpus (whole vCPUs), `--shm-size`, `--init`, DNS options, ulimits, tmpfs, labels and `--runtime` map natively; unsupported flags (`--privileged`, `--security-opt`, devices, GPUs, namespaces, restart policies, ...) emit one consolidated warning
+- **SSH agent** — native `--ssh` forwarding when `SSH_AUTH_SOCK` is set
 
 ### Known Limitations
 
-- **No Docker Compose support** — `capabilities().compose` is `false`
-- **No bridge networking** — only port forwarding is available
-- **File injection via bind mount** — uses a host-side staging directory instead of native `cp` (Apple's CLI lacks container file copy)
-- **Unsupported flags warn gracefully** — `--gpus`, `--privileged`, `--cap-add`, and similar Docker-specific flags emit warnings and are skipped
-- **Native SSH forwarding** — uses `--ssh` flag instead of socket bind-mounting
+- **No Docker Compose support** — `capabilities().compose` is `false`; Apple Container has no compose equivalent
+- **No managed agent** — `capabilities().managed_agent` is `false`. The cella daemon listens on the host loopback only, and Apple Container has no automatic `host.docker.internal` equivalent: the vmnet gateway cannot reach loopback-bound services, and Apple's `container system dns create <domain> --localhost <ip>` workaround requires sudo, disables iCloud Private Relay, and does not survive a reboot. Enabling the agent needs a daemon bind-address decision first (see `docs/specs/container-backends.md`).
+- **Host access needs one-time setup** — `host_gateway()` returns `host.container.internal`, which resolves only after `sudo container system dns create host.container.internal --localhost <ip>`
+- **No exit codes** — `container ls`/`inspect` do not report exit codes, so `ContainerInfo::exit_code` is `None`
+- **Anonymous volumes are never auto-removed** — unlike Docker, Apple Container keeps them until `container volume rm`
 
 ## Architecture
 
@@ -30,18 +38,18 @@ The backend discovers the `container` binary via `CELLA_CONTAINER_PATH` or `PATH
 
 - `AppleContainerBackend` — `ContainerBackend` implementation wrapping the Apple CLI
 - `ContainerCli` — typed handle to the discovered `container` binary with async methods for each CLI subcommand
-- `VersionInfo` — parsed version output for CLI validation
-- `ContainerInspect` / `ContainerListEntry` — parsed JSON types from CLI output
+- `DiscoveryError` — why discovery rejected a binary (missing, foreign, or pre-1.0)
+- `ContainerListEntry` / `NetworkListEntry` — parsed JSON types from CLI output
 
 ### Modules
 
 | Module | Purpose |
 |--------|---------|
 | `backend` | `ContainerBackend` trait implementation — maps cella operations to Apple CLI commands |
-| `discovery` | CLI binary discovery via environment variable and PATH search, version validation |
+| `discovery` | CLI binary discovery via environment variable and PATH search, 1.0.0 version gate |
 | `sdk/` | Typed wrapper around the `container` CLI binary |
 | `sdk/run` | Process spawning, output capture, and error handling for CLI invocations |
-| `sdk/types` | Serde types for parsing CLI JSON output (inspect, list, version) |
+| `sdk/types` | Serde types for parsing CLI JSON output (inspect, list, network, version) |
 
 ## Crate Dependencies
 
@@ -55,12 +63,10 @@ The backend discovers the `container` binary via `CELLA_CONTAINER_PATH` or `PATH
 cargo test -p cella-container
 ```
 
-Unit tests cover CLI argument assembly, JSON output parsing, and container state mapping. Integration tests require macOS 26 with the Apple Container CLI installed and use `#[runtime_test(apple_container)]` for runtime detection — they skip gracefully on other platforms.
+Unit tests cover CLI argument assembly, JSON output parsing, and container state mapping. Integration tests require macOS with the Apple Container CLI installed and use `#[runtime_test(apple_container)]` for runtime detection — they skip gracefully on other platforms.
 
 ## Development
 
 The `sdk/` module is the typed interface to the Apple CLI. When Apple adds new subcommands or changes output format, update `sdk/types.rs` (serde structs) and the corresponding `ContainerCli` methods.
 
 The `backend.rs` module maps `ContainerBackend` trait methods to `ContainerCli` calls. For unsupported Docker features, return `BackendError::NotSupported` with a clear message — the CLI layer handles these as warnings rather than hard failures.
-
-File injection uses a bind-mounted staging directory (`~/.cache/cella/containers/<id>/`) because the Apple CLI does not support `container cp`. Files are written to the host staging directory before container creation, and the directory is bind-mounted into the container at the target path.

--- a/crates/cella-container/src/backend.rs
+++ b/crates/cella-container/src/backend.rs
@@ -61,6 +61,26 @@ impl AppleContainerBackend {
             .await
     }
 
+    /// Exec a command as root inside the container, mapping a non-zero exit
+    /// to a runtime error labeled with `action`.
+    async fn exec_root_checked(
+        &self,
+        container_id: &str,
+        cmd: &[String],
+        action: &str,
+    ) -> Result<(), BackendError> {
+        let (exit_code, _, stderr) = self
+            .cli
+            .exec_capture(container_id, cmd, Some("root"), None, None)
+            .await?;
+        if exit_code != 0 {
+            return Err(BackendError::Runtime(
+                format!("{action} failed: {stderr}").into(),
+            ));
+        }
+        Ok(())
+    }
+
     /// Check whether a network with the given name exists.
     async fn named_network_exists(&self, name: &str) -> Result<bool, BackendError> {
         let networks = self.cli.network_list().await?;
@@ -134,6 +154,34 @@ impl AppleContainerBackend {
 
         networks
     }
+}
+
+/// Deduplicated parent directories for an upload batch, in first-seen order.
+fn upload_parent_dirs(files: &[FileToUpload]) -> Vec<String> {
+    let mut parents: Vec<String> = Vec::new();
+    for file in files {
+        let Some(parent) = Path::new(&file.path).parent() else {
+            continue;
+        };
+        let parent = parent.to_string_lossy().into_owned();
+        if !parent.is_empty() && !parents.contains(&parent) {
+            parents.push(parent);
+        }
+    }
+    parents
+}
+
+/// Group uploaded file paths by requested mode (sorted for determinism).
+fn files_by_mode(files: &[FileToUpload]) -> std::collections::BTreeMap<u32, Vec<String>> {
+    let mut by_mode: std::collections::BTreeMap<u32, Vec<String>> =
+        std::collections::BTreeMap::new();
+    for file in files {
+        by_mode
+            .entry(file.mode)
+            .or_default()
+            .push(file.path.clone());
+    }
+    by_mode
 }
 
 /// Build a `NotSupported` error for a network operation, mentioning the
@@ -533,20 +581,27 @@ impl ContainerBackend for AppleContainerBackend {
         files: &'a [FileToUpload],
     ) -> BoxFuture<'a, Result<(), BackendError>> {
         Box::pin(async move {
-            for file in files {
-                // Ensure the parent directory exists inside the container.
-                if let Some(parent) = Path::new(&file.path).parent() {
-                    let mkdir_cmd = vec![
-                        "mkdir".to_string(),
-                        "-p".to_string(),
-                        parent.to_string_lossy().to_string(),
-                    ];
-                    let _ = self
-                        .cli
-                        .exec_capture(container_id, &mkdir_cmd, Some("root"), None, None)
-                        .await;
-                }
+            if files.is_empty() {
+                return Ok(());
+            }
 
+            // Every CLI call is a subprocess, so metadata operations are
+            // batched: one mkdir for all parents, one cp per file (the CLI
+            // accepts a single source/destination pair), one chown for all
+            // files, and one chmod per distinct mode.
+            let parents = upload_parent_dirs(files);
+            if !parents.is_empty() {
+                let mut mkdir_cmd = vec!["mkdir".to_string(), "-p".to_string()];
+                mkdir_cmd.extend(parents);
+                // Best-effort, matching the old per-file behavior: existing
+                // directories are fine and cp reports real failures.
+                let _ = self
+                    .cli
+                    .exec_capture(container_id, &mkdir_cmd, Some("root"), None, None)
+                    .await;
+            }
+
+            for file in files {
                 // Stage the content in a host temp file and copy it in.
                 // The temp file is removed when `tmp` drops.
                 let tmp = tempfile::NamedTempFile::new()?;
@@ -554,35 +609,21 @@ impl ContainerBackend for AppleContainerBackend {
                 self.cli
                     .cp_into(tmp.path(), container_id, &file.path)
                     .await?;
+            }
 
-                // `container cp` preserves host-side metadata; normalize to
-                // the root ownership and explicit mode the old exec-based
-                // copy produced.
-                let chown_cmd = vec!["chown".to_string(), "0:0".to_string(), file.path.clone()];
-                let (exit_code, _, stderr) = self
-                    .cli
-                    .exec_capture(container_id, &chown_cmd, Some("root"), None, None)
-                    .await?;
-                if exit_code != 0 {
-                    return Err(BackendError::Runtime(
-                        format!("chown failed for {}: {stderr}", file.path).into(),
-                    ));
-                }
+            // `container cp` preserves host-side metadata; normalize to the
+            // root ownership and explicit modes the old exec-based copy
+            // produced.
+            let mut chown_cmd = vec!["chown".to_string(), "0:0".to_string()];
+            chown_cmd.extend(files.iter().map(|f| f.path.clone()));
+            self.exec_root_checked(container_id, &chown_cmd, "chown")
+                .await?;
 
-                let chmod_cmd = vec![
-                    "chmod".to_string(),
-                    format!("{:o}", file.mode),
-                    file.path.clone(),
-                ];
-                let (exit_code, _, stderr) = self
-                    .cli
-                    .exec_capture(container_id, &chmod_cmd, Some("root"), None, None)
+            for (mode, paths) in files_by_mode(files) {
+                let mut chmod_cmd = vec!["chmod".to_string(), format!("{mode:o}")];
+                chmod_cmd.extend(paths);
+                self.exec_root_checked(container_id, &chmod_cmd, "chmod")
                     .await?;
-                if exit_code != 0 {
-                    return Err(BackendError::Runtime(
-                        format!("chmod failed for {}: {stderr}", file.path).into(),
-                    ));
-                }
             }
 
             Ok(())
@@ -1672,6 +1713,55 @@ mod tests {
         assert_eq!(user, "root");
         assert!(env.is_empty());
         assert!(metadata.is_none());
+    }
+
+    #[test]
+    fn upload_parent_dirs_dedupes_in_order() {
+        let files = vec![
+            FileToUpload {
+                path: "/etc/app/one.conf".to_string(),
+                content: Vec::new(),
+                mode: 0o644,
+            },
+            FileToUpload {
+                path: "/etc/app/two.conf".to_string(),
+                content: Vec::new(),
+                mode: 0o600,
+            },
+            FileToUpload {
+                path: "/home/user/.ssh/config".to_string(),
+                content: Vec::new(),
+                mode: 0o600,
+            },
+        ];
+        assert_eq!(
+            upload_parent_dirs(&files),
+            vec!["/etc/app", "/home/user/.ssh"]
+        );
+    }
+
+    #[test]
+    fn files_by_mode_groups_paths() {
+        let files = vec![
+            FileToUpload {
+                path: "/a".to_string(),
+                content: Vec::new(),
+                mode: 0o600,
+            },
+            FileToUpload {
+                path: "/b".to_string(),
+                content: Vec::new(),
+                mode: 0o755,
+            },
+            FileToUpload {
+                path: "/c".to_string(),
+                content: Vec::new(),
+                mode: 0o600,
+            },
+        ];
+        let groups = files_by_mode(&files);
+        assert_eq!(groups[&0o600], vec!["/a", "/c"]);
+        assert_eq!(groups[&0o755], vec!["/b"]);
     }
 
     #[test]

--- a/crates/cella-container/src/backend.rs
+++ b/crates/cella-container/src/backend.rs
@@ -5,8 +5,7 @@ use std::path::Path;
 use std::process::Stdio;
 
 use cella_backend::network::{
-    CELLA_NETWORK_NAME, MANAGED_LABEL, MANAGED_VALUE, REPO_LABEL, repo_network_name,
-    workspace_network_name,
+    CELLA_NETWORK_NAME, MANAGED_LABEL, MANAGED_VALUE, REPO_LABEL, workspace_network_name,
 };
 use cella_backend::{
     BackendCapabilities, BackendError, BackendKind, BoxFuture, BuildOptions, ContainerBackend,
@@ -40,25 +39,45 @@ impl AppleContainerBackend {
         }
     }
 
-    /// Whether the network subcommands are usable (they only exist on
-    /// macOS 26+; on macOS 15 every invocation fails).
-    async fn networks_available(&self) -> bool {
-        *self
-            .networks_available
-            .get_or_init(|| async {
-                match self.cli.network_list().await {
-                    Ok(_) => true,
-                    Err(e) => {
-                        debug!(
-                            error = %e,
-                            "network commands unavailable (requires macOS 26+); \
-                             continuing without network integration"
-                        );
-                        false
-                    }
-                }
-            })
-            .await
+    /// Fetch the network list, lazily resolving whether the network
+    /// subcommands exist on this host (they require macOS 26+; on macOS 15
+    /// every invocation fails).
+    ///
+    /// `Ok(None)` means the commands are unavailable — that verdict is
+    /// cached for the process lifetime. Once availability has been
+    /// established, later failures propagate as `Err` instead of silently
+    /// flipping the backend into no-network mode.
+    async fn network_list_if_available(
+        &self,
+    ) -> Result<Option<Vec<crate::sdk::types::NetworkListEntry>>, BackendError> {
+        if self.networks_available.get() == Some(&false) {
+            return Ok(None);
+        }
+        match self.cli.network_list().await {
+            Ok(list) => {
+                let _ = self.networks_available.set(true);
+                Ok(Some(list))
+            }
+            Err(e) if self.networks_available.get() == Some(&true) => Err(e),
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    "Apple Container network commands unavailable (requires macOS 26+); \
+                     continuing without network integration"
+                );
+                let _ = self.networks_available.set(false);
+                Ok(None)
+            }
+        }
+    }
+
+    /// Whether the network subcommands are usable, without consuming the
+    /// fetched list.
+    async fn networks_available(&self) -> Result<bool, BackendError> {
+        if let Some(available) = self.networks_available.get() {
+            return Ok(*available);
+        }
+        Ok(self.network_list_if_available().await?.is_some())
     }
 
     /// Exec a command as root inside the container, mapping a non-zero exit
@@ -81,19 +100,20 @@ impl AppleContainerBackend {
         Ok(())
     }
 
-    /// Check whether a network with the given name exists.
+    /// Check whether a network with the given name exists (fresh fetch).
     async fn named_network_exists(&self, name: &str) -> Result<bool, BackendError> {
         let networks = self.cli.network_list().await?;
         Ok(networks.iter().any(|n| n.name() == Some(name)))
     }
 
-    /// Create `name` with `labels` unless it already exists.
+    /// Create `name` with `labels` unless it appears in `existing`.
     async fn ensure_named_network(
         &self,
         name: &str,
         labels: &[(&str, &str)],
+        existing: &[crate::sdk::types::NetworkListEntry],
     ) -> Result<(), BackendError> {
-        if self.named_network_exists(name).await? {
+        if existing.iter().any(|n| n.name() == Some(name)) {
             return Ok(());
         }
         match self.cli.network_create(name, labels).await {
@@ -113,17 +133,23 @@ impl AppleContainerBackend {
     /// attachment names for `container create`.
     ///
     /// Apple Container fixes network attachments at creation, so this runs
-    /// before every create. Network trouble degrades to fewer (or no)
+    /// before every create. One `network ls` answers availability and both
+    /// existence checks. Network trouble degrades to fewer (or no)
     /// attachments rather than failing container creation.
     async fn prepare_create_networks(&self, opts: &CreateContainerOptions) -> Vec<String> {
-        if !self.networks_available().await {
-            return Vec::new();
-        }
+        let existing = match self.network_list_if_available().await {
+            Ok(Some(list)) => list,
+            Ok(None) => return Vec::new(),
+            Err(e) => {
+                warn!(error = %e, "could not list networks; creating container without them");
+                return Vec::new();
+            }
+        };
 
         let mut networks = Vec::new();
 
         match self
-            .ensure_named_network(CELLA_NETWORK_NAME, &NETWORK_BASE_LABELS)
+            .ensure_named_network(CELLA_NETWORK_NAME, &NETWORK_BASE_LABELS, &existing)
             .await
         {
             Ok(()) => networks.push(CELLA_NETWORK_NAME.to_string()),
@@ -133,16 +159,14 @@ impl AppleContainerBackend {
             ),
         }
 
-        // The workspace label is canonicalized when labels are built, so the
-        // derived name matches what down/prune compute later.
+        // The workspace label is canonicalized when labels are built;
+        // workspace_network_name re-canonicalizes (idempotently) so the
+        // derived name always matches what down/prune compute later.
         if let Some(workspace) = opts.labels.get("dev.cella.workspace_path") {
-            let name = repo_network_name(Path::new(workspace));
-            let labels = [
-                NETWORK_BASE_LABELS[0],
-                NETWORK_BASE_LABELS[1],
-                (REPO_LABEL, workspace.as_str()),
-            ];
-            match self.ensure_named_network(&name, &labels).await {
+            let name = workspace_network_name(Path::new(workspace));
+            let mut labels = NETWORK_BASE_LABELS.to_vec();
+            labels.push((REPO_LABEL, workspace.as_str()));
+            match self.ensure_named_network(&name, &labels, &existing).await {
                 Ok(()) => networks.push(name),
                 Err(e) => warn!(
                     error = %e,
@@ -700,10 +724,10 @@ impl ContainerBackend for AppleContainerBackend {
 
     fn ensure_network(&self) -> BoxFuture<'_, Result<(), BackendError>> {
         Box::pin(async move {
-            if !self.networks_available().await {
+            let Some(existing) = self.network_list_if_available().await? else {
                 return Err(network_unavailable("ensure_network"));
-            }
-            self.ensure_named_network(CELLA_NETWORK_NAME, &NETWORK_BASE_LABELS)
+            };
+            self.ensure_named_network(CELLA_NETWORK_NAME, &NETWORK_BASE_LABELS, &existing)
                 .await
         })
     }
@@ -714,7 +738,7 @@ impl ContainerBackend for AppleContainerBackend {
         repo_path: &'a Path,
     ) -> BoxFuture<'a, Result<(), BackendError>> {
         Box::pin(async move {
-            if !self.networks_available().await {
+            if !self.networks_available().await? {
                 return Err(network_unavailable("ensure_container_network"));
             }
 
@@ -775,21 +799,15 @@ impl ContainerBackend for AppleContainerBackend {
 
     fn list_managed_networks(&self) -> BoxFuture<'_, Result<Vec<ManagedNetwork>, BackendError>> {
         Box::pin(async move {
-            if !self.networks_available().await {
+            let Some(networks) = self.network_list_if_available().await? else {
                 return Err(network_unavailable("list_managed_networks"));
-            }
-
-            let networks = self.cli.network_list().await?;
+            };
             let containers = self.cli.list().await?;
 
             let mut out = Vec::new();
             for net in &networks {
                 let Some(name) = net.name() else { continue };
-                let labels = net
-                    .configuration
-                    .as_ref()
-                    .and_then(|c| c.labels.clone())
-                    .unwrap_or_default();
+                let labels = net.labels();
                 if labels.get(MANAGED_LABEL).map(String::as_str) != Some(MANAGED_VALUE) {
                     continue;
                 }
@@ -798,17 +816,14 @@ impl ContainerBackend for AppleContainerBackend {
                     .iter()
                     .filter(|c| entry_attached_to_network(c, name))
                     .count();
-                let created_at = net
-                    .configuration
-                    .as_ref()
-                    .and_then(|c| c.creation_date.as_ref())
-                    .and_then(|v| v.as_str().map(String::from));
 
                 out.push(ManagedNetwork {
                     name: name.to_string(),
                     repo_path: labels.get(REPO_LABEL).cloned(),
+                    // The CLI emits creation dates as numeric Swift
+                    // reference-date values; not surfaced as RFC 3339.
+                    created_at: None,
                     container_count,
-                    created_at,
                     labels,
                 });
             }
@@ -821,22 +836,20 @@ impl ContainerBackend for AppleContainerBackend {
         name: &'a str,
     ) -> BoxFuture<'a, Result<RemovalOutcome, BackendError>> {
         Box::pin(async move {
-            if !self.networks_available().await {
+            let Some(networks) = self.network_list_if_available().await? else {
                 return Err(network_unavailable("remove_network_if_orphan"));
-            }
-
-            let networks = self.cli.network_list().await?;
+            };
             let Some(net) = networks.iter().find(|n| n.name() == Some(name)) else {
                 return Ok(RemovalOutcome::NotFound);
             };
 
-            let labels = net
-                .configuration
-                .as_ref()
-                .and_then(|c| c.labels.clone())
-                .unwrap_or_default();
+            let labels = net.labels();
             let managed = labels.get(MANAGED_LABEL).map(String::as_str) == Some(MANAGED_VALUE);
 
+            // Counting configured attachments includes stopped containers
+            // deliberately: attachments are fixed at creation, so deleting a
+            // network out from under a stopped container would break its
+            // next start (unlike Docker, which can reconnect).
             let containers = self.cli.list().await?;
             let container_count = containers
                 .iter()
@@ -854,7 +867,9 @@ impl ContainerBackend for AppleContainerBackend {
             match self.cli.network_delete(name).await {
                 Ok(()) => Ok(RemovalOutcome::Removed),
                 // Removed by a concurrent caller between list and delete.
-                Err(e) if e.to_string().contains("not found") => Ok(RemovalOutcome::NotFound),
+                Err(e) if e.to_string().to_lowercase().contains("not found") => {
+                    Ok(RemovalOutcome::NotFound)
+                }
                 Err(e) => Err(e),
             }
         })
@@ -875,10 +890,10 @@ impl ContainerBackend for AppleContainerBackend {
         network_name: &'a str,
     ) -> BoxFuture<'a, Result<bool, BackendError>> {
         Box::pin(async move {
-            if !self.networks_available().await {
+            let Some(networks) = self.network_list_if_available().await? else {
                 return Err(network_unavailable("network_exists"));
-            }
-            self.named_network_exists(network_name).await
+            };
+            Ok(networks.iter().any(|n| n.name() == Some(network_name)))
         })
     }
 

--- a/crates/cella-container/src/backend.rs
+++ b/crates/cella-container/src/backend.rs
@@ -476,9 +476,13 @@ impl ContainerBackend for AppleContainerBackend {
                 extra_args.push("--target".to_string());
                 extra_args.push(target.clone());
             }
-            for cache in &opts.cache_from {
-                extra_args.push("--cache-from".to_string());
-                extra_args.push(cache.clone());
+            // `container build` has no --cache-from; passing it would abort
+            // the build with an unknown-option error.
+            if !opts.cache_from.is_empty() {
+                warn!(
+                    images = ?opts.cache_from,
+                    "cacheFrom is not supported by Apple Container builds; ignoring"
+                );
             }
             for opt in &opts.options {
                 extra_args.push(opt.clone());

--- a/crates/cella-container/src/backend.rs
+++ b/crates/cella-container/src/backend.rs
@@ -1,7 +1,7 @@
 //! `ContainerBackend` implementation for the Apple Container runtime.
 
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Stdio;
 
 use cella_backend::{
@@ -17,18 +17,6 @@ use crate::sdk::types::{ContainerListEntry, FilesystemType};
 /// Apple Container backend — drives the `container` CLI binary.
 pub struct AppleContainerBackend {
     cli: ContainerCli,
-    staging_base: PathBuf,
-}
-
-impl AppleContainerBackend {
-    /// Resolve the staging directory for a container.
-    ///
-    /// Apple Container has no separate name field — `--name` sets the
-    /// container ID — so the create-time staging directory (keyed by name)
-    /// is directly addressable by ID.
-    fn staging_dir_for(&self, container_id: &str) -> PathBuf {
-        self.staging_base.join(container_id)
-    }
 }
 
 impl AppleContainerBackend {
@@ -38,22 +26,8 @@ impl AppleContainerBackend {
             "Apple Container backend is EXPERIMENTAL — \
              expect rough edges and missing features"
         );
-        let staging_base = default_staging_base();
-        Self { cli, staging_base }
+        Self { cli }
     }
-}
-
-/// Default host-side staging directory for file uploads.
-fn default_staging_base() -> PathBuf {
-    std::env::var("HOME").map_or_else(
-        |_| PathBuf::from("/tmp/cella/containers"),
-        |h| {
-            PathBuf::from(h)
-                .join(".cache")
-                .join("cella")
-                .join("containers")
-        },
-    )
 }
 
 // ---------------------------------------------------------------------------
@@ -105,12 +79,7 @@ impl ContainerBackend for AppleContainerBackend {
         opts: &'a CreateContainerOptions,
     ) -> BoxFuture<'a, Result<String, BackendError>> {
         Box::pin(async move {
-            // Ensure the staging directory exists before creating the container,
-            // since it is mounted as a volume.
-            let staging_dir = self.staging_base.join(&opts.name);
-            tokio::fs::create_dir_all(&staging_dir).await?;
-
-            let args = build_create_args(opts, &self.staging_base);
+            let args = build_create_args(opts);
             debug!(?args, "container create arguments");
             self.cli.create(&args).await
         })
@@ -132,11 +101,10 @@ impl ContainerBackend for AppleContainerBackend {
         Box::pin(async move {
             self.cli.rm(id).await?;
             if remove_volumes {
-                let staging_dir = self.staging_dir_for(id);
-                if staging_dir.exists() {
-                    debug!(path = %staging_dir.display(), "removing staging directory");
-                    let _ = tokio::fs::remove_dir_all(&staging_dir).await;
-                }
+                // Apple Container's delete never removes volumes, and this
+                // backend creates no per-container anonymous volumes — named
+                // volumes from user config are intentionally left in place.
+                debug!("remove_volumes requested; no backend-managed volumes to remove");
             }
             Ok(())
         })
@@ -435,25 +403,8 @@ impl ContainerBackend for AppleContainerBackend {
         files: &'a [FileToUpload],
     ) -> BoxFuture<'a, Result<(), BackendError>> {
         Box::pin(async move {
-            let staging_dir = self.staging_dir_for(container_id);
-            tokio::fs::create_dir_all(&staging_dir).await?;
-
-            let staging_mount = "/tmp/.cella-staging";
-
             for file in files {
-                // Write to host staging directory.
-                let host_path =
-                    staging_dir.join(file.path.trim_start_matches('/').replace('/', "_"));
-                tokio::fs::write(&host_path, &file.content).await?;
-
-                let staging_name = host_path
-                    .file_name()
-                    .unwrap_or_default()
-                    .to_string_lossy()
-                    .to_string();
-                let staging_src = format!("{staging_mount}/{staging_name}");
-
-                // Ensure parent directory exists inside the container.
+                // Ensure the parent directory exists inside the container.
                 if let Some(parent) = Path::new(&file.path).parent() {
                     let mkdir_cmd = vec![
                         "mkdir".to_string(),
@@ -466,19 +417,28 @@ impl ContainerBackend for AppleContainerBackend {
                         .await;
                 }
 
-                // Copy from staging mount to final path.
-                let cp_cmd = vec!["cp".to_string(), staging_src, file.path.clone()];
+                // Stage the content in a host temp file and copy it in.
+                // The temp file is removed when `tmp` drops.
+                let tmp = tempfile::NamedTempFile::new()?;
+                tokio::fs::write(tmp.path(), &file.content).await?;
+                self.cli
+                    .cp_into(tmp.path(), container_id, &file.path)
+                    .await?;
+
+                // `container cp` preserves host-side metadata; normalize to
+                // the root ownership and explicit mode the old exec-based
+                // copy produced.
+                let chown_cmd = vec!["chown".to_string(), "0:0".to_string(), file.path.clone()];
                 let (exit_code, _, stderr) = self
                     .cli
-                    .exec_capture(container_id, &cp_cmd, Some("root"), None, None)
+                    .exec_capture(container_id, &chown_cmd, Some("root"), None, None)
                     .await?;
                 if exit_code != 0 {
                     return Err(BackendError::Runtime(
-                        format!("cp failed for {}: {stderr}", file.path).into(),
+                        format!("chown failed for {}: {stderr}", file.path).into(),
                     ));
                 }
 
-                // Set permissions.
                 let chmod_cmd = vec![
                     "chmod".to_string(),
                     format!("{:o}", file.mode),
@@ -642,7 +602,7 @@ impl ContainerBackend for AppleContainerBackend {
 // ---------------------------------------------------------------------------
 
 /// Build CLI arguments for `container create` from `CreateContainerOptions`.
-fn build_create_args(opts: &CreateContainerOptions, staging_base: &Path) -> Vec<String> {
+fn build_create_args(opts: &CreateContainerOptions) -> Vec<String> {
     let mut args = Vec::new();
 
     // Name
@@ -688,11 +648,6 @@ fn build_create_args(opts: &CreateContainerOptions, staging_base: &Path) -> Vec<
         let ro_suffix = if mount.read_only { ":ro" } else { "" };
         args.push(format!("{}:{}{ro_suffix}", mount.source, mount.target));
     }
-
-    // Staging directory mount for file uploads.
-    let staging_dir = staging_base.join(&opts.name);
-    args.push("--volume".to_string());
-    args.push(format!("{}:/tmp/.cella-staging", staging_dir.display()));
 
     // Port bindings
     for (container_port, forwards) in &opts.port_bindings {
@@ -943,8 +898,7 @@ mod tests {
     #[test]
     fn build_create_args_minimal() {
         let opts = minimal_create_opts();
-        let staging = PathBuf::from("/tmp/staging");
-        let args = build_create_args(&opts, &staging);
+        let args = build_create_args(&opts);
 
         assert!(args.contains(&"--name".to_string()));
         assert!(args.contains(&"test-container".to_string()));
@@ -959,8 +913,7 @@ mod tests {
         let mut opts = minimal_create_opts();
         opts.labels
             .insert("dev.cella.tool".to_string(), "cella".to_string());
-        let staging = PathBuf::from("/tmp/staging");
-        let args = build_create_args(&opts, &staging);
+        let args = build_create_args(&opts);
 
         let label_idx = args.iter().position(|a| a == "--label").unwrap();
         assert_eq!(args[label_idx + 1], "dev.cella.tool=cella");
@@ -971,8 +924,7 @@ mod tests {
         let mut opts = minimal_create_opts();
         opts.env = vec!["FOO=bar".to_string()];
         opts.remote_env = vec!["BAZ=qux".to_string()];
-        let staging = PathBuf::from("/tmp/staging");
-        let args = build_create_args(&opts, &staging);
+        let args = build_create_args(&opts);
 
         let env_positions: Vec<usize> = args
             .iter()
@@ -988,8 +940,7 @@ mod tests {
     fn build_create_args_with_user() {
         let mut opts = minimal_create_opts();
         opts.user = Some("vscode".to_string());
-        let staging = PathBuf::from("/tmp/staging");
-        let args = build_create_args(&opts, &staging);
+        let args = build_create_args(&opts);
 
         let user_idx = args.iter().position(|a| a == "-u").unwrap();
         assert_eq!(args[user_idx + 1], "vscode");
@@ -1006,8 +957,7 @@ mod tests {
             read_only: false,
             external: false,
         });
-        let staging = PathBuf::from("/tmp/staging");
-        let args = build_create_args(&opts, &staging);
+        let args = build_create_args(&opts);
 
         let vol_idx = args.iter().position(|a| a == "--volume").unwrap();
         assert_eq!(args[vol_idx + 1], "/host/project:/workspace");
@@ -1024,8 +974,7 @@ mod tests {
             read_only: true,
             external: false,
         });
-        let staging = PathBuf::from("/tmp/staging");
-        let args = build_create_args(&opts, &staging);
+        let args = build_create_args(&opts);
 
         let vol_idx = args.iter().position(|a| a == "--volume").unwrap();
         assert_eq!(
@@ -1045,8 +994,7 @@ mod tests {
                 host_port: Some("3000".to_string()),
             }],
         );
-        let staging = PathBuf::from("/tmp/staging");
-        let args = build_create_args(&opts, &staging);
+        let args = build_create_args(&opts);
 
         let port_idx = args.iter().position(|a| a == "-p").unwrap();
         assert_eq!(args[port_idx + 1], "3000:8080/tcp");
@@ -1056,8 +1004,7 @@ mod tests {
     fn build_create_args_with_entrypoint() {
         let mut opts = minimal_create_opts();
         opts.entrypoint = Some(vec!["/bin/sh".to_string(), "-c".to_string()]);
-        let staging = PathBuf::from("/tmp/staging");
-        let args = build_create_args(&opts, &staging);
+        let args = build_create_args(&opts);
 
         let ep_idx = args.iter().position(|a| a == "--entrypoint").unwrap();
         assert_eq!(args[ep_idx + 1], "/bin/sh -c");
@@ -1067,8 +1014,7 @@ mod tests {
     fn build_create_args_with_cmd() {
         let mut opts = minimal_create_opts();
         opts.cmd = Some(vec!["sleep".to_string(), "infinity".to_string()]);
-        let staging = PathBuf::from("/tmp/staging");
-        let args = build_create_args(&opts, &staging);
+        let args = build_create_args(&opts);
 
         // Image should be followed by cmd.
         let img_idx = args.iter().position(|a| a == "ubuntu:latest").unwrap();
@@ -1077,24 +1023,14 @@ mod tests {
     }
 
     #[test]
-    fn build_create_args_staging_mount() {
+    fn build_create_args_has_no_staging_mount() {
         let opts = minimal_create_opts();
-        let staging = PathBuf::from("/tmp/staging");
-        let args = build_create_args(&opts, &staging);
+        let args = build_create_args(&opts);
 
-        // Should contain a volume mount for the staging directory.
-        let vol_args: Vec<&str> = args
-            .windows(2)
-            .filter_map(|w| {
-                if w[0] == "--volume" {
-                    Some(w[1].as_str())
-                } else {
-                    None
-                }
-            })
-            .collect();
-        let staging_mount = vol_args.iter().find(|v| v.contains(".cella-staging"));
-        assert!(staging_mount.is_some(), "expected staging volume mount");
+        assert!(
+            !args.iter().any(|a| a.contains(".cella-staging")),
+            "file uploads use `container cp`; no staging mount expected"
+        );
     }
 
     /// Test helper: a status with the given state and no network attachments.
@@ -1210,16 +1146,6 @@ mod tests {
     }
 
     #[test]
-    fn default_staging_base_contains_cella() {
-        let base = default_staging_base();
-        let base_str = base.to_string_lossy();
-        assert!(
-            base_str.contains("cella"),
-            "staging base should contain 'cella': {base_str}"
-        );
-    }
-
-    #[test]
     fn unsupported_warnings_do_not_panic() {
         let mut opts = minimal_create_opts();
         opts.privileged = true;
@@ -1259,8 +1185,7 @@ mod tests {
                 external: false,
             },
         ];
-        let staging = PathBuf::from("/tmp/staging");
-        let args = build_create_args(&opts, &staging);
+        let args = build_create_args(&opts);
 
         let vol_args: Vec<&str> = args
             .windows(2)
@@ -1293,8 +1218,7 @@ mod tests {
             read_only: true,
             external: false,
         }];
-        let staging = PathBuf::from("/tmp/staging");
-        let args = build_create_args(&opts, &staging);
+        let args = build_create_args(&opts);
 
         let vol_args: Vec<&str> = args
             .windows(2)
@@ -1322,8 +1246,7 @@ mod tests {
                 host_port: Some("8443".to_string()),
             }],
         );
-        let staging = PathBuf::from("/tmp/staging");
-        let args = build_create_args(&opts, &staging);
+        let args = build_create_args(&opts);
 
         let port_idx = args.iter().position(|a| a == "-p").unwrap();
         assert_eq!(args[port_idx + 1], "127.0.0.1:8443:443/tcp");
@@ -1339,8 +1262,7 @@ mod tests {
                 host_port: None,
             }],
         );
-        let staging = PathBuf::from("/tmp/staging");
-        let args = build_create_args(&opts, &staging);
+        let args = build_create_args(&opts);
 
         let port_idx = args.iter().position(|a| a == "-p").unwrap();
         assert_eq!(args[port_idx + 1], "0.0.0.0::80/tcp");
@@ -1356,8 +1278,7 @@ mod tests {
                 host_port: None,
             }],
         );
-        let staging = PathBuf::from("/tmp/staging");
-        let args = build_create_args(&opts, &staging);
+        let args = build_create_args(&opts);
 
         let port_idx = args.iter().position(|a| a == "-p").unwrap();
         // When both host_ip and host_port are None, just the container port.
@@ -1380,8 +1301,7 @@ mod tests {
                 },
             ],
         );
-        let staging = PathBuf::from("/tmp/staging");
-        let args = build_create_args(&opts, &staging);
+        let args = build_create_args(&opts);
 
         let port_count = args.iter().filter(|a| *a == "-p").count();
         assert_eq!(port_count, 2);
@@ -1391,8 +1311,7 @@ mod tests {
     fn build_create_args_empty_entrypoint_is_skipped() {
         let mut opts = minimal_create_opts();
         opts.entrypoint = Some(Vec::new());
-        let staging = PathBuf::from("/tmp/staging");
-        let args = build_create_args(&opts, &staging);
+        let args = build_create_args(&opts);
 
         assert!(
             !args.contains(&"--entrypoint".to_string()),
@@ -1403,8 +1322,7 @@ mod tests {
     #[test]
     fn build_create_args_none_entrypoint_is_skipped() {
         let opts = minimal_create_opts();
-        let staging = PathBuf::from("/tmp/staging");
-        let args = build_create_args(&opts, &staging);
+        let args = build_create_args(&opts);
 
         assert!(
             !args.contains(&"--entrypoint".to_string()),

--- a/crates/cella-container/src/backend.rs
+++ b/crates/cella-container/src/backend.rs
@@ -12,7 +12,7 @@ use cella_backend::{
 use tracing::{debug, warn};
 
 use crate::sdk::ContainerCli;
-use crate::sdk::types::ContainerListEntry;
+use crate::sdk::types::{ContainerListEntry, FilesystemType};
 
 /// Apple Container backend — drives the `container` CLI binary.
 pub struct AppleContainerBackend {
@@ -21,19 +21,13 @@ pub struct AppleContainerBackend {
 }
 
 impl AppleContainerBackend {
-    /// Resolve the staging directory for a container by looking up its name.
+    /// Resolve the staging directory for a container.
     ///
-    /// The staging directory is mounted at create time using the container name,
-    /// but subsequent operations receive the container ID. This helper bridges
-    /// the gap by inspecting the container to retrieve its name.
-    async fn staging_dir_for(&self, container_id: &str) -> Result<PathBuf, BackendError> {
-        let entry = self.cli.inspect(container_id).await?;
-        let name = entry
-            .configuration
-            .as_ref()
-            .and_then(|c| c.name.as_deref())
-            .unwrap_or(container_id);
-        Ok(self.staging_base.join(name))
+    /// Apple Container has no separate name field — `--name` sets the
+    /// container ID — so the create-time staging directory (keyed by name)
+    /// is directly addressable by ID.
+    fn staging_dir_for(&self, container_id: &str) -> PathBuf {
+        self.staging_base.join(container_id)
     }
 }
 
@@ -90,7 +84,7 @@ impl ContainerBackend for AppleContainerBackend {
                 .unwrap_or_else(|_| workspace_root.to_path_buf());
             let canonical_str = canonical.to_string_lossy();
 
-            let entries = self.cli.list(None).await?;
+            let entries = self.cli.list().await?;
 
             for entry in entries {
                 if let Some(info) = entry_to_container_info(&entry)
@@ -136,10 +130,9 @@ impl ContainerBackend for AppleContainerBackend {
         remove_volumes: bool,
     ) -> BoxFuture<'a, Result<(), BackendError>> {
         Box::pin(async move {
-            let staging_dir = self.staging_dir_for(id).await.ok();
             self.cli.rm(id).await?;
             if remove_volumes {
-                let staging_dir = staging_dir.unwrap_or_else(|| self.staging_base.join(id));
+                let staging_dir = self.staging_dir_for(id);
                 if staging_dir.exists() {
                     debug!(path = %staging_dir.display(), "removing staging directory");
                     let _ = tokio::fs::remove_dir_all(&staging_dir).await;
@@ -166,7 +159,7 @@ impl ContainerBackend for AppleContainerBackend {
         running_only: bool,
     ) -> BoxFuture<'_, Result<Vec<ContainerInfo>, BackendError>> {
         Box::pin(async move {
-            let entries = self.cli.list(None).await?;
+            let entries = self.cli.list().await?;
             let mut results = Vec::new();
             for entry in &entries {
                 if let Some(info) = entry_to_container_info(entry) {
@@ -199,7 +192,7 @@ impl ContainerBackend for AppleContainerBackend {
         Box::pin(async move {
             let (key, value) = label.split_once('=').unwrap_or((label, ""));
 
-            let entries = self.cli.list(None).await?;
+            let entries = self.cli.list().await?;
             for entry in entries {
                 if let Some(info) = entry_to_container_info(&entry)
                     && info
@@ -442,7 +435,7 @@ impl ContainerBackend for AppleContainerBackend {
         files: &'a [FileToUpload],
     ) -> BoxFuture<'a, Result<(), BackendError>> {
         Box::pin(async move {
-            let staging_dir = self.staging_dir_for(container_id).await?;
+            let staging_dir = self.staging_dir_for(container_id);
             tokio::fs::create_dir_all(&staging_dir).await?;
 
             let staging_mount = "/tmp/.cella-staging";
@@ -511,7 +504,7 @@ impl ContainerBackend for AppleContainerBackend {
     fn ping(&self) -> BoxFuture<'_, Result<(), BackendError>> {
         Box::pin(async move {
             // Verify the container CLI is reachable by running `container list`.
-            let _ = self.cli.list(None).await?;
+            let _ = self.cli.list().await?;
             Ok(())
         })
     }
@@ -807,8 +800,6 @@ fn entry_to_container_info(entry: &ContainerListEntry) -> Option<ContainerInfo> 
             },
         );
 
-    let exit_code = entry.status.as_ref().and_then(|s| s.exit_code);
-
     let labels = config.labels.clone().unwrap_or_default();
     let config_hash = labels.get("dev.cella.config_hash").cloned();
 
@@ -821,7 +812,7 @@ fn entry_to_container_info(entry: &ContainerListEntry) -> Option<ContainerInfo> 
                     Some(PortBinding {
                         container_port: p.container_port?,
                         host_port: p.host_port,
-                        protocol: p.protocol.clone().unwrap_or_else(|| "tcp".to_string()),
+                        protocol: p.proto.clone().unwrap_or_else(|| "tcp".to_string()),
                     })
                 })
                 .collect()
@@ -834,8 +825,20 @@ fn entry_to_container_info(entry: &ContainerListEntry) -> Option<ContainerInfo> 
         .map(|ms| {
             ms.iter()
                 .map(|m| MountInfo {
-                    mount_type: m.mount_type.clone().unwrap_or_default(),
-                    source: m.source.clone().unwrap_or_default(),
+                    mount_type: m
+                        .fs_type
+                        .as_ref()
+                        .map(|t| t.kind().to_string())
+                        .unwrap_or_default(),
+                    // Volume mounts surface the volume name (Docker parity);
+                    // the raw source is the host-side storage path.
+                    source: m
+                        .fs_type
+                        .as_ref()
+                        .and_then(FilesystemType::volume_name)
+                        .map(String::from)
+                        .or_else(|| m.source.clone())
+                        .unwrap_or_default(),
                     destination: m.destination.clone().unwrap_or_default(),
                 })
                 .collect()
@@ -845,16 +848,17 @@ fn entry_to_container_info(entry: &ContainerListEntry) -> Option<ContainerInfo> 
     let created_at = labels.get("dev.cella.created_at").cloned();
 
     Some(ContainerInfo {
+        name: id.clone(),
         id,
-        name: config.name.clone().unwrap_or_default(),
         state,
-        exit_code,
+        // 1.0.0 does not report exit codes through ls/inspect.
+        exit_code: None,
         labels,
         config_hash,
         ports,
         created_at,
         container_user: None,
-        image: config.image.clone(),
+        image: config.image.as_ref().and_then(|i| i.reference.clone()),
         mounts,
         backend: BackendKind::AppleContainer,
     })
@@ -1093,68 +1097,69 @@ mod tests {
         assert!(staging_mount.is_some(), "expected staging volume mount");
     }
 
+    /// Test helper: a status with the given state and no network attachments.
+    fn test_status(state: &str) -> crate::sdk::types::ContainerStatus {
+        crate::sdk::types::ContainerStatus {
+            state: Some(state.to_string()),
+            networks: Vec::new(),
+        }
+    }
+
+    /// Test helper: a configuration with the given ID and everything else
+    /// empty.
+    fn test_config(id: Option<&str>) -> crate::sdk::types::ContainerConfiguration {
+        crate::sdk::types::ContainerConfiguration {
+            id: id.map(String::from),
+            image: None,
+            labels: None,
+            published_ports: None,
+            mounts: None,
+            networks: Vec::new(),
+        }
+    }
+
     #[test]
     fn entry_to_container_info_basic() {
+        let mut config = test_config(Some("abc123"));
+        config.image = Some(crate::sdk::types::ImageDescription {
+            reference: Some("ubuntu:latest".to_string()),
+        });
+        config.labels = Some(HashMap::from([(
+            "dev.cella.tool".to_string(),
+            "cella".to_string(),
+        )]));
         let entry = ContainerListEntry {
-            status: Some(crate::sdk::types::ContainerStatus {
-                state: Some("running".to_string()),
-                exit_code: Some(0),
-            }),
-            configuration: Some(crate::sdk::types::ContainerConfiguration {
-                id: Some("abc123".to_string()),
-                name: Some("test".to_string()),
-                image: Some("ubuntu:latest".to_string()),
-                labels: Some(HashMap::from([(
-                    "dev.cella.tool".to_string(),
-                    "cella".to_string(),
-                )])),
-                published_ports: None,
-                mounts: None,
-            }),
+            status: Some(test_status("running")),
+            configuration: Some(config),
         };
 
         let info = entry_to_container_info(&entry).unwrap();
         assert_eq!(info.id, "abc123");
-        assert_eq!(info.name, "test");
+        // Containers have no separate name; the ID doubles as the name.
+        assert_eq!(info.name, "abc123");
         assert_eq!(info.state, ContainerState::Running);
-        assert_eq!(info.exit_code, Some(0));
+        assert_eq!(info.image.as_deref(), Some("ubuntu:latest"));
         assert_eq!(info.backend, BackendKind::AppleContainer);
     }
 
     #[test]
     fn entry_to_container_info_stopped_state() {
         let entry = ContainerListEntry {
-            status: Some(crate::sdk::types::ContainerStatus {
-                state: Some("stopped".to_string()),
-                exit_code: Some(137),
-            }),
-            configuration: Some(crate::sdk::types::ContainerConfiguration {
-                id: Some("def456".to_string()),
-                name: None,
-                image: None,
-                labels: None,
-                published_ports: None,
-                mounts: None,
-            }),
+            status: Some(test_status("stopped")),
+            configuration: Some(test_config(Some("def456"))),
         };
 
         let info = entry_to_container_info(&entry).unwrap();
         assert_eq!(info.state, ContainerState::Stopped);
-        assert_eq!(info.exit_code, Some(137));
+        // 1.0.0 does not report exit codes through ls/inspect.
+        assert_eq!(info.exit_code, None);
     }
 
     #[test]
     fn entry_to_container_info_no_id_returns_none() {
         let entry = ContainerListEntry {
             status: None,
-            configuration: Some(crate::sdk::types::ContainerConfiguration {
-                id: None,
-                name: Some("orphan".to_string()),
-                image: None,
-                labels: None,
-                published_ports: None,
-                mounts: None,
-            }),
+            configuration: Some(test_config(None)),
         };
 
         assert!(entry_to_container_info(&entry).is_none());
@@ -1163,10 +1168,7 @@ mod tests {
     #[test]
     fn entry_to_container_info_no_config_returns_none() {
         let entry = ContainerListEntry {
-            status: Some(crate::sdk::types::ContainerStatus {
-                state: Some("running".to_string()),
-                exit_code: None,
-            }),
+            status: Some(test_status("running")),
             configuration: None,
         };
 
@@ -1414,36 +1416,28 @@ mod tests {
 
     #[test]
     fn entry_to_container_info_with_ports() {
+        let mut config = test_config(Some("p1"));
+        config.published_ports = Some(vec![
+            crate::sdk::types::PublishedPort {
+                container_port: Some(80),
+                host_port: Some(8080),
+                proto: Some("tcp".to_string()),
+            },
+            crate::sdk::types::PublishedPort {
+                container_port: Some(443),
+                host_port: None,
+                proto: None,
+            },
+            // Port entry missing container_port should be filtered out.
+            crate::sdk::types::PublishedPort {
+                container_port: None,
+                host_port: Some(9999),
+                proto: None,
+            },
+        ]);
         let entry = ContainerListEntry {
-            status: Some(crate::sdk::types::ContainerStatus {
-                state: Some("running".to_string()),
-                exit_code: None,
-            }),
-            configuration: Some(crate::sdk::types::ContainerConfiguration {
-                id: Some("p1".to_string()),
-                name: Some("with-ports".to_string()),
-                image: Some("nginx".to_string()),
-                labels: None,
-                published_ports: Some(vec![
-                    crate::sdk::types::PublishedPort {
-                        container_port: Some(80),
-                        host_port: Some(8080),
-                        protocol: Some("tcp".to_string()),
-                    },
-                    crate::sdk::types::PublishedPort {
-                        container_port: Some(443),
-                        host_port: None,
-                        protocol: None,
-                    },
-                    // Port entry missing container_port should be filtered out.
-                    crate::sdk::types::PublishedPort {
-                        container_port: None,
-                        host_port: Some(9999),
-                        protocol: None,
-                    },
-                ]),
-                mounts: None,
-            }),
+            status: Some(test_status("running")),
+            configuration: Some(config),
         };
 
         let info = entry_to_container_info(&entry).unwrap();
@@ -1458,44 +1452,48 @@ mod tests {
 
     #[test]
     fn entry_to_container_info_with_mounts() {
+        let mut config = test_config(Some("m1"));
+        config.mounts = Some(vec![
+            crate::sdk::types::MountEntry {
+                source: Some("/host".to_string()),
+                destination: Some("/container".to_string()),
+                fs_type: Some(FilesystemType::Virtiofs(serde_json::Value::Null)),
+                options: Vec::new(),
+            },
+            crate::sdk::types::MountEntry {
+                source: Some("/var/lib/volumes/data".to_string()),
+                destination: Some("/data".to_string()),
+                fs_type: Some(FilesystemType::Volume {
+                    name: Some("data".to_string()),
+                }),
+                options: Vec::new(),
+            },
+        ]);
         let entry = ContainerListEntry {
             status: None,
-            configuration: Some(crate::sdk::types::ContainerConfiguration {
-                id: Some("m1".to_string()),
-                name: None,
-                image: None,
-                labels: None,
-                published_ports: None,
-                mounts: Some(vec![crate::sdk::types::MountEntry {
-                    source: Some("/host".to_string()),
-                    destination: Some("/container".to_string()),
-                    mount_type: Some("bind".to_string()),
-                }]),
-            }),
+            configuration: Some(config),
         };
 
         let info = entry_to_container_info(&entry).unwrap();
-        assert_eq!(info.mounts.len(), 1);
+        assert_eq!(info.mounts.len(), 2);
         assert_eq!(info.mounts[0].source, "/host");
         assert_eq!(info.mounts[0].destination, "/container");
         assert_eq!(info.mounts[0].mount_type, "bind");
+        // Volume mounts surface the volume name, not the storage path.
+        assert_eq!(info.mounts[1].source, "data");
+        assert_eq!(info.mounts[1].mount_type, "volume");
     }
 
     #[test]
     fn entry_to_container_info_with_config_hash_label() {
+        let mut config = test_config(Some("h1"));
+        config.labels = Some(HashMap::from([(
+            "dev.cella.config_hash".to_string(),
+            "abc123hash".to_string(),
+        )]));
         let entry = ContainerListEntry {
             status: None,
-            configuration: Some(crate::sdk::types::ContainerConfiguration {
-                id: Some("h1".to_string()),
-                name: None,
-                image: None,
-                labels: Some(HashMap::from([(
-                    "dev.cella.config_hash".to_string(),
-                    "abc123hash".to_string(),
-                )])),
-                published_ports: None,
-                mounts: None,
-            }),
+            configuration: Some(config),
         };
 
         let info = entry_to_container_info(&entry).unwrap();
@@ -1504,19 +1502,14 @@ mod tests {
 
     #[test]
     fn entry_to_container_info_with_created_at_label() {
+        let mut config = test_config(Some("ca1"));
+        config.labels = Some(HashMap::from([(
+            "dev.cella.created_at".to_string(),
+            "2026-01-01T00:00:00Z".to_string(),
+        )]));
         let entry = ContainerListEntry {
             status: None,
-            configuration: Some(crate::sdk::types::ContainerConfiguration {
-                id: Some("ca1".to_string()),
-                name: None,
-                image: None,
-                labels: Some(HashMap::from([(
-                    "dev.cella.created_at".to_string(),
-                    "2026-01-01T00:00:00Z".to_string(),
-                )])),
-                published_ports: None,
-                mounts: None,
-            }),
+            configuration: Some(config),
         };
 
         let info = entry_to_container_info(&entry).unwrap();
@@ -1526,36 +1519,19 @@ mod tests {
     #[test]
     fn entry_to_container_info_unknown_state() {
         let entry = ContainerListEntry {
-            status: Some(crate::sdk::types::ContainerStatus {
-                state: Some("paused".to_string()),
-                exit_code: None,
-            }),
-            configuration: Some(crate::sdk::types::ContainerConfiguration {
-                id: Some("u1".to_string()),
-                name: None,
-                image: None,
-                labels: None,
-                published_ports: None,
-                mounts: None,
-            }),
+            status: Some(test_status("stopping")),
+            configuration: Some(test_config(Some("u1"))),
         };
 
         let info = entry_to_container_info(&entry).unwrap();
-        assert_eq!(info.state, ContainerState::Other("paused".to_string()));
+        assert_eq!(info.state, ContainerState::Other("stopping".to_string()));
     }
 
     #[test]
     fn entry_to_container_info_no_status_defaults_to_unknown() {
         let entry = ContainerListEntry {
             status: None,
-            configuration: Some(crate::sdk::types::ContainerConfiguration {
-                id: Some("ns1".to_string()),
-                name: None,
-                image: None,
-                labels: None,
-                published_ports: None,
-                mounts: None,
-            }),
+            configuration: Some(test_config(Some("ns1"))),
         };
 
         let info = entry_to_container_info(&entry).unwrap();
@@ -1564,20 +1540,16 @@ mod tests {
 
     #[test]
     fn entry_to_container_info_empty_mount_fields() {
+        let mut config = test_config(Some("em1"));
+        config.mounts = Some(vec![crate::sdk::types::MountEntry {
+            source: None,
+            destination: None,
+            fs_type: None,
+            options: Vec::new(),
+        }]);
         let entry = ContainerListEntry {
             status: None,
-            configuration: Some(crate::sdk::types::ContainerConfiguration {
-                id: Some("em1".to_string()),
-                name: None,
-                image: None,
-                labels: None,
-                published_ports: None,
-                mounts: Some(vec![crate::sdk::types::MountEntry {
-                    source: None,
-                    destination: None,
-                    mount_type: None,
-                }]),
-            }),
+            configuration: Some(config),
         };
 
         let info = entry_to_container_info(&entry).unwrap();

--- a/crates/cella-container/src/backend.rs
+++ b/crates/cella-container/src/backend.rs
@@ -4,19 +4,31 @@ use std::io::Write;
 use std::path::Path;
 use std::process::Stdio;
 
+use cella_backend::network::{
+    CELLA_NETWORK_NAME, MANAGED_LABEL, MANAGED_VALUE, REPO_LABEL, repo_network_name,
+    workspace_network_name,
+};
 use cella_backend::{
     BackendCapabilities, BackendError, BackendKind, BoxFuture, BuildOptions, ContainerBackend,
     ContainerInfo, ContainerState, CreateContainerOptions, ExecOptions, ExecResult, FileToUpload,
-    ImageDetails, InteractiveExecOptions, MountInfo, Platform, PortBinding, RunArgsOverrides,
+    ImageDetails, InteractiveExecOptions, ManagedNetwork, MountInfo, Platform, PortBinding,
+    RemovalOutcome, RunArgsOverrides,
 };
 use tracing::{debug, warn};
 
 use crate::sdk::ContainerCli;
 use crate::sdk::types::{ContainerListEntry, FilesystemType};
 
+/// Labels applied to every cella-managed network.
+const NETWORK_BASE_LABELS: [(&str, &str); 2] =
+    [("dev.cella.tool", "cella"), (MANAGED_LABEL, MANAGED_VALUE)];
+
 /// Apple Container backend — drives the `container` CLI binary.
 pub struct AppleContainerBackend {
     cli: ContainerCli,
+    /// Whether `container network` commands work on this host (macOS 26+).
+    /// Probed lazily, once per backend instance.
+    networks_available: tokio::sync::OnceCell<bool>,
 }
 
 impl AppleContainerBackend {
@@ -26,8 +38,131 @@ impl AppleContainerBackend {
             "Apple Container backend is EXPERIMENTAL — \
              expect rough edges and missing features"
         );
-        Self { cli }
+        Self {
+            cli,
+            networks_available: tokio::sync::OnceCell::new(),
+        }
     }
+
+    /// Whether the network subcommands are usable (they only exist on
+    /// macOS 26+; on macOS 15 every invocation fails).
+    async fn networks_available(&self) -> bool {
+        *self
+            .networks_available
+            .get_or_init(|| async {
+                match self.cli.network_list().await {
+                    Ok(_) => true,
+                    Err(e) => {
+                        debug!(
+                            error = %e,
+                            "network commands unavailable (requires macOS 26+); \
+                             continuing without network integration"
+                        );
+                        false
+                    }
+                }
+            })
+            .await
+    }
+
+    /// Check whether a network with the given name exists.
+    async fn named_network_exists(&self, name: &str) -> Result<bool, BackendError> {
+        let networks = self.cli.network_list().await?;
+        Ok(networks.iter().any(|n| n.name() == Some(name)))
+    }
+
+    /// Create `name` with `labels` unless it already exists.
+    async fn ensure_named_network(
+        &self,
+        name: &str,
+        labels: &[(&str, &str)],
+    ) -> Result<(), BackendError> {
+        if self.named_network_exists(name).await? {
+            return Ok(());
+        }
+        match self.cli.network_create(name, labels).await {
+            Ok(()) => Ok(()),
+            // Lost a creation race? An existing network is still success.
+            Err(e) => {
+                if self.named_network_exists(name).await.unwrap_or(false) {
+                    Ok(())
+                } else {
+                    Err(e)
+                }
+            }
+        }
+    }
+
+    /// Ensure the shared and per-workspace networks exist and return the
+    /// attachment names for `container create`.
+    ///
+    /// Apple Container fixes network attachments at creation, so this runs
+    /// before every create. Network trouble degrades to fewer (or no)
+    /// attachments rather than failing container creation.
+    async fn prepare_create_networks(&self, opts: &CreateContainerOptions) -> Vec<String> {
+        if !self.networks_available().await {
+            return Vec::new();
+        }
+
+        let mut networks = Vec::new();
+
+        match self
+            .ensure_named_network(CELLA_NETWORK_NAME, &NETWORK_BASE_LABELS)
+            .await
+        {
+            Ok(()) => networks.push(CELLA_NETWORK_NAME.to_string()),
+            Err(e) => warn!(
+                error = %e,
+                "could not ensure '{CELLA_NETWORK_NAME}' network; creating container without it"
+            ),
+        }
+
+        // The workspace label is canonicalized when labels are built, so the
+        // derived name matches what down/prune compute later.
+        if let Some(workspace) = opts.labels.get("dev.cella.workspace_path") {
+            let name = repo_network_name(Path::new(workspace));
+            let labels = [
+                NETWORK_BASE_LABELS[0],
+                NETWORK_BASE_LABELS[1],
+                (REPO_LABEL, workspace.as_str()),
+            ];
+            match self.ensure_named_network(&name, &labels).await {
+                Ok(()) => networks.push(name),
+                Err(e) => warn!(
+                    error = %e,
+                    network = %name,
+                    "could not ensure workspace network; creating container without it"
+                ),
+            }
+        }
+
+        networks
+    }
+}
+
+/// Build a `NotSupported` error for a network operation, mentioning the
+/// macOS 26 requirement.
+fn network_unavailable(operation: &str) -> BackendError {
+    BackendError::NotSupported {
+        backend: "apple-container".to_string(),
+        operation: format!("{operation} (network commands require macOS 26+)"),
+    }
+}
+
+/// Whether a list entry is attached to `name`, either by configuration
+/// (create-time) or live status.
+fn entry_attached_to_network(entry: &ContainerListEntry, name: &str) -> bool {
+    let configured = entry.configuration.as_ref().is_some_and(|c| {
+        c.networks
+            .iter()
+            .any(|n| n.network.as_deref() == Some(name))
+    });
+    let live = entry.status.as_ref().is_some_and(|s| {
+        s.networks
+            .iter()
+            .any(|n| n.network.as_deref() == Some(name))
+    });
+    configured || live
 }
 
 // ---------------------------------------------------------------------------
@@ -79,7 +214,10 @@ impl ContainerBackend for AppleContainerBackend {
         opts: &'a CreateContainerOptions,
     ) -> BoxFuture<'a, Result<String, BackendError>> {
         Box::pin(async move {
-            let args = build_create_args(opts);
+            // Network attachments are fixed at creation, so the shared and
+            // per-workspace networks must exist (and be requested) up front.
+            let networks = self.prepare_create_networks(opts).await;
+            let args = build_create_args(opts, &networks);
             debug!(?args, "container create arguments");
             self.cli.create(&args).await
         })
@@ -526,31 +664,186 @@ impl ContainerBackend for AppleContainerBackend {
 
     fn ensure_network(&self) -> BoxFuture<'_, Result<(), BackendError>> {
         Box::pin(async move {
-            Err(BackendError::NotSupported {
-                backend: "apple-container".to_string(),
-                operation: "ensure_network".to_string(),
-            })
+            if !self.networks_available().await {
+                return Err(network_unavailable("ensure_network"));
+            }
+            self.ensure_named_network(CELLA_NETWORK_NAME, &NETWORK_BASE_LABELS)
+                .await
         })
     }
 
     fn ensure_container_network<'a>(
         &'a self,
-        _container_id: &'a str,
-        _repo_path: &'a Path,
+        container_id: &'a str,
+        repo_path: &'a Path,
     ) -> BoxFuture<'a, Result<(), BackendError>> {
         Box::pin(async move {
-            Err(BackendError::NotSupported {
-                backend: "apple-container".to_string(),
-                operation: "ensure_container_network".to_string(),
-            })
+            if !self.networks_available().await {
+                return Err(network_unavailable("ensure_container_network"));
+            }
+
+            // Attachments are fixed at creation; verify the create-time
+            // attachments cover what the orchestrator expects.
+            let entry = self.cli.inspect(container_id).await?;
+            let expected = [
+                CELLA_NETWORK_NAME.to_string(),
+                workspace_network_name(repo_path),
+            ];
+            let missing: Vec<&str> = expected
+                .iter()
+                .filter(|name| !entry_attached_to_network(&entry, name))
+                .map(String::as_str)
+                .collect();
+
+            if missing.is_empty() {
+                Ok(())
+            } else {
+                Err(BackendError::NotSupported {
+                    backend: "apple-container".to_string(),
+                    operation: format!(
+                        "attaching networks to an existing container ({}); \
+                         attachments are fixed at creation — recreate the \
+                         container to join them",
+                        missing.join(", ")
+                    ),
+                })
+            }
         })
     }
 
     fn get_container_ip<'a>(
         &'a self,
-        _container_id: &'a str,
+        container_id: &'a str,
     ) -> BoxFuture<'a, Result<Option<String>, BackendError>> {
-        Box::pin(async move { Ok(None) })
+        Box::pin(async move {
+            let entry = self.cli.inspect(container_id).await?;
+            let Some(status) = entry.status else {
+                return Ok(None);
+            };
+
+            // Prefer the shared cella network, mirroring the Docker backend.
+            if let Some(ip) = status
+                .networks
+                .iter()
+                .find(|n| n.network.as_deref() == Some(CELLA_NETWORK_NAME))
+                .and_then(|n| n.ipv4())
+            {
+                return Ok(Some(ip.to_string()));
+            }
+            Ok(status
+                .networks
+                .iter()
+                .find_map(|n| n.ipv4().map(String::from)))
+        })
+    }
+
+    fn list_managed_networks(&self) -> BoxFuture<'_, Result<Vec<ManagedNetwork>, BackendError>> {
+        Box::pin(async move {
+            if !self.networks_available().await {
+                return Err(network_unavailable("list_managed_networks"));
+            }
+
+            let networks = self.cli.network_list().await?;
+            let containers = self.cli.list().await?;
+
+            let mut out = Vec::new();
+            for net in &networks {
+                let Some(name) = net.name() else { continue };
+                let labels = net
+                    .configuration
+                    .as_ref()
+                    .and_then(|c| c.labels.clone())
+                    .unwrap_or_default();
+                if labels.get(MANAGED_LABEL).map(String::as_str) != Some(MANAGED_VALUE) {
+                    continue;
+                }
+
+                let container_count = containers
+                    .iter()
+                    .filter(|c| entry_attached_to_network(c, name))
+                    .count();
+                let created_at = net
+                    .configuration
+                    .as_ref()
+                    .and_then(|c| c.creation_date.as_ref())
+                    .and_then(|v| v.as_str().map(String::from));
+
+                out.push(ManagedNetwork {
+                    name: name.to_string(),
+                    repo_path: labels.get(REPO_LABEL).cloned(),
+                    container_count,
+                    created_at,
+                    labels,
+                });
+            }
+            Ok(out)
+        })
+    }
+
+    fn remove_network_if_orphan<'a>(
+        &'a self,
+        name: &'a str,
+    ) -> BoxFuture<'a, Result<RemovalOutcome, BackendError>> {
+        Box::pin(async move {
+            if !self.networks_available().await {
+                return Err(network_unavailable("remove_network_if_orphan"));
+            }
+
+            let networks = self.cli.network_list().await?;
+            let Some(net) = networks.iter().find(|n| n.name() == Some(name)) else {
+                return Ok(RemovalOutcome::NotFound);
+            };
+
+            let labels = net
+                .configuration
+                .as_ref()
+                .and_then(|c| c.labels.clone())
+                .unwrap_or_default();
+            let managed = labels.get(MANAGED_LABEL).map(String::as_str) == Some(MANAGED_VALUE);
+
+            let containers = self.cli.list().await?;
+            let container_count = containers
+                .iter()
+                .filter(|c| entry_attached_to_network(c, name))
+                .count();
+
+            if !managed || container_count > 0 {
+                debug!(
+                    network = name,
+                    managed, container_count, "network not an orphan, leaving in place"
+                );
+                return Ok(RemovalOutcome::SkippedInUse);
+            }
+
+            match self.cli.network_delete(name).await {
+                Ok(()) => Ok(RemovalOutcome::Removed),
+                // Removed by a concurrent caller between list and delete.
+                Err(e) if e.to_string().contains("not found") => Ok(RemovalOutcome::NotFound),
+                Err(e) => Err(e),
+            }
+        })
+    }
+
+    fn remove_workspace_network<'a>(
+        &'a self,
+        workspace_root: &'a Path,
+    ) -> BoxFuture<'a, Result<RemovalOutcome, BackendError>> {
+        Box::pin(async move {
+            let name = workspace_network_name(workspace_root);
+            self.remove_network_if_orphan(&name).await
+        })
+    }
+
+    fn network_exists<'a>(
+        &'a self,
+        network_name: &'a str,
+    ) -> BoxFuture<'a, Result<bool, BackendError>> {
+        Box::pin(async move {
+            if !self.networks_available().await {
+                return Err(network_unavailable("network_exists"));
+            }
+            self.named_network_exists(network_name).await
+        })
     }
 
     // -- Agent provisioning --
@@ -602,8 +895,17 @@ impl ContainerBackend for AppleContainerBackend {
 // ---------------------------------------------------------------------------
 
 /// Build CLI arguments for `container create` from `CreateContainerOptions`.
-fn build_create_args(opts: &CreateContainerOptions) -> Vec<String> {
+///
+/// `networks` lists pre-created networks to attach; attachments cannot be
+/// added after creation.
+fn build_create_args(opts: &CreateContainerOptions, networks: &[String]) -> Vec<String> {
     let mut args = Vec::new();
+
+    // Network attachments.
+    for network in networks {
+        args.push("--network".to_string());
+        args.push(network.clone());
+    }
 
     // Name
     args.push("--name".to_string());
@@ -1025,7 +1327,7 @@ mod tests {
     #[test]
     fn build_create_args_minimal() {
         let opts = minimal_create_opts();
-        let args = build_create_args(&opts);
+        let args = build_create_args(&opts, &[]);
 
         assert!(args.contains(&"--name".to_string()));
         assert!(args.contains(&"test-container".to_string()));
@@ -1040,7 +1342,7 @@ mod tests {
         let mut opts = minimal_create_opts();
         opts.labels
             .insert("dev.cella.tool".to_string(), "cella".to_string());
-        let args = build_create_args(&opts);
+        let args = build_create_args(&opts, &[]);
 
         let label_idx = args.iter().position(|a| a == "--label").unwrap();
         assert_eq!(args[label_idx + 1], "dev.cella.tool=cella");
@@ -1051,7 +1353,7 @@ mod tests {
         let mut opts = minimal_create_opts();
         opts.env = vec!["FOO=bar".to_string()];
         opts.remote_env = vec!["BAZ=qux".to_string()];
-        let args = build_create_args(&opts);
+        let args = build_create_args(&opts, &[]);
 
         let env_positions: Vec<usize> = args
             .iter()
@@ -1067,7 +1369,7 @@ mod tests {
     fn build_create_args_with_user() {
         let mut opts = minimal_create_opts();
         opts.user = Some("vscode".to_string());
-        let args = build_create_args(&opts);
+        let args = build_create_args(&opts, &[]);
 
         let user_idx = args.iter().position(|a| a == "-u").unwrap();
         assert_eq!(args[user_idx + 1], "vscode");
@@ -1084,7 +1386,7 @@ mod tests {
             read_only: false,
             external: false,
         });
-        let args = build_create_args(&opts);
+        let args = build_create_args(&opts, &[]);
 
         let vol_idx = args.iter().position(|a| a == "--volume").unwrap();
         assert_eq!(args[vol_idx + 1], "/host/project:/workspace");
@@ -1101,7 +1403,7 @@ mod tests {
             read_only: true,
             external: false,
         });
-        let args = build_create_args(&opts);
+        let args = build_create_args(&opts, &[]);
 
         let vol_idx = args.iter().position(|a| a == "--volume").unwrap();
         assert_eq!(
@@ -1121,7 +1423,7 @@ mod tests {
                 host_port: Some("3000".to_string()),
             }],
         );
-        let args = build_create_args(&opts);
+        let args = build_create_args(&opts, &[]);
 
         let port_idx = args.iter().position(|a| a == "-p").unwrap();
         assert_eq!(args[port_idx + 1], "3000:8080/tcp");
@@ -1131,7 +1433,7 @@ mod tests {
     fn build_create_args_with_entrypoint() {
         let mut opts = minimal_create_opts();
         opts.entrypoint = Some(vec!["/bin/sh".to_string(), "-c".to_string()]);
-        let args = build_create_args(&opts);
+        let args = build_create_args(&opts, &[]);
 
         let ep_idx = args.iter().position(|a| a == "--entrypoint").unwrap();
         assert_eq!(args[ep_idx + 1], "/bin/sh -c");
@@ -1141,7 +1443,7 @@ mod tests {
     fn build_create_args_with_cmd() {
         let mut opts = minimal_create_opts();
         opts.cmd = Some(vec!["sleep".to_string(), "infinity".to_string()]);
-        let args = build_create_args(&opts);
+        let args = build_create_args(&opts, &[]);
 
         // Image should be followed by cmd.
         let img_idx = args.iter().position(|a| a == "ubuntu:latest").unwrap();
@@ -1152,12 +1454,74 @@ mod tests {
     #[test]
     fn build_create_args_has_no_staging_mount() {
         let opts = minimal_create_opts();
-        let args = build_create_args(&opts);
+        let args = build_create_args(&opts, &[]);
 
         assert!(
             !args.iter().any(|a| a.contains(".cella-staging")),
             "file uploads use `container cp`; no staging mount expected"
         );
+    }
+
+    #[test]
+    fn build_create_args_attaches_networks() {
+        let opts = minimal_create_opts();
+        let networks = vec!["cella".to_string(), "cella-net-abcdef123456".to_string()];
+        let args = build_create_args(&opts, &networks);
+
+        let attached: Vec<&str> = args
+            .windows(2)
+            .filter(|w| w[0] == "--network")
+            .map(|w| w[1].as_str())
+            .collect();
+        assert_eq!(attached, vec!["cella", "cella-net-abcdef123456"]);
+    }
+
+    #[test]
+    fn build_create_args_no_networks_no_flag() {
+        let opts = minimal_create_opts();
+        let args = build_create_args(&opts, &[]);
+        assert!(!args.contains(&"--network".to_string()));
+    }
+
+    #[test]
+    fn entry_attached_to_network_checks_configuration() {
+        let mut config = test_config(Some("c1"));
+        config.networks = vec![crate::sdk::types::AttachmentConfiguration {
+            network: Some("cella".to_string()),
+        }];
+        let entry = ContainerListEntry {
+            status: None,
+            configuration: Some(config),
+        };
+
+        assert!(entry_attached_to_network(&entry, "cella"));
+        assert!(!entry_attached_to_network(&entry, "other"));
+    }
+
+    #[test]
+    fn entry_attached_to_network_checks_live_status() {
+        let mut status = test_status("running");
+        status.networks = vec![crate::sdk::types::NetworkAttachment {
+            network: Some("cella-net-abc".to_string()),
+            hostname: None,
+            ipv4_address: Some("192.168.65.2/24".to_string()),
+            ipv4_gateway: None,
+        }];
+        let entry = ContainerListEntry {
+            status: Some(status),
+            configuration: Some(test_config(Some("c2"))),
+        };
+
+        assert!(entry_attached_to_network(&entry, "cella-net-abc"));
+        assert!(!entry_attached_to_network(&entry, "cella"));
+    }
+
+    #[test]
+    fn network_unavailable_mentions_macos_requirement() {
+        let err = network_unavailable("ensure_network");
+        let msg = err.to_string();
+        assert!(msg.contains("apple-container"), "msg: {msg}");
+        assert!(msg.contains("macOS 26"), "msg: {msg}");
     }
 
     /// Test helper: a status with the given state and no network attachments.
@@ -1276,7 +1640,7 @@ mod tests {
     fn build_create_args_passes_capabilities() {
         let mut opts = minimal_create_opts();
         opts.cap_add = vec!["SYS_PTRACE".to_string(), "NET_RAW".to_string()];
-        let args = build_create_args(&opts);
+        let args = build_create_args(&opts, &[]);
 
         let cap_values: Vec<&str> = args
             .windows(2)
@@ -1377,7 +1741,7 @@ mod tests {
             read_only: false,
             external: false,
         }];
-        let args = build_create_args(&opts);
+        let args = build_create_args(&opts, &[]);
 
         let mut pairs = args.windows(2).map(|w| (w[0].as_str(), w[1].as_str()));
         assert!(pairs.any(|p| p == ("--tmpfs", "/run/scratch")));
@@ -1449,7 +1813,7 @@ mod tests {
                 external: false,
             },
         ];
-        let args = build_create_args(&opts);
+        let args = build_create_args(&opts, &[]);
 
         let vol_args: Vec<&str> = args
             .windows(2)
@@ -1482,7 +1846,7 @@ mod tests {
             read_only: true,
             external: false,
         }];
-        let args = build_create_args(&opts);
+        let args = build_create_args(&opts, &[]);
 
         let vol_args: Vec<&str> = args
             .windows(2)
@@ -1510,7 +1874,7 @@ mod tests {
                 host_port: Some("8443".to_string()),
             }],
         );
-        let args = build_create_args(&opts);
+        let args = build_create_args(&opts, &[]);
 
         let port_idx = args.iter().position(|a| a == "-p").unwrap();
         assert_eq!(args[port_idx + 1], "127.0.0.1:8443:443/tcp");
@@ -1526,7 +1890,7 @@ mod tests {
                 host_port: None,
             }],
         );
-        let args = build_create_args(&opts);
+        let args = build_create_args(&opts, &[]);
 
         let port_idx = args.iter().position(|a| a == "-p").unwrap();
         assert_eq!(args[port_idx + 1], "0.0.0.0::80/tcp");
@@ -1542,7 +1906,7 @@ mod tests {
                 host_port: None,
             }],
         );
-        let args = build_create_args(&opts);
+        let args = build_create_args(&opts, &[]);
 
         let port_idx = args.iter().position(|a| a == "-p").unwrap();
         // When both host_ip and host_port are None, just the container port.
@@ -1565,7 +1929,7 @@ mod tests {
                 },
             ],
         );
-        let args = build_create_args(&opts);
+        let args = build_create_args(&opts, &[]);
 
         let port_count = args.iter().filter(|a| *a == "-p").count();
         assert_eq!(port_count, 2);
@@ -1575,7 +1939,7 @@ mod tests {
     fn build_create_args_empty_entrypoint_is_skipped() {
         let mut opts = minimal_create_opts();
         opts.entrypoint = Some(Vec::new());
-        let args = build_create_args(&opts);
+        let args = build_create_args(&opts, &[]);
 
         assert!(
             !args.contains(&"--entrypoint".to_string()),
@@ -1586,7 +1950,7 @@ mod tests {
     #[test]
     fn build_create_args_none_entrypoint_is_skipped() {
         let opts = minimal_create_opts();
-        let args = build_create_args(&opts);
+        let args = build_create_args(&opts, &[]);
 
         assert!(
             !args.contains(&"--entrypoint".to_string()),

--- a/crates/cella-container/src/backend.rs
+++ b/crates/cella-container/src/backend.rs
@@ -514,16 +514,8 @@ impl ContainerBackend for AppleContainerBackend {
         image: &'a str,
     ) -> BoxFuture<'a, Result<ImageDetails, BackendError>> {
         Box::pin(async move {
-            // The Apple Container CLI's image inspect format is not fully
-            // documented. For now we return sensible defaults and parse what
-            // we can from the raw JSON output.
-            // TODO: parse OCI image config for user, env, labels once the
-            // CLI output format stabilizes.
             let raw = self.cli.image_inspect(image).await?;
-
-            // Attempt to extract user and env from a JSON blob that might
-            // contain Docker-style config fields.
-            let (user, env, metadata) = parse_image_details_best_effort(&raw);
+            let (user, env, metadata) = parse_image_details(&raw, host_oci_arch());
 
             Ok(ImageDetails {
                 user,
@@ -608,9 +600,12 @@ impl ContainerBackend for AppleContainerBackend {
     }
 
     fn host_gateway(&self) -> &'static str {
-        // Apple Container uses the standard macOS localhost; containers
-        // can reach the host via this address when networking is enabled.
-        "host.local"
+        // Apple Container ships no automatic host alias. Apple's documented
+        // convention is a user-created localhost domain:
+        //   sudo container system dns create host.container.internal --localhost <ip>
+        // Returning that name makes cella's injected URLs work as soon as
+        // the user runs the one-time setup.
+        "host.container.internal"
     }
 
     // -- Platform detection --
@@ -1248,44 +1243,87 @@ fn entry_to_container_info(entry: &ContainerListEntry) -> Option<ContainerInfo> 
     })
 }
 
-/// Best-effort extraction of user, env, and metadata from raw image inspect JSON.
-fn parse_image_details_best_effort(raw: &str) -> (String, Vec<String>, Option<String>) {
+/// The OCI architecture string for the host (`arm64`/`amd64`).
+const fn host_oci_arch() -> &'static str {
+    if cfg!(target_arch = "aarch64") {
+        "arm64"
+    } else {
+        "amd64"
+    }
+}
+
+/// Extract user, env, and devcontainer metadata from `container image
+/// inspect` output.
+///
+/// The CLI emits an array of image resources whose `variants[].config`
+/// carry full OCI image configs; the variant matching `prefer_arch` wins,
+/// falling back to the first variant. Docker-style top-level `Config`
+/// objects are also recognized for robustness.
+fn parse_image_details(raw: &str, prefer_arch: &str) -> (String, Vec<String>, Option<String>) {
     let mut user = "root".to_string();
     let mut env = Vec::new();
     let mut metadata = None;
 
-    if let Ok(value) = serde_json::from_str::<serde_json::Value>(raw) {
-        // Try Docker-style config paths.
-        let config = value
-            .get("Config")
-            .or_else(|| value.get("config"))
-            .or_else(|| value.get("container_config"));
-
-        if let Some(cfg) = config {
-            if let Some(u) = cfg.get("User").or_else(|| cfg.get("user"))
-                && let Some(u_str) = u.as_str()
-                && !u_str.is_empty()
-            {
-                // Take only the user part (before any colon).
-                user = u_str.split(':').next().unwrap_or(u_str).to_string();
-            }
-            if let Some(e) = cfg.get("Env").or_else(|| cfg.get("env"))
-                && let Some(arr) = e.as_array()
-            {
-                env = arr
-                    .iter()
-                    .filter_map(|v| v.as_str().map(String::from))
-                    .collect();
-            }
-            if let Some(labels) = cfg.get("Labels").or_else(|| cfg.get("labels"))
-                && let Some(md) = labels.get("devcontainer.metadata").and_then(|v| v.as_str())
-            {
-                metadata = Some(md.to_string());
-            }
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(raw)
+        && let Some(cfg) = find_oci_config(&value, prefer_arch)
+    {
+        if let Some(u) = cfg.get("User").or_else(|| cfg.get("user"))
+            && let Some(u_str) = u.as_str()
+            && !u_str.is_empty()
+        {
+            // Take only the user part (before any colon).
+            user = u_str.split(':').next().unwrap_or(u_str).to_string();
+        }
+        if let Some(e) = cfg.get("Env").or_else(|| cfg.get("env"))
+            && let Some(arr) = e.as_array()
+        {
+            env = arr
+                .iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect();
+        }
+        if let Some(labels) = cfg.get("Labels").or_else(|| cfg.get("labels"))
+            && let Some(md) = labels.get("devcontainer.metadata").and_then(|v| v.as_str())
+        {
+            metadata = Some(md.to_string());
         }
     }
 
     (user, env, metadata)
+}
+
+/// Locate the OCI runtime `config` object inside image inspect JSON,
+/// preferring the variant built for `prefer_arch`.
+fn find_oci_config<'v>(
+    value: &'v serde_json::Value,
+    prefer_arch: &str,
+) -> Option<&'v serde_json::Value> {
+    // The CLI wraps results in an array; tolerate a bare object too.
+    let resource = if let Some(arr) = value.as_array() {
+        arr.first()?
+    } else {
+        value
+    };
+
+    // 1.0.0 shape: image resource with per-platform variants.
+    if let Some(variants) = resource.get("variants").and_then(|v| v.as_array()) {
+        let preferred = variants.iter().find(|var| {
+            var.get("platform")
+                .and_then(|p| p.get("architecture"))
+                .and_then(|a| a.as_str())
+                == Some(prefer_arch)
+        });
+        let variant = preferred.or_else(|| variants.first())?;
+        return variant
+            .get("config")
+            .and_then(|img| img.get("config").or_else(|| img.get("Config")));
+    }
+
+    // Docker-style fallback.
+    resource
+        .get("Config")
+        .or_else(|| resource.get("config"))
+        .or_else(|| resource.get("container_config"))
 }
 
 // ---------------------------------------------------------------------------
@@ -1614,7 +1652,7 @@ mod tests {
             }
         }"#;
 
-        let (user, env, metadata) = parse_image_details_best_effort(raw);
+        let (user, env, metadata) = parse_image_details(raw, "arm64");
         assert_eq!(user, "vscode");
         assert_eq!(env.len(), 2);
         assert!(metadata.is_some());
@@ -1622,7 +1660,7 @@ mod tests {
 
     #[test]
     fn parse_image_details_empty_json() {
-        let (user, env, metadata) = parse_image_details_best_effort("{}");
+        let (user, env, metadata) = parse_image_details("{}", "arm64");
         assert_eq!(user, "root");
         assert!(env.is_empty());
         assert!(metadata.is_none());
@@ -1630,7 +1668,7 @@ mod tests {
 
     #[test]
     fn parse_image_details_invalid_json() {
-        let (user, env, metadata) = parse_image_details_best_effort("not json");
+        let (user, env, metadata) = parse_image_details("not json", "arm64");
         assert_eq!(user, "root");
         assert!(env.is_empty());
         assert!(metadata.is_none());
@@ -2105,7 +2143,87 @@ mod tests {
         assert_eq!(info.mounts[0].mount_type, "");
     }
 
-    // -- Additional parse_image_details_best_effort edge cases ----------------
+    #[test]
+    fn parse_image_details_one_zero_variants() {
+        let raw = r#"[{
+            "id": "abc",
+            "configuration": {
+                "name": "ghcr.io/foo/devimage:latest",
+                "creationDate": 771234567.0,
+                "descriptor": { "digest": "sha256:abc", "size": 1 }
+            },
+            "variants": [
+                {
+                    "platform": { "architecture": "amd64", "os": "linux" },
+                    "digest": "sha256:d1",
+                    "size": 100,
+                    "config": {
+                        "architecture": "amd64",
+                        "os": "linux",
+                        "config": { "User": "intel-user", "Env": ["A=1"] }
+                    }
+                },
+                {
+                    "platform": { "architecture": "arm64", "os": "linux" },
+                    "digest": "sha256:d2",
+                    "size": 100,
+                    "config": {
+                        "architecture": "arm64",
+                        "os": "linux",
+                        "config": {
+                            "User": "vscode",
+                            "Env": ["PATH=/usr/bin", "HOME=/home/vscode"],
+                            "Labels": {
+                                "devcontainer.metadata": "[{\"remoteUser\":\"vscode\"}]"
+                            }
+                        }
+                    }
+                }
+            ]
+        }]"#;
+
+        let (user, env, metadata) = parse_image_details(raw, "arm64");
+        assert_eq!(user, "vscode", "must pick the arm64 variant");
+        assert_eq!(env, vec!["PATH=/usr/bin", "HOME=/home/vscode"]);
+        assert!(metadata.is_some());
+
+        let (user, _, _) = parse_image_details(raw, "amd64");
+        assert_eq!(user, "intel-user", "must pick the amd64 variant");
+    }
+
+    #[test]
+    fn parse_image_details_falls_back_to_first_variant() {
+        let raw = r#"[{
+            "variants": [
+                {
+                    "platform": { "architecture": "amd64", "os": "linux" },
+                    "config": { "config": { "User": "only-user" } }
+                }
+            ]
+        }]"#;
+
+        let (user, _, _) = parse_image_details(raw, "arm64");
+        assert_eq!(
+            user, "only-user",
+            "no arch match should fall back to the first variant"
+        );
+    }
+
+    #[test]
+    fn parse_image_details_empty_variants() {
+        let raw = r#"[{ "variants": [] }]"#;
+        let (user, env, metadata) = parse_image_details(raw, "arm64");
+        assert_eq!(user, "root");
+        assert!(env.is_empty());
+        assert!(metadata.is_none());
+    }
+
+    #[test]
+    fn host_oci_arch_is_known_value() {
+        assert!(matches!(host_oci_arch(), "arm64" | "amd64"));
+    }
+
+    // -- Additional parse_image_details edge cases -----------------------------
 
     #[test]
     fn parse_image_details_lowercase_keys() {
@@ -2118,7 +2236,7 @@ mod tests {
                 }
             }
         }"#;
-        let (user, env, metadata) = parse_image_details_best_effort(raw);
+        let (user, env, metadata) = parse_image_details(raw, "arm64");
         assert_eq!(user, "app");
         assert_eq!(env, vec!["PATH=/usr/bin"]);
         assert!(metadata.is_some());
@@ -2132,7 +2250,7 @@ mod tests {
                 "Env": ["LANG=C"]
             }
         }"#;
-        let (user, env, metadata) = parse_image_details_best_effort(raw);
+        let (user, env, metadata) = parse_image_details(raw, "arm64");
         assert_eq!(user, "deploy");
         assert_eq!(env, vec!["LANG=C"]);
         assert!(metadata.is_none());
@@ -2141,7 +2259,7 @@ mod tests {
     #[test]
     fn parse_image_details_user_with_colon() {
         let raw = r#"{"Config": {"User": "1000:1000"}}"#;
-        let (user, env, metadata) = parse_image_details_best_effort(raw);
+        let (user, env, metadata) = parse_image_details(raw, "arm64");
         assert_eq!(user, "1000");
         assert!(env.is_empty());
         assert!(metadata.is_none());
@@ -2150,14 +2268,14 @@ mod tests {
     #[test]
     fn parse_image_details_empty_user_stays_root() {
         let raw = r#"{"Config": {"User": ""}}"#;
-        let (user, _, _) = parse_image_details_best_effort(raw);
+        let (user, _, _) = parse_image_details(raw, "arm64");
         assert_eq!(user, "root");
     }
 
     #[test]
     fn parse_image_details_no_labels() {
         let raw = r#"{"Config": {"User": "web", "Env": []}}"#;
-        let (user, env, metadata) = parse_image_details_best_effort(raw);
+        let (user, env, metadata) = parse_image_details(raw, "arm64");
         assert_eq!(user, "web");
         assert!(env.is_empty());
         assert!(metadata.is_none());
@@ -2166,7 +2284,7 @@ mod tests {
     #[test]
     fn parse_image_details_env_with_non_string_values() {
         let raw = r#"{"Config": {"Env": ["GOOD=val", 42, null]}}"#;
-        let (_, env, _) = parse_image_details_best_effort(raw);
+        let (_, env, _) = parse_image_details(raw, "arm64");
         // Only string values should be collected.
         assert_eq!(env, vec!["GOOD=val"]);
     }

--- a/crates/cella-container/src/backend.rs
+++ b/crates/cella-container/src/backend.rs
@@ -7,7 +7,7 @@ use std::process::Stdio;
 use cella_backend::{
     BackendCapabilities, BackendError, BackendKind, BoxFuture, BuildOptions, ContainerBackend,
     ContainerInfo, ContainerState, CreateContainerOptions, ExecOptions, ExecResult, FileToUpload,
-    ImageDetails, InteractiveExecOptions, MountInfo, Platform, PortBinding,
+    ImageDetails, InteractiveExecOptions, MountInfo, Platform, PortBinding, RunArgsOverrides,
 };
 use tracing::{debug, warn};
 
@@ -642,11 +642,17 @@ fn build_create_args(opts: &CreateContainerOptions) -> Vec<String> {
         args.push(format!("{}:{}{ro_suffix}", wm.source, wm.target));
     }
 
-    // Additional mounts
+    // Additional mounts. Named volumes work through `-v name:target`
+    // natively; tmpfs entries use the dedicated flag.
     for mount in &opts.mounts {
-        args.push("--volume".to_string());
-        let ro_suffix = if mount.read_only { ":ro" } else { "" };
-        args.push(format!("{}:{}{ro_suffix}", mount.source, mount.target));
+        if mount.mount_type == "tmpfs" {
+            args.push("--tmpfs".to_string());
+            args.push(mount.target.clone());
+        } else {
+            args.push("--volume".to_string());
+            let ro_suffix = if mount.read_only { ":ro" } else { "" };
+            args.push(format!("{}:{}{ro_suffix}", mount.source, mount.target));
+        }
     }
 
     // Port bindings
@@ -675,6 +681,17 @@ fn build_create_args(opts: &CreateContainerOptions) -> Vec<String> {
         args.push(ep.join(" "));
     }
 
+    // Linux capabilities (supported since Apple Container 0.12.0).
+    for cap in &opts.cap_add {
+        args.push("--cap-add".to_string());
+        args.push(cap.clone());
+    }
+
+    // runArgs overrides with native CLI equivalents.
+    if let Some(ref overrides) = opts.run_args_overrides {
+        push_override_args(&mut args, overrides);
+    }
+
     // SSH agent forwarding
     if std::env::var("SSH_AUTH_SOCK").is_ok() {
         args.push("--ssh".to_string());
@@ -696,16 +713,119 @@ fn build_create_args(opts: &CreateContainerOptions) -> Vec<String> {
     args
 }
 
+/// Append runArgs overrides that have native Apple Container equivalents.
+fn push_override_args(args: &mut Vec<String>, overrides: &RunArgsOverrides) {
+    if let Some(memory) = overrides.memory
+        && memory > 0
+    {
+        args.push("--memory".to_string());
+        args.push(memory.to_string());
+    }
+
+    // Docker counts in nano-CPUs; Apple Container allocates whole vCPUs.
+    if let Some(nano_cpus) = overrides.nano_cpus
+        && let Ok(nano) = u64::try_from(nano_cpus)
+        && nano > 0
+    {
+        args.push("--cpus".to_string());
+        args.push(nano.div_ceil(1_000_000_000).to_string());
+    }
+
+    if let Some(shm_size) = overrides.shm_size
+        && shm_size > 0
+    {
+        args.push("--shm-size".to_string());
+        args.push(shm_size.to_string());
+    }
+
+    if overrides.init == Some(true) {
+        args.push("--init".to_string());
+    }
+
+    for ip in &overrides.dns {
+        args.push("--dns".to_string());
+        args.push(ip.clone());
+    }
+    for domain in &overrides.dns_search {
+        args.push("--dns-search".to_string());
+        args.push(domain.clone());
+    }
+
+    for ulimit in &overrides.ulimits {
+        args.push("--ulimit".to_string());
+        args.push(format!("{}={}:{}", ulimit.name, ulimit.soft, ulimit.hard));
+    }
+
+    for (path, options) in &overrides.tmpfs {
+        if !options.is_empty() {
+            warn!(
+                path,
+                options, "tmpfs mount options are not supported by Apple Container; mounting plain"
+            );
+        }
+        args.push("--tmpfs".to_string());
+        args.push(path.clone());
+    }
+
+    for (key, value) in &overrides.labels {
+        args.push("--label".to_string());
+        args.push(format!("{key}={value}"));
+    }
+
+    if let Some(ref runtime) = overrides.runtime {
+        args.push("--runtime".to_string());
+        args.push(runtime.clone());
+    }
+}
+
+/// Collect runArgs override flags that Apple Container has no equivalent for.
+fn collect_unsupported_overrides(overrides: &RunArgsOverrides) -> Vec<&'static str> {
+    let mut ignored = Vec::new();
+
+    let flags: [(bool, &'static str); 22] = [
+        (overrides.network_mode.is_some(), "--network"),
+        (overrides.hostname.is_some(), "--hostname"),
+        (!overrides.extra_hosts.is_empty(), "--add-host"),
+        (overrides.mac_address.is_some(), "--mac-address"),
+        (overrides.memory_swap.is_some(), "--memory-swap"),
+        (
+            overrides.memory_reservation.is_some(),
+            "--memory-reservation",
+        ),
+        (overrides.cpu_shares.is_some(), "--cpu-shares"),
+        (overrides.cpu_period.is_some(), "--cpu-period"),
+        (overrides.cpu_quota.is_some(), "--cpu-quota"),
+        (overrides.cpuset_cpus.is_some(), "--cpuset-cpus"),
+        (overrides.cpuset_mems.is_some(), "--cpuset-mems"),
+        (overrides.pids_limit.is_some(), "--pids-limit"),
+        (overrides.userns_mode.is_some(), "--userns"),
+        (overrides.cgroup_parent.is_some(), "--cgroup-parent"),
+        (overrides.cgroupns_mode.is_some(), "--cgroupns"),
+        (!overrides.sysctls.is_empty(), "--sysctl"),
+        (overrides.pid_mode.is_some(), "--pid"),
+        (overrides.ipc_mode.is_some(), "--ipc"),
+        (overrides.uts_mode.is_some(), "--uts"),
+        (!overrides.storage_opt.is_empty(), "--storage-opt"),
+        (
+            overrides.log_driver.is_some() || !overrides.log_opt.is_empty(),
+            "--log-driver/--log-opt",
+        ),
+        (overrides.restart_policy.is_some(), "--restart"),
+    ];
+
+    for (present, flag) in flags {
+        if present {
+            ignored.push(flag);
+        }
+    }
+
+    ignored
+}
+
 /// Emit warnings for Docker-specific options that Apple Container does not support.
 fn emit_unsupported_warnings(opts: &CreateContainerOptions) {
     if opts.privileged {
         warn!("--privileged is not supported by Apple Container; ignoring");
-    }
-    if !opts.cap_add.is_empty() {
-        warn!(
-            caps = ?opts.cap_add,
-            "--cap-add is not supported by Apple Container; ignoring"
-        );
     }
     if !opts.security_opt.is_empty() {
         warn!(
@@ -723,6 +843,13 @@ fn emit_unsupported_warnings(opts: &CreateContainerOptions) {
         }
         if overrides.gpus.is_some() {
             warn!("--gpus is not supported by Apple Container; ignoring");
+        }
+        let ignored = collect_unsupported_overrides(overrides);
+        if !ignored.is_empty() {
+            warn!(
+                flags = ?ignored,
+                "runArgs not supported by Apple Container; ignoring"
+            );
         }
         if !overrides.unrecognized.is_empty() {
             warn!(
@@ -1143,6 +1270,143 @@ mod tests {
         assert_eq!(user, "root");
         assert!(env.is_empty());
         assert!(metadata.is_none());
+    }
+
+    #[test]
+    fn build_create_args_passes_capabilities() {
+        let mut opts = minimal_create_opts();
+        opts.cap_add = vec!["SYS_PTRACE".to_string(), "NET_RAW".to_string()];
+        let args = build_create_args(&opts);
+
+        let cap_values: Vec<&str> = args
+            .windows(2)
+            .filter(|w| w[0] == "--cap-add")
+            .map(|w| w[1].as_str())
+            .collect();
+        assert_eq!(cap_values, vec!["SYS_PTRACE", "NET_RAW"]);
+    }
+
+    #[test]
+    fn push_override_args_maps_resources() {
+        let overrides = RunArgsOverrides {
+            memory: Some(2_147_483_648),
+            nano_cpus: Some(1_500_000_000),
+            shm_size: Some(67_108_864),
+            init: Some(true),
+            ..RunArgsOverrides::default()
+        };
+        let mut args = Vec::new();
+        push_override_args(&mut args, &overrides);
+
+        let pairs: Vec<(&str, &str)> = args
+            .windows(2)
+            .map(|w| (w[0].as_str(), w[1].as_str()))
+            .collect();
+        assert!(pairs.contains(&("--memory", "2147483648")));
+        // 1.5 CPUs rounds up to 2 whole vCPUs.
+        assert!(pairs.contains(&("--cpus", "2")));
+        assert!(pairs.contains(&("--shm-size", "67108864")));
+        assert!(args.contains(&"--init".to_string()));
+    }
+
+    #[test]
+    fn push_override_args_maps_dns_and_ulimits() {
+        let overrides = RunArgsOverrides {
+            dns: vec!["1.1.1.1".to_string()],
+            dns_search: vec!["internal.example".to_string()],
+            ulimits: vec![cella_backend::UlimitSpec {
+                name: "nofile".to_string(),
+                soft: 1024,
+                hard: 4096,
+            }],
+            ..RunArgsOverrides::default()
+        };
+        let mut args = Vec::new();
+        push_override_args(&mut args, &overrides);
+
+        let pairs: Vec<(&str, &str)> = args
+            .windows(2)
+            .map(|w| (w[0].as_str(), w[1].as_str()))
+            .collect();
+        assert!(pairs.contains(&("--dns", "1.1.1.1")));
+        assert!(pairs.contains(&("--dns-search", "internal.example")));
+        assert!(pairs.contains(&("--ulimit", "nofile=1024:4096")));
+    }
+
+    #[test]
+    fn push_override_args_maps_tmpfs_labels_runtime() {
+        let overrides = RunArgsOverrides {
+            tmpfs: HashMap::from([("/scratch".to_string(), String::new())]),
+            labels: HashMap::from([("from.runargs".to_string(), "yes".to_string())]),
+            runtime: Some("container-runtime-linux".to_string()),
+            ..RunArgsOverrides::default()
+        };
+        let mut args = Vec::new();
+        push_override_args(&mut args, &overrides);
+
+        let pairs: Vec<(&str, &str)> = args
+            .windows(2)
+            .map(|w| (w[0].as_str(), w[1].as_str()))
+            .collect();
+        assert!(pairs.contains(&("--tmpfs", "/scratch")));
+        assert!(pairs.contains(&("--label", "from.runargs=yes")));
+        assert!(pairs.contains(&("--runtime", "container-runtime-linux")));
+    }
+
+    #[test]
+    fn push_override_args_skips_non_positive_resources() {
+        let overrides = RunArgsOverrides {
+            memory: Some(0),
+            nano_cpus: Some(-1),
+            shm_size: Some(0),
+            ..RunArgsOverrides::default()
+        };
+        let mut args = Vec::new();
+        push_override_args(&mut args, &overrides);
+        assert!(args.is_empty(), "non-positive resources must be skipped");
+    }
+
+    #[test]
+    fn build_create_args_tmpfs_mount_config() {
+        let mut opts = minimal_create_opts();
+        opts.mounts = vec![MountConfig {
+            mount_type: "tmpfs".to_string(),
+            source: String::new(),
+            target: "/run/scratch".to_string(),
+            consistency: None,
+            read_only: false,
+            external: false,
+        }];
+        let args = build_create_args(&opts);
+
+        let mut pairs = args.windows(2).map(|w| (w[0].as_str(), w[1].as_str()));
+        assert!(pairs.any(|p| p == ("--tmpfs", "/run/scratch")));
+        assert!(
+            !args.iter().any(|a| a.starts_with(":/run/scratch")),
+            "tmpfs must not be emitted as an empty-source volume"
+        );
+    }
+
+    #[test]
+    fn collect_unsupported_overrides_lists_flags() {
+        let overrides = RunArgsOverrides {
+            network_mode: Some("host".to_string()),
+            hostname: Some("custom".to_string()),
+            sysctls: HashMap::from([("net.core.somaxconn".to_string(), "1024".to_string())]),
+            restart_policy: Some("always".to_string()),
+            ..RunArgsOverrides::default()
+        };
+        let ignored = collect_unsupported_overrides(&overrides);
+        assert!(ignored.contains(&"--network"));
+        assert!(ignored.contains(&"--hostname"));
+        assert!(ignored.contains(&"--sysctl"));
+        assert!(ignored.contains(&"--restart"));
+        assert_eq!(ignored.len(), 4);
+    }
+
+    #[test]
+    fn collect_unsupported_overrides_empty_for_default() {
+        assert!(collect_unsupported_overrides(&RunArgsOverrides::default()).is_empty());
     }
 
     #[test]

--- a/crates/cella-container/src/backend.rs
+++ b/crates/cella-container/src/backend.rs
@@ -259,21 +259,8 @@ impl ContainerBackend for AppleContainerBackend {
             let canonical = workspace_root
                 .canonicalize()
                 .unwrap_or_else(|_| workspace_root.to_path_buf());
-            let canonical_str = canonical.to_string_lossy();
-
-            let entries = self.cli.list().await?;
-
-            for entry in entries {
-                if let Some(info) = entry_to_container_info(&entry)
-                    && info
-                        .labels
-                        .get("dev.cella.workspace_path")
-                        .is_some_and(|wp| wp == canonical_str.as_ref())
-                {
-                    return Ok(Some(info));
-                }
-            }
-            Ok(None)
+            let label = format!("dev.cella.workspace_path={}", canonical.to_string_lossy());
+            self.find_container_by_label(&label).await
         })
     }
 
@@ -679,11 +666,7 @@ impl ContainerBackend for AppleContainerBackend {
         Box::pin(async move {
             Ok(Platform {
                 os: "linux".to_string(),
-                arch: if cfg!(target_arch = "aarch64") {
-                    "arm64".to_string()
-                } else {
-                    "amd64".to_string()
-                },
+                arch: host_oci_arch().to_string(),
             })
         })
     }
@@ -1220,20 +1203,13 @@ fn entry_to_container_info(entry: &ContainerListEntry) -> Option<ContainerInfo> 
     let config = entry.configuration.as_ref()?;
     let id = config.id.clone()?;
 
-    let state = entry
-        .status
-        .as_ref()
-        .and_then(|s| s.state.as_deref())
-        .map_or_else(
-            || ContainerState::Other("unknown".to_string()),
-            |s| {
-                // Apple Container uses "stopped" rather than Docker's "exited".
-                match s {
-                    "stopped" => ContainerState::Stopped,
-                    other => ContainerState::parse(other),
-                }
-            },
-        );
+    let state = ContainerState::parse(
+        entry
+            .status
+            .as_ref()
+            .and_then(|s| s.state.as_deref())
+            .unwrap_or("unknown"),
+    );
 
     let labels = config.labels.clone().unwrap_or_default();
     let config_hash = labels.get("dev.cella.config_hash").cloned();

--- a/crates/cella-container/src/backend.rs
+++ b/crates/cella-container/src/backend.rs
@@ -269,6 +269,17 @@ impl ContainerBackend for AppleContainerBackend {
         opts: &'a CreateContainerOptions,
     ) -> BoxFuture<'a, Result<String, BackendError>> {
         Box::pin(async move {
+            // The image is the only argv token not anchored to a flag, so a
+            // leading dash would be parsed as an option. A `--` separator is
+            // no defense: the CLI's passthrough arguments capture it as a
+            // literal (swift-argument-parser captureForPassthrough). Valid
+            // OCI references never start with `-`, so reject instead.
+            if opts.image.starts_with('-') {
+                return Err(BackendError::Runtime(
+                    format!("invalid image reference '{}'", opts.image).into(),
+                ));
+            }
+
             // Network attachments are fixed at creation, so the shared and
             // per-workspace networks must exist (and be requested) up front.
             let networks = self.prepare_create_networks(opts).await;
@@ -1702,6 +1713,22 @@ mod tests {
         assert_eq!(user, "root");
         assert!(env.is_empty());
         assert!(metadata.is_none());
+    }
+
+    #[tokio::test]
+    async fn create_container_rejects_dash_prefixed_image() {
+        let backend = AppleContainerBackend::new(ContainerCli::new(
+            std::path::PathBuf::from("/nonexistent/container"),
+            "1.0.0".to_string(),
+        ));
+        let mut opts = minimal_create_opts();
+        opts.image = "--volume=/:/host".to_string();
+
+        let err = backend.create_container(&opts).await.unwrap_err();
+        assert!(
+            err.to_string().contains("invalid image reference"),
+            "got: {err}"
+        );
     }
 
     #[test]

--- a/crates/cella-container/src/backend.rs
+++ b/crates/cella-container/src/backend.rs
@@ -1597,9 +1597,7 @@ mod tests {
         let mut status = test_status("running");
         status.networks = vec![crate::sdk::types::NetworkAttachment {
             network: Some("cella-net-abc".to_string()),
-            hostname: None,
             ipv4_address: Some("192.168.65.2/24".to_string()),
-            ipv4_gateway: None,
         }];
         let entry = ContainerListEntry {
             status: Some(status),
@@ -2147,7 +2145,6 @@ mod tests {
                 source: Some("/host".to_string()),
                 destination: Some("/container".to_string()),
                 fs_type: Some(FilesystemType::Virtiofs(serde_json::Value::Null)),
-                options: Vec::new(),
             },
             crate::sdk::types::MountEntry {
                 source: Some("/var/lib/volumes/data".to_string()),
@@ -2155,7 +2152,6 @@ mod tests {
                 fs_type: Some(FilesystemType::Volume {
                     name: Some("data".to_string()),
                 }),
-                options: Vec::new(),
             },
         ]);
         let entry = ContainerListEntry {
@@ -2234,7 +2230,6 @@ mod tests {
             source: None,
             destination: None,
             fs_type: None,
-            options: Vec::new(),
         }]);
         let entry = ContainerListEntry {
             status: None,

--- a/crates/cella-container/src/backend.rs
+++ b/crates/cella-container/src/backend.rs
@@ -34,10 +34,6 @@ pub struct AppleContainerBackend {
 impl AppleContainerBackend {
     /// Create a new backend wrapping the given CLI handle.
     pub fn new(cli: ContainerCli) -> Self {
-        warn!(
-            "Apple Container backend is EXPERIMENTAL — \
-             expect rough edges and missing features"
-        );
         Self {
             cli,
             networks_available: tokio::sync::OnceCell::new(),

--- a/crates/cella-container/src/discovery.rs
+++ b/crates/cella-container/src/discovery.rs
@@ -309,36 +309,8 @@ mod tests {
         MOCKS.get_or_init(|| {
             let dir = tempfile::TempDir::new().unwrap();
 
-            let write_script = |name: &str, body: &str| -> PathBuf {
-                use std::io::Write;
-                let path = dir.path().join(name);
-                let mut file = std::fs::File::create(&path).unwrap();
-                file.write_all(format!("#!/bin/sh\n{body}\n").as_bytes())
-                    .unwrap();
-                file.sync_all().unwrap();
-                drop(file);
-                #[cfg(unix)]
-                {
-                    use std::os::unix::fs::PermissionsExt;
-                    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
-                        .unwrap();
-                }
-                // ETXTBSY guard: the kernel may not have released the inode
-                // write reference yet (deferred __fput). Spin until exec works.
-                for _ in 0..50 {
-                    match std::process::Command::new(&path)
-                        .arg("--etxtbsy-probe")
-                        .stdout(std::process::Stdio::null())
-                        .stderr(std::process::Stdio::null())
-                        .output()
-                    {
-                        Err(e) if e.kind() == std::io::ErrorKind::ExecutableFileBusy => {
-                            std::thread::sleep(std::time::Duration::from_millis(1));
-                        }
-                        _ => break,
-                    }
-                }
-                path
+            let write_script = |name: &str, body: &str| {
+                crate::test_support::write_mock_script(dir.path(), name, body)
             };
 
             DiscMocks {

--- a/crates/cella-container/src/discovery.rs
+++ b/crates/cella-container/src/discovery.rs
@@ -1,9 +1,11 @@
 //! CLI binary discovery for the Apple Container runtime.
 //!
 //! Searches for the `container` binary using environment variables and `PATH`,
-//! then validates it by checking version output.
+//! then validates it by querying `container system version` and enforcing the
+//! minimum supported release.
 
 use std::env;
+use std::fmt;
 use std::path::{Path, PathBuf};
 
 use tracing::{debug, warn};
@@ -18,16 +20,74 @@ const ENV_BINARY_PATH: &str = "CELLA_CONTAINER_PATH";
 /// Default binary name to search for in `PATH`.
 const BINARY_NAME: &str = "container";
 
+/// Minimum supported Apple Container release.
+///
+/// 1.0.0 stabilized the CLI surface and the structured-output shapes the SDK
+/// parses (`container ls/inspect`, `image inspect`, `network`, `volume`).
+/// Earlier releases emit incompatible JSON and lack `container cp`.
+pub const MIN_SUPPORTED_VERSION: &str = "1.0.0";
+
+/// Why discovery did not produce a usable CLI handle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiscoveryError {
+    /// No `container` binary found via `CELLA_CONTAINER_PATH` or `PATH`.
+    BinaryNotFound,
+    /// A binary was found but did not behave like Apple's container CLI.
+    NotAppleContainer {
+        /// Path of the rejected binary.
+        path: PathBuf,
+        /// Human-readable reason for the rejection.
+        reason: String,
+    },
+    /// Apple's CLI was found but is older than [`MIN_SUPPORTED_VERSION`].
+    UnsupportedVersion {
+        /// Path of the outdated binary.
+        path: PathBuf,
+        /// Version string reported by the binary.
+        found: String,
+    },
+}
+
+impl fmt::Display for DiscoveryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BinaryNotFound => write!(
+                f,
+                "Apple Container CLI not found. \
+                 Install from https://github.com/apple/container"
+            ),
+            Self::NotAppleContainer { path, reason } => write!(
+                f,
+                "binary at {} is not the Apple Container CLI: {reason}",
+                path.display()
+            ),
+            Self::UnsupportedVersion { path, found } => write!(
+                f,
+                "Apple Container CLI at {} is version {found}, but cella requires \
+                 {MIN_SUPPORTED_VERSION} or newer. \
+                 Upgrade from https://github.com/apple/container/releases",
+                path.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for DiscoveryError {}
+
 /// Discover the Apple Container CLI binary.
 ///
 /// Strategy:
 /// 1. Check `CELLA_CONTAINER_PATH` environment variable
 /// 2. Search for `container` in `PATH`
-/// 3. Run `container version --format json` to validate it is Apple's tool
+/// 3. Run `container system version --format json` to validate it is Apple's
+///    tool and enforce [`MIN_SUPPORTED_VERSION`]
 ///
-/// Returns `None` if the binary is not found or is not the Apple Container CLI.
-pub fn discover() -> Option<ContainerCli> {
-    let binary_path = find_binary()?;
+/// # Errors
+///
+/// Returns [`DiscoveryError`] describing whether the binary is missing,
+/// foreign, or too old.
+pub fn discover() -> Result<ContainerCli, DiscoveryError> {
+    let binary_path = find_binary().ok_or(DiscoveryError::BinaryNotFound)?;
     debug!(path = %binary_path.display(), "found container binary");
 
     // Validate by running version command (blocking on an async operation).
@@ -39,18 +99,21 @@ pub fn discover() -> Option<ContainerCli> {
         tokio::task::block_in_place(|| handle.block_on(validate_binary(&binary_path)))
     } else {
         // No runtime yet — create a temporary one.
-        let rt = tokio::runtime::Runtime::new().ok()?;
+        let rt = tokio::runtime::Runtime::new().map_err(|e| DiscoveryError::NotAppleContainer {
+            path: binary_path.clone(),
+            reason: format!("failed to create validation runtime: {e}"),
+        })?;
         rt.block_on(validate_binary(&binary_path))
     };
 
     match version_result {
         Ok(version) => {
             debug!(version, "validated Apple Container CLI");
-            Some(ContainerCli::new(binary_path, version))
+            Ok(ContainerCli::new(binary_path, version))
         }
         Err(e) => {
-            debug!(error = %e, "binary at path is not a valid Apple Container CLI");
-            None
+            debug!(error = %e, "binary at path is not a usable Apple Container CLI");
+            Err(e)
         }
     }
 }
@@ -85,38 +148,55 @@ fn which_binary(name: &str) -> Option<PathBuf> {
     None
 }
 
-/// Validate that the binary is Apple's Container CLI and extract the version.
-///
-/// Tries `container version --format json` first. If the version plugin is not
-/// available (common with .pkg installs), falls back to `container system status`
-/// to confirm the binary is a working Apple Container CLI.
-///
-/// Returns `Err` if the binary cannot be executed or is not the Apple Container CLI.
-async fn validate_binary(binary: &Path) -> Result<String, String> {
-    match validate_via_version(binary).await {
-        Ok(version) => return Ok(version),
-        Err(e) => debug!(error = %e, "version check failed, trying system status fallback"),
+/// Validate that the binary is Apple's Container CLI running a supported
+/// release, and return the version string.
+async fn validate_binary(binary: &Path) -> Result<String, DiscoveryError> {
+    match query_version(binary).await {
+        Ok(version) => {
+            if version_supported(&version) {
+                Ok(version)
+            } else {
+                Err(DiscoveryError::UnsupportedVersion {
+                    path: binary.to_path_buf(),
+                    found: version,
+                })
+            }
+        }
+        Err(reason) => {
+            debug!(error = %reason, "system version probe failed, classifying binary");
+            // Releases before 1.0.0 may not support `system version --format
+            // json`. `system status` distinguishes an old Apple CLI (reject as
+            // outdated) from a foreign binary (reject as not Apple's tool).
+            if is_apple_container_via_system_status(binary).await {
+                Err(DiscoveryError::UnsupportedVersion {
+                    path: binary.to_path_buf(),
+                    found: "unknown (pre-1.0)".to_string(),
+                })
+            } else {
+                Err(DiscoveryError::NotAppleContainer {
+                    path: binary.to_path_buf(),
+                    reason,
+                })
+            }
+        }
     }
-
-    // Fallback: the version plugin may not be installed (e.g. .pkg installs).
-    // Use `system status` to confirm this is a working Apple Container CLI.
-    validate_via_system_status(binary).await
 }
 
-/// Try `container version --format json` for version extraction.
-async fn validate_via_version(binary: &Path) -> Result<String, String> {
-    let output = run_cli(binary, &["version", "--format", "json"])
+/// Query `container system version --format json` for the CLI version.
+async fn query_version(binary: &Path) -> Result<String, String> {
+    let output = run_cli(binary, &["system", "version", "--format", "json"])
         .await
-        .map_err(|e| format!("failed to run version command: {e}"))?;
+        .map_err(|e| format!("failed to run system version: {e}"))?;
 
     if output.exit_code != 0 {
         return Err(format!(
-            "version command exited with code {}",
+            "system version exited with code {}",
             output.exit_code
         ));
     }
 
-    // Parse as array of VersionInfo.
+    // Parse as array of VersionInfo (CLI entry plus, when the API server is
+    // running, a server entry).
     let entries: Vec<VersionInfo> = serde_json::from_str(&output.stdout)
         .map_err(|e| format!("failed to parse version JSON: {e}"))?;
 
@@ -141,32 +221,60 @@ async fn validate_via_version(binary: &Path) -> Result<String, String> {
     Err("no recognizable Apple Container version entry found".to_string())
 }
 
-/// Fallback validation using `container system status`.
-///
-/// The system plugin is always present in .pkg installs. If the command
-/// runs successfully, we know this is Apple's Container CLI.
-async fn validate_via_system_status(binary: &Path) -> Result<String, String> {
-    let output = run_cli(binary, &["system", "status"])
-        .await
-        .map_err(|e| format!("failed to run system status: {e}"))?;
+/// Probe `container system status` to tell an old Apple Container CLI apart
+/// from an unrelated binary that happens to be named `container`.
+async fn is_apple_container_via_system_status(binary: &Path) -> bool {
+    let Ok(output) = run_cli(binary, &["system", "status"]).await else {
+        return false;
+    };
 
     // Reject if the plugin itself is missing.
     if output.stderr.contains("Plugin") && output.stderr.contains("not found") {
-        return Err("system status plugin not available".to_string());
+        return false;
     }
 
-    // Reject if the command failed with a non-zero exit and no meaningful output.
-    // A running Apple Container CLI returns exit 0 for "running" or outputs
+    // A working Apple Container CLI returns exit 0 for "running" or outputs
     // status info even when the service is stopped.
-    if output.exit_code != 0 && output.stdout.trim().is_empty() {
-        return Err(format!(
-            "system status exited with code {}",
-            output.exit_code
-        ));
-    }
+    output.exit_code == 0 || !output.stdout.trim().is_empty()
+}
 
-    debug!("validated Apple Container CLI via system status fallback");
-    Ok("unknown".to_string())
+/// Check whether a reported version satisfies [`MIN_SUPPORTED_VERSION`].
+///
+/// Fails open: a version string that cannot be parsed is accepted with a
+/// warning, so a future format change in Apple's version output cannot lock
+/// users out. The gate exists to reject *known-old* releases.
+fn version_supported(version: &str) -> bool {
+    let Some(found) = parse_version(version) else {
+        warn!(
+            version,
+            "could not parse Apple Container version; assuming supported"
+        );
+        return true;
+    };
+    // MIN_SUPPORTED_VERSION is a valid literal; parse cannot fail.
+    let minimum = parse_version(MIN_SUPPORTED_VERSION).unwrap_or((1, 0, 0));
+    found >= minimum
+}
+
+/// Parse a `major.minor.patch` version string into a comparable tuple.
+///
+/// Tolerates missing segments (`"1.2"` → `(1, 2, 0)`) and non-numeric
+/// suffixes (`"1.0.0-beta.2"` → `(1, 0, 0)`). Returns `None` when the major
+/// segment has no leading digits.
+fn parse_version(version: &str) -> Option<(u64, u64, u64)> {
+    let mut segments = version.trim().splitn(3, '.');
+    let major = parse_segment(segments.next()?)?;
+    let minor = segments.next().and_then(parse_segment).unwrap_or(0);
+    let patch = segments.next().and_then(parse_segment).unwrap_or(0);
+    Some((major, minor, patch))
+}
+
+/// Parse the leading decimal digits of a version segment.
+fn parse_segment(segment: &str) -> Option<u64> {
+    let digits: &str = segment
+        .find(|c: char| !c.is_ascii_digit())
+        .map_or(segment, |end| &segment[..end]);
+    digits.parse().ok()
 }
 
 /// Check whether a version entry looks like it belongs to Apple's container tool.
@@ -187,11 +295,13 @@ mod tests {
     struct DiscMocks {
         _dir: tempfile::TempDir,
         valid_version: PathBuf,
+        old_version: PathBuf,
         fail: PathBuf,
         invalid_json: PathBuf,
         empty_array: PathBuf,
         unknown_app: PathBuf,
         no_version: PathBuf,
+        pre_one_zero: PathBuf,
     }
 
     fn disc_mocks() -> &'static DiscMocks {
@@ -238,6 +348,10 @@ mod tests {
                     "valid_version.sh",
                     r#"echo '[{"version":"2.0.0","appName":"container"}]'"#,
                 ),
+                old_version: write_script(
+                    "old_version.sh",
+                    r#"echo '[{"version":"0.12.3","appName":"container"}]'"#,
+                ),
                 fail: write_script("fail.sh", "exit 1"),
                 invalid_json: write_script("invalid_json.sh", "echo 'not json'"),
                 empty_array: write_script("empty_array.sh", "echo '[]'"),
@@ -246,6 +360,16 @@ mod tests {
                     r#"echo '[{"version":"3.0.0","appName":"some-other-tool"}]'"#,
                 ),
                 no_version: write_script("no_version.sh", "echo '[{}]'"),
+                // Pre-1.0 behavior: `system version` is unavailable but
+                // `system status` works.
+                pre_one_zero: write_script(
+                    "pre_one_zero.sh",
+                    r#"case "$1 $2" in
+"system version") echo 'Error: unknown subcommand' >&2; exit 1;;
+"system status") echo 'apiserver is running'; exit 0;;
+*) exit 1;;
+esac"#,
+                ),
                 _dir: dir,
             }
         })
@@ -323,80 +447,152 @@ mod tests {
         assert!(result.is_some(), "expected to find 'cat' in PATH");
     }
 
+    // -- parse_version / version_supported -------------------------------------
+
+    #[test]
+    fn parse_version_full() {
+        assert_eq!(parse_version("1.2.3"), Some((1, 2, 3)));
+    }
+
+    #[test]
+    fn parse_version_short() {
+        assert_eq!(parse_version("1.2"), Some((1, 2, 0)));
+        assert_eq!(parse_version("2"), Some((2, 0, 0)));
+    }
+
+    #[test]
+    fn parse_version_prerelease_suffix() {
+        assert_eq!(parse_version("1.0.0-beta.2"), Some((1, 0, 0)));
+        assert_eq!(parse_version("1.0.1+build5"), Some((1, 0, 1)));
+    }
+
+    #[test]
+    fn parse_version_garbage() {
+        assert_eq!(parse_version("unknown"), None);
+        assert_eq!(parse_version(""), None);
+    }
+
+    #[test]
+    fn version_supported_accepts_minimum_and_newer() {
+        assert!(version_supported("1.0.0"));
+        assert!(version_supported("1.0.1"));
+        assert!(version_supported("1.2.0"));
+        assert!(version_supported("2.0.0"));
+    }
+
+    #[test]
+    fn version_supported_rejects_pre_one_zero() {
+        assert!(!version_supported("0.12.3"));
+        assert!(!version_supported("0.9.0"));
+    }
+
+    #[test]
+    fn version_supported_fails_open_on_unparseable() {
+        assert!(version_supported("unknown"));
+    }
+
     // -- validate_binary tests ------------------------------------------------
 
     #[tokio::test]
-    async fn validate_via_version_with_valid_json() {
-        let result = validate_via_version(&disc_mocks().valid_version).await;
-        assert!(result.is_ok());
+    async fn query_version_with_valid_json() {
+        let result = query_version(&disc_mocks().valid_version).await;
         assert_eq!(result.unwrap(), "2.0.0");
     }
 
     #[tokio::test]
-    async fn validate_via_version_with_nonzero_exit() {
-        let result = validate_via_version(&disc_mocks().fail).await;
-        assert!(result.is_err());
+    async fn query_version_with_nonzero_exit() {
+        let result = query_version(&disc_mocks().fail).await;
         assert!(result.unwrap_err().contains("exited with code"));
     }
 
     #[tokio::test]
-    async fn validate_via_version_with_invalid_json() {
-        let result = validate_via_version(&disc_mocks().invalid_json).await;
-        assert!(result.is_err());
+    async fn query_version_with_invalid_json() {
+        let result = query_version(&disc_mocks().invalid_json).await;
         assert!(result.unwrap_err().contains("parse version JSON"));
     }
 
     #[tokio::test]
-    async fn validate_via_version_empty_array() {
-        let result = validate_via_version(&disc_mocks().empty_array).await;
-        assert!(result.is_err());
+    async fn query_version_empty_array() {
+        let result = query_version(&disc_mocks().empty_array).await;
         assert!(result.unwrap_err().contains("no recognizable"));
     }
 
     #[tokio::test]
-    async fn validate_via_version_unknown_app_name_with_version() {
-        let result = validate_via_version(&disc_mocks().unknown_app).await;
-        assert!(result.is_ok());
+    async fn query_version_unknown_app_name_with_version() {
+        let result = query_version(&disc_mocks().unknown_app).await;
         assert_eq!(result.unwrap(), "3.0.0");
     }
 
     #[tokio::test]
-    async fn validate_via_version_no_version_no_app_name() {
-        let result = validate_via_version(&disc_mocks().no_version).await;
+    async fn query_version_no_version_no_app_name() {
+        let result = query_version(&disc_mocks().no_version).await;
         assert!(result.is_err());
     }
 
     #[tokio::test]
     async fn validate_binary_nonexistent_path() {
         let result = validate_binary(Path::new("/nonexistent/binary")).await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("failed to run"));
+        assert!(matches!(
+            result,
+            Err(DiscoveryError::NotAppleContainer { .. })
+        ));
     }
 
     #[tokio::test]
-    async fn validate_binary_falls_back_to_system_status() {
-        // A script that fails `version` but succeeds for other subcommands
-        // should still be accepted via the system status fallback.
+    async fn validate_binary_rejects_old_release() {
+        let result = validate_binary(&disc_mocks().old_version).await;
+        match result {
+            Err(DiscoveryError::UnsupportedVersion { found, .. }) => {
+                assert_eq!(found, "0.12.3");
+            }
+            other => panic!("expected UnsupportedVersion, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn validate_binary_classifies_pre_one_zero_as_unsupported() {
+        let result = validate_binary(&disc_mocks().pre_one_zero).await;
+        match result {
+            Err(DiscoveryError::UnsupportedVersion { found, .. }) => {
+                assert!(found.contains("pre-1.0"), "found: {found}");
+            }
+            other => panic!("expected UnsupportedVersion, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn validate_binary_rejects_foreign_binary() {
+        // fail.sh exits 1 for every subcommand: neither the version probe nor
+        // the system status probe recognizes it.
         let result = validate_binary(&disc_mocks().fail).await;
-        // fail.sh exits 1 for all args, so both version and system status fail.
-        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            Err(DiscoveryError::NotAppleContainer { .. })
+        ));
     }
 
     #[tokio::test]
-    async fn validate_binary_uses_version_when_available() {
+    async fn validate_binary_accepts_supported_release() {
         let result = validate_binary(&disc_mocks().valid_version).await;
-        assert!(result.is_ok());
         assert_eq!(result.unwrap(), "2.0.0");
     }
 
-    // -- is_apple_container_entry additional tests ----------------------------
+    // -- DiscoveryError display -------------------------------------------------
 
     #[test]
-    fn is_apple_container_entry_partial_name_match() {
-        let entry = VersionInfo {
-            version: Some("1.0.0".to_string()),
-            app_name: Some("MyContainerApp".to_string()),
-        };
-        assert!(is_apple_container_entry(&entry));
+    fn discovery_error_not_found_mentions_install() {
+        let msg = DiscoveryError::BinaryNotFound.to_string();
+        assert!(msg.contains("github.com/apple/container"));
+    }
+
+    #[test]
+    fn discovery_error_unsupported_mentions_minimum() {
+        let msg = DiscoveryError::UnsupportedVersion {
+            path: PathBuf::from("/usr/local/bin/container"),
+            found: "0.12.3".to_string(),
+        }
+        .to_string();
+        assert!(msg.contains("0.12.3"));
+        assert!(msg.contains(MIN_SUPPORTED_VERSION));
     }
 }

--- a/crates/cella-container/src/discovery.rs
+++ b/crates/cella-container/src/discovery.rs
@@ -212,10 +212,8 @@ async fn query_version(binary: &Path) -> Result<String, String> {
 
     // If we got valid JSON with at least one entry, accept it even if the
     // app_name doesn't exactly match — the CLI format may evolve.
-    if let Some(first) = entries.first()
-        && first.version.is_some()
-    {
-        return Ok(first.version.clone().unwrap_or_default());
+    if let Some(version) = entries.first().and_then(|e| e.version.clone()) {
+        return Ok(version);
     }
 
     Err("no recognizable Apple Container version entry found".to_string())

--- a/crates/cella-container/src/integration_tests.rs
+++ b/crates/cella-container/src/integration_tests.rs
@@ -570,3 +570,81 @@ async fn test_workspace_folder_label_set() {
         Some("/workspace"),
     );
 }
+
+#[cella_testing::runtime_test(apple_container, flavor = "multi_thread")]
+async fn test_network_ensure_and_exists() {
+    let (backend, _cli_path) = setup_backend();
+
+    // Network commands need macOS 26+; skip quietly on older hosts where
+    // the backend reports NotSupported.
+    match backend.ensure_network().await {
+        Ok(()) => {}
+        Err(cella_backend::BackendError::NotSupported { .. }) => return,
+        Err(e) => panic!("ensure_network failed: {e}"),
+    }
+
+    assert!(
+        backend.network_exists("cella").await.unwrap(),
+        "cella network should exist after ensure_network"
+    );
+
+    let managed = backend.list_managed_networks().await.unwrap();
+    assert!(
+        managed.iter().any(|n| n.name == "cella"),
+        "cella network should be listed as managed: {managed:?}"
+    );
+}
+
+#[cella_testing::runtime_test(apple_container, flavor = "multi_thread")]
+async fn test_container_attaches_to_networks_and_reports_ip() {
+    let (backend, cli_path) = setup_backend();
+
+    match backend.ensure_network().await {
+        Ok(()) => {}
+        Err(cella_backend::BackendError::NotSupported { .. }) => return,
+        Err(e) => panic!("ensure_network failed: {e}"),
+    }
+
+    let name = test_container_name("netattach");
+    let mut guard = ContainerGuard::new(cli_path);
+    let workspace = std::env::temp_dir().join(&name);
+    std::fs::create_dir_all(&workspace).unwrap();
+    let canonical = workspace.canonicalize().unwrap();
+
+    backend.pull_image(TEST_IMAGE).await.unwrap();
+
+    let mut opts = minimal_create_opts(&name);
+    opts.labels
+        .insert("dev.cella.tool".to_string(), "cella".to_string());
+    opts.labels.insert(
+        "dev.cella.workspace_path".to_string(),
+        canonical.to_string_lossy().to_string(),
+    );
+
+    let id = backend.create_container(&opts).await.unwrap();
+    guard.set_id(id.clone());
+    backend.start_container(&id).await.unwrap();
+
+    // The create-time attachments must satisfy ensure_container_network.
+    backend
+        .ensure_container_network(&id, &canonical)
+        .await
+        .unwrap();
+
+    let ip = backend.get_container_ip(&id).await.unwrap();
+    assert!(ip.is_some(), "running container should report an IPv4");
+
+    // Workspace network must not be removable while the container uses it.
+    let outcome = backend.remove_workspace_network(&canonical).await.unwrap();
+    assert_eq!(outcome, cella_backend::RemovalOutcome::SkippedInUse);
+
+    backend.stop_container(&id).await.unwrap();
+    backend.remove_container(&id, false).await.unwrap();
+    guard.container_id = None;
+
+    // After removal the workspace network is an orphan and gets cleaned up.
+    let outcome = backend.remove_workspace_network(&canonical).await.unwrap();
+    assert_eq!(outcome, cella_backend::RemovalOutcome::Removed);
+
+    std::fs::remove_dir_all(&workspace).ok();
+}

--- a/crates/cella-container/src/integration_tests.rs
+++ b/crates/cella-container/src/integration_tests.rs
@@ -580,16 +580,22 @@ async fn test_labels_roundtrip_through_inspect() {
     );
 }
 
+/// Ensure the shared cella network, returning `false` to skip the test on
+/// hosts without network commands (macOS 15 reports `NotSupported`).
+async fn ensure_network_or_skip(backend: &AppleContainerBackend) -> bool {
+    match backend.ensure_network().await {
+        Ok(()) => true,
+        Err(cella_backend::BackendError::NotSupported { .. }) => false,
+        Err(e) => panic!("ensure_network failed: {e}"),
+    }
+}
+
 #[cella_testing::runtime_test(apple_container, flavor = "multi_thread")]
 async fn test_network_ensure_and_exists() {
     let (backend, _cli_path) = setup_backend();
 
-    // Network commands need macOS 26+; skip quietly on older hosts where
-    // the backend reports NotSupported.
-    match backend.ensure_network().await {
-        Ok(()) => {}
-        Err(cella_backend::BackendError::NotSupported { .. }) => return,
-        Err(e) => panic!("ensure_network failed: {e}"),
+    if !ensure_network_or_skip(&backend).await {
+        return;
     }
 
     assert!(
@@ -608,10 +614,8 @@ async fn test_network_ensure_and_exists() {
 async fn test_container_attaches_to_networks_and_reports_ip() {
     let (backend, cli_path) = setup_backend();
 
-    match backend.ensure_network().await {
-        Ok(()) => {}
-        Err(cella_backend::BackendError::NotSupported { .. }) => return,
-        Err(e) => panic!("ensure_network failed: {e}"),
+    if !ensure_network_or_skip(&backend).await {
+        return;
     }
 
     let name = test_container_name("netattach");

--- a/crates/cella-container/src/integration_tests.rs
+++ b/crates/cella-container/src/integration_tests.rs
@@ -549,20 +549,29 @@ async fn test_remove_nonexistent_container() {
 }
 
 #[cella_testing::runtime_test(apple_container, flavor = "multi_thread")]
-async fn test_workspace_folder_label_set() {
+async fn test_labels_roundtrip_through_inspect() {
     let (backend, cli_path) = setup_backend();
     let name = test_container_name("wslabel");
     let mut guard = ContainerGuard::new(cli_path);
 
+    // The backend emits exactly the labels it is given (the orchestrator is
+    // what adds dev.cella.workspace_folder and friends).
     let mut opts = minimal_create_opts(&name);
     opts.labels
         .insert("dev.cella.tool".to_string(), "cella".to_string());
+    opts.labels.insert(
+        "dev.cella.workspace_folder".to_string(),
+        "/workspace".to_string(),
+    );
 
     let id = backend.create_container(&opts).await.unwrap();
     guard.set_id(id.clone());
 
     let info = backend.inspect_container(&id).await.unwrap();
-    // workspace_folder from create opts should be reflected
+    assert_eq!(
+        info.labels.get("dev.cella.tool").map(String::as_str),
+        Some("cella"),
+    );
     assert_eq!(
         info.labels
             .get("dev.cella.workspace_folder")

--- a/crates/cella-container/src/lib.rs
+++ b/crates/cella-container/src/lib.rs
@@ -12,3 +12,5 @@ pub use backend::AppleContainerBackend;
 
 #[cfg(all(test, target_os = "macos"))]
 mod integration_tests;
+#[cfg(test)]
+mod test_support;

--- a/crates/cella-container/src/lib.rs
+++ b/crates/cella-container/src/lib.rs
@@ -1,8 +1,8 @@
 //! Apple Container backend for cella.
 //!
 //! This crate implements `cella_backend::ContainerBackend` by driving
-//! the Apple `container` CLI binary. It is an EXPERIMENTAL backend —
-//! the CLI output format is pre-1.0 and may change between releases.
+//! the Apple `container` CLI binary (1.0.0 or newer; the stable
+//! structured-output shapes shipped with 1.0.0).
 
 pub mod backend;
 pub mod discovery;

--- a/crates/cella-container/src/sdk/mod.rs
+++ b/crates/cella-container/src/sdk/mod.rs
@@ -100,29 +100,34 @@ impl ContainerCli {
 
     /// Inspect a container and return its full metadata.
     ///
+    /// `container inspect` always emits a JSON array; the first entry is
+    /// returned.
+    ///
     /// # Errors
     ///
     /// Returns an error if the container does not exist, the CLI exits
     /// non-zero, or the JSON output cannot be parsed.
     pub async fn inspect(&self, id: &str) -> Result<types::ContainerInspect, BackendError> {
-        run_cli_json(&self.binary_path, &["inspect", id, "--format", "json"]).await
+        let entries: Vec<types::ContainerInspect> =
+            run_cli_json(&self.binary_path, &["inspect", id]).await?;
+        entries
+            .into_iter()
+            .next()
+            .ok_or_else(|| BackendError::ContainerNotFound {
+                identifier: id.to_string(),
+            })
     }
 
-    /// List containers, optionally filtering by a label.
+    /// List all containers (running and stopped).
+    ///
+    /// The CLI has no server-side filtering; callers filter on labels from
+    /// the returned entries.
     ///
     /// # Errors
     ///
     /// Returns an error if the CLI exits non-zero or JSON parsing fails.
-    pub async fn list(
-        &self,
-        label_filter: Option<&str>,
-    ) -> Result<Vec<types::ContainerListEntry>, BackendError> {
-        let mut args = vec!["ls", "--format", "json", "--all"];
-        if let Some(label) = label_filter {
-            args.push("--filter");
-            args.push(label);
-        }
-        run_cli_json(&self.binary_path, &args).await
+    pub async fn list(&self) -> Result<Vec<types::ContainerListEntry>, BackendError> {
+        run_cli_json(&self.binary_path, &["ls", "--format", "json", "--all"]).await
     }
 
     /// Fetch the last `tail` lines of container logs.
@@ -132,7 +137,7 @@ impl ContainerCli {
     /// Returns an error if the CLI cannot be spawned.
     pub async fn logs(&self, id: &str, tail: u32) -> Result<String, BackendError> {
         let tail_str = tail.to_string();
-        let output = run_cli(&self.binary_path, &["logs", id, "--tail", &tail_str]).await?;
+        let output = run_cli(&self.binary_path, &["logs", id, "-n", &tail_str]).await?;
         // Logs may come on stderr for some runtimes; combine both.
         let mut combined = output.stdout;
         if !output.stderr.is_empty() {
@@ -268,17 +273,14 @@ impl ContainerCli {
         Ok(output.exit_code == 0)
     }
 
-    /// Inspect an image and return raw JSON output.
+    /// Inspect an image and return raw JSON output (an array of image
+    /// resources).
     ///
     /// # Errors
     ///
     /// Returns `BackendError::ImageNotFound` if the image does not exist.
     pub async fn image_inspect(&self, image: &str) -> Result<String, BackendError> {
-        let output = run_cli(
-            &self.binary_path,
-            &["image", "inspect", image, "--format", "json"],
-        )
-        .await?;
+        let output = run_cli(&self.binary_path, &["image", "inspect", image]).await?;
         if output.exit_code != 0 {
             return Err(BackendError::ImageNotFound {
                 image: image.to_string(),
@@ -349,8 +351,8 @@ mod tests {
                 let content = format!("#!/bin/sh\n{body}\n");
                 // Only write if missing or content changed; avoids ETXTBSY
                 // when another thread is executing the same file.
-                let needs_write = std::fs::read_to_string(&path)
-                    .map_or(true, |existing| existing != content);
+                let needs_write =
+                    std::fs::read_to_string(&path).map_or(true, |existing| existing != content);
                 if needs_write {
                     let mut file = std::fs::File::create(&path).unwrap();
                     file.write_all(content.as_bytes()).unwrap();
@@ -360,10 +362,7 @@ mod tests {
                 #[cfg(unix)]
                 {
                     use std::os::unix::fs::PermissionsExt;
-                    let _ = std::fs::set_permissions(
-                        &path,
-                        std::fs::Permissions::from_mode(0o755),
-                    );
+                    let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755));
                 }
                 // ETXTBSY guard: the kernel may not have released the inode
                 // write reference yet (deferred __fput). Spin until exec works.
@@ -375,9 +374,7 @@ mod tests {
                             .stderr(std::process::Stdio::null())
                             .output()
                         {
-                            Err(e)
-                                if e.kind() == std::io::ErrorKind::ExecutableFileBusy =>
-                            {
+                            Err(e) if e.kind() == std::io::ErrorKind::ExecutableFileBusy => {
                                 std::thread::sleep(std::time::Duration::from_millis(1));
                             }
                             _ => break,
@@ -396,7 +393,7 @@ mod tests {
                 build_fail: write_script("build_fail.sh", "echo 'build failed' >&2; exit 1"),
                 inspect_json: write_script(
                     "inspect_json.sh",
-                    r#"echo '{"status":{"state":"running"},"configuration":{"id":"x","name":"n"}}'"#,
+                    r#"echo '[{"status":{"state":"running"},"configuration":{"id":"x"}}]'"#,
                 ),
                 list_json: write_script(
                     "list_json.sh",
@@ -524,20 +521,30 @@ mod tests {
         assert!(result.is_err(), "expected JSON parse error");
     }
 
+    #[tokio::test]
+    async fn inspect_empty_array_is_not_found() {
+        let cli = cli_from(&mock_scripts().empty_list);
+        let result = cli.inspect("ghost").await;
+        assert!(
+            matches!(result, Err(BackendError::ContainerNotFound { .. })),
+            "expected ContainerNotFound for empty inspect output"
+        );
+    }
+
     // -- list -----------------------------------------------------------------
 
     #[tokio::test]
     async fn list_parses_valid_json_array() {
         let cli = cli_from(&mock_scripts().list_json);
-        let result = cli.list(None).await;
+        let result = cli.list().await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap().len(), 1);
     }
 
     #[tokio::test]
-    async fn list_with_label_filter() {
+    async fn list_empty_array() {
         let cli = cli_from(&mock_scripts().empty_list);
-        let result = cli.list(Some("dev.cella.tool=cella")).await;
+        let result = cli.list().await;
         assert!(result.is_ok());
         assert!(result.unwrap().is_empty());
     }
@@ -545,7 +552,7 @@ mod tests {
     #[tokio::test]
     async fn list_error_on_invalid_json() {
         let cli = echo_cli();
-        let result = cli.list(None).await;
+        let result = cli.list().await;
         assert!(result.is_err(), "expected JSON parse error");
     }
 

--- a/crates/cella-container/src/sdk/mod.rs
+++ b/crates/cella-container/src/sdk/mod.rs
@@ -397,44 +397,8 @@ mod tests {
             let dir = PathBuf::from("/tmp/cella_sdk_mock_scripts");
             std::fs::create_dir_all(&dir).unwrap();
 
-            let write_script = |name: &str, body: &str| -> PathBuf {
-                use std::io::Write;
-                let path = dir.join(name);
-                let content = format!("#!/bin/sh\n{body}\n");
-                // Only write if missing or content changed; avoids ETXTBSY
-                // when another thread is executing the same file.
-                let needs_write =
-                    std::fs::read_to_string(&path).map_or(true, |existing| existing != content);
-                if needs_write {
-                    let mut file = std::fs::File::create(&path).unwrap();
-                    file.write_all(content.as_bytes()).unwrap();
-                    file.sync_all().unwrap();
-                    drop(file);
-                }
-                #[cfg(unix)]
-                {
-                    use std::os::unix::fs::PermissionsExt;
-                    let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755));
-                }
-                // ETXTBSY guard: the kernel may not have released the inode
-                // write reference yet (deferred __fput). Spin until exec works.
-                if needs_write {
-                    for _ in 0..50 {
-                        match std::process::Command::new(&path)
-                            .arg("--etxtbsy-probe")
-                            .stdout(std::process::Stdio::null())
-                            .stderr(std::process::Stdio::null())
-                            .output()
-                        {
-                            Err(e) if e.kind() == std::io::ErrorKind::ExecutableFileBusy => {
-                                std::thread::sleep(std::time::Duration::from_millis(1));
-                            }
-                            _ => break,
-                        }
-                    }
-                }
-                path
-            };
+            let write_script =
+                |name: &str, body: &str| crate::test_support::write_mock_script(&dir, name, body);
 
             MockScripts {
                 fail: write_script("fail.sh", "exit 1"),

--- a/crates/cella-container/src/sdk/mod.rs
+++ b/crates/cella-container/src/sdk/mod.rs
@@ -316,19 +316,6 @@ impl ContainerCli {
         Ok(())
     }
 
-    /// Create a named volume.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the CLI exits non-zero or cannot be spawned.
-    pub async fn volume_create(&self, name: &str) -> Result<(), BackendError> {
-        let output = run_cli(&self.binary_path, &["volume", "create", name]).await?;
-        if output.exit_code != 0 {
-            return Err(BackendError::Runtime(output.stderr.into()));
-        }
-        Ok(())
-    }
-
     // -- Network operations (macOS 26+) --
 
     /// Create a network with the given labels.
@@ -770,22 +757,6 @@ mod tests {
             matches!(err, BackendError::ImageNotFound { .. }),
             "expected ImageNotFound, got: {err:?}"
         );
-    }
-
-    // -- volume_create --------------------------------------------------------
-
-    #[tokio::test]
-    async fn volume_create_succeeds_with_echo() {
-        let cli = echo_cli();
-        let result = cli.volume_create("my-volume").await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn volume_create_error_on_nonzero_exit() {
-        let cli = cli_from(&mock_scripts().fail);
-        let result = cli.volume_create("my-volume").await;
-        assert!(result.is_err());
     }
 
     // -- nonexistent binary ---------------------------------------------------

--- a/crates/cella-container/src/sdk/mod.rs
+++ b/crates/cella-container/src/sdk/mod.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use cella_backend::BackendError;
 use tracing::debug;
 
-use self::run::{run_cli, run_cli_json, run_cli_owned};
+use self::run::{run_cli, run_cli_checked, run_cli_checked_owned, run_cli_json, run_cli_owned};
 
 /// Handle to a discovered Apple Container CLI binary.
 pub struct ContainerCli {
@@ -52,10 +52,7 @@ impl ContainerCli {
     pub async fn create(&self, args: &[String]) -> Result<String, BackendError> {
         let mut cli_args = vec!["create".to_string()];
         cli_args.extend_from_slice(args);
-        let output = run_cli_owned(&self.binary_path, &cli_args).await?;
-        if output.exit_code != 0 {
-            return Err(BackendError::Runtime(output.stderr.into()));
-        }
+        let output = run_cli_checked_owned(&self.binary_path, &cli_args).await?;
         Ok(output.stdout.trim().to_string())
     }
 
@@ -65,11 +62,9 @@ impl ContainerCli {
     ///
     /// Returns an error if the CLI exits non-zero or cannot be spawned.
     pub async fn start(&self, id: &str) -> Result<(), BackendError> {
-        let output = run_cli(&self.binary_path, &["start", id]).await?;
-        if output.exit_code != 0 {
-            return Err(BackendError::Runtime(output.stderr.into()));
-        }
-        Ok(())
+        run_cli_checked(&self.binary_path, &["start", id])
+            .await
+            .map(drop)
     }
 
     /// Stop a running container.
@@ -78,11 +73,9 @@ impl ContainerCli {
     ///
     /// Returns an error if the CLI exits non-zero or cannot be spawned.
     pub async fn stop(&self, id: &str) -> Result<(), BackendError> {
-        let output = run_cli(&self.binary_path, &["stop", id]).await?;
-        if output.exit_code != 0 {
-            return Err(BackendError::Runtime(output.stderr.into()));
-        }
-        Ok(())
+        run_cli_checked(&self.binary_path, &["stop", id])
+            .await
+            .map(drop)
     }
 
     /// Remove a container.
@@ -91,11 +84,9 @@ impl ContainerCli {
     ///
     /// Returns an error if the CLI exits non-zero or cannot be spawned.
     pub async fn rm(&self, id: &str) -> Result<(), BackendError> {
-        let output = run_cli(&self.binary_path, &["rm", id]).await?;
-        if output.exit_code != 0 {
-            return Err(BackendError::Runtime(output.stderr.into()));
-        }
-        Ok(())
+        run_cli_checked(&self.binary_path, &["rm", id])
+            .await
+            .map(drop)
     }
 
     /// Inspect a container and return its full metadata.
@@ -202,11 +193,9 @@ impl ContainerCli {
     /// Returns an error if the CLI exits non-zero or cannot be spawned.
     pub async fn pull(&self, image: &str) -> Result<(), BackendError> {
         debug!(image, "pulling image");
-        let output = run_cli(&self.binary_path, &["image", "pull", image]).await?;
-        if output.exit_code != 0 {
-            return Err(BackendError::Runtime(output.stderr.into()));
-        }
-        Ok(())
+        run_cli_checked(&self.binary_path, &["image", "pull", image])
+            .await
+            .map(drop)
     }
 
     /// Build an image from a Dockerfile.
@@ -307,13 +296,14 @@ impl ContainerCli {
             host_path.to_string_lossy().into_owned(),
             format!("{id}:{container_path}"),
         ];
-        let output = run_cli_owned(&self.binary_path, &args).await?;
-        if output.exit_code != 0 {
-            return Err(BackendError::Runtime(
-                format!("container cp to {container_path} failed: {}", output.stderr).into(),
-            ));
-        }
-        Ok(())
+        run_cli_checked_owned(&self.binary_path, &args)
+            .await
+            .map(drop)
+            .map_err(|e| {
+                BackendError::Runtime(
+                    format!("container cp to {container_path} failed: {e}").into(),
+                )
+            })
     }
 
     // -- Network operations (macOS 26+) --
@@ -336,13 +326,10 @@ impl ContainerCli {
         }
         args.push(name.to_string());
 
-        let output = run_cli_owned(&self.binary_path, &args).await?;
-        if output.exit_code != 0 {
-            return Err(BackendError::Runtime(
-                format!("network create {name} failed: {}", output.stderr).into(),
-            ));
-        }
-        Ok(())
+        run_cli_checked_owned(&self.binary_path, &args)
+            .await
+            .map(drop)
+            .map_err(|e| BackendError::Runtime(format!("network create {name} failed: {e}").into()))
     }
 
     /// List networks.
@@ -361,13 +348,10 @@ impl ContainerCli {
     ///
     /// Returns an error if the CLI exits non-zero or cannot be spawned.
     pub async fn network_delete(&self, name: &str) -> Result<(), BackendError> {
-        let output = run_cli(&self.binary_path, &["network", "delete", name]).await?;
-        if output.exit_code != 0 {
-            return Err(BackendError::Runtime(
-                format!("network delete {name} failed: {}", output.stderr).into(),
-            ));
-        }
-        Ok(())
+        run_cli_checked(&self.binary_path, &["network", "delete", name])
+            .await
+            .map(drop)
+            .map_err(|e| BackendError::Runtime(format!("network delete {name} failed: {e}").into()))
     }
 }
 

--- a/crates/cella-container/src/sdk/mod.rs
+++ b/crates/cella-container/src/sdk/mod.rs
@@ -289,6 +289,33 @@ impl ContainerCli {
         Ok(output.stdout)
     }
 
+    /// Copy a file from the host into a running container.
+    ///
+    /// Wraps `container cp <host_path> <id>:<container_path>`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the CLI exits non-zero or cannot be spawned.
+    pub async fn cp_into(
+        &self,
+        host_path: &Path,
+        id: &str,
+        container_path: &str,
+    ) -> Result<(), BackendError> {
+        let args = vec![
+            "cp".to_string(),
+            host_path.to_string_lossy().into_owned(),
+            format!("{id}:{container_path}"),
+        ];
+        let output = run_cli_owned(&self.binary_path, &args).await?;
+        if output.exit_code != 0 {
+            return Err(BackendError::Runtime(
+                format!("container cp to {container_path} failed: {}", output.stderr).into(),
+            ));
+        }
+        Ok(())
+    }
+
     /// Create a named volume.
     ///
     /// # Errors

--- a/crates/cella-container/src/sdk/mod.rs
+++ b/crates/cella-container/src/sdk/mod.rs
@@ -328,6 +328,60 @@ impl ContainerCli {
         }
         Ok(())
     }
+
+    // -- Network operations (macOS 26+) --
+
+    /// Create a network with the given labels.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the CLI exits non-zero (including on macOS 15,
+    /// where the network commands do not exist) or cannot be spawned.
+    pub async fn network_create(
+        &self,
+        name: &str,
+        labels: &[(&str, &str)],
+    ) -> Result<(), BackendError> {
+        let mut args = vec!["network".to_string(), "create".to_string()];
+        for (key, value) in labels {
+            args.push("--label".to_string());
+            args.push(format!("{key}={value}"));
+        }
+        args.push(name.to_string());
+
+        let output = run_cli_owned(&self.binary_path, &args).await?;
+        if output.exit_code != 0 {
+            return Err(BackendError::Runtime(
+                format!("network create {name} failed: {}", output.stderr).into(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// List networks.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the CLI exits non-zero (including on macOS 15,
+    /// where the network commands do not exist) or JSON parsing fails.
+    pub async fn network_list(&self) -> Result<Vec<types::NetworkListEntry>, BackendError> {
+        run_cli_json(&self.binary_path, &["network", "ls", "--format", "json"]).await
+    }
+
+    /// Delete a network by name.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the CLI exits non-zero or cannot be spawned.
+    pub async fn network_delete(&self, name: &str) -> Result<(), BackendError> {
+        let output = run_cli(&self.binary_path, &["network", "delete", name]).await?;
+        if output.exit_code != 0 {
+            return Err(BackendError::Runtime(
+                format!("network delete {name} failed: {}", output.stderr).into(),
+            ));
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/cella-container/src/sdk/run.rs
+++ b/crates/cella-container/src/sdk/run.rs
@@ -63,6 +63,33 @@ pub async fn run_cli_owned(binary: &Path, args: &[String]) -> Result<CommandOutp
     run_cli(binary, &refs).await
 }
 
+/// Run the CLI, mapping a non-zero exit to `BackendError::Runtime` carrying
+/// the stderr output.
+///
+/// # Errors
+///
+/// Returns an error if the CLI exits non-zero or cannot be spawned.
+pub async fn run_cli_checked(binary: &Path, args: &[&str]) -> Result<CommandOutput, BackendError> {
+    let output = run_cli(binary, args).await?;
+    if output.exit_code != 0 {
+        return Err(BackendError::Runtime(output.stderr.into()));
+    }
+    Ok(output)
+}
+
+/// Owned-args version of [`run_cli_checked`].
+///
+/// # Errors
+///
+/// Returns an error if the CLI exits non-zero or cannot be spawned.
+pub async fn run_cli_checked_owned(
+    binary: &Path,
+    args: &[String],
+) -> Result<CommandOutput, BackendError> {
+    let refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    run_cli_checked(binary, &refs).await
+}
+
 /// Run the CLI and parse the JSON stdout into `T`.
 ///
 /// # Errors
@@ -73,10 +100,7 @@ pub async fn run_cli_json<T: serde::de::DeserializeOwned>(
     binary: &Path,
     args: &[&str],
 ) -> Result<T, BackendError> {
-    let output = run_cli(binary, args).await?;
-    if output.exit_code != 0 {
-        return Err(BackendError::Runtime(output.stderr.into()));
-    }
+    let output = run_cli_checked(binary, args).await?;
     serde_json::from_str(&output.stdout).map_err(|e| BackendError::Runtime(Box::new(e)))
 }
 

--- a/crates/cella-container/src/sdk/types.rs
+++ b/crates/cella-container/src/sdk/types.rs
@@ -209,6 +209,15 @@ impl NetworkListEntry {
             .and_then(|c| c.name.as_deref())
             .or(self.id.as_deref())
     }
+
+    /// The network's labels (empty when absent).
+    #[must_use]
+    pub fn labels(&self) -> HashMap<String, String> {
+        self.configuration
+            .as_ref()
+            .and_then(|c| c.labels.clone())
+            .unwrap_or_default()
+    }
 }
 
 /// A single entry from `container system version --format json` (returns an

--- a/crates/cella-container/src/sdk/types.rs
+++ b/crates/cella-container/src/sdk/types.rs
@@ -35,21 +35,18 @@ pub struct ContainerStatus {
 }
 
 /// A live network attachment on a running container.
+///
+/// The CLI also reports `hostname`, `ipv4Gateway`, `macAddress`, and `mtu`;
+/// add fields when a consumer appears.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NetworkAttachment {
     /// Name of the attached network (e.g. `"default"`).
     #[serde(default)]
     pub network: Option<String>,
-    /// Hostname assigned to the container on this network.
-    #[serde(default)]
-    pub hostname: Option<String>,
     /// Interface address in CIDR form (e.g. `"192.168.64.2/24"`).
     #[serde(default)]
     pub ipv4_address: Option<String>,
-    /// Gateway address (e.g. `"192.168.64.1"`).
-    #[serde(default)]
-    pub ipv4_gateway: Option<String>,
 }
 
 impl NetworkAttachment {
@@ -114,6 +111,9 @@ pub struct PublishedPort {
 }
 
 /// A mount/volume attached to the container.
+///
+/// The CLI also reports mount `options` (e.g. `["ro"]`); surface them when
+/// `MountInfo` grows a read-only field.
 #[derive(Debug, Deserialize)]
 pub struct MountEntry {
     #[serde(default)]
@@ -124,9 +124,6 @@ pub struct MountEntry {
     /// externally-tagged object (e.g. `{"virtiofs": {}}`).
     #[serde(default, rename = "type")]
     pub fs_type: Option<FilesystemType>,
-    /// Mount options (e.g. `["ro"]`).
-    #[serde(default)]
-    pub options: Vec<String>,
 }
 
 /// Filesystem attachment type for a mount.
@@ -187,6 +184,9 @@ pub struct NetworkListEntry {
 }
 
 /// Persistent configuration of a network.
+///
+/// The CLI also reports `creationDate` as a numeric Swift reference-date
+/// value; parse it when a consumer needs RFC 3339 timestamps.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NetworkConfiguration {
@@ -194,9 +194,6 @@ pub struct NetworkConfiguration {
     pub name: Option<String>,
     #[serde(default)]
     pub labels: Option<HashMap<String, String>>,
-    /// Creation timestamp as emitted by the CLI.
-    #[serde(default)]
-    pub creation_date: Option<serde_json::Value>,
 }
 
 impl NetworkListEntry {
@@ -286,10 +283,6 @@ mod tests {
         assert_eq!(status.state.as_deref(), Some("running"));
         assert_eq!(status.networks.len(), 1);
         assert_eq!(status.networks[0].ipv4(), Some("192.168.64.2"));
-        assert_eq!(
-            status.networks[0].ipv4_gateway.as_deref(),
-            Some("192.168.64.1")
-        );
 
         let config = entry.configuration.unwrap();
         assert_eq!(config.id.as_deref(), Some("abc123"));
@@ -356,7 +349,7 @@ mod tests {
     }
 
     #[test]
-    fn deserialize_mount_with_ro_option() {
+    fn deserialize_mount_ignores_unmapped_keys() {
         let json = r#"{
             "type": { "virtiofs": {} },
             "source": "/h",
@@ -364,7 +357,7 @@ mod tests {
             "options": ["ro"]
         }"#;
         let mount: MountEntry = serde_json::from_str(json).unwrap();
-        assert_eq!(mount.options, vec!["ro"]);
+        assert_eq!(mount.source.as_deref(), Some("/h"));
     }
 
     #[test]

--- a/crates/cella-container/src/sdk/types.rs
+++ b/crates/cella-container/src/sdk/types.rs
@@ -1,14 +1,18 @@
 //! Typed structs for JSON output from the Apple `container` CLI.
 //!
-//! The CLI output format is pre-1.0 and subject to change.
-//! All optional fields use `#[serde(default)]` so missing keys
-//! are silently skipped rather than causing parse failures.
+//! Shapes follow the stable 1.0.0 output format (`ManagedResource`-conformant
+//! `{id, configuration, status}` objects). All optional fields use
+//! `#[serde(default)]` so missing keys are silently skipped rather than
+//! causing parse failures; unknown keys are ignored for forward
+//! compatibility.
 
 use std::collections::HashMap;
 
 use serde::Deserialize;
 
 /// Entry returned by `container ls --format json --all`.
+///
+/// `container inspect` emits an array of the same shape.
 #[derive(Debug, Deserialize)]
 pub struct ContainerListEntry {
     #[serde(default)]
@@ -21,29 +25,79 @@ pub struct ContainerListEntry {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ContainerStatus {
-    /// One of `"running"`, `"stopped"`, `"created"`, etc.
+    /// One of `"running"`, `"stopped"`, `"stopping"`, `"unknown"`.
     #[serde(default)]
     pub state: Option<String>,
+    /// Live network attachments with assigned addresses (populated while
+    /// the container runs).
     #[serde(default)]
-    pub exit_code: Option<i64>,
+    pub networks: Vec<NetworkAttachment>,
+}
+
+/// A live network attachment on a running container.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NetworkAttachment {
+    /// Name of the attached network (e.g. `"default"`).
+    #[serde(default)]
+    pub network: Option<String>,
+    /// Hostname assigned to the container on this network.
+    #[serde(default)]
+    pub hostname: Option<String>,
+    /// Interface address in CIDR form (e.g. `"192.168.64.2/24"`).
+    #[serde(default)]
+    pub ipv4_address: Option<String>,
+    /// Gateway address (e.g. `"192.168.64.1"`).
+    #[serde(default)]
+    pub ipv4_gateway: Option<String>,
+}
+
+impl NetworkAttachment {
+    /// The bare IPv4 address with any CIDR prefix length stripped.
+    #[must_use]
+    pub fn ipv4(&self) -> Option<&str> {
+        self.ipv4_address
+            .as_deref()
+            .map(|cidr| cidr.split('/').next().unwrap_or(cidr))
+    }
 }
 
 /// Container configuration / metadata.
+///
+/// Containers have no separate name field — the ID doubles as the name.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ContainerConfiguration {
     #[serde(default)]
     pub id: Option<String>,
     #[serde(default)]
-    pub name: Option<String>,
-    #[serde(default)]
-    pub image: Option<String>,
+    pub image: Option<ImageDescription>,
     #[serde(default)]
     pub labels: Option<HashMap<String, String>>,
     #[serde(default)]
     pub published_ports: Option<Vec<PublishedPort>>,
     #[serde(default)]
     pub mounts: Option<Vec<MountEntry>>,
+    /// Networks the container was created with (configured attachments;
+    /// see [`ContainerStatus::networks`] for live address assignments).
+    #[serde(default)]
+    pub networks: Vec<AttachmentConfiguration>,
+}
+
+/// Image reference recorded on a container's configuration.
+#[derive(Debug, Deserialize)]
+pub struct ImageDescription {
+    #[serde(default)]
+    pub reference: Option<String>,
+}
+
+/// A configured (create-time) network attachment.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AttachmentConfiguration {
+    /// Name of the network to attach to.
+    #[serde(default)]
+    pub network: Option<String>,
 }
 
 /// A port mapping exposed by the container.
@@ -54,34 +108,111 @@ pub struct PublishedPort {
     pub container_port: Option<u16>,
     #[serde(default)]
     pub host_port: Option<u16>,
+    /// `"tcp"` or `"udp"`.
     #[serde(default)]
-    pub protocol: Option<String>,
+    pub proto: Option<String>,
 }
 
 /// A mount/volume attached to the container.
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct MountEntry {
     #[serde(default)]
     pub source: Option<String>,
     #[serde(default)]
     pub destination: Option<String>,
+    /// Filesystem type. Swift encodes the `FSType` enum as an
+    /// externally-tagged object (e.g. `{"virtiofs": {}}`).
     #[serde(default, rename = "type")]
-    pub mount_type: Option<String>,
+    pub fs_type: Option<FilesystemType>,
+    /// Mount options (e.g. `["ro"]`).
+    #[serde(default)]
+    pub options: Vec<String>,
 }
 
-/// `container inspect <id>` returns the same structure as a list entry
-/// but may include additional detail.
+/// Filesystem attachment type for a mount.
+///
+/// Mirrors the Swift `Filesystem.FSType` enum, whose Codable synthesis
+/// encodes each case as `{"caseName": {associated values}}` — cases without
+/// useful payload carry an ignored object.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FilesystemType {
+    /// Disk-image backed filesystem.
+    Block(serde_json::Value),
+    /// Named (or anonymous) managed volume.
+    Volume {
+        #[serde(default)]
+        name: Option<String>,
+    },
+    /// Host directory shared via virtiofs — the bind-mount mechanism.
+    Virtiofs(serde_json::Value),
+    /// In-memory filesystem.
+    Tmpfs(serde_json::Value),
+}
+
+impl FilesystemType {
+    /// Docker-parity mount-type string (`virtiofs` surfaces as `"bind"`).
+    #[must_use]
+    pub const fn kind(&self) -> &'static str {
+        match self {
+            Self::Block(_) => "block",
+            Self::Volume { .. } => "volume",
+            Self::Virtiofs(_) => "bind",
+            Self::Tmpfs(_) => "tmpfs",
+        }
+    }
+
+    /// The volume name for [`FilesystemType::Volume`] mounts.
+    #[must_use]
+    pub fn volume_name(&self) -> Option<&str> {
+        match self {
+            Self::Volume { name } => name.as_deref(),
+            _ => None,
+        }
+    }
+}
+
+/// `container inspect <id>` returns an array of the same entries as
+/// `container ls`.
 pub type ContainerInspect = ContainerListEntry;
 
-/// Entry returned by `container image ls --format json`.
+/// Entry returned by `container network ls --format json` and
+/// `container network inspect`.
 #[derive(Debug, Deserialize)]
-pub struct ImageListEntry {
+pub struct NetworkListEntry {
     #[serde(default)]
-    pub reference: Option<String>,
+    pub id: Option<String>,
+    #[serde(default)]
+    pub configuration: Option<NetworkConfiguration>,
 }
 
-/// A single entry from `container version --format json` (returns an array).
+/// Persistent configuration of a network.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NetworkConfiguration {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub labels: Option<HashMap<String, String>>,
+    /// Creation timestamp as emitted by the CLI.
+    #[serde(default)]
+    pub creation_date: Option<serde_json::Value>,
+}
+
+impl NetworkListEntry {
+    /// The network name (`id` and `configuration.name` are identical; either
+    /// may be missing in a degraded entry).
+    #[must_use]
+    pub fn name(&self) -> Option<&str> {
+        self.configuration
+            .as_ref()
+            .and_then(|c| c.name.as_deref())
+            .or(self.id.as_deref())
+    }
+}
+
+/// A single entry from `container system version --format json` (returns an
+/// array: the CLI entry plus, when running, an API-server entry).
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct VersionInfo {
@@ -98,17 +229,45 @@ mod tests {
     #[test]
     fn deserialize_container_list_entry() {
         let json = r#"{
-            "status": { "state": "running", "exitCode": 0 },
+            "id": "abc123",
+            "status": {
+                "state": "running",
+                "networks": [
+                    {
+                        "network": "default",
+                        "hostname": "abc123",
+                        "ipv4Address": "192.168.64.2/24",
+                        "ipv4Gateway": "192.168.64.1",
+                        "macAddress": "02:42:ac:11:00:02",
+                        "mtu": 1500
+                    }
+                ],
+                "startedDate": 771234567.0
+            },
             "configuration": {
                 "id": "abc123",
-                "name": "test-container",
-                "image": "ubuntu:latest",
+                "image": {
+                    "reference": "docker.io/library/ubuntu:latest",
+                    "descriptor": { "digest": "sha256:abc", "size": 1 }
+                },
                 "labels": { "dev.cella.tool": "cella" },
                 "publishedPorts": [
-                    { "containerPort": 8080, "hostPort": 8080, "protocol": "tcp" }
+                    {
+                        "hostAddress": "0.0.0.0",
+                        "containerPort": 80,
+                        "hostPort": 8080,
+                        "proto": "tcp",
+                        "count": 1
+                    }
                 ],
+                "networks": [ { "network": "default" } ],
                 "mounts": [
-                    { "source": "/host/path", "destination": "/container/path", "type": "bind" }
+                    {
+                        "type": { "virtiofs": {} },
+                        "source": "/host/path",
+                        "destination": "/container/path",
+                        "options": []
+                    }
                 ]
             }
         }"#;
@@ -116,23 +275,36 @@ mod tests {
         let entry: ContainerListEntry = serde_json::from_str(json).unwrap();
         let status = entry.status.unwrap();
         assert_eq!(status.state.as_deref(), Some("running"));
-        assert_eq!(status.exit_code, Some(0));
+        assert_eq!(status.networks.len(), 1);
+        assert_eq!(status.networks[0].ipv4(), Some("192.168.64.2"));
+        assert_eq!(
+            status.networks[0].ipv4_gateway.as_deref(),
+            Some("192.168.64.1")
+        );
 
         let config = entry.configuration.unwrap();
         assert_eq!(config.id.as_deref(), Some("abc123"));
-        assert_eq!(config.name.as_deref(), Some("test-container"));
-        assert_eq!(config.image.as_deref(), Some("ubuntu:latest"));
+        assert_eq!(
+            config.image.unwrap().reference.as_deref(),
+            Some("docker.io/library/ubuntu:latest")
+        );
 
         let labels = config.labels.unwrap();
         assert_eq!(labels.get("dev.cella.tool").unwrap(), "cella");
 
         let ports = config.published_ports.unwrap();
         assert_eq!(ports.len(), 1);
-        assert_eq!(ports[0].container_port, Some(8080));
+        assert_eq!(ports[0].container_port, Some(80));
+        assert_eq!(ports[0].host_port, Some(8080));
+        assert_eq!(ports[0].proto.as_deref(), Some("tcp"));
+
+        assert_eq!(config.networks.len(), 1);
+        assert_eq!(config.networks[0].network.as_deref(), Some("default"));
 
         let mounts = config.mounts.unwrap();
         assert_eq!(mounts.len(), 1);
         assert_eq!(mounts[0].source.as_deref(), Some("/host/path"));
+        assert_eq!(mounts[0].fs_type.as_ref().unwrap().kind(), "bind");
     }
 
     #[test]
@@ -149,19 +321,88 @@ mod tests {
         let entry: ContainerListEntry = serde_json::from_str(json).unwrap();
         let status = entry.status.unwrap();
         assert_eq!(status.state.as_deref(), Some("stopped"));
-        assert!(status.exit_code.is_none());
+        assert!(status.networks.is_empty());
     }
 
     #[test]
-    fn deserialize_image_list_entry() {
-        let json = r#"{ "reference": "ubuntu:latest" }"#;
-        let entry: ImageListEntry = serde_json::from_str(json).unwrap();
-        assert_eq!(entry.reference.as_deref(), Some("ubuntu:latest"));
+    fn deserialize_mount_types() {
+        let json = r#"[
+            { "type": { "virtiofs": {} }, "source": "/h", "destination": "/c" },
+            { "type": { "volume": { "name": "data", "format": "ext4" } },
+              "source": "/var/lib/volumes/data", "destination": "/data" },
+            { "type": { "tmpfs": {} }, "source": "", "destination": "/tmp/x" },
+            { "type": { "block": { "format": "ext4" } }, "source": "/img", "destination": "/b" }
+        ]"#;
+        let mounts: Vec<MountEntry> = serde_json::from_str(json).unwrap();
+        let kinds: Vec<&str> = mounts
+            .iter()
+            .map(|m| m.fs_type.as_ref().unwrap().kind())
+            .collect();
+        assert_eq!(kinds, vec!["bind", "volume", "tmpfs", "block"]);
+        assert_eq!(
+            mounts[1].fs_type.as_ref().unwrap().volume_name(),
+            Some("data")
+        );
+        assert_eq!(mounts[0].fs_type.as_ref().unwrap().volume_name(), None);
+    }
+
+    #[test]
+    fn deserialize_mount_with_ro_option() {
+        let json = r#"{
+            "type": { "virtiofs": {} },
+            "source": "/h",
+            "destination": "/c",
+            "options": ["ro"]
+        }"#;
+        let mount: MountEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(mount.options, vec!["ro"]);
+    }
+
+    #[test]
+    fn deserialize_network_attachment_without_prefix() {
+        let json = r#"{ "network": "cella", "ipv4Address": "192.168.65.3" }"#;
+        let att: NetworkAttachment = serde_json::from_str(json).unwrap();
+        assert_eq!(att.ipv4(), Some("192.168.65.3"));
+    }
+
+    #[test]
+    fn deserialize_network_list_entry() {
+        let json = r#"{
+            "id": "cella",
+            "configuration": {
+                "name": "cella",
+                "mode": "nat",
+                "creationDate": 771234567.0,
+                "labels": { "dev.cella.managed": "true" },
+                "plugin": "container-network-vmnet",
+                "options": {}
+            },
+            "status": {
+                "ipv4Subnet": "192.168.65.0/24",
+                "ipv4Gateway": "192.168.65.1"
+            }
+        }"#;
+        let entry: NetworkListEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.name(), Some("cella"));
+        let labels = entry.configuration.unwrap().labels.unwrap();
+        assert_eq!(labels.get("dev.cella.managed").unwrap(), "true");
+    }
+
+    #[test]
+    fn network_list_entry_name_falls_back_to_id() {
+        let json = r#"{ "id": "cella" }"#;
+        let entry: NetworkListEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.name(), Some("cella"));
     }
 
     #[test]
     fn deserialize_version_info() {
-        let json = r#"[{ "version": "1.0.0", "appName": "container" }]"#;
+        let json = r#"[{
+            "version": "1.0.0",
+            "buildType": "release",
+            "commit": "abcdef0",
+            "appName": "container"
+        }]"#;
         let entries: Vec<VersionInfo> = serde_json::from_str(json).unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].version.as_deref(), Some("1.0.0"));

--- a/crates/cella-container/src/test_support.rs
+++ b/crates/cella-container/src/test_support.rs
@@ -1,0 +1,50 @@
+//! Shared helpers for tests that mock the `container` CLI with shell scripts.
+
+use std::path::{Path, PathBuf};
+
+/// Write an executable `#!/bin/sh` mock script at `dir/name` and return its
+/// path.
+///
+/// The write is skipped when the content is already current, so a script
+/// file is never rewritten while another thread may be executing it (which
+/// would race `ETXTBSY` on overlayfs). After a fresh write, the function
+/// spins until the kernel releases the inode's write reference (deferred
+/// `__fput`) and the script becomes executable.
+pub fn write_mock_script(dir: &Path, name: &str, body: &str) -> PathBuf {
+    use std::io::Write;
+
+    let path = dir.join(name);
+    let content = format!("#!/bin/sh\n{body}\n");
+
+    let needs_write = std::fs::read_to_string(&path).map_or(true, |existing| existing != content);
+    if needs_write {
+        let mut file = std::fs::File::create(&path).unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        file.sync_all().unwrap();
+        drop(file);
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755));
+    }
+
+    if needs_write {
+        for _ in 0..50 {
+            match std::process::Command::new(&path)
+                .arg("--etxtbsy-probe")
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .output()
+            {
+                Err(e) if e.kind() == std::io::ErrorKind::ExecutableFileBusy => {
+                    std::thread::sleep(std::time::Duration::from_millis(1));
+                }
+                _ => break,
+            }
+        }
+    }
+
+    path
+}

--- a/crates/cella-daemon-client/src/ssh_proxy.rs
+++ b/crates/cella-daemon-client/src/ssh_proxy.rs
@@ -45,7 +45,7 @@ pub struct ResolvedSshProxy {
 ///
 /// `host_gateway` is the hostname the container uses to reach the daemon
 /// — typically `host.docker.internal` (Docker Desktop, `OrbStack`, recent
-/// colima) or `host.local` (Apple Container).
+/// colima) or `host.container.internal` (Apple Container).
 pub async fn register_proxy(
     daemon_socket: &Path,
     workspace: &Path,

--- a/crates/cella-docker/src/integration_tests/network_tests.rs
+++ b/crates/cella-docker/src/integration_tests/network_tests.rs
@@ -5,9 +5,7 @@ use std::collections::HashMap;
 use bollard::Docker;
 use cella_backend::RemovalOutcome;
 
-use crate::network::{
-    list_managed_networks, remove_network_if_orphan, repo_network_name, workspace_network_name,
-};
+use crate::network::{list_managed_networks, remove_network_if_orphan};
 
 /// Create a bridge network with the given labels. Returns the network name.
 async fn create_test_network(
@@ -162,22 +160,6 @@ async fn list_managed_networks_filters_by_label() {
     force_remove(&docker, &unlabeled).await;
 }
 
-/// `workspace_network_name` matches `repo_network_name` for the same
-/// canonicalized path — the contract `cella down --rm` relies on to
-/// find the network it's trying to remove.
-#[tokio::test]
-async fn workspace_network_name_matches_repo_network_name_for_real_path() {
-    let tmpdir =
-        std::env::temp_dir().join(format!("cella-integration-wsroot-{}", std::process::id()));
-    let _ = std::fs::create_dir_all(&tmpdir);
-    let canonical = tmpdir.canonicalize().expect("canonicalize tmpdir");
-
-    let via_workspace = workspace_network_name(&tmpdir);
-    let via_repo = repo_network_name(&canonical);
-    assert_eq!(
-        via_workspace, via_repo,
-        "workspace_network_name should canonicalize then hash"
-    );
-
-    let _ = std::fs::remove_dir_all(&tmpdir);
-}
+// The canonicalize-then-hash naming contract is covered by
+// `workspace_network_name_canonicalizes_then_hashes` in
+// cella-backend::network, next to the implementation.

--- a/crates/cella-docker/src/network.rs
+++ b/crates/cella-docker/src/network.rs
@@ -45,7 +45,7 @@ pub async fn ensure_network(docker: &Docker) -> Result<(), CellaDockerError> {
         labels: Some(
             [
                 ("dev.cella.tool".to_string(), "cella".to_string()),
-                ("dev.cella.managed".to_string(), "true".to_string()),
+                (MANAGED_LABEL.to_string(), MANAGED_VALUE.to_string()),
             ]
             .into_iter()
             .collect(),

--- a/crates/cella-docker/src/network.rs
+++ b/crates/cella-docker/src/network.rs
@@ -4,24 +4,18 @@
 //! container-to-container communication via Docker DNS.
 
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use bollard::Docker;
+use cella_backend::network::{MANAGED_LABEL, MANAGED_VALUE, REPO_LABEL};
 use cella_backend::{ManagedNetwork, RemovalOutcome};
-use sha2::{Digest, Sha256};
 use tracing::{debug, info, warn};
 
 use crate::CellaDockerError;
 
-/// Label that marks a Docker network as cella-managed.
-const MANAGED_LABEL: &str = "dev.cella.managed";
-/// Label value required on `MANAGED_LABEL` for cella-managed networks.
-const MANAGED_VALUE: &str = "true";
-/// Label that carries the workspace path on per-repo networks.
-const REPO_LABEL: &str = "dev.cella.repo";
-
-/// Default network name for cella containers.
-pub const CELLA_NETWORK_NAME: &str = "cella";
+pub use cella_backend::network::{
+    CELLA_NETWORK_NAME, canonicalize_for_network, repo_network_name, workspace_network_name,
+};
 
 /// Ensure the cella bridge network exists.
 ///
@@ -120,31 +114,6 @@ pub async fn ensure_container_connected(
     connect_container(docker, container_id).await
 }
 
-/// Derive a per-repository network name from a repo path.
-///
-/// Returns `cella-net-{first 12 hex chars of SHA-256 of repo_path}`.
-pub fn repo_network_name(repo_path: &Path) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(repo_path.to_string_lossy().as_bytes());
-    let hash = hasher.finalize();
-    let short = hex::encode(&hash[..6]); // 6 bytes = 12 hex chars
-    format!("cella-net-{short}")
-}
-
-/// Canonicalize a path for network identity, falling back to the
-/// original path if canonicalization fails (e.g. path doesn't exist).
-///
-/// Must be applied consistently at every network-op boundary so that
-/// `cella down --rm` and `cella prune` hash to the same name the
-/// container was created with. `container_labels` already canonicalizes
-/// the `dev.cella.workspace_path` label, so this keeps network names
-/// aligned with that source of truth.
-fn canonicalize_for_network(repo_path: &Path) -> PathBuf {
-    repo_path
-        .canonicalize()
-        .unwrap_or_else(|_| repo_path.to_path_buf())
-}
-
 /// Ensure a per-repository bridge network exists and connect the container.
 ///
 /// # Errors
@@ -198,12 +167,6 @@ pub async fn ensure_repo_network(
     debug!("Connected container {container_id} to repo network '{net_name}'");
 
     Ok(net_name)
-}
-
-/// Derive the workspace network name the same way `cella up` does, so
-/// `cella down --rm` / `cella prune` target the matching network.
-pub fn workspace_network_name(workspace_root: &Path) -> String {
-    repo_network_name(&canonicalize_for_network(workspace_root))
 }
 
 /// Return `true` when a network's labels + endpoint count indicate it's
@@ -380,129 +343,9 @@ pub async fn get_container_ip(docker: &Docker, container_id: &str) -> Option<Str
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::Path;
 
-    #[test]
-    fn cella_network_name_constant() {
-        assert_eq!(CELLA_NETWORK_NAME, "cella");
-    }
-
-    #[test]
-    fn repo_network_name_deterministic() {
-        let path = Path::new("/home/user/my-project");
-        let name1 = repo_network_name(path);
-        let name2 = repo_network_name(path);
-        assert_eq!(name1, name2);
-    }
-
-    #[test]
-    fn repo_network_name_has_prefix() {
-        let name = repo_network_name(Path::new("/any/path"));
-        assert!(
-            name.starts_with("cella-net-"),
-            "name should start with 'cella-net-': {name}"
-        );
-    }
-
-    #[test]
-    fn repo_network_name_has_12_hex_chars() {
-        let name = repo_network_name(Path::new("/some/repo"));
-        let hash_part = name.strip_prefix("cella-net-").unwrap();
-        assert_eq!(
-            hash_part.len(),
-            12,
-            "hash portion should be 12 hex chars: {hash_part}"
-        );
-        assert!(
-            hash_part.chars().all(|c| c.is_ascii_hexdigit()),
-            "hash portion should be hex: {hash_part}"
-        );
-    }
-
-    #[test]
-    fn repo_network_name_different_paths_differ() {
-        let name1 = repo_network_name(Path::new("/project/a"));
-        let name2 = repo_network_name(Path::new("/project/b"));
-        assert_ne!(name1, name2);
-    }
-
-    #[test]
-    fn repo_network_name_empty_path() {
-        // Edge case: empty path should still produce a valid name
-        let name = repo_network_name(Path::new(""));
-        assert!(name.starts_with("cella-net-"));
-        let hash_part = name.strip_prefix("cella-net-").unwrap();
-        assert_eq!(hash_part.len(), 12);
-    }
-
-    // -----------------------------------------------------------------------
-    // repo_network_name additional tests
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn repo_network_name_with_unicode_path() {
-        let name = repo_network_name(Path::new("/home/user/proyecto-espanol"));
-        assert!(name.starts_with("cella-net-"));
-        let hash = name.strip_prefix("cella-net-").unwrap();
-        assert_eq!(hash.len(), 12);
-        assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
-    }
-
-    #[test]
-    fn repo_network_name_with_spaces() {
-        let name = repo_network_name(Path::new("/home/user/my project"));
-        assert!(name.starts_with("cella-net-"));
-        let hash = name.strip_prefix("cella-net-").unwrap();
-        assert_eq!(hash.len(), 12);
-    }
-
-    #[test]
-    fn repo_network_name_with_dots() {
-        let name = repo_network_name(Path::new("/home/user/.hidden-project"));
-        assert!(name.starts_with("cella-net-"));
-    }
-
-    #[test]
-    fn repo_network_name_very_long_path() {
-        let long_path = "/".to_string() + &"a".repeat(1000);
-        let name = repo_network_name(Path::new(&long_path));
-        assert!(name.starts_with("cella-net-"));
-        let hash = name.strip_prefix("cella-net-").unwrap();
-        assert_eq!(
-            hash.len(),
-            12,
-            "hash should always be 12 chars regardless of path length"
-        );
-    }
-
-    #[test]
-    fn repo_network_name_root_path() {
-        let name = repo_network_name(Path::new("/"));
-        assert!(name.starts_with("cella-net-"));
-    }
-
-    #[test]
-    fn repo_network_name_similar_paths_differ() {
-        let name1 = repo_network_name(Path::new("/project/a"));
-        let name2 = repo_network_name(Path::new("/project/A"));
-        assert_ne!(
-            name1, name2,
-            "case-different paths should produce different hashes"
-        );
-    }
-
-    // -----------------------------------------------------------------------
-    // Network constant test
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn cella_network_name_is_valid_docker_network_name() {
-        // Docker network names must be lowercase alphanumeric
-        assert!(
-            CELLA_NETWORK_NAME.chars().all(|c| c.is_ascii_lowercase()),
-            "network name should be all lowercase"
-        );
-    }
+    // Naming-rule tests live in cella-backend::network with the
+    // implementation; this module covers the Docker API integration.
 
     // -----------------------------------------------------------------------
     // Orphan predicate tests

--- a/crates/cella-protocol/src/lib.rs
+++ b/crates/cella-protocol/src/lib.rs
@@ -376,7 +376,7 @@ pub enum ManagementResponse {
     /// SSH-agent bridge registered (or refcount bumped). `bridge_port` is
     /// the localhost TCP port the in-container `cella-agent` should
     /// connect to (reachable from the container as `host.docker.internal`,
-    /// `host.local`, or the equivalent host-gateway hostname). `refcount`
+    /// `host.container.internal`, or the equivalent host-gateway hostname). `refcount`
     /// is the post-register count; `1` means a fresh bridge was created,
     /// `>1` means an existing one was reused.
     SshAgentProxyRegistered { bridge_port: u16, refcount: usize },

--- a/docs/specs/container-backends.md
+++ b/docs/specs/container-backends.md
@@ -48,7 +48,7 @@ graph TD
 |---|---|---|
 | `cella-backend` | Foundation | Trait definitions, shared types, error types, naming/label utilities, mount abstractions, container target resolution |
 | `cella-docker` | Domain | Docker Engine implementation via bollard, socket discovery, config mapping to Docker API, network/volume management |
-| `cella-container` | Domain | Apple Container implementation via CLI subprocess, staging directory file injection, best-effort OCI image parsing |
+| `cella-container` | Domain | Apple Container implementation via CLI subprocess (1.0.0+), `container cp` file injection, OCI variant image parsing |
 | `cella-doctor` | Domain | Runtime availability checks, engine version validation, security advisory detection |
 
 ## Backend Trait
@@ -369,49 +369,70 @@ Compose-managed containers additionally carry `dev.cella.compose_project` and `d
 
 The Apple Container backend drives the macOS-native container runtime through the `container` CLI binary. The runtime uses Apple's Virtualization.framework (vz) to run Linux containers as lightweight VMs on Apple Silicon, providing near-native performance without a third-party hypervisor. The backend implements `ContainerBackend` by translating trait method calls into CLI subprocess invocations via `ContainerCli`.
 
+Discovery requires Apple Container **1.0.0 or newer**: the probe runs `container system version --format json`, and older releases are rejected with `DiscoveryError::UnsupportedVersion` (their structured-output shapes are incompatible and they lack `container cp`). A binary that fails the version probe but answers `container system status` is classified as a pre-1.0 Apple CLI; anything else is rejected as a foreign binary.
+
 Key differences from the Docker backend:
 
 | Aspect | Docker | Apple Container |
 |---|---|---|
 | API client | bollard (async Rust, Docker Engine API) | CLI subprocess (`container` binary) |
-| Compose | Supported | Not supported |
-| Agent provisioning | Shared Docker volume | Not supported |
-| Network management | Docker bridge networks | Not supported (returns `NotSupported`) |
-| Host gateway | `host.docker.internal` | `host.local` |
-| Mount types | bind, volume, tmpfs, npipe | bind (via `--volume` flag) |
+| Compose | Supported | Not supported (no compose equivalent exists) |
+| Agent provisioning | Shared Docker volume | Not supported (see below) |
+| Network management | Docker bridge networks; connect any time | vmnet networks; attachments fixed at creation (macOS 26+) |
+| Host gateway | `host.docker.internal` | `host.container.internal` (requires one-time `sudo container system dns create`) |
+| Mount types | bind, volume, tmpfs, npipe | bind (`-v src:dst[:ro]`), named volume (`-v name:dst`), tmpfs (`--tmpfs`) |
 | State mapping | Docker's `exited`/`dead` -> `Stopped` | Apple's `stopped` -> `Stopped` |
+| Exit codes | Reported via inspect | Not reported (`ContainerInfo::exit_code` is `None`) |
+
+### Networks
+
+On macOS 26+ the backend manages the same network topology as Docker: the shared `cella` network plus per-workspace `cella-net-{hash}` networks, all labeled `dev.cella.managed=true` (workspace networks additionally carry `dev.cella.repo`). Naming and labels come from `cella_backend::network`, so `cella list`, `cella prune`, and `cella down --rm` behave identically across backends.
+
+vmnet fixes attachments at creation: `create_container` ensures the networks exist and passes `--network` flags, and `ensure_container_network` verifies the create-time attachments instead of connecting afterwards (a container created before network support reports `NotSupported` until recreated). `get_container_ip` reads the live attachment address, preferring the `cella` network.
+
+The network subcommands do not exist on macOS 15. A one-shot probe (`container network ls`) detects this and the backend degrades gracefully: containers attach to the default vmnet network and the network trait methods report `NotSupported`.
+
+### Managed Agent (not supported)
+
+`capabilities().managed_agent` is `false`. The blocker is connectivity, not volume mechanics: the in-container cella-agent must dial the host daemon (`CELLA_DAEMON_ADDR={host_gateway}:{control_port}`), and the daemon's control listener binds `127.0.0.1` only. Docker Desktop, OrbStack, and Colima forward `host.docker.internal` into the host loopback; Apple Container has no automatic equivalent:
+
+- The vmnet gateway IP (e.g. `192.168.64.1`) reaches the host's bridge interface but **not** loopback-bound services. Using it would require the daemon to bind `0.0.0.0` or the bridge interface — a security-posture change (token-authenticated, but exposed beyond loopback) and a lifecycle problem (the bridge interface only exists while a container runs).
+- Apple's `container system dns create <domain> --localhost <ip>` does reach loopback via a pf redirect, but requires sudo, disables iCloud Private Relay, and the pf rule is lost on reboot — too fragile to depend on silently.
+
+Everything else needed for agent support exists in 1.0.0 (named volumes, `container cp` for populating them). If a daemon bind-address policy for non-loopback listeners is decided, agent provisioning can mirror the Docker volume flow. `host_gateway()` returns `host.container.internal` so injected URLs work for users who have run the one-time DNS setup.
 
 ### File Injection
 
-Without Docker's tar-upload API, the Apple Container backend uses a staging directory pattern for file injection:
+File injection uses the native `container cp` command (added in 1.0.0):
 
-1. Create a host-side staging directory at `~/.cache/cella/containers/{container-name}/`.
-2. Mount the staging directory into the container at `/tmp/.cella-staging`.
-3. Write files to the host staging directory.
-4. Execute `cp` inside the container to move files from the staging mount to their final paths.
-5. Execute `chmod` to set correct permissions.
-
-The staging directory is cleaned up when the container is removed with `remove_volumes: true`.
+1. Execute `mkdir -p` inside the container for the destination's parent directory.
+2. Write the content to a host temp file and run `container cp <tmp> <id>:<path>`.
+3. Execute `chown 0:0` and `chmod` to normalize ownership and permissions.
 
 ### Image Inspection
 
-Image metadata parsing uses best-effort extraction from the raw `container image inspect` JSON output. The parser checks multiple key paths for Docker/OCI compatibility:
+`container image inspect` emits an array of image resources whose `variants[]` carry full OCI image configs. The parser selects the variant matching the host architecture (falling back to the first variant) and reads the OCI `config` object:
 
-- `Config.User` / `config.user` / `container_config.User` -- user field (colon-delimited, only the user portion is extracted; defaults to `"root"` if empty)
-- `Config.Env` / `config.env` -- environment variable array
-- `Config.Labels` / `config.labels` -> `devcontainer.metadata` -- raw metadata JSON string
+- `config.User` -- user field (colon-delimited, only the user portion is extracted; defaults to `"root"` if empty)
+- `config.Env` -- environment variable array
+- `config.Labels` -> `devcontainer.metadata` -- raw metadata JSON string
 
-### Unsupported Docker Options
+Docker-style top-level `Config` objects are still recognized as a fallback.
 
-When Docker-specific creation flags are present, the Apple Container backend MUST emit warnings and proceed:
+### runArgs Mapping
+
+runArgs with native equivalents are passed through; the rest MUST emit warnings and proceed:
 
 | Flag | Behavior |
 |---|---|
+| `--cap-add` | Passed through (`container create --cap-add`) |
+| `--memory`, `--cpus`, `--shm-size` | Passed through; nano-CPUs round up to whole vCPUs |
+| `--init`, `--dns`, `--dns-search`, `--ulimit`, `--tmpfs`, `--label`, `--runtime` | Passed through |
 | `--privileged` | Warning emitted, ignored |
-| `--cap-add` | Warning emitted, ignored |
 | `--security-opt` | Warning emitted, ignored |
 | `--gpus` / `gpu_request` | Warning emitted, ignored |
 | `--device` | Warning emitted, ignored |
+| Namespace/cgroup/restart flags (`--pid`, `--ipc`, `--uts`, `--userns`, `--cgroupns`, `--restart`, ...) | One consolidated warning listing the ignored flags |
 | Unrecognized `runArgs` | Warning emitted, ignored |
 
 ## Docker Compose Configuration
@@ -495,9 +516,9 @@ The Apple Container CLI is discovered through a separate process:
 
 1. **`CELLA_CONTAINER_PATH` env var** -- explicit override pointing to the `container` binary.
 2. **PATH search** -- locate `container` in the system `PATH`.
-3. **Validation** -- confirm the binary is Apple's Container CLI (not a coincidental name collision):
-   - Primary: `container version --format json` -- parse JSON output for version info. An entry with `appName` containing "container" (case-insensitive) or any entry with a version field is accepted.
-   - Fallback: `container system status` -- confirms the binary is a working Apple Container CLI when the version plugin is not installed (common with `.pkg` installs).
+3. **Validation** -- confirm the binary is Apple's Container CLI (not a coincidental name collision) and enforce the minimum version:
+   - Primary: `container system version --format json` -- parse JSON output for version info. An entry with `appName` containing "container" (case-insensitive) or any entry with a version field is accepted. Versions below 1.0.0 are rejected as `DiscoveryError::UnsupportedVersion`; an unparseable version string fails open (the gate exists to reject known-old releases).
+   - Classifier: when the version probe fails, `container system status` distinguishes a pre-1.0 Apple CLI (rejected as outdated) from a foreign binary (rejected as not Apple's tool).
 
 ### Runtime Health Checks
 
@@ -755,7 +776,7 @@ The Docker backend's `connect_with_host` method accepts TCP URLs, enabling conne
 
 ## Limitations
 
-- **Apple Container CLI stability.** The `container` CLI output format is pre-1.0 and may change between macOS releases. The backend uses best-effort JSON parsing with multiple key-path fallbacks to tolerate format changes.
+- **Apple Container host connectivity.** Containers cannot reach loopback-bound host services without the one-time `sudo container system dns create` setup, which blocks managed-agent support (see the Apple Container Backend section). Serde parsing stays tolerant (`#[serde(default)]`, unknown keys ignored) so additive CLI output changes don't break the backend.
 - **Container label immutability.** Docker container labels and environment variables are immutable after creation. Configuration changes that affect labels require container recreation.
 - **macOS container-IP routing.** Colima and Docker Desktop for Mac run containers inside a VM. Container IPs are not routable from the host. Port access requires explicit forwarding through the daemon's tunnel infrastructure. OrbStack is the exception -- its native `.local` domain routing provides direct container access.
 


### PR DESCRIPTION
## Summary

- Require apple/container 1.0.0 and probe via `system version`
- Align SDK parsing with 1.0.0 CLI output and surface changes
- Replace staging-mount file upload with `container cp`
- Pass through `runArgs` that 1.0.0 supports natively
- Add network support for apple/container on macOS 26+
- Move network naming rules into cella-backend (shared with Docker)
- Batch metadata execs and fetch network list once per operation
- Drop the experimental label, update docs

## Highlights

- **Breaking:** requires apple/container >= 1.0.0
- **Network:** full cella network support on the container backend
- **Perf:** batched execs + single network list fetch
- **Refactor:** shared test utilities, centralized exit-code checks, cleaned SDK surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)