### PR TITLE
feat: features info command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,6 +376,7 @@ dependencies = [
  "cella-git",
  "cella-jsonc",
  "cella-network",
+ "cella-oci",
  "cella-orchestrator",
  "cella-protocol",
  "cella-templates",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,6 +653,7 @@ dependencies = [
  "base64 0.22.1",
  "dirs",
  "flate2",
+ "miette",
  "oci-distribution",
  "serde",
  "serde_json",

--- a/crates/cella-cli/Cargo.toml
+++ b/crates/cella-cli/Cargo.toml
@@ -13,6 +13,7 @@ cella-backend.workspace = true
 cella-compose.workspace = true
 cella-config.workspace = true
 cella-features.workspace = true
+cella-oci.workspace = true
 cella-jsonc.workspace = true
 cella-daemon.workspace = true
 cella-daemon-client.workspace = true

--- a/crates/cella-cli/src/commands/features/info.rs
+++ b/crates/cella-cli/src/commands/features/info.rs
@@ -251,18 +251,16 @@ impl InfoArgs {
 /// separator by requiring the `:` to appear *after* the last `/`.
 pub fn build_canonical_id(reference: &str, hex_digest: &str) -> String {
     // Strip an existing digest reference (@sha256:...) first.
-    let base = if let Some(pos) = reference.find('@') {
-        &reference[..pos]
-    } else {
-        // Look for a tag-separating `:` — it must appear after the last `/`.
-        let last_slash = reference.rfind('/').map_or(0, |p| p + 1);
-        let colon_after_last_slash = reference[last_slash..].find(':');
-        if let Some(rel) = colon_after_last_slash {
-            &reference[..last_slash + rel]
-        } else {
-            reference
-        }
-    };
+    let base = reference.find('@').map_or_else(
+        || {
+            // Look for a tag-separating `:` — it must appear after the last `/`.
+            let last_slash = reference.rfind('/').map_or(0, |p| p + 1);
+            reference[last_slash..]
+                .find(':')
+                .map_or(reference, |rel| &reference[..last_slash + rel])
+        },
+        |pos| &reference[..pos],
+    );
     format!("{base}@sha256:{hex_digest}")
 }
 

--- a/crates/cella-cli/src/commands/features/info.rs
+++ b/crates/cella-cli/src/commands/features/info.rs
@@ -219,10 +219,17 @@ impl InfoArgs {
                         eprintln!("Failed to fetch tags: {e}");
                     }
                 }
-                // Dependencies section
-                let edges = build_dependency_graph(&self.feature).await?;
-                println!("=== Dependency Graph ===");
-                println!("{}", render_mermaid(&self.feature, &edges));
+                // Dependencies section — failure is non-fatal, symmetric with
+                // the manifest and tags sections above.
+                match build_dependency_graph(&self.feature).await {
+                    Ok(edges) => {
+                        println!("=== Dependency Graph ===");
+                        println!("{}", render_mermaid(&self.feature, &edges));
+                    }
+                    Err(e) => {
+                        eprintln!("Failed to build dependency graph: {e}");
+                    }
+                }
             }
         }
         Ok(())
@@ -234,12 +241,29 @@ impl InfoArgs {
 // ---------------------------------------------------------------------------
 
 /// Build the canonical OCI identifier: `registry/repository@sha256:hex`.
+///
+/// Handles three reference forms correctly:
+/// - `registry/repo/name:tag`  → strips `:tag`, appends digest
+/// - `registry/repo/name@sha256:<hex>` → strips `@…` suffix, appends digest
+/// - `localhost:5000/ns/name`  → no tag after last `/`, appends digest as-is
+///
+/// The `:` in a registry host (`localhost:5000`) is distinguished from a tag
+/// separator by requiring the `:` to appear *after* the last `/`.
 pub fn build_canonical_id(reference: &str, hex_digest: &str) -> String {
-    // Strip the tag to get `registry/repository`, then append the digest.
-    let without_tag = reference
-        .rsplit_once(':')
-        .map_or(reference, |(base, _)| base);
-    format!("{without_tag}@sha256:{hex_digest}")
+    // Strip an existing digest reference (@sha256:...) first.
+    let base = if let Some(pos) = reference.find('@') {
+        &reference[..pos]
+    } else {
+        // Look for a tag-separating `:` — it must appear after the last `/`.
+        let last_slash = reference.rfind('/').map_or(0, |p| p + 1);
+        let colon_after_last_slash = reference[last_slash..].find(':');
+        if let Some(rel) = colon_after_last_slash {
+            &reference[..last_slash + rel]
+        } else {
+            reference
+        }
+    };
+    format!("{base}@sha256:{hex_digest}")
 }
 
 /// Construct the boxed error returned on manifest fetch failure.
@@ -365,14 +389,38 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
+    fn canonical_id_plain_ref_no_tag() {
+        // No tag, no digest — just append.
+        let id = build_canonical_id("ghcr.io/devcontainers/features/node", "abc123");
+        assert_eq!(id, "ghcr.io/devcontainers/features/node@sha256:abc123");
+    }
+
+    #[test]
     fn canonical_id_strips_tag_appends_digest() {
         let id = build_canonical_id("ghcr.io/devcontainers/features/node:1", "abc123");
         assert_eq!(id, "ghcr.io/devcontainers/features/node@sha256:abc123");
     }
 
     #[test]
-    fn canonical_id_no_tag_still_works() {
-        let id = build_canonical_id("ghcr.io/devcontainers/features/node", "abc123");
+    fn canonical_id_digest_ref_does_not_double_append() {
+        // Input already has @sha256:... — strip it and use our digest.
+        let id = build_canonical_id(
+            "ghcr.io/devcontainers/features/node@sha256:deadbeef",
+            "abc123",
+        );
         assert_eq!(id, "ghcr.io/devcontainers/features/node@sha256:abc123");
+    }
+
+    #[test]
+    fn canonical_id_registry_with_port_no_tag() {
+        // The `:5000` is part of the registry host, not a tag separator.
+        let id = build_canonical_id("localhost:5000/ns/myfeature", "abc123");
+        assert_eq!(id, "localhost:5000/ns/myfeature@sha256:abc123");
+    }
+
+    #[test]
+    fn canonical_id_registry_with_port_and_tag() {
+        let id = build_canonical_id("localhost:5000/ns/myfeature:latest", "abc123");
+        assert_eq!(id, "localhost:5000/ns/myfeature@sha256:abc123");
     }
 }

--- a/crates/cella-cli/src/commands/features/info.rs
+++ b/crates/cella-cli/src/commands/features/info.rs
@@ -9,6 +9,7 @@
 use clap::{Parser, ValueEnum};
 use serde::Serialize;
 
+use crate::commands::LogLevel;
 use cella_features::graph::{build_dependency_graph, render_mermaid};
 use cella_oci::{fetch_manifest_with_digest, fetch_published_tags};
 
@@ -27,7 +28,7 @@ pub struct InfoArgs {
 
     /// Log verbosity.
     #[arg(long, default_value = "info")]
-    pub log_level: InfoLogLevel,
+    pub log_level: LogLevel,
 
     /// Output format.
     #[arg(long, value_enum, default_value = "text")]
@@ -45,14 +46,6 @@ pub enum InfoMode {
     Dependencies,
     /// Show manifest + tags + dependency graph.
     Verbose,
-}
-
-/// Log level for the info command (mirrors the official CLI's `--log-level`).
-#[derive(Debug, Clone, Copy, ValueEnum)]
-pub enum InfoLogLevel {
-    Info,
-    Debug,
-    Trace,
 }
 
 /// Output format.
@@ -183,7 +176,8 @@ impl InfoArgs {
                     Ok((m, d)) => (m, build_canonical_id(&self.feature, &d)),
                     Err(e) => return Err(manifest_fetch_error(e, self.output_format)),
                 };
-                let published_tags = tags_result.unwrap_or_default();
+                let published_tags =
+                    tags_result.map_err(|e| tags_fetch_error(e, self.output_format))?;
                 let out = VerboseOutput {
                     manifest,
                     canonical_id,

--- a/crates/cella-cli/src/commands/features/info.rs
+++ b/crates/cella-cli/src/commands/features/info.rs
@@ -1,0 +1,378 @@
+//! `cella features info` — inspect OCI feature manifests, tags, and dependencies.
+//!
+//! Drop-in replacement for `devcontainer features info`.
+//! Exact contract:
+//!   cella features info <mode> <feature>
+//!   --log-level  info|debug|trace  (default info)
+//!   --output-format text|json      (default text)
+
+use clap::{Parser, ValueEnum};
+use serde::Serialize;
+
+use cella_features::graph::{build_dependency_graph, render_mermaid};
+use cella_oci::{fetch_manifest_with_digest, fetch_published_tags};
+
+// ---------------------------------------------------------------------------
+// Args
+// ---------------------------------------------------------------------------
+
+/// Show information about a devcontainer feature from an OCI registry.
+#[derive(Debug, Clone, Parser)]
+pub struct InfoArgs {
+    /// What to show: manifest | tags | dependencies | verbose.
+    pub mode: InfoMode,
+
+    /// OCI feature reference, e.g. `ghcr.io/devcontainers/features/node:1`.
+    pub feature: String,
+
+    /// Log verbosity.
+    #[arg(long, default_value = "info")]
+    pub log_level: InfoLogLevel,
+
+    /// Output format.
+    #[arg(long, value_enum, default_value = "text")]
+    pub output_format: OutputFormat,
+}
+
+/// Info sub-mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum InfoMode {
+    /// Show the OCI manifest JSON.
+    Manifest,
+    /// List published tags.
+    Tags,
+    /// Render the dependency graph as a Mermaid diagram.
+    Dependencies,
+    /// Show manifest + tags + dependency graph.
+    Verbose,
+}
+
+/// Log level for the info command (mirrors the official CLI's `--log-level`).
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum InfoLogLevel {
+    Info,
+    Debug,
+    Trace,
+}
+
+/// Output format.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum OutputFormat {
+    Text,
+    Json,
+}
+
+// ---------------------------------------------------------------------------
+// JSON output shapes (camelCase to match official CLI)
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ManifestOutput {
+    manifest: serde_json::Value,
+    canonical_id: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TagsOutput {
+    published_tags: Vec<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct VerboseOutput {
+    manifest: serde_json::Value,
+    canonical_id: String,
+    published_tags: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Execution
+// ---------------------------------------------------------------------------
+
+impl InfoArgs {
+    /// Execute the info command.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on OCI fetch failure or serialisation errors.
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        match self.mode {
+            InfoMode::Manifest => self.run_manifest().await,
+            InfoMode::Tags => self.run_tags().await,
+            InfoMode::Dependencies => self.run_dependencies().await,
+            InfoMode::Verbose => self.run_verbose().await,
+        }
+    }
+
+    async fn run_manifest(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        match fetch_manifest_with_digest(&self.feature).await {
+            Ok((manifest, digest)) => {
+                let canonical_id = build_canonical_id(&self.feature, &digest);
+                match self.output_format {
+                    OutputFormat::Json => {
+                        let out = ManifestOutput {
+                            manifest,
+                            canonical_id,
+                        };
+                        println!("{}", serde_json::to_string_pretty(&out)?);
+                    }
+                    OutputFormat::Text => {
+                        println!("{}", serde_json::to_string_pretty(&manifest)?);
+                        println!();
+                        println!("Canonical identifier: {canonical_id}");
+                    }
+                }
+            }
+            Err(e) => {
+                return Err(manifest_fetch_error(e, self.output_format));
+            }
+        }
+        Ok(())
+    }
+
+    async fn run_tags(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        match fetch_published_tags(&self.feature).await {
+            Ok(tags) if tags.is_empty() => {
+                return Err(tags_empty_error(self.output_format));
+            }
+            Ok(tags) => match self.output_format {
+                OutputFormat::Json => {
+                    let out = TagsOutput {
+                        published_tags: tags,
+                    };
+                    println!("{}", serde_json::to_string_pretty(&out)?);
+                }
+                OutputFormat::Text => {
+                    for tag in &tags {
+                        println!("{tag}");
+                    }
+                }
+            },
+            Err(e) => {
+                return Err(tags_fetch_error(e, self.output_format));
+            }
+        }
+        Ok(())
+    }
+
+    async fn run_dependencies(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        match self.output_format {
+            OutputFormat::Json => {
+                // NOTE: the official devcontainer CLI outputs nothing in JSON mode for
+                // the `dependencies` sub-mode. This is a known omission in the upstream
+                // implementation. We match that behaviour for parity.
+            }
+            OutputFormat::Text => {
+                let edges = build_dependency_graph(&self.feature).await?;
+                let diagram = render_mermaid(&self.feature, &edges);
+                println!("{diagram}");
+            }
+        }
+        Ok(())
+    }
+
+    async fn run_verbose(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let manifest_result = fetch_manifest_with_digest(&self.feature).await;
+        let tags_result = fetch_published_tags(&self.feature).await;
+
+        match self.output_format {
+            OutputFormat::Json => {
+                let (manifest, canonical_id) = match manifest_result {
+                    Ok((m, d)) => (m, build_canonical_id(&self.feature, &d)),
+                    Err(e) => return Err(manifest_fetch_error(e, self.output_format)),
+                };
+                let published_tags = tags_result.unwrap_or_default();
+                let out = VerboseOutput {
+                    manifest,
+                    canonical_id,
+                    published_tags,
+                };
+                println!("{}", serde_json::to_string_pretty(&out)?);
+            }
+            OutputFormat::Text => {
+                // Manifest section
+                match manifest_result {
+                    Ok((manifest, digest)) => {
+                        let canonical_id = build_canonical_id(&self.feature, &digest);
+                        println!("=== Manifest ===");
+                        println!("{}", serde_json::to_string_pretty(&manifest)?);
+                        println!();
+                        println!("Canonical identifier: {canonical_id}");
+                        println!();
+                    }
+                    Err(e) => {
+                        eprintln!("Failed to fetch manifest: {e}");
+                    }
+                }
+                // Tags section
+                match tags_result {
+                    Ok(tags) => {
+                        println!("=== Published Tags ===");
+                        for tag in &tags {
+                            println!("{tag}");
+                        }
+                        println!();
+                    }
+                    Err(e) => {
+                        eprintln!("Failed to fetch tags: {e}");
+                    }
+                }
+                // Dependencies section
+                let edges = build_dependency_graph(&self.feature).await?;
+                println!("=== Dependency Graph ===");
+                println!("{}", render_mermaid(&self.feature, &edges));
+            }
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+/// Build the canonical OCI identifier: `registry/repository@sha256:hex`.
+pub fn build_canonical_id(reference: &str, hex_digest: &str) -> String {
+    // Strip the tag to get `registry/repository`, then append the digest.
+    let without_tag = reference
+        .rsplit_once(':')
+        .map_or(reference, |(base, _)| base);
+    format!("{without_tag}@sha256:{hex_digest}")
+}
+
+/// Construct the boxed error returned on manifest fetch failure.
+fn manifest_fetch_error(
+    e: impl std::fmt::Display,
+    fmt: OutputFormat,
+) -> Box<dyn std::error::Error + Send + Sync> {
+    match fmt {
+        OutputFormat::Json => {
+            println!("{{}}");
+            format!("failed to fetch manifest: {e}").into()
+        }
+        OutputFormat::Text => format!("failed to fetch manifest: {e}").into(),
+    }
+}
+
+/// Construct the boxed error returned when no tags are found.
+fn tags_empty_error(fmt: OutputFormat) -> Box<dyn std::error::Error + Send + Sync> {
+    match fmt {
+        OutputFormat::Json => {
+            println!("{{}}");
+            "no published tags found".into()
+        }
+        OutputFormat::Text => "no published tags found".into(),
+    }
+}
+
+/// Construct the boxed error returned on tag fetch failure.
+fn tags_fetch_error(
+    e: impl std::fmt::Display,
+    fmt: OutputFormat,
+) -> Box<dyn std::error::Error + Send + Sync> {
+    match fmt {
+        OutputFormat::Json => {
+            println!("{{}}");
+            format!("failed to fetch tags: {e}").into()
+        }
+        OutputFormat::Text => format!("failed to fetch tags: {e}").into(),
+    }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------------
+    // InfoMode parsing via clap ValueEnum
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn info_mode_from_str_all_variants() {
+        use clap::ValueEnum;
+        assert!(InfoMode::from_str("manifest", true).is_ok());
+        assert!(InfoMode::from_str("tags", true).is_ok());
+        assert!(InfoMode::from_str("dependencies", true).is_ok());
+        assert!(InfoMode::from_str("verbose", true).is_ok());
+    }
+
+    #[test]
+    fn info_mode_invalid_rejected() {
+        use clap::ValueEnum;
+        assert!(InfoMode::from_str("unknown-mode", true).is_err());
+        assert!(InfoMode::from_str("", true).is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // JSON serialisation shape
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn manifest_output_camel_case_keys() {
+        let out = ManifestOutput {
+            manifest: serde_json::json!({"schemaVersion": 2}),
+            canonical_id: "ghcr.io/devcontainers/features/node@sha256:abc".to_owned(),
+        };
+        let json: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&out).unwrap()).unwrap();
+        assert!(json.get("manifest").is_some(), "manifest key missing");
+        assert!(json.get("canonicalId").is_some(), "canonicalId key missing");
+        assert!(
+            json.get("canonical_id").is_none(),
+            "snake_case key must not appear"
+        );
+    }
+
+    #[test]
+    fn tags_output_camel_case_keys() {
+        let out = TagsOutput {
+            published_tags: vec!["1".to_owned(), "latest".to_owned()],
+        };
+        let json: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&out).unwrap()).unwrap();
+        assert!(
+            json.get("publishedTags").is_some(),
+            "publishedTags key missing"
+        );
+        assert!(
+            json.get("published_tags").is_none(),
+            "snake_case key must not appear"
+        );
+    }
+
+    #[test]
+    fn verbose_output_camel_case_keys() {
+        let out = VerboseOutput {
+            manifest: serde_json::json!({}),
+            canonical_id: "id".to_owned(),
+            published_tags: vec![],
+        };
+        let json: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&out).unwrap()).unwrap();
+        assert!(json.get("manifest").is_some());
+        assert!(json.get("canonicalId").is_some());
+        assert!(json.get("publishedTags").is_some());
+    }
+
+    // -----------------------------------------------------------------------
+    // build_canonical_id
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn canonical_id_strips_tag_appends_digest() {
+        let id = build_canonical_id("ghcr.io/devcontainers/features/node:1", "abc123");
+        assert_eq!(id, "ghcr.io/devcontainers/features/node@sha256:abc123");
+    }
+
+    #[test]
+    fn canonical_id_no_tag_still_works() {
+        let id = build_canonical_id("ghcr.io/devcontainers/features/node", "abc123");
+        assert_eq!(id, "ghcr.io/devcontainers/features/node@sha256:abc123");
+    }
+}

--- a/crates/cella-cli/src/commands/features/mod.rs
+++ b/crates/cella-cli/src/commands/features/mod.rs
@@ -2,6 +2,7 @@
 //! devcontainer configurations.
 
 pub mod edit;
+pub mod info;
 pub mod jsonc_edit;
 pub mod list;
 pub mod prompts;
@@ -24,6 +25,8 @@ pub struct FeaturesArgs {
 pub enum FeaturesCommand {
     /// Edit features in an existing devcontainer configuration.
     Edit(edit::EditArgs),
+    /// Show information about a feature (manifest, tags, dependencies).
+    Info(info::InfoArgs),
     /// List configured or available features.
     List(list::ListArgs),
     /// Check for and apply feature version updates.
@@ -37,6 +40,7 @@ impl FeaturesArgs {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         match self.command {
             FeaturesCommand::Edit(args) => args.execute().await,
+            FeaturesCommand::Info(args) => args.execute().await,
             FeaturesCommand::List(args) => args.execute().await,
             FeaturesCommand::Update(args) => args.execute().await,
         }

--- a/crates/cella-cli/src/commands/features/mod.rs
+++ b/crates/cella-cli/src/commands/features/mod.rs
@@ -11,6 +11,7 @@ pub mod update;
 
 use clap::{Args, Subcommand};
 
+use crate::commands::LogLevel;
 use crate::progress::Progress;
 
 /// Manage devcontainer features.
@@ -34,6 +35,17 @@ pub enum FeaturesCommand {
 }
 
 impl FeaturesArgs {
+    /// Return the `--log-level` from the `info` subcommand, if active.
+    ///
+    /// Read by [`super::Command::log_level`] so the global tracing filter is
+    /// seeded before dispatch — the same pattern used by `up` and templates.
+    pub const fn log_level(&self) -> Option<LogLevel> {
+        match &self.command {
+            FeaturesCommand::Info(args) => Some(args.log_level),
+            _ => None,
+        }
+    }
+
     pub async fn execute(
         self,
         _progress: Progress,

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -199,7 +199,7 @@ pub enum UpdateRemoteUserUidDefault {
 }
 
 /// Log verbosity for lifecycle/terminal logging.
-#[derive(Clone, Copy, ValueEnum)]
+#[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum LogLevel {
     Info,
     Debug,
@@ -333,6 +333,7 @@ impl Command {
             Self::Code(args) => args.up.compat.log_level,
             Self::RunUserCommands(args) => args.compat.log_level,
             Self::Templates(args) => args.apply_log_level(),
+            Self::Features(args) => args.log_level(),
             _ => None,
         }
     }

--- a/crates/cella-cli/src/main.rs
+++ b/crates/cella-cli/src/main.rs
@@ -1094,6 +1094,29 @@ mod tests {
         let cli = parse(&["cella", "up", "--omit-config-remote-env-from-metadata"]).unwrap();
         assert!(matches!(cli.command, super::commands::Command::Up(_)));
     }
+
+    // ── features info --log-level wiring ────────────────────────────
+
+    #[test]
+    fn features_info_log_level_feeds_global_filter() {
+        let cli = parse(&[
+            "cella",
+            "features",
+            "info",
+            "dependencies",
+            "ghcr.io/devcontainers/features/node:1",
+            "--log-level",
+            "debug",
+        ])
+        .unwrap();
+        assert!(
+            matches!(
+                cli.command.log_level(),
+                Some(super::commands::LogLevel::Debug)
+            ),
+            "features info --log-level must reach Command::log_level()"
+        );
+    }
 }
 
 // ── log directive / spinner predicate helpers ───────────────────────

--- a/crates/cella-features/src/graph.rs
+++ b/crates/cella-features/src/graph.rs
@@ -225,6 +225,18 @@ fn parse_norm_ref(reference: &str) -> Result<NormalizedRef, FeatureError> {
                 reason: "expected registry/repository format".to_owned(),
             })?;
 
+    // Digest-pinned references (`repo@sha256:<hex>`) carry a `:` inside the
+    // digest. Splitting on it would treat the hex as a tag and `@sha256` as
+    // part of the repository, fetching the wrong artifact. Reject them
+    // explicitly rather than silently resolving the wrong target — dependency
+    // graphs don't yet resolve digest pins.
+    if rest.contains('@') {
+        return Err(FeatureError::InvalidReference {
+            reference: reference.to_owned(),
+            reason: "digest-pinned dependency references are not supported".to_owned(),
+        });
+    }
+
     let (repository, tag) = rest.rsplit_once(':').map_or_else(
         || (rest.to_owned(), "latest".to_owned()),
         |(r, t)| (r.to_owned(), t.to_owned()),
@@ -375,5 +387,17 @@ mod tests {
     #[test]
     fn parse_norm_ref_no_slash_errors() {
         assert!(parse_norm_ref("not-valid").is_err());
+    }
+
+    #[test]
+    fn parse_norm_ref_rejects_digest() {
+        // A digest pin must not be silently mis-parsed (repo `node@sha256`,
+        // tag `<hex>`); it should be rejected explicitly.
+        let err = parse_norm_ref(
+            "ghcr.io/devcontainers/features/node@sha256:\
+             aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+        .unwrap_err();
+        assert!(matches!(err, FeatureError::InvalidReference { .. }));
     }
 }

--- a/crates/cella-features/src/graph.rs
+++ b/crates/cella-features/src/graph.rs
@@ -284,9 +284,8 @@ mod tests {
             ),
         ];
         let output = render_mermaid("ghcr.io/devcontainers/features/node:1", &edges);
-        let lines: Vec<&str> = output.lines().collect();
         // Header + 2 edge lines
-        assert_eq!(lines.len(), 3);
+        assert_eq!(output.lines().count(), 3);
         assert!(output.contains("node:1"));
         assert!(output.contains("common-utils:2"));
         assert!(output.contains("git:1"));

--- a/crates/cella-features/src/graph.rs
+++ b/crates/cella-features/src/graph.rs
@@ -1,8 +1,12 @@
 //! Dependency graph builder and Mermaid renderer for devcontainer features.
 //!
-//! Builds the `dependsOn` (i.e. `installsAfter`) graph by recursively fetching
-//! and parsing `devcontainer-feature.json` from OCI registries, then renders
-//! the result as a Mermaid `flowchart TD` diagram.
+//! Builds the dependency graph by recursively fetching and parsing
+//! `devcontainer-feature.json` from OCI registries, then renders the result as
+//! a Mermaid `flowchart TD` diagram.
+//!
+//! Two edge kinds are modelled to match the official devcontainer CLI renderer:
+//! - **`dependsOn`** (hard dependency) → solid arrow `A --> B`
+//! - **`installsAfter`** (soft ordering hint) → dashed arrow `A -.-> B`
 
 use std::collections::{HashMap, HashSet};
 
@@ -15,14 +19,26 @@ use crate::oci::{FeatureFetcher, OciFetcher};
 use crate::reference::NormalizedRef;
 use crate::types::Platform;
 
-/// An edge in the feature dependency graph: `(from_ref, to_ref)` means
-/// `from_ref` depends on `to_ref` (installs after it).
-pub type DepEdge = (String, String);
+/// The kind of dependency relationship represented by a graph edge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EdgeKind {
+    /// Hard dependency declared via `dependsOn` — rendered as a solid arrow `-->`.
+    DependsOn,
+    /// Soft ordering hint declared via `installsAfter` — rendered as a dashed arrow `-.->`.
+    InstallsAfter,
+}
+
+/// An edge in the feature dependency graph.
+///
+/// `(from_ref, to_ref, kind)` means `from_ref` depends on (or installs after) `to_ref`.
+pub type DepEdge = (String, String, EdgeKind);
 
 /// Recursively build the dependency graph starting from `root_ref`.
 ///
-/// Uses `installsAfter` metadata to discover edges. Visits each unique
-/// reference at most once (cycle protection via a `HashSet` of visited refs).
+/// Discovers edges from both `dependsOn` (hard, solid arrow) and `installsAfter`
+/// (soft, dashed arrow) metadata fields. Each unique reference is visited at
+/// most once (cycle protection via a `HashSet`). Only `dependsOn` targets are
+/// recursed into; `installsAfter` targets are recorded as edges but not walked.
 ///
 /// Progress message "Building dependency graph..." is printed to stderr.
 ///
@@ -57,6 +73,10 @@ pub async fn build_dependency_graph(root_ref: &str) -> Result<Vec<DepEdge>, Feat
 ///
 /// Node labels use the short form `name:tag` (last path segment + tag).
 /// When `edges` is empty the diagram still renders with just the root node.
+///
+/// Edge rendering matches the official devcontainer CLI:
+/// - `dependsOn` → solid arrow `A --> B`
+/// - `installsAfter` → dashed arrow `A -.-> B`
 pub fn render_mermaid(root: &str, edges: &[DepEdge]) -> String {
     let mut node_ids: HashMap<String, String> = HashMap::new();
     let mut next_id = 0usize;
@@ -83,13 +103,17 @@ pub fn render_mermaid(root: &str, edges: &[DepEdge]) -> String {
         let label = short_label(root);
         lines.push(format!("    {id}[\"{label}\"]"));
     } else {
-        for (from, to) in edges {
+        for (from, to, kind) in edges {
             let from_id = get_id(from);
             let to_id = get_id(to);
             let from_label = short_label(from);
             let to_label = short_label(to);
+            let arrow = match kind {
+                EdgeKind::DependsOn => "-->",
+                EdgeKind::InstallsAfter => "-.->",
+            };
             lines.push(format!(
-                "    {from_id}[\"{from_label}\"] --> {to_id}[\"{to_label}\"]"
+                "    {from_id}[\"{from_label}\"] {arrow} {to_id}[\"{to_label}\"]"
             ));
         }
     }
@@ -171,10 +195,21 @@ async fn visit(
 
     let metadata = parse_feature_metadata(&json)?;
 
-    for dep in &metadata.installs_after {
-        edges.push((reference.to_owned(), dep.clone()));
+    // Hard dependencies: recurse into each and emit a solid edge.
+    for dep_ref in metadata.depends_on.keys() {
+        edges.push((reference.to_owned(), dep_ref.clone(), EdgeKind::DependsOn));
         // Box the recursive future to avoid infinitely-sized stack frames.
-        Box::pin(visit(dep, fetcher, platform, cache, edges, visited)).await?;
+        Box::pin(visit(dep_ref, fetcher, platform, cache, edges, visited)).await?;
+    }
+
+    // Soft ordering hints: record the edge but do not recurse (the target may
+    // not be in the resolved feature set at all).
+    for dep_ref in &metadata.installs_after {
+        edges.push((
+            reference.to_owned(),
+            dep_ref.clone(),
+            EdgeKind::InstallsAfter,
+        ));
     }
 
     Ok(())
@@ -259,36 +294,61 @@ mod tests {
     }
 
     #[test]
-    fn render_mermaid_single_edge() {
+    fn render_mermaid_depends_on_edge() {
         let edges = vec![(
             "ghcr.io/devcontainers/features/node:1".to_owned(),
             "ghcr.io/devcontainers/features/common-utils:2".to_owned(),
+            EdgeKind::DependsOn,
         )];
         let output = render_mermaid("ghcr.io/devcontainers/features/node:1", &edges);
         assert!(output.starts_with("flowchart TD"));
-        assert!(output.contains("-->"));
+        // Hard dep → solid arrow
+        assert!(output.contains("-->"), "expected solid arrow");
+        assert!(!output.contains("-.-"), "unexpected dashed arrow");
         assert!(output.contains("node:1"));
         assert!(output.contains("common-utils:2"));
     }
 
     #[test]
-    fn render_mermaid_multiple_edges() {
+    fn render_mermaid_installs_after_edge() {
+        let edges = vec![(
+            "ghcr.io/devcontainers/features/node:1".to_owned(),
+            "ghcr.io/devcontainers/features/common-utils:2".to_owned(),
+            EdgeKind::InstallsAfter,
+        )];
+        let output = render_mermaid("ghcr.io/devcontainers/features/node:1", &edges);
+        assert!(output.starts_with("flowchart TD"));
+        // Soft dep → dashed arrow
+        assert!(output.contains("-.-"), "expected dashed arrow");
+        assert!(output.contains("node:1"));
+        assert!(output.contains("common-utils:2"));
+    }
+
+    #[test]
+    fn render_mermaid_mixed_edges() {
         let edges = vec![
             (
                 "ghcr.io/devcontainers/features/node:1".to_owned(),
-                "ghcr.io/devcontainers/features/common-utils:2".to_owned(),
+                "ghcr.io/devcontainers/features/git:1".to_owned(),
+                EdgeKind::DependsOn,
             ),
             (
                 "ghcr.io/devcontainers/features/node:1".to_owned(),
-                "ghcr.io/devcontainers/features/git:1".to_owned(),
+                "ghcr.io/devcontainers/features/common-utils:2".to_owned(),
+                EdgeKind::InstallsAfter,
             ),
         ];
         let output = render_mermaid("ghcr.io/devcontainers/features/node:1", &edges);
         // Header + 2 edge lines
         assert_eq!(output.lines().count(), 3);
+        assert!(output.contains("-->"), "expected solid arrow for dependsOn");
+        assert!(
+            output.contains("-.-"),
+            "expected dashed arrow for installsAfter"
+        );
         assert!(output.contains("node:1"));
-        assert!(output.contains("common-utils:2"));
         assert!(output.contains("git:1"));
+        assert!(output.contains("common-utils:2"));
     }
 
     // -----------------------------------------------------------------------

--- a/crates/cella-features/src/graph.rs
+++ b/crates/cella-features/src/graph.rs
@@ -1,0 +1,320 @@
+//! Dependency graph builder and Mermaid renderer for devcontainer features.
+//!
+//! Builds the `dependsOn` (i.e. `installsAfter`) graph by recursively fetching
+//! and parsing `devcontainer-feature.json` from OCI registries, then renders
+//! the result as a Mermaid `flowchart TD` diagram.
+
+use std::collections::{HashMap, HashSet};
+
+use tracing::debug;
+
+use crate::FeatureError;
+use crate::cache::FeatureCache;
+use crate::metadata::parse_feature_metadata;
+use crate::oci::{FeatureFetcher, OciFetcher};
+use crate::reference::NormalizedRef;
+use crate::types::Platform;
+
+/// An edge in the feature dependency graph: `(from_ref, to_ref)` means
+/// `from_ref` depends on `to_ref` (installs after it).
+pub type DepEdge = (String, String);
+
+/// Recursively build the dependency graph starting from `root_ref`.
+///
+/// Uses `installsAfter` metadata to discover edges. Visits each unique
+/// reference at most once (cycle protection via a `HashSet` of visited refs).
+///
+/// Progress message "Building dependency graph..." is printed to stderr.
+///
+/// # Errors
+///
+/// Returns an error when a feature reference cannot be parsed, normalised, or
+/// fetched. Errors on transitive dependencies are propagated.
+pub async fn build_dependency_graph(root_ref: &str) -> Result<Vec<DepEdge>, FeatureError> {
+    eprintln!("Building dependency graph...");
+
+    let cache = FeatureCache::new();
+    let fetcher = OciFetcher::new();
+    let platform = host_platform();
+
+    let mut edges: Vec<DepEdge> = Vec::new();
+    let mut visited: HashSet<String> = HashSet::new();
+
+    visit(
+        root_ref,
+        &fetcher,
+        &platform,
+        &cache,
+        &mut edges,
+        &mut visited,
+    )
+    .await?;
+
+    Ok(edges)
+}
+
+/// Render a dependency graph as a Mermaid `flowchart TD` diagram.
+///
+/// Node labels use the short form `name:tag` (last path segment + tag).
+/// When `edges` is empty the diagram still renders with just the root node.
+pub fn render_mermaid(root: &str, edges: &[DepEdge]) -> String {
+    let mut node_ids: HashMap<String, String> = HashMap::new();
+    let mut next_id = 0usize;
+
+    // Assign stable single-letter / short node IDs.
+    let mut get_id = |ref_str: &str| -> String {
+        node_ids
+            .entry(ref_str.to_owned())
+            .or_insert_with(|| {
+                let id = node_label_from_id(next_id);
+                next_id += 1;
+                id
+            })
+            .clone()
+    };
+
+    // Ensure root always gets node A.
+    get_id(root);
+
+    let mut lines: Vec<String> = vec!["flowchart TD".to_owned()];
+
+    if edges.is_empty() {
+        let id = get_id(root);
+        let label = short_label(root);
+        lines.push(format!("    {id}[\"{label}\"]"));
+    } else {
+        for (from, to) in edges {
+            let from_id = get_id(from);
+            let to_id = get_id(to);
+            let from_label = short_label(from);
+            let to_label = short_label(to);
+            lines.push(format!(
+                "    {from_id}[\"{from_label}\"] --> {to_id}[\"{to_label}\"]"
+            ));
+        }
+    }
+
+    lines.join("\n")
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Produce a short human-readable label: `name:tag` from a full OCI ref.
+fn short_label(reference: &str) -> String {
+    // Strip registry: everything after the first `/`
+    let after_registry = reference.split_once('/').map_or(reference, |(_, r)| r);
+    // Last path segment (the feature name), possibly with a tag
+    after_registry
+        .rsplit('/')
+        .next()
+        .unwrap_or(reference)
+        .to_owned()
+}
+
+/// Generate a deterministic Mermaid node identifier from a sequential index.
+///
+/// Produces `A`, `B`, …, `Z`, `AA`, `AB`, … — short and legible in diagrams.
+fn node_label_from_id(index: usize) -> String {
+    let mut n = index;
+    let mut label = String::new();
+    loop {
+        let remainder = n % 26;
+        label.insert(0, (b'A' + u8::try_from(remainder).unwrap_or(0)) as char);
+        if n < 26 {
+            break;
+        }
+        n = n / 26 - 1;
+    }
+    label
+}
+
+/// Determine the host platform for feature fetching.
+fn host_platform() -> Platform {
+    let os = std::env::consts::OS;
+    let arch = match std::env::consts::ARCH {
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        other => other,
+    };
+    Platform {
+        os: os.to_owned(),
+        architecture: arch.to_owned(),
+    }
+}
+
+/// Recursively visit a feature reference, collecting edges into `edges`.
+async fn visit(
+    reference: &str,
+    fetcher: &OciFetcher,
+    platform: &Platform,
+    cache: &FeatureCache,
+    edges: &mut Vec<DepEdge>,
+    visited: &mut HashSet<String>,
+) -> Result<(), FeatureError> {
+    if !visited.insert(reference.to_owned()) {
+        debug!("graph: already visited {reference}, skipping");
+        return Ok(());
+    }
+
+    let norm_ref = parse_norm_ref(reference)?;
+
+    let artifact_dir = fetcher.fetch(&norm_ref, platform, cache).await?;
+
+    let metadata_path = artifact_dir.join("devcontainer-feature.json");
+    let json =
+        std::fs::read_to_string(&metadata_path).map_err(|e| FeatureError::InvalidMetadata {
+            feature_id: reference.to_owned(),
+            reason: format!("cannot read devcontainer-feature.json: {e}"),
+        })?;
+
+    let metadata = parse_feature_metadata(&json)?;
+
+    for dep in &metadata.installs_after {
+        edges.push((reference.to_owned(), dep.clone()));
+        // Box the recursive future to avoid infinitely-sized stack frames.
+        Box::pin(visit(dep, fetcher, platform, cache, edges, visited)).await?;
+    }
+
+    Ok(())
+}
+
+/// Parse a plain OCI reference string into a [`NormalizedRef`].
+fn parse_norm_ref(reference: &str) -> Result<NormalizedRef, FeatureError> {
+    let (registry, rest) =
+        reference
+            .split_once('/')
+            .ok_or_else(|| FeatureError::InvalidReference {
+                reference: reference.to_owned(),
+                reason: "expected registry/repository format".to_owned(),
+            })?;
+
+    let (repository, tag) = rest.rsplit_once(':').map_or_else(
+        || (rest.to_owned(), "latest".to_owned()),
+        |(r, t)| (r.to_owned(), t.to_owned()),
+    );
+
+    Ok(NormalizedRef::OciTarget {
+        registry: registry.to_owned(),
+        repository,
+        tag,
+    })
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------------
+    // short_label
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn short_label_full_ref() {
+        assert_eq!(
+            short_label("ghcr.io/devcontainers/features/node:1"),
+            "node:1"
+        );
+    }
+
+    #[test]
+    fn short_label_no_registry() {
+        assert_eq!(short_label("features/node:1"), "node:1");
+    }
+
+    #[test]
+    fn short_label_no_tag() {
+        assert_eq!(short_label("ghcr.io/devcontainers/features/node"), "node");
+    }
+
+    // -----------------------------------------------------------------------
+    // node_label_from_id
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn node_ids_sequential() {
+        assert_eq!(node_label_from_id(0), "A");
+        assert_eq!(node_label_from_id(1), "B");
+        assert_eq!(node_label_from_id(25), "Z");
+        assert_eq!(node_label_from_id(26), "AA");
+        assert_eq!(node_label_from_id(27), "AB");
+    }
+
+    // -----------------------------------------------------------------------
+    // render_mermaid
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn render_mermaid_no_edges() {
+        let output = render_mermaid("ghcr.io/devcontainers/features/node:1", &[]);
+        assert!(output.starts_with("flowchart TD"));
+        assert!(output.contains("A[\"node:1\"]"));
+        // No arrow present
+        assert!(!output.contains("-->"));
+    }
+
+    #[test]
+    fn render_mermaid_single_edge() {
+        let edges = vec![(
+            "ghcr.io/devcontainers/features/node:1".to_owned(),
+            "ghcr.io/devcontainers/features/common-utils:2".to_owned(),
+        )];
+        let output = render_mermaid("ghcr.io/devcontainers/features/node:1", &edges);
+        assert!(output.starts_with("flowchart TD"));
+        assert!(output.contains("-->"));
+        assert!(output.contains("node:1"));
+        assert!(output.contains("common-utils:2"));
+    }
+
+    #[test]
+    fn render_mermaid_multiple_edges() {
+        let edges = vec![
+            (
+                "ghcr.io/devcontainers/features/node:1".to_owned(),
+                "ghcr.io/devcontainers/features/common-utils:2".to_owned(),
+            ),
+            (
+                "ghcr.io/devcontainers/features/node:1".to_owned(),
+                "ghcr.io/devcontainers/features/git:1".to_owned(),
+            ),
+        ];
+        let output = render_mermaid("ghcr.io/devcontainers/features/node:1", &edges);
+        let lines: Vec<&str> = output.lines().collect();
+        // Header + 2 edge lines
+        assert_eq!(lines.len(), 3);
+        assert!(output.contains("node:1"));
+        assert!(output.contains("common-utils:2"));
+        assert!(output.contains("git:1"));
+    }
+
+    // -----------------------------------------------------------------------
+    // parse_norm_ref
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_norm_ref_valid() {
+        let result = parse_norm_ref("ghcr.io/devcontainers/features/node:1").unwrap();
+        match result {
+            NormalizedRef::OciTarget {
+                registry,
+                repository,
+                tag,
+            } => {
+                assert_eq!(registry, "ghcr.io");
+                assert_eq!(repository, "devcontainers/features/node");
+                assert_eq!(tag, "1");
+            }
+            _ => panic!("expected OciTarget"),
+        }
+    }
+
+    #[test]
+    fn parse_norm_ref_no_slash_errors() {
+        assert!(parse_norm_ref("not-valid").is_err());
+    }
+}

--- a/crates/cella-features/src/lib.rs
+++ b/crates/cella-features/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cache;
 pub mod dockerfile;
 mod error;
 pub mod fetch;
+pub mod graph;
 pub mod merge;
 pub mod metadata;
 pub mod oci;

--- a/crates/cella-features/src/metadata.rs
+++ b/crates/cella-features/src/metadata.rs
@@ -1,6 +1,6 @@
 //! Parser for `devcontainer-feature.json` metadata files.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use serde::Deserialize;
 
@@ -53,8 +53,10 @@ struct FeatureMetadataDto {
     options: HashMap<String, FeatureOptionDto>,
     /// Hard dependencies: `Record<featureId, options>` where options is
     /// `string | boolean | Record<string, string | boolean>`.
+    ///
+    /// `BTreeMap` for deterministic iteration (stable dependency-graph output).
     #[serde(default)]
-    depends_on: HashMap<String, serde_json::Value>,
+    depends_on: BTreeMap<String, serde_json::Value>,
     /// Soft ordering hints: array of feature reference strings.
     #[serde(default)]
     installs_after: Vec<String>,

--- a/crates/cella-features/src/metadata.rs
+++ b/crates/cella-features/src/metadata.rs
@@ -51,6 +51,11 @@ struct FeatureMetadataDto {
     description: Option<String>,
     #[serde(default)]
     options: HashMap<String, FeatureOptionDto>,
+    /// Hard dependencies: `Record<featureId, options>` where options is
+    /// `string | boolean | Record<string, string | boolean>`.
+    #[serde(default)]
+    depends_on: HashMap<String, serde_json::Value>,
+    /// Soft ordering hints: array of feature reference strings.
     #[serde(default)]
     installs_after: Vec<String>,
     container_user: Option<String>,
@@ -134,6 +139,7 @@ impl FeatureMetadataDto {
             name: self.name,
             description: self.description,
             options,
+            depends_on: self.depends_on,
             installs_after: self.installs_after,
             container_user: self.container_user,
             entrypoint: self.entrypoint,
@@ -168,6 +174,7 @@ mod tests {
         assert!(meta.name.is_none());
         assert!(meta.description.is_none());
         assert!(meta.options.is_empty());
+        assert!(meta.depends_on.is_empty());
         assert!(meta.installs_after.is_empty());
         assert!(meta.container_user.is_none());
         assert!(meta.entrypoint.is_none());
@@ -206,6 +213,9 @@ mod tests {
                     "default": true,
                     "description": "Install Yarn package manager"
                 }
+            },
+            "dependsOn": {
+                "ghcr.io/devcontainers/features/git:1": {}
             },
             "installsAfter": ["ghcr.io/devcontainers/features/common-utils"],
             "containerUser": "node",
@@ -255,6 +265,11 @@ mod tests {
         assert!(yarn_opt.enum_values.is_none());
 
         // Other fields
+        assert!(
+            meta.depends_on
+                .contains_key("ghcr.io/devcontainers/features/git:1"),
+            "dependsOn key missing"
+        );
         assert_eq!(
             meta.installs_after,
             vec!["ghcr.io/devcontainers/features/common-utils"]
@@ -474,6 +489,42 @@ mod tests {
         }"#;
         let meta = parse_feature_metadata(json).expect("mount without source should parse");
         assert_eq!(meta.mounts[0], "type=volume,source=,target=/data");
+    }
+
+    #[test]
+    fn depends_on_and_installs_after_parsed() {
+        // dependsOn values may be empty object, options map, or scalar bool/string per spec.
+        let json = r#"{
+            "id": "my-feature",
+            "version": "1.0.0",
+            "dependsOn": {
+                "ghcr.io/devcontainers/features/git:1": {},
+                "ghcr.io/devcontainers/features/common-utils:2": {
+                    "installZsh": true,
+                    "username": "vscode"
+                }
+            },
+            "installsAfter": [
+                "ghcr.io/devcontainers/features/base:1"
+            ]
+        }"#;
+        let meta = parse_feature_metadata(json).expect("should parse dependsOn + installsAfter");
+
+        // dependsOn: two hard-dependency refs
+        assert_eq!(meta.depends_on.len(), 2);
+        assert!(
+            meta.depends_on
+                .contains_key("ghcr.io/devcontainers/features/git:1")
+        );
+        let cu_opts = &meta.depends_on["ghcr.io/devcontainers/features/common-utils:2"];
+        assert_eq!(cu_opts["installZsh"], serde_json::json!(true));
+        assert_eq!(cu_opts["username"], serde_json::json!("vscode"));
+
+        // installsAfter: soft ordering hint
+        assert_eq!(
+            meta.installs_after,
+            vec!["ghcr.io/devcontainers/features/base:1"]
+        );
     }
 
     #[test]

--- a/crates/cella-features/src/types.rs
+++ b/crates/cella-features/src/types.rs
@@ -1,6 +1,6 @@
 //! Core types shared across the cella-features crate.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 
 /// Target platform for multi-arch feature resolution.
@@ -33,7 +33,10 @@ pub struct FeatureMetadata {
     ///
     /// Keys are feature reference strings; values are the options map to pass to
     /// that feature (arbitrary JSON — `string | boolean | object` per spec).
-    pub depends_on: HashMap<String, serde_json::Value>,
+    ///
+    /// A `BTreeMap` keeps iteration order stable so dependency-graph rendering
+    /// (e.g. the Mermaid diagram) is deterministic across runs.
+    pub depends_on: BTreeMap<String, serde_json::Value>,
     /// Soft ordering hints declared via `installsAfter`.
     pub installs_after: Vec<String>,
     pub container_user: Option<String>,

--- a/crates/cella-features/src/types.rs
+++ b/crates/cella-features/src/types.rs
@@ -29,6 +29,12 @@ pub struct FeatureMetadata {
     pub name: Option<String>,
     pub description: Option<String>,
     pub options: HashMap<String, FeatureOption>,
+    /// Hard dependencies declared via `dependsOn` in `devcontainer-feature.json`.
+    ///
+    /// Keys are feature reference strings; values are the options map to pass to
+    /// that feature (arbitrary JSON — `string | boolean | object` per spec).
+    pub depends_on: HashMap<String, serde_json::Value>,
+    /// Soft ordering hints declared via `installsAfter`.
     pub installs_after: Vec<String>,
     pub container_user: Option<String>,
     pub entrypoint: Option<String>,

--- a/crates/cella-oci/Cargo.toml
+++ b/crates/cella-oci/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 base64.workspace = true
 dirs.workspace = true
 flate2.workspace = true
+miette.workspace = true
 oci-distribution.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/cella-oci/src/inspect.rs
+++ b/crates/cella-oci/src/inspect.rs
@@ -27,7 +27,7 @@ const TAG_PAGE_SIZE: usize = 100;
 pub async fn fetch_manifest_with_digest(
     reference: &str,
 ) -> miette::Result<(serde_json::Value, String)> {
-    let (registry, repository, tag) = parse_reference(reference)?;
+    let (registry, repository, version) = parse_reference(reference)?;
 
     let config = ClientConfig {
         protocol: ClientProtocol::Https,
@@ -35,10 +35,17 @@ pub async fn fetch_manifest_with_digest(
     };
     let client = oci_distribution::Client::new(config);
 
-    let oci_ref = Reference::with_tag(registry.clone(), repository.clone(), tag.clone());
+    let oci_ref = match &version {
+        ReferenceVersion::Tag(tag) => {
+            Reference::with_tag(registry.clone(), repository.clone(), tag.clone())
+        }
+        ReferenceVersion::Digest(digest) => {
+            Reference::with_digest(registry.clone(), repository.clone(), digest.clone())
+        }
+    };
     let auth = build_registry_auth(&registry);
 
-    debug!("fetching manifest for {registry}/{repository}:{tag}");
+    debug!("fetching manifest for {registry}/{repository} ({version:?})");
 
     let (manifest, digest) = client
         .pull_image_manifest(&oci_ref, &auth)
@@ -54,7 +61,7 @@ pub async fn fetch_manifest_with_digest(
     let json_value = serde_json::to_value(&manifest)
         .map_err(|e| miette::miette!("failed to serialize manifest: {e}"))?;
 
-    debug!("fetched manifest for {registry}/{repository}:{tag} (digest={hex_digest})");
+    debug!("fetched manifest for {registry}/{repository} ({version:?}, digest={hex_digest})");
 
     Ok((json_value, hex_digest))
 }
@@ -84,7 +91,7 @@ pub async fn fetch_manifest_with_digest(
 /// Returns an error when the reference cannot be parsed or any registry
 /// request fails.
 pub async fn fetch_published_tags(reference: &str) -> miette::Result<Vec<String>> {
-    let (registry, repository, _tag) = parse_reference(reference)?;
+    let (registry, repository, _version) = parse_reference(reference)?;
 
     let config = ClientConfig {
         protocol: ClientProtocol::Https,
@@ -101,10 +108,23 @@ pub async fn fetch_published_tags(reference: &str) -> miette::Result<Vec<String>
     let mut last: Option<String> = None;
 
     loop {
-        let response = client
+        let response = match client
             .list_tags(&oci_ref, &auth, Some(TAG_PAGE_SIZE), last.as_deref())
             .await
-            .map_err(|e| miette::miette!("failed to list tags for {reference}: {e}"))?;
+        {
+            Ok(response) => response,
+            // A follow-up page can fail on registries that answer the final
+            // page with `{"tags": null}` (e.g. GHCR when the previous page
+            // was exactly full): treat it as end-of-list instead of failing
+            // the whole listing.
+            Err(e) if !all_tags.is_empty() => {
+                debug!("treating tag pagination error as end-of-list: {e}");
+                break;
+            }
+            Err(e) => {
+                return Err(miette::miette!("failed to list tags for {reference}: {e}"));
+            }
+        };
 
         let page_len = response.tags.len();
         last = response.tags.last().cloned();
@@ -121,28 +141,44 @@ pub async fn fetch_published_tags(reference: &str) -> miette::Result<Vec<String>
     Ok(all_tags)
 }
 
-/// Parse a feature OCI reference into `(registry, repository, tag)`.
+/// The version component of an OCI reference: a tag or a digest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReferenceVersion {
+    /// A named tag, e.g. `1` or `latest`.
+    Tag(String),
+    /// A content digest, e.g. `sha256:<hex>`.
+    Digest(String),
+}
+
+/// Parse a feature OCI reference into `(registry, repository, version)`.
 ///
-/// Accepts `registry/[namespace/]name:tag` or `registry/[namespace/]name`
-/// (defaulting the tag to `"latest"`).
+/// Accepts `registry/[namespace/]name:tag`, `registry/[namespace/]name@digest`,
+/// or `registry/[namespace/]name` (defaulting the tag to `"latest"`).
 ///
 /// # Errors
 ///
 /// Returns an error when the reference has no `/` separator (i.e., it is
 /// not a registry-qualified reference).
-pub fn parse_reference(reference: &str) -> miette::Result<(String, String, String)> {
+pub fn parse_reference(reference: &str) -> miette::Result<(String, String, ReferenceVersion)> {
     // Split registry from the rest on the first `/`.
     let (registry, rest) = reference.split_once('/').ok_or_else(|| {
         miette::miette!("invalid OCI reference (expected registry/repo): {reference}")
     })?;
 
-    // Split repository and tag on the last `:` in `rest`.
-    let (repository, tag) = rest.rsplit_once(':').map_or_else(
-        || (rest.to_owned(), "latest".to_owned()),
-        |(repo, t)| (repo.to_owned(), t.to_owned()),
+    // A digest reference uses `@` (e.g. `name@sha256:<hex>`); check it first
+    // because the digest itself contains a `:`.
+    let (repository, version) = rest.rsplit_once('@').map_or_else(
+        || {
+            // Split repository and tag on the last `:` in `rest`.
+            rest.rsplit_once(':').map_or_else(
+                || (rest.to_owned(), ReferenceVersion::Tag("latest".to_owned())),
+                |(repo, t)| (repo.to_owned(), ReferenceVersion::Tag(t.to_owned())),
+            )
+        },
+        |(repo, digest)| (repo.to_owned(), ReferenceVersion::Digest(digest.to_owned())),
     );
 
-    Ok((registry.to_owned(), repository, tag))
+    Ok((registry.to_owned(), repository, version))
 }
 
 // ===========================================================================
@@ -155,18 +191,31 @@ mod tests {
 
     #[test]
     fn parse_reference_with_tag() {
-        let (reg, repo, tag) = parse_reference("ghcr.io/devcontainers/features/node:1").unwrap();
+        let (reg, repo, version) =
+            parse_reference("ghcr.io/devcontainers/features/node:1").unwrap();
         assert_eq!(reg, "ghcr.io");
         assert_eq!(repo, "devcontainers/features/node");
-        assert_eq!(tag, "1");
+        assert_eq!(version, ReferenceVersion::Tag("1".to_owned()));
     }
 
     #[test]
     fn parse_reference_without_tag_defaults_latest() {
-        let (reg, repo, tag) = parse_reference("ghcr.io/devcontainers/features/node").unwrap();
+        let (reg, repo, version) = parse_reference("ghcr.io/devcontainers/features/node").unwrap();
         assert_eq!(reg, "ghcr.io");
         assert_eq!(repo, "devcontainers/features/node");
-        assert_eq!(tag, "latest");
+        assert_eq!(version, ReferenceVersion::Tag("latest".to_owned()));
+    }
+
+    #[test]
+    fn parse_reference_with_digest() {
+        let (reg, repo, version) =
+            parse_reference("ghcr.io/devcontainers/features/node@sha256:abc123").unwrap();
+        assert_eq!(reg, "ghcr.io");
+        assert_eq!(repo, "devcontainers/features/node");
+        assert_eq!(
+            version,
+            ReferenceVersion::Digest("sha256:abc123".to_owned())
+        );
     }
 
     #[test]
@@ -176,10 +225,10 @@ mod tests {
 
     #[test]
     fn parse_reference_deep_path() {
-        let (reg, repo, tag) =
+        let (reg, repo, version) =
             parse_reference("mcr.microsoft.com/devcontainers/base:ubuntu").unwrap();
         assert_eq!(reg, "mcr.microsoft.com");
         assert_eq!(repo, "devcontainers/base");
-        assert_eq!(tag, "ubuntu");
+        assert_eq!(version, ReferenceVersion::Tag("ubuntu".to_owned()));
     }
 }

--- a/crates/cella-oci/src/inspect.rs
+++ b/crates/cella-oci/src/inspect.rs
@@ -1,0 +1,152 @@
+//! OCI manifest inspection helpers.
+//!
+//! Provides a thin wrapper around `oci_distribution` to fetch a manifest
+//! and return it as a raw JSON value together with the resolved sha256 digest.
+
+use oci_distribution::Reference;
+use oci_distribution::client::{ClientConfig, ClientProtocol};
+use tracing::debug;
+
+use crate::build_registry_auth;
+
+/// Fetch the OCI manifest for a feature reference and return the manifest JSON
+/// together with its sha256 digest hex string (without the `sha256:` prefix).
+///
+/// `reference` must be a fully-qualified OCI reference in one of these forms:
+/// - `registry/repo/name:tag`
+/// - `registry/repo/name@sha256:<hex>`
+///
+/// # Errors
+///
+/// Returns an error wrapped via [`miette`] when the reference cannot be
+/// parsed, when the registry is unreachable, or when the manifest response
+/// cannot be decoded.
+pub async fn fetch_manifest_with_digest(
+    reference: &str,
+) -> miette::Result<(serde_json::Value, String)> {
+    let (registry, repository, tag) = parse_reference(reference)?;
+
+    let config = ClientConfig {
+        protocol: ClientProtocol::Https,
+        ..ClientConfig::default()
+    };
+    let client = oci_distribution::Client::new(config);
+
+    let oci_ref = Reference::with_tag(registry.clone(), repository.clone(), tag.clone());
+    let auth = build_registry_auth(&registry);
+
+    debug!("fetching manifest for {registry}/{repository}:{tag}");
+
+    let (manifest, digest) = client
+        .pull_image_manifest(&oci_ref, &auth)
+        .await
+        .map_err(|e| miette::miette!("failed to fetch manifest for {reference}: {e}"))?;
+
+    // Strip the "sha256:" prefix if present to return only the hex portion.
+    let hex_digest = digest
+        .strip_prefix("sha256:")
+        .map(str::to_owned)
+        .unwrap_or(digest);
+
+    let json_value = serde_json::to_value(&manifest)
+        .map_err(|e| miette::miette!("failed to serialize manifest: {e}"))?;
+
+    debug!("fetched manifest for {registry}/{repository}:{tag} (digest={hex_digest})");
+
+    Ok((json_value, hex_digest))
+}
+
+/// Fetch all published tags for an OCI reference.
+///
+/// The reference must include at least `registry/repository` — the tag
+/// component is ignored (a synthetic `"latest"` tag is used internally to
+/// target the repository namespace).
+///
+/// # Errors
+///
+/// Returns an error when the reference cannot be parsed or the registry
+/// request fails.
+pub async fn fetch_published_tags(reference: &str) -> miette::Result<Vec<String>> {
+    let (registry, repository, _tag) = parse_reference(reference)?;
+
+    let config = ClientConfig {
+        protocol: ClientProtocol::Https,
+        ..ClientConfig::default()
+    };
+    let client = oci_distribution::Client::new(config);
+
+    let oci_ref = Reference::with_tag(registry.clone(), repository.clone(), "latest".to_owned());
+    let auth = build_registry_auth(&registry);
+
+    debug!("listing tags for {registry}/{repository}");
+
+    let response = client
+        .list_tags(&oci_ref, &auth, None, None)
+        .await
+        .map_err(|e| miette::miette!("failed to list tags for {reference}: {e}"))?;
+
+    Ok(response.tags)
+}
+
+/// Parse a feature OCI reference into `(registry, repository, tag)`.
+///
+/// Accepts `registry/[namespace/]name:tag` or `registry/[namespace/]name`
+/// (defaulting the tag to `"latest"`).
+///
+/// # Errors
+///
+/// Returns an error when the reference has no `/` separator (i.e., it is
+/// not a registry-qualified reference).
+pub fn parse_reference(reference: &str) -> miette::Result<(String, String, String)> {
+    // Split registry from the rest on the first `/`.
+    let (registry, rest) = reference.split_once('/').ok_or_else(|| {
+        miette::miette!("invalid OCI reference (expected registry/repo): {reference}")
+    })?;
+
+    // Split repository and tag on the last `:` in `rest`.
+    let (repository, tag) = rest.rsplit_once(':').map_or_else(
+        || (rest.to_owned(), "latest".to_owned()),
+        |(repo, t)| (repo.to_owned(), t.to_owned()),
+    );
+
+    Ok((registry.to_owned(), repository, tag))
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_reference_with_tag() {
+        let (reg, repo, tag) = parse_reference("ghcr.io/devcontainers/features/node:1").unwrap();
+        assert_eq!(reg, "ghcr.io");
+        assert_eq!(repo, "devcontainers/features/node");
+        assert_eq!(tag, "1");
+    }
+
+    #[test]
+    fn parse_reference_without_tag_defaults_latest() {
+        let (reg, repo, tag) = parse_reference("ghcr.io/devcontainers/features/node").unwrap();
+        assert_eq!(reg, "ghcr.io");
+        assert_eq!(repo, "devcontainers/features/node");
+        assert_eq!(tag, "latest");
+    }
+
+    #[test]
+    fn parse_reference_no_slash_errors() {
+        assert!(parse_reference("not-a-valid-ref").is_err());
+    }
+
+    #[test]
+    fn parse_reference_deep_path() {
+        let (reg, repo, tag) =
+            parse_reference("mcr.microsoft.com/devcontainers/base:ubuntu").unwrap();
+        assert_eq!(reg, "mcr.microsoft.com");
+        assert_eq!(repo, "devcontainers/base");
+        assert_eq!(tag, "ubuntu");
+    }
+}

--- a/crates/cella-oci/src/inspect.rs
+++ b/crates/cella-oci/src/inspect.rs
@@ -9,6 +9,9 @@ use tracing::debug;
 
 use crate::build_registry_auth;
 
+/// Number of tags to request per registry page when listing tags.
+const TAG_PAGE_SIZE: usize = 100;
+
 /// Fetch the OCI manifest for a feature reference and return the manifest JSON
 /// together with its sha256 digest hex string (without the `sha256:` prefix).
 ///
@@ -56,15 +59,29 @@ pub async fn fetch_manifest_with_digest(
     Ok((json_value, hex_digest))
 }
 
-/// Fetch all published tags for an OCI reference.
+/// Fetch **all** published tags for an OCI reference, paginating as needed.
 ///
 /// The reference must include at least `registry/repository` — the tag
 /// component is ignored (a synthetic `"latest"` tag is used internally to
 /// target the repository namespace).
 ///
+/// ## Pagination contract
+///
+/// `oci_distribution`'s `list_tags(ref, auth, n, last)` maps to the OCI
+/// Distribution Spec's `GET /v2/<name>/tags/list?n=<n>&last=<last>` endpoint.
+/// `TagResponse` has no cursor field — pagination is driven by passing the
+/// last tag name from the previous page as the `last` parameter on the next
+/// call.
+///
+/// Some registries (e.g. GHCR) return `{"tags": null}` on the final page
+/// instead of an empty array, which causes `oci_distribution`'s
+/// `TagResponse { tags: Vec<String> }` to produce a deserialization error.
+/// We avoid triggering that path by stopping as soon as a page returns fewer
+/// tags than [`TAG_PAGE_SIZE`] — a partial page always means end-of-list.
+///
 /// # Errors
 ///
-/// Returns an error when the reference cannot be parsed or the registry
+/// Returns an error when the reference cannot be parsed or any registry
 /// request fails.
 pub async fn fetch_published_tags(reference: &str) -> miette::Result<Vec<String>> {
     let (registry, repository, _tag) = parse_reference(reference)?;
@@ -80,12 +97,28 @@ pub async fn fetch_published_tags(reference: &str) -> miette::Result<Vec<String>
 
     debug!("listing tags for {registry}/{repository}");
 
-    let response = client
-        .list_tags(&oci_ref, &auth, None, None)
-        .await
-        .map_err(|e| miette::miette!("failed to list tags for {reference}: {e}"))?;
+    let mut all_tags: Vec<String> = Vec::new();
+    let mut last: Option<String> = None;
 
-    Ok(response.tags)
+    loop {
+        let response = client
+            .list_tags(&oci_ref, &auth, Some(TAG_PAGE_SIZE), last.as_deref())
+            .await
+            .map_err(|e| miette::miette!("failed to list tags for {reference}: {e}"))?;
+
+        let page_len = response.tags.len();
+        last = response.tags.last().cloned();
+        all_tags.extend(response.tags);
+
+        // A partial page means we've reached the end. Avoid making a
+        // follow-up request that would trigger the null-tags deserialization
+        // bug in some registries (including GHCR).
+        if page_len < TAG_PAGE_SIZE {
+            break;
+        }
+    }
+
+    Ok(all_tags)
 }
 
 /// Parse a feature OCI reference into `(registry, repository, tag)`.

--- a/crates/cella-oci/src/inspect.rs
+++ b/crates/cella-oci/src/inspect.rs
@@ -5,6 +5,7 @@
 
 use oci_distribution::Reference;
 use oci_distribution::client::{ClientConfig, ClientProtocol};
+use oci_distribution::errors::OciDistributionError;
 use tracing::debug;
 
 use crate::build_registry_auth;
@@ -114,11 +115,13 @@ pub async fn fetch_published_tags(reference: &str) -> miette::Result<Vec<String>
         {
             Ok(response) => response,
             // A follow-up page can fail on registries that answer the final
-            // page with `{"tags": null}` (e.g. GHCR when the previous page
-            // was exactly full): treat it as end-of-list instead of failing
-            // the whole listing.
-            Err(e) if !all_tags.is_empty() => {
-                debug!("treating tag pagination error as end-of-list: {e}");
+            // page with `{"tags": null}` (e.g. GHCR when the previous page was
+            // exactly full): the null body fails JSON deserialization. Treat
+            // *only* that case as end-of-list. Network/auth/registry errors
+            // must propagate — otherwise a transient failure on page 2+ would
+            // silently truncate the listing and look like a complete result.
+            Err(OciDistributionError::JsonError(_)) if !all_tags.is_empty() => {
+                debug!("treating null-tags deserialization on follow-up page as end-of-list");
                 break;
             }
             Err(e) => {

--- a/crates/cella-oci/src/lib.rs
+++ b/crates/cella-oci/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod auth;
 pub mod cache;
 pub mod extract;
+pub mod inspect;
 
 pub use auth::{DockerCredentials, resolve_credentials};
 pub use cache::{commit_staging, staging_path};
 pub use extract::{ExtractionError, extract_layer, is_extractable_layer};
+pub use inspect::{fetch_manifest_with_digest, fetch_published_tags, parse_reference};
 
 use oci_distribution::secrets::RegistryAuth;
 use tracing::debug;


### PR DESCRIPTION
Adds `cella features info <mode> <feature>`, a drop-in for `devcontainer features info`.

- Modes: `manifest` (OCI manifest + canonical `name@sha256:...` id), `tags` (all published tags), `dependencies` (Mermaid flowchart), `verbose` (all three). `--output-format text|json`, `--log-level info|debug|trace`, data on stdout, progress on stderr — same contract as the official CLI, including the upstream quirk that `dependencies` prints nothing in json mode.
- Graph edges match the official renderer: solid arrows for `dependsOn` (recursed), dashed for `installsAfter` (recorded, not walked). This required adding `dependsOn` parsing to cella-features metadata — it was previously not parsed at all (only `installsAfter` was).
- New `cella-oci` inspect helpers: manifest fetch with digest, tag listing with proper OCI pagination (the single-page call silently truncated at the registry page size), and reference parsing that handles `name@sha256:...` digest refs and registries with ports. GHCR's `{"tags":null}` final-page response is tolerated instead of failing the listing.
- `verbose` text mode now degrades gracefully when one section fails (previously a dependency-graph fetch failure killed the manifest/tags output too).

Smoke-tested live against ghcr.io: manifest by tag and by digest, tags pagination, and the desktop-lite dependency graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)