### PR TITLE
fix: VS Code attach failure from cella code on non-default Docker endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,6 +382,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "hex",
  "indicatif",
  "inquire",
  "insta",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,6 @@ dependencies = [
  "miette",
  "nix 0.31.3",
  "owo-colors",
- "serde",
  "serde_json",
  "tempfile",
  "terminal_size",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,6 +389,7 @@ dependencies = [
  "miette",
  "nix 0.31.3",
  "owo-colors",
+ "serde",
  "serde_json",
  "tempfile",
  "terminal_size",

--- a/crates/cella-backend/src/lib.rs
+++ b/crates/cella-backend/src/lib.rs
@@ -27,8 +27,9 @@ pub use network::{ManagedNetwork, RemovalOutcome};
 pub use resolve::ContainerTarget;
 pub use traits::{BackendCapabilities, BoxFuture, ContainerBackend, Platform};
 pub use types::{
-    BackendKind, BuildOptions, BuildSecret, ContainerInfo, ContainerState, CreateContainerOptions,
-    DeviceSpec, ExecOptions, ExecResult, FileToUpload, GpuAvailability, GpuRequest, ImageDetails,
-    InteractiveExecOptions, MountConfig, MountInfo, PortBinding, PortForward, RunArgsOverrides,
-    SshAgentProxyStatus, UlimitSpec, UpdateRemoteUserUidDefault, should_update_uid,
+    BackendEndpoint, BackendKind, BuildOptions, BuildSecret, ContainerInfo, ContainerState,
+    CreateContainerOptions, DeviceSpec, ExecOptions, ExecResult, FileToUpload, GpuAvailability,
+    GpuRequest, ImageDetails, InteractiveExecOptions, MountConfig, MountInfo, PortBinding,
+    PortForward, RunArgsOverrides, SshAgentProxyStatus, UlimitSpec, UpdateRemoteUserUidDefault,
+    should_update_uid,
 };

--- a/crates/cella-backend/src/traits.rs
+++ b/crates/cella-backend/src/traits.rs
@@ -11,8 +11,8 @@ use std::pin::Pin;
 use crate::error::BackendError;
 use crate::network::{ManagedNetwork, RemovalOutcome};
 use crate::types::{
-    BackendKind, BuildOptions, ContainerInfo, CreateContainerOptions, ExecOptions, ExecResult,
-    FileToUpload, ImageDetails, InteractiveExecOptions,
+    BackendEndpoint, BackendKind, BuildOptions, ContainerInfo, CreateContainerOptions, ExecOptions,
+    ExecResult, FileToUpload, ImageDetails, InteractiveExecOptions,
 };
 
 /// Container platform information (OS and architecture).
@@ -203,6 +203,14 @@ pub trait ContainerBackend: Send + Sync {
     ///
     /// Docker: `"host.docker.internal"`, Podman: `"host.containers.internal"`.
     fn host_gateway(&self) -> &'static str;
+
+    /// How an external tool can reach the daemon this backend is connected to.
+    ///
+    /// Returns `None` when the backend has no externally usable endpoint
+    /// (e.g. mock or non-Docker backends).
+    fn endpoint(&self) -> Option<BackendEndpoint> {
+        None
+    }
 
     // -- Platform detection --
 

--- a/crates/cella-backend/src/types.rs
+++ b/crates/cella-backend/src/types.rs
@@ -12,10 +12,10 @@ use std::str::FromStr;
 /// How an external tool (e.g. VS Code) can reach the same daemon this backend uses.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BackendEndpoint {
-    /// Explicit host URI (`unix://…` or `tcp://…`), maps to `DOCKER_HOST`.
-    DockerHost(String),
-    /// Named docker context, maps to `DOCKER_CONTEXT`.
-    DockerContext(String),
+    /// Explicit daemon URI (`unix://…` or `tcp://…`). Docker maps this to `DOCKER_HOST`.
+    HostUri(String),
+    /// Named connection profile. Docker maps this to `DOCKER_CONTEXT`.
+    NamedContext(String),
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/cella-backend/src/types.rs
+++ b/crates/cella-backend/src/types.rs
@@ -6,6 +6,19 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 // ---------------------------------------------------------------------------
+// Backend endpoint
+// ---------------------------------------------------------------------------
+
+/// How an external tool (e.g. VS Code) can reach the same daemon this backend uses.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BackendEndpoint {
+    /// Explicit host URI (`unix://…` or `tcp://…`), maps to `DOCKER_HOST`.
+    DockerHost(String),
+    /// Named docker context, maps to `DOCKER_CONTEXT`.
+    DockerContext(String),
+}
+
+// ---------------------------------------------------------------------------
 // Backend kind
 // ---------------------------------------------------------------------------
 

--- a/crates/cella-cli/Cargo.toml
+++ b/crates/cella-cli/Cargo.toml
@@ -31,6 +31,7 @@ inquire.workspace = true
 miette.workspace = true
 nix.workspace = true
 owo-colors.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 terminal_size.workspace = true
 tokio.workspace = true

--- a/crates/cella-cli/Cargo.toml
+++ b/crates/cella-cli/Cargo.toml
@@ -32,7 +32,6 @@ inquire.workspace = true
 miette.workspace = true
 nix.workspace = true
 owo-colors.workspace = true
-serde.workspace = true
 serde_json.workspace = true
 terminal_size.workspace = true
 tokio.workspace = true

--- a/crates/cella-cli/Cargo.toml
+++ b/crates/cella-cli/Cargo.toml
@@ -27,6 +27,7 @@ cella-protocol.workspace = true
 chrono.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
+hex.workspace = true
 inquire.workspace = true
 miette.workspace = true
 nix.workspace = true

--- a/crates/cella-cli/src/commands/code.rs
+++ b/crates/cella-cli/src/commands/code.rs
@@ -2,10 +2,11 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use clap::{Args, ValueEnum};
+use serde::Serialize;
 use serde_json::json;
 use tracing::debug;
 
-use cella_backend::ExecOptions;
+use cella_backend::{BackendEndpoint, ExecOptions};
 
 use super::OutputFormat;
 use super::up::{UpArgs, UpContext, UpRenderData, UpResult, output_result};
@@ -124,23 +125,13 @@ impl CodeArgs {
                 .map_err(super::boxed_err_to_report)?
         };
 
-        // 4. Resolve compose service if needed
-        let container_id = if self.service.is_some() {
-            let container = ctx.client.inspect_container(&result.container_id).await?;
-            let resolved = super::resolve_service_container(
-                ctx.client.as_ref(),
-                container,
-                self.service.as_deref(),
-            )
-            .await
-            .map_err(super::boxed_err_to_report)?;
-            resolved.id
-        } else {
-            result.container_id.clone()
-        };
+        // 4. Resolve the attach target (id + `/`-trimmed name)
+        let (container_id, container_name) =
+            resolve_attach_target(&ctx, &result.container_id, self.service.as_deref()).await?;
 
         // 5. Build the attached-container URI
-        let uri = build_vscode_uri(&container_id, &result.workspace_folder);
+        let endpoint = ctx.client.endpoint();
+        let uri = build_vscode_uri(&container_name, endpoint.as_ref(), &result.workspace_folder);
         debug!("VS Code URI: {uri}");
 
         // 6. Launch editor
@@ -188,6 +179,23 @@ impl CodeArgs {
     }
 }
 
+/// Resolve the container the editor should attach to, returning its `(id, name)`.
+///
+/// The returned name is `/`-trimmed (as carried by [`cella_backend::ContainerInfo`]).
+/// Inspects `container_id` — revalidating it right before the editor launches —
+/// and, for `--service`, resolves the requested compose service container from it.
+async fn resolve_attach_target(
+    ctx: &UpContext,
+    container_id: &str,
+    service: Option<&str>,
+) -> miette::Result<(String, String)> {
+    let container = ctx.client.inspect_container(container_id).await?;
+    let resolved = super::resolve_service_container(ctx.client.as_ref(), container, service)
+        .await
+        .map_err(super::boxed_err_to_report)?;
+    Ok((resolved.id, resolved.name))
+}
+
 /// Emit the `cella code` result.
 ///
 /// `code` has no official devcontainer-CLI analogue, so its JSON shape keeps
@@ -230,14 +238,58 @@ fn emit_code_result(
     }
 }
 
-/// Hex-encode a container ID for the attached-container URI scheme.
+/// JSON payload encoded into the attached-container URI authority.
 ///
-/// Each ASCII byte of the container ID is converted to its two-character hex
+/// The Dev Containers extension hex-decodes the authority; when the decoded
+/// bytes start with `{` it parses them as this JSON object. `containerName`
+/// carries the `/`-prefixed Docker container name (matching `docker inspect`
+/// `.Name`) and `settings` tells the extension which Docker endpoint to use.
+#[derive(Serialize)]
+struct AttachPayload {
+    #[serde(rename = "containerName")]
+    container_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    settings: Option<AttachSettings>,
+}
+
+/// Docker endpoint hints the extension reads to reach the same daemon cella used.
+///
+/// `host` maps to `DOCKER_HOST`, `context` maps to `DOCKER_CONTEXT`. Each is
+/// omitted when absent; the whole object is omitted when the backend exposes
+/// no endpoint, in which case the extension falls back to its own defaults.
+#[derive(Serialize)]
+struct AttachSettings {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    host: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    context: Option<String>,
+}
+
+impl AttachSettings {
+    /// Build settings from a backend endpoint, mapping the variant to the
+    /// matching extension key.
+    fn from_endpoint(endpoint: &BackendEndpoint) -> Self {
+        match endpoint {
+            BackendEndpoint::DockerHost(host) => Self {
+                host: Some(host.clone()),
+                context: None,
+            },
+            BackendEndpoint::DockerContext(context) => Self {
+                host: None,
+                context: Some(context.clone()),
+            },
+        }
+    }
+}
+
+/// Hex-encode a string for the attached-container URI authority.
+///
+/// Each UTF-8 byte is converted to its two-character lowercase hex
 /// representation. For example, `"a"` (0x61) becomes `"61"`.
-fn hex_encode_container_id(id: &str) -> String {
+fn hex_encode(value: &str) -> String {
     use std::fmt::Write;
-    let mut encoded = String::with_capacity(id.len() * 2);
-    for byte in id.bytes() {
+    let mut encoded = String::with_capacity(value.len() * 2);
+    for byte in value.bytes() {
         let _ = write!(encoded, "{byte:02x}");
     }
     encoded
@@ -245,10 +297,26 @@ fn hex_encode_container_id(id: &str) -> String {
 
 /// Build the VS Code attached-container remote URI.
 ///
-/// Format: `vscode-remote://attached-container+{hex_encoded_id}{workspace_path}`
-fn build_vscode_uri(container_id: &str, workspace_folder: &str) -> String {
-    let hex_id = hex_encode_container_id(container_id);
-    format!("vscode-remote://attached-container+{hex_id}{workspace_folder}")
+/// Format: `vscode-remote://attached-container+{hex}{workspace_folder}`, where
+/// `hex` is the byte-hex of a JSON [`AttachPayload`]. The Dev Containers
+/// extension hex-decodes the authority, parses the JSON, and reads
+/// `settings.host`/`settings.context` to pick its Docker endpoint.
+///
+/// `container_name` is the `/`-trimmed name from [`cella_backend::ContainerInfo`];
+/// the leading `/` (as in `docker inspect` `.Name`) is re-prepended here.
+fn build_vscode_uri(
+    container_name: &str,
+    endpoint: Option<&BackendEndpoint>,
+    workspace_folder: &str,
+) -> String {
+    let payload = AttachPayload {
+        container_name: format!("/{container_name}"),
+        settings: endpoint.map(AttachSettings::from_endpoint),
+    };
+    let json = serde_json::to_string(&payload)
+        .expect("AttachPayload contains only strings and is always serializable");
+    let hex = hex_encode(&json);
+    format!("vscode-remote://attached-container+{hex}{workspace_folder}")
 }
 
 /// Resolve which editor binary to use.
@@ -403,22 +471,44 @@ async fn poll_vscode_server(
 mod tests {
     use super::*;
 
+    /// Decode the hex authority of an attached-container URI back to its JSON.
+    ///
+    /// Strips the scheme prefix and the trailing workspace folder, then
+    /// hex-decodes the remaining authority payload to a UTF-8 string.
+    fn decode_uri_payload(uri: &str, workspace_folder: &str) -> String {
+        let authority = uri
+            .strip_prefix("vscode-remote://attached-container+")
+            .expect("URI should carry the attached-container prefix");
+        let hex = authority
+            .strip_suffix(workspace_folder)
+            .expect("URI should end with the workspace folder");
+        assert!(
+            hex.len().is_multiple_of(2),
+            "hex payload must be byte-aligned"
+        );
+        let bytes: Vec<u8> = (0..hex.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).expect("valid hex"))
+            .collect();
+        String::from_utf8(bytes).expect("payload should be valid UTF-8")
+    }
+
     #[test]
     fn hex_encode_empty_string() {
-        assert_eq!(hex_encode_container_id(""), "");
+        assert_eq!(hex_encode(""), "");
     }
 
     #[test]
     fn hex_encode_single_char() {
         // 'a' = 0x61
-        assert_eq!(hex_encode_container_id("a"), "61");
+        assert_eq!(hex_encode("a"), "61");
     }
 
     #[test]
-    fn hex_encode_known_container_id() {
+    fn hex_encode_known_string() {
         // A short example: "abc123" -> each char's hex
         // a=61, b=62, c=63, 1=31, 2=32, 3=33
-        assert_eq!(hex_encode_container_id("abc123"), "616263313233");
+        assert_eq!(hex_encode("abc123"), "616263313233");
     }
 
     #[test]
@@ -426,35 +516,94 @@ mod tests {
         // All hex digits: 0-9 a-f
         let input = "0123456789abcdef";
         let expected = "30313233343536373839616263646566";
-        assert_eq!(hex_encode_container_id(input), expected);
+        assert_eq!(hex_encode(input), expected);
     }
 
     #[test]
     fn hex_encode_full_docker_id() {
-        // 64-char container ID should produce 128-char encoded string
+        // 64-char string should produce 128-char encoded string
         let id = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
-        let encoded = hex_encode_container_id(id);
+        let encoded = hex_encode(id);
         assert_eq!(encoded.len(), 128);
     }
 
     #[test]
     fn build_uri_basic() {
-        let uri = build_vscode_uri("abc123", "/workspaces/myapp");
+        let uri = build_vscode_uri("my-container", None, "/workspaces/myapp");
+        assert!(uri.starts_with("vscode-remote://attached-container+"));
+        assert!(uri.ends_with("/workspaces/myapp"));
+        let payload = decode_uri_payload(&uri, "/workspaces/myapp");
+        assert_eq!(payload, r#"{"containerName":"/my-container"}"#);
+    }
+
+    #[test]
+    fn build_uri_with_endpoint_pins_exact_payload() {
+        let endpoint = BackendEndpoint::DockerHost("unix:///var/run/docker.sock".to_string());
+        let uri = build_vscode_uri("deadbeef", Some(&endpoint), "/workspaces/test");
+        let payload = decode_uri_payload(&uri, "/workspaces/test");
         assert_eq!(
-            uri,
-            "vscode-remote://attached-container+616263313233/workspaces/myapp"
+            payload,
+            r#"{"containerName":"/deadbeef","settings":{"host":"unix:///var/run/docker.sock"}}"#
         );
     }
 
     #[test]
-    fn build_uri_with_full_id() {
-        let id = "deadbeef";
-        let uri = build_vscode_uri(id, "/workspaces/test");
-        // d=64, e=65, a=61, d=64, b=62, e=65, e=65, f=66
+    fn build_uri_roundtrip_docker_host() {
+        let endpoint =
+            BackendEndpoint::DockerHost("unix:///Users/x/.colima/default/docker.sock".to_string());
+        let uri = build_vscode_uri("my-container", Some(&endpoint), "/workspaces/app");
+        let payload = decode_uri_payload(&uri, "/workspaces/app");
+        let value: serde_json::Value = serde_json::from_str(&payload).expect("valid JSON");
+        assert_eq!(value["containerName"], "/my-container");
         assert_eq!(
-            uri,
-            "vscode-remote://attached-container+6465616462656566/workspaces/test"
+            value["settings"]["host"],
+            "unix:///Users/x/.colima/default/docker.sock"
         );
+        assert!(value["settings"].get("context").is_none());
+    }
+
+    #[test]
+    fn build_uri_roundtrip_docker_context() {
+        let endpoint = BackendEndpoint::DockerContext("orbstack".to_string());
+        let uri = build_vscode_uri("my-container", Some(&endpoint), "/workspaces/app");
+        let payload = decode_uri_payload(&uri, "/workspaces/app");
+        let value: serde_json::Value = serde_json::from_str(&payload).expect("valid JSON");
+        assert_eq!(value["containerName"], "/my-container");
+        assert_eq!(value["settings"]["context"], "orbstack");
+        assert!(value["settings"].get("host").is_none());
+    }
+
+    #[test]
+    fn build_uri_no_endpoint_omits_settings() {
+        let uri = build_vscode_uri("my-container", None, "/workspaces/app");
+        let payload = decode_uri_payload(&uri, "/workspaces/app");
+        let value: serde_json::Value = serde_json::from_str(&payload).expect("valid JSON");
+        assert_eq!(value["containerName"], "/my-container");
+        assert!(
+            value.get("settings").is_none(),
+            "settings key must be absent without an endpoint"
+        );
+    }
+
+    #[test]
+    fn build_uri_shape_decodes_to_json_object() {
+        let endpoint = BackendEndpoint::DockerHost("tcp://localhost:2375".to_string());
+        let uri = build_vscode_uri("c", Some(&endpoint), "/workspaces/x");
+        assert!(uri.starts_with("vscode-remote://attached-container+"));
+        assert!(uri.ends_with("/workspaces/x"));
+        let payload = decode_uri_payload(&uri, "/workspaces/x");
+        assert!(payload.starts_with('{'), "payload must be a JSON object");
+    }
+
+    #[test]
+    fn build_uri_prepends_leading_slash_exactly_once() {
+        // Name input never carries a leading slash; output always begins `"/`.
+        let uri = build_vscode_uri("my-container", None, "");
+        let payload = decode_uri_payload(&uri, "");
+        let value: serde_json::Value = serde_json::from_str(&payload).expect("valid JSON");
+        let name = value["containerName"].as_str().expect("string name");
+        assert_eq!(name, "/my-container");
+        assert!(!name.starts_with("//"), "no double-slash prefix");
     }
 
     #[test]
@@ -530,8 +679,9 @@ mod tests {
 
     #[test]
     fn build_uri_empty_workspace() {
-        let uri = build_vscode_uri("abc", "");
-        assert_eq!(uri, "vscode-remote://attached-container+616263");
+        let uri = build_vscode_uri("abc", None, "");
+        let payload = decode_uri_payload(&uri, "");
+        assert_eq!(payload, r#"{"containerName":"/abc"}"#);
     }
 
     #[test]
@@ -581,12 +731,12 @@ mod tests {
         assert!(!is_localhost_tcp("tcp://"));
     }
 
-    // ── hex_encode_container_id ────────────────────────────────────
+    // ── hex_encode ─────────────────────────────────────────────────
 
     #[test]
     fn hex_encode_uppercase_chars() {
         // Uppercase A-F should encode correctly
-        let encoded = hex_encode_container_id("ABCDEF");
+        let encoded = hex_encode("ABCDEF");
         assert_eq!(encoded, "414243444546");
     }
 
@@ -594,7 +744,7 @@ mod tests {
 
     #[test]
     fn build_uri_with_nested_workspace() {
-        let uri = build_vscode_uri("abc", "/workspaces/project/sub/dir");
+        let uri = build_vscode_uri("abc", None, "/workspaces/project/sub/dir");
         assert!(uri.starts_with("vscode-remote://attached-container+"));
         assert!(uri.ends_with("/workspaces/project/sub/dir"));
     }

--- a/crates/cella-cli/src/commands/code.rs
+++ b/crates/cella-cli/src/commands/code.rs
@@ -496,39 +496,6 @@ mod tests {
     }
 
     #[test]
-    fn build_uri_no_endpoint_omits_settings() {
-        let uri = build_vscode_uri("my-container", None, "/workspaces/app");
-        let payload = decode_uri_payload(&uri, "/workspaces/app");
-        let value: serde_json::Value = serde_json::from_str(&payload).expect("valid JSON");
-        assert_eq!(value["containerName"], "/my-container");
-        assert!(
-            value.get("settings").is_none(),
-            "settings key must be absent without an endpoint"
-        );
-    }
-
-    #[test]
-    fn build_uri_shape_decodes_to_json_object() {
-        let endpoint = BackendEndpoint::HostUri("tcp://localhost:2375".to_string());
-        let uri = build_vscode_uri("c", Some(&endpoint), "/workspaces/x");
-        assert!(uri.starts_with("vscode-remote://attached-container+"));
-        assert!(uri.ends_with("/workspaces/x"));
-        let payload = decode_uri_payload(&uri, "/workspaces/x");
-        assert!(payload.starts_with('{'), "payload must be a JSON object");
-    }
-
-    #[test]
-    fn build_uri_prepends_leading_slash_exactly_once() {
-        // Name input never carries a leading slash; output always begins `"/`.
-        let uri = build_vscode_uri("my-container", None, "");
-        let payload = decode_uri_payload(&uri, "");
-        let value: serde_json::Value = serde_json::from_str(&payload).expect("valid JSON");
-        let name = value["containerName"].as_str().expect("string name");
-        assert_eq!(name, "/my-container");
-        assert!(!name.starts_with("//"), "no double-slash prefix");
-    }
-
-    #[test]
     fn is_localhost_tcp_variants() {
         assert!(is_localhost_tcp("tcp://localhost:2375"));
         assert!(is_localhost_tcp("tcp://127.0.0.1:2375"));
@@ -706,40 +673,21 @@ mod tests {
     // ── vscode_server_probe_cmd ────────────────────────────────────
 
     #[test]
-    fn probe_cmd_has_three_elements() {
+    fn probe_cmd_covers_all_editors_via_home() {
+        // Regression guard for the original bug: the probe hardcoded
+        // /home/<user> and only knew stable VS Code.
         let cmd = vscode_server_probe_cmd();
         assert_eq!(cmd.len(), 3, "must be [sh, -c, <script>]");
-        assert_eq!(cmd[0], "sh");
-        assert_eq!(cmd[1], "-c");
-    }
-
-    #[test]
-    fn probe_cmd_script_covers_all_server_dirs() {
-        let script = &vscode_server_probe_cmd()[2];
-        assert!(
-            script.contains(".vscode-server"),
-            "must include .vscode-server"
-        );
-        assert!(
-            script.contains(".vscode-server-insiders"),
-            "must include .vscode-server-insiders"
-        );
-        assert!(
-            script.contains(".cursor-server"),
-            "must include .cursor-server"
-        );
-    }
-
-    #[test]
-    fn probe_cmd_script_uses_home_variable_not_hardcoded_path() {
-        let script = &vscode_server_probe_cmd()[2];
-        assert!(
-            script.contains("$HOME"),
-            "must use $HOME, not a hardcoded path"
-        );
-        assert!(
-            !script.contains("/home/"),
-            "must not hardcode /home/ — use $HOME instead"
-        );
+        assert_eq!(&cmd[..2], ["sh", "-c"]);
+        let script = &cmd[2];
+        for dir in [
+            ".vscode-server",
+            ".vscode-server-insiders",
+            ".cursor-server",
+        ] {
+            assert!(script.contains(dir), "must probe {dir}");
+        }
+        assert!(script.contains("$HOME"), "must expand $HOME per exec user");
+        assert!(!script.contains("/home/"), "must not hardcode /home/");
     }
 }

--- a/crates/cella-cli/src/commands/code.rs
+++ b/crates/cella-cli/src/commands/code.rs
@@ -414,10 +414,25 @@ fn is_localhost_tcp(url: &str) -> bool {
         || authority == "::1"
 }
 
+/// Build the shell probe command that detects any VS Code-family server.
+///
+/// Returns a three-element `["sh", "-c", <script>]` command that expands
+/// `$HOME` for the exec user and succeeds (exit 0) as soon as any of
+/// `.vscode-server`, `.vscode-server-insiders`, or `.cursor-server` has a
+/// `bin/` subdirectory. This covers stable VS Code, VS Code Insiders, and
+/// Cursor, and works for any home directory (root, custom, etc.).
+fn vscode_server_probe_cmd() -> Vec<String> {
+    let script = "for d in .vscode-server .vscode-server-insiders .cursor-server; \
+         do [ -d \"$HOME/$d/bin\" ] && exit 0; done; exit 1";
+    vec!["sh".to_string(), "-c".to_string(), script.to_string()]
+}
+
 /// Poll for VS Code Server installation inside the container.
 ///
-/// Checks for `~/.vscode-server/bin` directory every 2 seconds, up to 60 seconds.
-/// Returns `true` if server was detected, `false` on timeout.
+/// Checks `$HOME/{.vscode-server,.vscode-server-insiders,.cursor-server}/bin`
+/// for the exec user every 2 seconds, up to 60 seconds. Covers stable VS Code,
+/// VS Code Insiders, and Cursor, and any home directory (including root).
+/// Returns `true` if a server was detected, `false` on timeout.
 async fn poll_vscode_server(
     client: &dyn cella_backend::ContainerBackend,
     container_id: &str,
@@ -434,11 +449,7 @@ async fn poll_vscode_server(
             .exec_command(
                 container_id,
                 &ExecOptions {
-                    cmd: vec![
-                        "test".to_string(),
-                        "-d".to_string(),
-                        format!("/home/{remote_user}/.vscode-server/bin"),
-                    ],
+                    cmd: vscode_server_probe_cmd(),
                     user: Some(remote_user.to_string()),
                     env: None,
                     working_dir: None,
@@ -784,5 +795,45 @@ mod tests {
             .unwrap();
         assert!(rendered.contains("help:"), "missing help section");
         assert!(!rendered.contains("\\n"), "literal \\n in output");
+    }
+
+    // ── vscode_server_probe_cmd ────────────────────────────────────
+
+    #[test]
+    fn probe_cmd_has_three_elements() {
+        let cmd = vscode_server_probe_cmd();
+        assert_eq!(cmd.len(), 3, "must be [sh, -c, <script>]");
+        assert_eq!(cmd[0], "sh");
+        assert_eq!(cmd[1], "-c");
+    }
+
+    #[test]
+    fn probe_cmd_script_covers_all_server_dirs() {
+        let script = &vscode_server_probe_cmd()[2];
+        assert!(
+            script.contains(".vscode-server"),
+            "must include .vscode-server"
+        );
+        assert!(
+            script.contains(".vscode-server-insiders"),
+            "must include .vscode-server-insiders"
+        );
+        assert!(
+            script.contains(".cursor-server"),
+            "must include .cursor-server"
+        );
+    }
+
+    #[test]
+    fn probe_cmd_script_uses_home_variable_not_hardcoded_path() {
+        let script = &vscode_server_probe_cmd()[2];
+        assert!(
+            script.contains("$HOME"),
+            "must use $HOME, not a hardcoded path"
+        );
+        assert!(
+            !script.contains("/home/"),
+            "must not hardcode /home/ — use $HOME instead"
+        );
     }
 }

--- a/crates/cella-cli/src/commands/code.rs
+++ b/crates/cella-cli/src/commands/code.rs
@@ -275,11 +275,11 @@ impl AttachSettings {
     /// matching extension key.
     fn from_endpoint(endpoint: &BackendEndpoint) -> Self {
         match endpoint {
-            BackendEndpoint::DockerHost(host) => Self {
+            BackendEndpoint::HostUri(host) => Self {
                 host: Some(host.clone()),
                 context: None,
             },
-            BackendEndpoint::DockerContext(context) => Self {
+            BackendEndpoint::NamedContext(context) => Self {
                 host: None,
                 context: Some(context.clone()),
             },
@@ -554,7 +554,7 @@ mod tests {
 
     #[test]
     fn build_uri_with_endpoint_pins_exact_payload() {
-        let endpoint = BackendEndpoint::DockerHost("unix:///var/run/docker.sock".to_string());
+        let endpoint = BackendEndpoint::HostUri("unix:///var/run/docker.sock".to_string());
         let uri = build_vscode_uri("deadbeef", Some(&endpoint), "/workspaces/test");
         let payload = decode_uri_payload(&uri, "/workspaces/test");
         assert_eq!(
@@ -566,7 +566,7 @@ mod tests {
     #[test]
     fn build_uri_roundtrip_docker_host() {
         let endpoint =
-            BackendEndpoint::DockerHost("unix:///Users/x/.colima/default/docker.sock".to_string());
+            BackendEndpoint::HostUri("unix:///Users/x/.colima/default/docker.sock".to_string());
         let uri = build_vscode_uri("my-container", Some(&endpoint), "/workspaces/app");
         let payload = decode_uri_payload(&uri, "/workspaces/app");
         let value: serde_json::Value = serde_json::from_str(&payload).expect("valid JSON");
@@ -580,7 +580,7 @@ mod tests {
 
     #[test]
     fn build_uri_roundtrip_docker_context() {
-        let endpoint = BackendEndpoint::DockerContext("orbstack".to_string());
+        let endpoint = BackendEndpoint::NamedContext("orbstack".to_string());
         let uri = build_vscode_uri("my-container", Some(&endpoint), "/workspaces/app");
         let payload = decode_uri_payload(&uri, "/workspaces/app");
         let value: serde_json::Value = serde_json::from_str(&payload).expect("valid JSON");
@@ -603,7 +603,7 @@ mod tests {
 
     #[test]
     fn build_uri_shape_decodes_to_json_object() {
-        let endpoint = BackendEndpoint::DockerHost("tcp://localhost:2375".to_string());
+        let endpoint = BackendEndpoint::HostUri("tcp://localhost:2375".to_string());
         let uri = build_vscode_uri("c", Some(&endpoint), "/workspaces/x");
         assert!(uri.starts_with("vscode-remote://attached-container+"));
         assert!(uri.ends_with("/workspaces/x"));

--- a/crates/cella-cli/src/commands/code.rs
+++ b/crates/cella-cli/src/commands/code.rs
@@ -287,19 +287,6 @@ impl AttachSettings {
     }
 }
 
-/// Hex-encode a string for the attached-container URI authority.
-///
-/// Each UTF-8 byte is converted to its two-character lowercase hex
-/// representation. For example, `"a"` (0x61) becomes `"61"`.
-fn hex_encode(value: &str) -> String {
-    use std::fmt::Write;
-    let mut encoded = String::with_capacity(value.len() * 2);
-    for byte in value.bytes() {
-        let _ = write!(encoded, "{byte:02x}");
-    }
-    encoded
-}
-
 /// Build the VS Code attached-container remote URI.
 ///
 /// Format: `vscode-remote://attached-container+{hex}{workspace_folder}`, where
@@ -320,7 +307,7 @@ fn build_vscode_uri(
     };
     let json = serde_json::to_string(&payload)
         .expect("AttachPayload contains only strings and is always serializable");
-    let hex = hex_encode(&json);
+    let hex = hex::encode(json);
     format!("vscode-remote://attached-container+{hex}{workspace_folder}")
 }
 
@@ -498,49 +485,8 @@ mod tests {
         let hex = authority
             .strip_suffix(workspace_folder)
             .expect("URI should end with the workspace folder");
-        assert!(
-            hex.len().is_multiple_of(2),
-            "hex payload must be byte-aligned"
-        );
-        let bytes: Vec<u8> = (0..hex.len())
-            .step_by(2)
-            .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).expect("valid hex"))
-            .collect();
+        let bytes = hex::decode(hex).expect("valid hex payload");
         String::from_utf8(bytes).expect("payload should be valid UTF-8")
-    }
-
-    #[test]
-    fn hex_encode_empty_string() {
-        assert_eq!(hex_encode(""), "");
-    }
-
-    #[test]
-    fn hex_encode_single_char() {
-        // 'a' = 0x61
-        assert_eq!(hex_encode("a"), "61");
-    }
-
-    #[test]
-    fn hex_encode_known_string() {
-        // A short example: "abc123" -> each char's hex
-        // a=61, b=62, c=63, 1=31, 2=32, 3=33
-        assert_eq!(hex_encode("abc123"), "616263313233");
-    }
-
-    #[test]
-    fn hex_encode_hex_chars() {
-        // All hex digits: 0-9 a-f
-        let input = "0123456789abcdef";
-        let expected = "30313233343536373839616263646566";
-        assert_eq!(hex_encode(input), expected);
-    }
-
-    #[test]
-    fn hex_encode_full_docker_id() {
-        // 64-char string should produce 128-char encoded string
-        let id = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
-        let encoded = hex_encode(id);
-        assert_eq!(encoded.len(), 128);
     }
 
     #[test]
@@ -745,15 +691,6 @@ mod tests {
     #[test]
     fn is_localhost_tcp_empty_authority() {
         assert!(!is_localhost_tcp("tcp://"));
-    }
-
-    // ── hex_encode ─────────────────────────────────────────────────
-
-    #[test]
-    fn hex_encode_uppercase_chars() {
-        // Uppercase A-F should encode correctly
-        let encoded = hex_encode("ABCDEF");
-        assert_eq!(encoded, "414243444546");
     }
 
     // ── build_vscode_uri ───────────────────────────────────────────

--- a/crates/cella-cli/src/commands/code.rs
+++ b/crates/cella-cli/src/commands/code.rs
@@ -53,7 +53,12 @@ pub enum CodeError {
     RemoteDockerHost { protocol: String },
 
     #[error("`cella code` requires the Docker backend (VS Code attach is Docker-specific)")]
-    #[diagnostic(code(cella::code::non_docker_backend))]
+    #[diagnostic(
+        code(cella::code::non_docker_backend),
+        help(
+            "VS Code's Dev Containers extension attaches through the Docker API and cannot see containers managed by the apple/container backend.\nWorkaround: enable VS Code's experimental `dev.containers.experimentalAppleContainerSupport` setting and let the extension manage the container itself."
+        )
+    )]
     NonDockerBackend,
 }
 
@@ -761,10 +766,14 @@ mod tests {
     }
 
     #[test]
-    fn code_error_non_docker_has_no_help() {
+    fn code_error_non_docker_has_help() {
         use miette::Diagnostic;
         let err = CodeError::NonDockerBackend;
-        assert!(err.help().is_none());
+        let help = err.help().expect("should have help text");
+        assert!(
+            help.to_string()
+                .contains("dev.containers.experimentalAppleContainerSupport")
+        );
     }
 
     #[test]

--- a/crates/cella-cli/src/commands/code.rs
+++ b/crates/cella-cli/src/commands/code.rs
@@ -2,7 +2,6 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use clap::{Args, ValueEnum};
-use serde::Serialize;
 use serde_json::json;
 use tracing::debug;
 
@@ -243,71 +242,32 @@ fn emit_code_result(
     }
 }
 
-/// JSON payload encoded into the attached-container URI authority.
-///
-/// The Dev Containers extension hex-decodes the authority; when the decoded
-/// bytes start with `{` it parses them as this JSON object. `containerName`
-/// carries the `/`-prefixed Docker container name (matching `docker inspect`
-/// `.Name`) and `settings` tells the extension which Docker endpoint to use.
-#[derive(Serialize)]
-struct AttachPayload {
-    #[serde(rename = "containerName")]
-    container_name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    settings: Option<AttachSettings>,
-}
-
-/// Docker endpoint hints the extension reads to reach the same daemon cella used.
-///
-/// `host` maps to `DOCKER_HOST`, `context` maps to `DOCKER_CONTEXT`. Each is
-/// omitted when absent; the whole object is omitted when the backend exposes
-/// no endpoint, in which case the extension falls back to its own defaults.
-#[derive(Serialize)]
-struct AttachSettings {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    host: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    context: Option<String>,
-}
-
-impl AttachSettings {
-    /// Build settings from a backend endpoint, mapping the variant to the
-    /// matching extension key.
-    fn from_endpoint(endpoint: &BackendEndpoint) -> Self {
-        match endpoint {
-            BackendEndpoint::HostUri(host) => Self {
-                host: Some(host.clone()),
-                context: None,
-            },
-            BackendEndpoint::NamedContext(context) => Self {
-                host: None,
-                context: Some(context.clone()),
-            },
-        }
-    }
-}
-
 /// Build the VS Code attached-container remote URI.
 ///
 /// Format: `vscode-remote://attached-container+{hex}{workspace_folder}`, where
-/// `hex` is the byte-hex of a JSON [`AttachPayload`]. The Dev Containers
-/// extension hex-decodes the authority, parses the JSON, and reads
-/// `settings.host`/`settings.context` to pick its Docker endpoint.
+/// `hex` is the byte-hex of a JSON payload. The Dev Containers extension
+/// hex-decodes the authority; when the decoded bytes start with `{` it parses
+/// them as JSON and reads `containerName` (the `/`-prefixed name matching
+/// `docker inspect` `.Name`) plus `settings.host`/`settings.context` to pick
+/// its Docker endpoint (`DOCKER_HOST`/`DOCKER_CONTEXT`, context wins). The
+/// `settings` key is omitted when the backend exposes no endpoint, leaving
+/// the extension on its own defaults.
 ///
 /// `container_name` is the `/`-trimmed name from [`cella_backend::ContainerInfo`];
-/// the leading `/` (as in `docker inspect` `.Name`) is re-prepended here.
+/// the leading `/` is re-prepended here.
 fn build_vscode_uri(
     container_name: &str,
     endpoint: Option<&BackendEndpoint>,
     workspace_folder: &str,
 ) -> String {
-    let payload = AttachPayload {
-        container_name: format!("/{container_name}"),
-        settings: endpoint.map(AttachSettings::from_endpoint),
-    };
-    let json = serde_json::to_string(&payload)
-        .expect("AttachPayload contains only strings and is always serializable");
-    let hex = hex::encode(json);
+    let mut payload = json!({ "containerName": format!("/{container_name}") });
+    if let Some(endpoint) = endpoint {
+        payload["settings"] = match endpoint {
+            BackendEndpoint::HostUri(host) => json!({ "host": host }),
+            BackendEndpoint::NamedContext(context) => json!({ "context": context }),
+        };
+    }
+    let hex = hex::encode(payload.to_string());
     format!("vscode-remote://attached-container+{hex}{workspace_folder}")
 }
 

--- a/crates/cella-docker/src/client.rs
+++ b/crates/cella-docker/src/client.rs
@@ -77,8 +77,12 @@ impl DockerClient {
                     ),
                 })?;
             tracing::info!("Connected to Docker via discovered socket: {path_str}");
-            let endpoint =
-                BackendEndpoint::HostUri(format!("unix://{}", discovered.path.display()));
+            // Prefer the context name: the editor-side docker CLI resolves it to
+            // the same daemon while inheriting the context's TLS/auth config.
+            let endpoint = discovered.context_name.map_or_else(
+                || BackendEndpoint::HostUri(format!("unix://{}", discovered.path.display())),
+                BackendEndpoint::NamedContext,
+            );
             return Ok(Self {
                 inner: docker,
                 endpoint,

--- a/crates/cella-docker/src/client.rs
+++ b/crates/cella-docker/src/client.rs
@@ -1,13 +1,42 @@
 //! Docker daemon connection management.
 
 use bollard::Docker;
+use cella_backend::BackendEndpoint;
 use tracing::debug;
 
 use crate::CellaDockerError;
 
+/// Normalize a `--docker-host` value to a full URI string.
+///
+/// Bare socket paths (starting with `/`) are prefixed with `unix://`.
+/// Values that already carry a scheme (`unix://`, `tcp://`, etc.) pass through unchanged.
+fn normalize_host_endpoint(host: &str) -> String {
+    if host.starts_with('/') {
+        format!("unix://{host}")
+    } else {
+        host.to_string()
+    }
+}
+
+/// The endpoint bollard's local-defaults path actually connects to.
+///
+/// Mirrors `Docker::connect_with_unix_defaults`: `DOCKER_HOST` is honored only
+/// when it starts with `unix://`; any other value is ignored and the default
+/// socket is used. Recording anything else would advertise an endpoint the
+/// connection never used.
+fn local_defaults_endpoint(docker_host: Option<String>) -> BackendEndpoint {
+    BackendEndpoint::DockerHost(
+        docker_host
+            .filter(|v| v.starts_with("unix://"))
+            .unwrap_or_else(|| "unix:///var/run/docker.sock".to_string()),
+    )
+}
+
 /// Wrapper around the bollard Docker client.
 pub struct DockerClient {
     inner: Docker,
+    /// Resolved daemon endpoint recorded at connect time.
+    pub(crate) endpoint: BackendEndpoint,
 }
 
 impl DockerClient {
@@ -26,7 +55,11 @@ impl DockerClient {
         match Docker::connect_with_local_defaults() {
             Ok(docker) => {
                 debug!("Connected to Docker via default socket");
-                return Ok(Self { inner: docker });
+                let endpoint = local_defaults_endpoint(std::env::var("DOCKER_HOST").ok());
+                return Ok(Self {
+                    inner: docker,
+                    endpoint,
+                });
             }
             Err(e) => {
                 debug!("Default Docker connection failed: {e}, trying alternative sockets");
@@ -44,7 +77,12 @@ impl DockerClient {
                     ),
                 })?;
             tracing::info!("Connected to Docker via discovered socket: {path_str}");
-            return Ok(Self { inner: docker });
+            let endpoint =
+                BackendEndpoint::DockerHost(format!("unix://{}", discovered.path.display()));
+            return Ok(Self {
+                inner: docker,
+                endpoint,
+            });
         }
 
         // All methods failed
@@ -68,7 +106,11 @@ impl DockerClient {
         .map_err(|e| CellaDockerError::RuntimeNotFound {
             message: format!("failed to connect to Docker at {host}: {e}"),
         })?;
-        Ok(Self { inner: docker })
+        let endpoint = BackendEndpoint::DockerHost(normalize_host_endpoint(host));
+        Ok(Self {
+            inner: docker,
+            endpoint,
+        })
     }
 
     /// Ping the daemon to verify connection.
@@ -85,6 +127,61 @@ impl DockerClient {
     /// Access the inner bollard client.
     pub const fn inner(&self) -> &Docker {
         &self.inner
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BackendEndpoint, local_defaults_endpoint, normalize_host_endpoint};
+
+    #[test]
+    fn bare_path_gets_unix_prefix() {
+        assert_eq!(
+            normalize_host_endpoint("/var/run/docker.sock"),
+            "unix:///var/run/docker.sock"
+        );
+    }
+
+    #[test]
+    fn unix_scheme_passes_through() {
+        assert_eq!(
+            normalize_host_endpoint("unix:///var/run/docker.sock"),
+            "unix:///var/run/docker.sock"
+        );
+    }
+
+    #[test]
+    fn tcp_scheme_passes_through() {
+        assert_eq!(
+            normalize_host_endpoint("tcp://localhost:2375"),
+            "tcp://localhost:2375"
+        );
+    }
+
+    #[test]
+    fn local_defaults_without_docker_host_uses_default_socket() {
+        assert_eq!(
+            local_defaults_endpoint(None),
+            BackendEndpoint::DockerHost("unix:///var/run/docker.sock".to_string())
+        );
+    }
+
+    #[test]
+    fn local_defaults_honors_unix_docker_host() {
+        assert_eq!(
+            local_defaults_endpoint(Some("unix:///tmp/custom.sock".to_string())),
+            BackendEndpoint::DockerHost("unix:///tmp/custom.sock".to_string())
+        );
+    }
+
+    #[test]
+    fn local_defaults_ignores_non_unix_docker_host() {
+        // Mirrors bollard: a tcp:// DOCKER_HOST is ignored by
+        // connect_with_unix_defaults, so it must not be advertised.
+        assert_eq!(
+            local_defaults_endpoint(Some("tcp://localhost:2375".to_string())),
+            BackendEndpoint::DockerHost("unix:///var/run/docker.sock".to_string())
+        );
     }
 }
 

--- a/crates/cella-docker/src/client.rs
+++ b/crates/cella-docker/src/client.rs
@@ -25,7 +25,7 @@ fn normalize_host_endpoint(host: &str) -> String {
 /// socket is used. Recording anything else would advertise an endpoint the
 /// connection never used.
 fn local_defaults_endpoint(docker_host: Option<String>) -> BackendEndpoint {
-    BackendEndpoint::DockerHost(
+    BackendEndpoint::HostUri(
         docker_host
             .filter(|v| v.starts_with("unix://"))
             .unwrap_or_else(|| "unix:///var/run/docker.sock".to_string()),
@@ -78,7 +78,7 @@ impl DockerClient {
                 })?;
             tracing::info!("Connected to Docker via discovered socket: {path_str}");
             let endpoint =
-                BackendEndpoint::DockerHost(format!("unix://{}", discovered.path.display()));
+                BackendEndpoint::HostUri(format!("unix://{}", discovered.path.display()));
             return Ok(Self {
                 inner: docker,
                 endpoint,
@@ -106,7 +106,7 @@ impl DockerClient {
         .map_err(|e| CellaDockerError::RuntimeNotFound {
             message: format!("failed to connect to Docker at {host}: {e}"),
         })?;
-        let endpoint = BackendEndpoint::DockerHost(normalize_host_endpoint(host));
+        let endpoint = BackendEndpoint::HostUri(normalize_host_endpoint(host));
         Ok(Self {
             inner: docker,
             endpoint,
@@ -162,7 +162,7 @@ mod tests {
     fn local_defaults_without_docker_host_uses_default_socket() {
         assert_eq!(
             local_defaults_endpoint(None),
-            BackendEndpoint::DockerHost("unix:///var/run/docker.sock".to_string())
+            BackendEndpoint::HostUri("unix:///var/run/docker.sock".to_string())
         );
     }
 
@@ -170,7 +170,7 @@ mod tests {
     fn local_defaults_honors_unix_docker_host() {
         assert_eq!(
             local_defaults_endpoint(Some("unix:///tmp/custom.sock".to_string())),
-            BackendEndpoint::DockerHost("unix:///tmp/custom.sock".to_string())
+            BackendEndpoint::HostUri("unix:///tmp/custom.sock".to_string())
         );
     }
 
@@ -180,7 +180,7 @@ mod tests {
         // connect_with_unix_defaults, so it must not be advertised.
         assert_eq!(
             local_defaults_endpoint(Some("tcp://localhost:2375".to_string())),
-            BackendEndpoint::DockerHost("unix:///var/run/docker.sock".to_string())
+            BackendEndpoint::HostUri("unix:///var/run/docker.sock".to_string())
         );
     }
 }

--- a/crates/cella-docker/src/discovery.rs
+++ b/crates/cella-docker/src/discovery.rs
@@ -15,6 +15,10 @@ pub struct DiscoveredSocket {
     pub path: PathBuf,
     /// How the socket was found (for diagnostics).
     pub method: DiscoveryMethod,
+    /// Name of the docker context the socket came from, when discovered via
+    /// `docker context inspect`. Lets consumers reference the daemon by
+    /// context name (inheriting its TLS/auth config) instead of a raw path.
+    pub context_name: Option<String>,
 }
 
 /// How a socket was discovered.
@@ -57,7 +61,7 @@ fn discover_from_docker_context() -> Option<DiscoveredSocket> {
             "context",
             "inspect",
             "--format",
-            "{{.Endpoints.docker.Host}}",
+            "{{.Name}}\t{{.Endpoints.docker.Host}}",
         ])
         .output()
         .ok()?;
@@ -67,16 +71,8 @@ fn discover_from_docker_context() -> Option<DiscoveredSocket> {
         return None;
     }
 
-    let endpoint = String::from_utf8_lossy(&output.stdout).trim().to_string();
-
-    let path = if let Some(stripped) = endpoint.strip_prefix("unix://") {
-        PathBuf::from(stripped)
-    } else if endpoint.starts_with('/') {
-        PathBuf::from(&endpoint)
-    } else {
-        debug!("docker context endpoint is not a unix socket: {endpoint}");
-        return None;
-    };
+    let line = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let (context_name, path) = parse_context_inspect_line(&line)?;
 
     if path.exists() {
         info!(
@@ -86,11 +82,32 @@ fn discover_from_docker_context() -> Option<DiscoveredSocket> {
         Some(DiscoveredSocket {
             path,
             method: DiscoveryMethod::DockerContext,
+            context_name,
         })
     } else {
         debug!("docker context socket does not exist: {}", path.display());
         None
     }
+}
+
+/// Parse one line of `docker context inspect --format '{{.Name}}\t{{.Endpoints.docker.Host}}'`.
+///
+/// Returns the context name (`None` when empty) and the endpoint's socket
+/// path, or `None` when the endpoint is not a unix socket.
+fn parse_context_inspect_line(line: &str) -> Option<(Option<String>, PathBuf)> {
+    let (name, endpoint) = line.split_once('\t')?;
+
+    let path = if let Some(stripped) = endpoint.strip_prefix("unix://") {
+        PathBuf::from(stripped)
+    } else if endpoint.starts_with('/') {
+        PathBuf::from(endpoint)
+    } else {
+        debug!("docker context endpoint is not a unix socket: {endpoint}");
+        return None;
+    };
+
+    let name = (!name.is_empty()).then(|| name.to_string());
+    Some((name, path))
 }
 
 /// Probe known filesystem paths for runtime sockets.
@@ -106,6 +123,7 @@ fn discover_from_known_paths() -> Option<DiscoveredSocket> {
             return Some(DiscoveredSocket {
                 path: path.clone(),
                 method: DiscoveryMethod::FilesystemProbe,
+                context_name: None,
             });
         }
         debug!("Socket not found: {}", path.display());
@@ -195,6 +213,53 @@ mod tests {
         assert!(msg.contains("Colima"));
         assert!(msg.contains("Podman"));
         assert!(msg.contains("Rancher Desktop"));
+    }
+
+    #[test]
+    fn parse_context_line_unix_endpoint() {
+        let parsed =
+            parse_context_inspect_line("orbstack\tunix:///Users/x/.orbstack/run/docker.sock");
+        assert_eq!(
+            parsed,
+            Some((
+                Some("orbstack".to_string()),
+                PathBuf::from("/Users/x/.orbstack/run/docker.sock")
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_context_line_bare_path_endpoint() {
+        let parsed = parse_context_inspect_line("default\t/var/run/docker.sock");
+        assert_eq!(
+            parsed,
+            Some((
+                Some("default".to_string()),
+                PathBuf::from("/var/run/docker.sock")
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_context_line_empty_name_becomes_none() {
+        let parsed = parse_context_inspect_line("\tunix:///var/run/docker.sock");
+        assert_eq!(parsed, Some((None, PathBuf::from("/var/run/docker.sock"))));
+    }
+
+    #[test]
+    fn parse_context_line_rejects_tcp_endpoint() {
+        assert_eq!(
+            parse_context_inspect_line("remote\ttcp://example.com:2376"),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_context_line_rejects_missing_tab() {
+        assert_eq!(
+            parse_context_inspect_line("unix:///var/run/docker.sock"),
+            None
+        );
     }
 
     #[test]
@@ -300,6 +365,7 @@ mod tests {
         let socket = DiscoveredSocket {
             path: PathBuf::from("/var/run/docker.sock"),
             method: DiscoveryMethod::FilesystemProbe,
+            context_name: None,
         };
         let debug_str = format!("{socket:?}");
         assert!(debug_str.contains("docker.sock"));
@@ -311,9 +377,11 @@ mod tests {
         let socket = DiscoveredSocket {
             path: PathBuf::from("/tmp/test.sock"),
             method: DiscoveryMethod::DockerContext,
+            context_name: Some("orbstack".to_string()),
         };
         let cloned = socket.clone();
         assert_eq!(cloned.path, socket.path);
+        assert_eq!(cloned.context_name, socket.context_name);
         assert!(matches!(cloned.method, DiscoveryMethod::DockerContext));
     }
 

--- a/crates/cella-docker/src/docker_api_impl.rs
+++ b/crates/cella-docker/src/docker_api_impl.rs
@@ -4,9 +4,9 @@ use std::io::Write;
 use std::path::Path;
 
 use cella_backend::{
-    BackendCapabilities, BackendError, BackendKind, BoxFuture, BuildOptions, ContainerBackend,
-    ContainerInfo, CreateContainerOptions, ExecOptions, ExecResult, FileToUpload, ImageDetails,
-    InteractiveExecOptions, ManagedNetwork, Platform, RemovalOutcome,
+    BackendCapabilities, BackendEndpoint, BackendError, BackendKind, BoxFuture, BuildOptions,
+    ContainerBackend, ContainerInfo, CreateContainerOptions, ExecOptions, ExecResult, FileToUpload,
+    ImageDetails, InteractiveExecOptions, ManagedNetwork, Platform, RemovalOutcome,
 };
 
 use crate::client::DockerClient;
@@ -296,6 +296,10 @@ impl ContainerBackend for DockerClient {
 
     fn host_gateway(&self) -> &'static str {
         "host.docker.internal"
+    }
+
+    fn endpoint(&self) -> Option<BackendEndpoint> {
+        Some(self.endpoint.clone())
     }
 
     // -- Platform detection --


### PR DESCRIPTION
`cella code` on OrbStack/Colima opened VS Code into a "container no longer exists" dialog, and the "Waiting for VS Code to connect" step always timed out after 60s. Two separate bugs.

**Attach failure:** we encoded the raw container ID into the `attached-container+<hex>` URI. The Dev Containers extension only picks its Docker endpoint from a `settings` field inside the hex payload — with no settings it forces `DOCKER_CONTEXT=default` and never finds the container cella created through a non-default socket (microsoft/vscode-remote-release#2003). The URI payload is now the JSON the extension itself emits: `{"containerName":"/<name>","settings":{"host":"<endpoint>"}}`, using the container name from inspect (which also revalidates the container right before launching the editor).

To know what to put in `settings.host`, backends now expose the endpoint they actually connected through: new `BackendEndpoint` enum + `ContainerBackend::endpoint()` (default `None`, so mock/apple backends are untouched), recorded by `DockerClient` on all three connect paths. One subtlety found in review: bollard's local-defaults path only honors `DOCKER_HOST` when it starts with `unix://`, so we mirror that filter instead of advertising an endpoint the connection never used.

**Connect poll:** the server check was hardcoded to `/home/<user>/.vscode-server/bin` — wrong for root, custom home dirs, Insiders, and Cursor. It now probes `$HOME/{.vscode-server,.vscode-server-insiders,.cursor-server}/bin` via `sh -c` as the remote user.

Also adds help text to the `NonDockerBackend` error pointing at VS Code's experimental apple/container setting.

Tests: payload round-trip (hex-decode → JSON field asserts), both endpoint variants, settings omitted without endpoint, endpoint normalization, probe command shape. Verified with fmt/clippy (pedantic+nursery)/full workspace tests.

Tested manually pending on macOS + OrbStack/Colima (the repro environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)