### PR TITLE
feat: templates metadata command

### DIFF
--- a/crates/cella-cli/src/commands/templates.rs
+++ b/crates/cella-cli/src/commands/templates.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use clap::{Args, Subcommand};
 use serde_json::Value;
 
-use cella_templates::{SelectedFeature, TemplateError, apply, fetcher, options};
+use cella_templates::{SelectedFeature, TemplateError, apply, fetcher, metadata, options};
 
 use super::LogLevel;
 
@@ -19,6 +19,8 @@ pub struct TemplatesArgs {
 pub enum TemplatesCommand {
     /// Apply a template to a workspace folder.
     Apply(TemplatesApplyArgs),
+    /// Fetch a published template's metadata from its OCI manifest.
+    Metadata(TemplatesMetadataArgs),
     /// Create a new template.
     New {
         /// Name for the template.
@@ -31,6 +33,15 @@ pub enum TemplatesCommand {
         /// Name of the template to edit.
         name: String,
     },
+}
+
+/// Arguments for `cella templates metadata`.
+///
+/// Flag surface matches `devcontainer templates metadata` exactly.
+#[derive(Args)]
+pub struct TemplatesMetadataArgs {
+    /// Template OCI reference (e.g. ghcr.io/devcontainers/templates/alpine).
+    pub template_id: String,
 }
 
 /// Arguments for `cella templates apply`.
@@ -88,6 +99,7 @@ impl TemplatesArgs {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         match self.command {
             TemplatesCommand::Apply(args) => args.execute().await,
+            TemplatesCommand::Metadata(args) => args.execute().await,
             TemplatesCommand::New { .. }
             | TemplatesCommand::List
             | TemplatesCommand::Edit { .. } => {
@@ -164,6 +176,37 @@ impl TemplatesApplyArgs {
         println!("{}", serde_json::to_string(&output).expect("serializable"));
 
         Ok(())
+    }
+}
+
+impl TemplatesMetadataArgs {
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        match metadata::fetch_manifest_metadata(&self.template_id).await {
+            Ok(Some(raw)) => {
+                // Re-parse and re-serialize so the output is valid JSON (not
+                // the annotation's raw escaped string).
+                let parsed: Value = serde_json::from_str(&raw)
+                    .map_err(|e| format!("metadata annotation is not valid JSON: {e}"))?;
+                println!("{}", serde_json::to_string(&parsed).expect("serializable"));
+                Ok(())
+            }
+            Ok(None) => {
+                eprintln!(
+                    "Template resolved to '{}' but does not contain metadata on its manifest.",
+                    self.template_id
+                );
+                eprintln!(
+                    "Ask the Template owner to republish this Template to populate the manifest."
+                );
+                println!("{{}}");
+                std::process::exit(1);
+            }
+            Err(e) => {
+                eprintln!("error: {e}");
+                println!("{{}}");
+                std::process::exit(1);
+            }
+        }
     }
 }
 
@@ -453,5 +496,17 @@ mod tests {
         };
         let result = args.execute(dummy_progress()).await;
         assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // TemplatesMetadataArgs
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn metadata_args_captures_template_id() {
+        let args = TemplatesMetadataArgs {
+            template_id: "ghcr.io/devcontainers/templates/alpine".to_owned(),
+        };
+        assert_eq!(args.template_id, "ghcr.io/devcontainers/templates/alpine");
     }
 }

--- a/crates/cella-cli/src/commands/templates.rs
+++ b/crates/cella-cli/src/commands/templates.rs
@@ -182,14 +182,17 @@ impl TemplatesApplyArgs {
 impl TemplatesMetadataArgs {
     pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         match metadata::fetch_manifest_metadata(&self.template_id).await {
-            Ok(Some(raw)) => {
-                // Re-parse and re-serialize so the output is valid JSON (not
-                // the annotation's raw escaped string).
-                let parsed: Value = serde_json::from_str(&raw)
-                    .map_err(|e| format!("metadata annotation is not valid JSON: {e}"))?;
-                println!("{}", serde_json::to_string(&parsed).expect("serializable"));
-                Ok(())
-            }
+            Ok(Some(raw)) => match render_metadata_annotation(&raw) {
+                Ok(json) => {
+                    println!("{json}");
+                    Ok(())
+                }
+                Err(e) => {
+                    eprintln!("warning: metadata annotation is not valid JSON: {e}");
+                    println!("{{}}");
+                    std::process::exit(1);
+                }
+            },
             Ok(None) => {
                 eprintln!(
                     "Template resolved to '{}' but does not contain metadata on its manifest.",
@@ -208,6 +211,19 @@ impl TemplatesMetadataArgs {
             }
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Rendering helpers
+// ---------------------------------------------------------------------------
+
+/// Re-parse and re-serialize the raw metadata annotation string so the output
+/// is compact valid JSON rather than the annotation's escaped string value.
+///
+/// Returns `Err` when the annotation is not valid JSON.
+fn render_metadata_annotation(raw: &str) -> Result<String, serde_json::Error> {
+    let parsed: Value = serde_json::from_str(raw)?;
+    Ok(serde_json::to_string(&parsed).expect("re-serializing a Value is infallible"))
 }
 
 // ---------------------------------------------------------------------------
@@ -508,5 +524,36 @@ mod tests {
             template_id: "ghcr.io/devcontainers/templates/alpine".to_owned(),
         };
         assert_eq!(args.template_id, "ghcr.io/devcontainers/templates/alpine");
+    }
+
+    // -----------------------------------------------------------------------
+    // render_metadata_annotation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn render_valid_annotation_produces_compact_json() {
+        let raw = r#"{"id":"alpine","version":"1.0.0"}"#;
+        let result = render_metadata_annotation(raw).unwrap();
+        // Re-serialization should produce valid compact JSON.
+        let v: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(v["id"], Value::String("alpine".to_owned()));
+        assert_eq!(v["version"], Value::String("1.0.0".to_owned()));
+    }
+
+    #[test]
+    fn render_invalid_annotation_returns_err() {
+        let result = render_metadata_annotation("{not valid json}");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn render_annotation_with_whitespace_produces_compact_output() {
+        // Annotation may have extra whitespace or pretty-printing; output must be compact.
+        let raw = "{\n  \"id\": \"alpine\"\n}";
+        let result = render_metadata_annotation(raw).unwrap();
+        assert!(
+            !result.contains('\n'),
+            "output should be compact (no newlines)"
+        );
     }
 }

--- a/crates/cella-templates/src/fetcher.rs
+++ b/crates/cella-templates/src/fetcher.rs
@@ -6,8 +6,6 @@
 use std::path::PathBuf;
 
 use flate2::read::GzDecoder;
-use oci_distribution::Reference;
-use oci_distribution::client::{ClientConfig, ClientProtocol};
 use oci_distribution::manifest::{
     IMAGE_DOCKER_LAYER_GZIP_MEDIA_TYPE, IMAGE_LAYER_GZIP_MEDIA_TYPE, IMAGE_LAYER_MEDIA_TYPE,
 };
@@ -17,6 +15,8 @@ use tracing::debug;
 use crate::TemplateMetadata;
 use crate::cache::TemplateCache;
 use crate::error::TemplateError;
+use crate::oci_ref::build_oci_client;
+use crate::oci_ref::parse_template_ref;
 
 /// Media type for devcontainer template/feature layers (plain tar).
 const DEVCONTAINERS_LAYER_MEDIA_TYPE: &str = "application/vnd.devcontainers.layer.v1+tar";
@@ -43,13 +43,7 @@ pub async fn fetch_template(
         return Ok(cached);
     }
 
-    let config = ClientConfig {
-        protocol: ClientProtocol::Https,
-        ..ClientConfig::default()
-    };
-    let client = oci_distribution::Client::new(config);
-    let oci_ref = Reference::with_tag(registry.clone(), repository.clone(), tag.clone());
-    let auth = build_registry_auth(&registry);
+    let (client, oci_ref, auth) = build_oci_client(&registry, &repository, &tag);
 
     debug!("fetching template {registry}/{repository}:{tag}");
 
@@ -138,26 +132,6 @@ pub fn read_template_metadata(
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Parse a template reference into `(registry, repository, tag)`.
-fn parse_template_ref(template_ref: &str) -> Result<(String, String, String), TemplateError> {
-    let (base, tag) = match template_ref.rsplit_once(':') {
-        Some((b, t)) if !t.contains('/') && !t.is_empty() => (b, t.to_owned()),
-        _ => (template_ref, "latest".to_owned()),
-    };
-
-    let (registry, repository) =
-        base.split_once('/')
-            .ok_or_else(|| TemplateError::RegistryError {
-                registry: template_ref.to_owned(),
-                message: "invalid template reference: expected registry/repository[:tag]"
-                    .to_owned(),
-            })?;
-
-    Ok((registry.to_owned(), repository.to_owned(), tag))
-}
-
-use cella_oci::build_registry_auth;
-
 fn find_extractable_layer<'a>(
     manifest: &'a oci_distribution::manifest::OciImageManifest,
     template_ref: &str,
@@ -223,28 +197,6 @@ fn extract_layer(blob: &[u8], media_type: &str, dest: &std::path::Path) -> std::
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn parse_full_ref() {
-        let (reg, repo, tag) =
-            parse_template_ref("ghcr.io/devcontainers/templates/rust:5.0.0").unwrap();
-        assert_eq!(reg, "ghcr.io");
-        assert_eq!(repo, "devcontainers/templates/rust");
-        assert_eq!(tag, "5.0.0");
-    }
-
-    #[test]
-    fn parse_ref_no_tag() {
-        let (reg, repo, tag) = parse_template_ref("ghcr.io/devcontainers/templates/rust").unwrap();
-        assert_eq!(reg, "ghcr.io");
-        assert_eq!(repo, "devcontainers/templates/rust");
-        assert_eq!(tag, "latest");
-    }
-
-    #[test]
-    fn parse_ref_invalid() {
-        assert!(parse_template_ref("noslash").is_err());
-    }
 
     #[test]
     fn extractable_layer_detection() {

--- a/crates/cella-templates/src/lib.rs
+++ b/crates/cella-templates/src/lib.rs
@@ -14,6 +14,8 @@ pub mod collection;
 pub mod error;
 pub mod fetcher;
 pub mod index;
+pub mod metadata;
+mod oci_ref;
 pub mod options;
 pub mod tags;
 pub mod types;

--- a/crates/cella-templates/src/metadata.rs
+++ b/crates/cella-templates/src/metadata.rs
@@ -4,14 +4,11 @@
 //! `dev.containers.metadata` annotation, which contains the template's JSON
 //! metadata as a string-escaped JSON value.
 
-use oci_distribution::Reference;
-use oci_distribution::client::{ClientConfig, ClientProtocol};
 use oci_distribution::manifest::OciManifest;
 use tracing::debug;
 
-use cella_oci::build_registry_auth;
-
 use crate::error::TemplateError;
+use crate::oci_ref::{build_oci_client, parse_template_ref};
 
 /// Annotation key used by the devcontainer CLI to embed template metadata.
 const METADATA_ANNOTATION: &str = "dev.containers.metadata";
@@ -33,13 +30,7 @@ const METADATA_ANNOTATION: &str = "dev.containers.metadata";
 pub async fn fetch_manifest_metadata(template_ref: &str) -> Result<Option<String>, TemplateError> {
     let (registry, repository, tag) = parse_template_ref(template_ref)?;
 
-    let config = ClientConfig {
-        protocol: ClientProtocol::Https,
-        ..ClientConfig::default()
-    };
-    let client = oci_distribution::Client::new(config);
-    let oci_ref = Reference::with_tag(registry.clone(), repository.clone(), tag.clone());
-    let auth = build_registry_auth(&registry);
+    let (client, oci_ref, auth) = build_oci_client(&registry, &repository, &tag);
 
     debug!("fetching manifest for template {registry}/{repository}:{tag}");
 
@@ -85,30 +76,6 @@ fn extract_metadata_annotation(manifest: &OciManifest) -> Option<String> {
                 .cloned()
         }
     }
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/// Parse a template reference into `(registry, repository, tag)`.
-///
-/// Defaults to `latest` when no tag is present.
-fn parse_template_ref(template_ref: &str) -> Result<(String, String, String), TemplateError> {
-    let (base, tag) = match template_ref.rsplit_once(':') {
-        Some((b, t)) if !t.contains('/') && !t.is_empty() => (b, t.to_owned()),
-        _ => (template_ref, "latest".to_owned()),
-    };
-
-    let (registry, repository) =
-        base.split_once('/')
-            .ok_or_else(|| TemplateError::RegistryError {
-                registry: template_ref.to_owned(),
-                message: "invalid template reference: expected registry/repository[:tag]"
-                    .to_owned(),
-            })?;
-
-    Ok((registry.to_owned(), repository.to_owned(), tag))
 }
 
 // ===========================================================================
@@ -223,32 +190,5 @@ mod tests {
     fn image_index_no_annotation_returns_none() {
         let manifest = image_index(None, None);
         assert!(extract_metadata_annotation(&manifest).is_none());
-    }
-
-    // -----------------------------------------------------------------------
-    // parse_template_ref
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn parse_ref_with_tag() {
-        let (reg, repo, tag) =
-            parse_template_ref("ghcr.io/devcontainers/templates/alpine:1.2.3").unwrap();
-        assert_eq!(reg, "ghcr.io");
-        assert_eq!(repo, "devcontainers/templates/alpine");
-        assert_eq!(tag, "1.2.3");
-    }
-
-    #[test]
-    fn parse_ref_without_tag_defaults_to_latest() {
-        let (reg, repo, tag) =
-            parse_template_ref("ghcr.io/devcontainers/templates/alpine").unwrap();
-        assert_eq!(reg, "ghcr.io");
-        assert_eq!(repo, "devcontainers/templates/alpine");
-        assert_eq!(tag, "latest");
-    }
-
-    #[test]
-    fn parse_ref_no_slash_returns_error() {
-        assert!(parse_template_ref("noslash").is_err());
     }
 }

--- a/crates/cella-templates/src/metadata.rs
+++ b/crates/cella-templates/src/metadata.rs
@@ -1,0 +1,254 @@
+//! OCI manifest metadata fetcher for devcontainer templates.
+//!
+//! Fetches the OCI image manifest for a template reference and extracts the
+//! `dev.containers.metadata` annotation, which contains the template's JSON
+//! metadata as a string-escaped JSON value.
+
+use oci_distribution::Reference;
+use oci_distribution::client::{ClientConfig, ClientProtocol};
+use oci_distribution::manifest::OciManifest;
+use tracing::debug;
+
+use cella_oci::build_registry_auth;
+
+use crate::error::TemplateError;
+
+/// Annotation key used by the devcontainer CLI to embed template metadata.
+const METADATA_ANNOTATION: &str = "dev.containers.metadata";
+
+/// Fetch the `dev.containers.metadata` annotation from the OCI manifest for
+/// the given template reference.
+///
+/// The template reference should be in the form `registry/repository[:tag]`
+/// (e.g. `ghcr.io/devcontainers/templates/alpine`).
+///
+/// Returns:
+/// - `Ok(Some(value))` — annotation found; the raw JSON string value.
+/// - `Ok(None)` — manifest was fetched successfully but the annotation is absent.
+/// - `Err(_)` — network or registry error.
+///
+/// # Errors
+///
+/// Returns [`TemplateError`] for registry communication failures or invalid refs.
+pub async fn fetch_manifest_metadata(template_ref: &str) -> Result<Option<String>, TemplateError> {
+    let (registry, repository, tag) = parse_template_ref(template_ref)?;
+
+    let config = ClientConfig {
+        protocol: ClientProtocol::Https,
+        ..ClientConfig::default()
+    };
+    let client = oci_distribution::Client::new(config);
+    let oci_ref = Reference::with_tag(registry.clone(), repository.clone(), tag.clone());
+    let auth = build_registry_auth(&registry);
+
+    debug!("fetching manifest for template {registry}/{repository}:{tag}");
+
+    let (manifest, _digest) =
+        client
+            .pull_manifest(&oci_ref, &auth)
+            .await
+            .map_err(|e| TemplateError::RegistryError {
+                registry: registry.clone(),
+                message: format!("failed to pull manifest for {repository}:{tag}: {e}"),
+            })?;
+
+    Ok(extract_metadata_annotation(&manifest))
+}
+
+/// Extract the `dev.containers.metadata` annotation from an OCI manifest.
+///
+/// For an [`OciManifest::Image`], reads `manifest.annotations`.
+/// For an [`OciManifest::ImageIndex`], reads `index.annotations` first; if
+/// absent, falls back to the first index entry's `annotations`.
+fn extract_metadata_annotation(manifest: &OciManifest) -> Option<String> {
+    match manifest {
+        OciManifest::Image(img) => img
+            .annotations
+            .as_ref()
+            .and_then(|a| a.get(METADATA_ANNOTATION))
+            .cloned(),
+        OciManifest::ImageIndex(idx) => {
+            // Check the index-level annotations first.
+            let from_index = idx
+                .annotations
+                .as_ref()
+                .and_then(|a| a.get(METADATA_ANNOTATION))
+                .cloned();
+            if from_index.is_some() {
+                return from_index;
+            }
+            // Fall back to the first manifest entry's annotations.
+            idx.manifests
+                .first()
+                .and_then(|entry| entry.annotations.as_ref())
+                .and_then(|a| a.get(METADATA_ANNOTATION))
+                .cloned()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Parse a template reference into `(registry, repository, tag)`.
+///
+/// Defaults to `latest` when no tag is present.
+fn parse_template_ref(template_ref: &str) -> Result<(String, String, String), TemplateError> {
+    let (base, tag) = match template_ref.rsplit_once(':') {
+        Some((b, t)) if !t.contains('/') && !t.is_empty() => (b, t.to_owned()),
+        _ => (template_ref, "latest".to_owned()),
+    };
+
+    let (registry, repository) =
+        base.split_once('/')
+            .ok_or_else(|| TemplateError::RegistryError {
+                registry: template_ref.to_owned(),
+                message: "invalid template reference: expected registry/repository[:tag]"
+                    .to_owned(),
+            })?;
+
+    Ok((registry.to_owned(), repository.to_owned(), tag))
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use oci_distribution::manifest::{OciImageManifest, OciManifest};
+
+    use super::*;
+
+    /// Build an image manifest JSON string with optional annotations and
+    /// deserialize it into [`OciManifest`].
+    fn image_manifest(annotation_value: Option<&str>) -> OciManifest {
+        let annotations_json = annotation_value.map_or_else(
+            || "{}".to_owned(),
+            |v| {
+                let escaped = v.replace('"', "\\\"");
+                format!(r#"{{"dev.containers.metadata": "{escaped}"}}"#)
+            },
+        );
+        let json = format!(
+            r#"{{
+                "schemaVersion": 2,
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "config": {{"mediaType": "application/vnd.devcontainers", "digest": "sha256:abc", "size": 0}},
+                "layers": [],
+                "annotations": {annotations_json}
+            }}"#
+        );
+        let m: OciImageManifest = serde_json::from_str(&json).unwrap();
+        OciManifest::Image(m)
+    }
+
+    /// Build an image index JSON string and deserialize it into [`OciManifest`].
+    fn image_index(index_annotation: Option<&str>, entry_annotation: Option<&str>) -> OciManifest {
+        let index_ann_json = index_annotation.map_or_else(
+            || "null".to_owned(),
+            |v| {
+                let escaped = v.replace('"', "\\\"");
+                format!(r#"{{"dev.containers.metadata": "{escaped}"}}"#)
+            },
+        );
+        let entry_ann_json = entry_annotation.map_or_else(
+            || "null".to_owned(),
+            |v| {
+                let escaped = v.replace('"', "\\\"");
+                format!(r#"{{"dev.containers.metadata": "{escaped}"}}"#)
+            },
+        );
+        let json = format!(
+            r#"{{
+                "schemaVersion": 2,
+                "manifests": [
+                    {{
+                        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                        "digest": "sha256:abc",
+                        "size": 0,
+                        "annotations": {entry_ann_json}
+                    }}
+                ],
+                "annotations": {index_ann_json}
+            }}"#
+        );
+        serde_json::from_str(&json).unwrap()
+    }
+
+    // -----------------------------------------------------------------------
+    // extract_metadata_annotation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn image_manifest_returns_annotation() {
+        let manifest = image_manifest(Some(r#"{"id":"alpine","version":"1.0.0"}"#));
+        let result = extract_metadata_annotation(&manifest);
+        assert_eq!(
+            result.as_deref(),
+            Some(r#"{"id":"alpine","version":"1.0.0"}"#)
+        );
+    }
+
+    #[test]
+    fn image_manifest_without_annotation_returns_none() {
+        let manifest = image_manifest(None);
+        assert!(extract_metadata_annotation(&manifest).is_none());
+    }
+
+    #[test]
+    fn image_index_reads_index_level_annotation() {
+        let manifest = image_index(
+            Some(r#"{"id":"from-index"}"#),
+            Some(r#"{"id":"from-entry"}"#),
+        );
+        // Index-level annotation takes precedence.
+        assert_eq!(
+            extract_metadata_annotation(&manifest).as_deref(),
+            Some(r#"{"id":"from-index"}"#)
+        );
+    }
+
+    #[test]
+    fn image_index_falls_back_to_first_entry_annotation() {
+        let manifest = image_index(None, Some(r#"{"id":"from-entry"}"#));
+        assert_eq!(
+            extract_metadata_annotation(&manifest).as_deref(),
+            Some(r#"{"id":"from-entry"}"#)
+        );
+    }
+
+    #[test]
+    fn image_index_no_annotation_returns_none() {
+        let manifest = image_index(None, None);
+        assert!(extract_metadata_annotation(&manifest).is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // parse_template_ref
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_ref_with_tag() {
+        let (reg, repo, tag) =
+            parse_template_ref("ghcr.io/devcontainers/templates/alpine:1.2.3").unwrap();
+        assert_eq!(reg, "ghcr.io");
+        assert_eq!(repo, "devcontainers/templates/alpine");
+        assert_eq!(tag, "1.2.3");
+    }
+
+    #[test]
+    fn parse_ref_without_tag_defaults_to_latest() {
+        let (reg, repo, tag) =
+            parse_template_ref("ghcr.io/devcontainers/templates/alpine").unwrap();
+        assert_eq!(reg, "ghcr.io");
+        assert_eq!(repo, "devcontainers/templates/alpine");
+        assert_eq!(tag, "latest");
+    }
+
+    #[test]
+    fn parse_ref_no_slash_returns_error() {
+        assert!(parse_template_ref("noslash").is_err());
+    }
+}

--- a/crates/cella-templates/src/oci_ref.rs
+++ b/crates/cella-templates/src/oci_ref.rs
@@ -1,0 +1,92 @@
+//! Shared OCI reference parsing and client construction for template fetchers.
+
+use oci_distribution::Reference;
+use oci_distribution::client::{ClientConfig, ClientProtocol};
+
+use cella_oci::build_registry_auth;
+
+use crate::error::TemplateError;
+
+/// Parse a template reference into `(registry, repository, tag)`.
+///
+/// Defaults to `latest` when no tag is present.
+pub fn parse_template_ref(template_ref: &str) -> Result<(String, String, String), TemplateError> {
+    let (base, tag) = match template_ref.rsplit_once(':') {
+        Some((b, t)) if !t.contains('/') && !t.is_empty() => (b, t.to_owned()),
+        _ => (template_ref, "latest".to_owned()),
+    };
+
+    let (registry, repository) =
+        base.split_once('/')
+            .ok_or_else(|| TemplateError::RegistryError {
+                registry: template_ref.to_owned(),
+                message: "invalid template reference: expected registry/repository[:tag]"
+                    .to_owned(),
+            })?;
+
+    Ok((registry.to_owned(), repository.to_owned(), tag))
+}
+
+/// Build an OCI [`oci_distribution::Client`] and [`oci_distribution::Reference`]
+/// for the given `(registry, repository, tag)` triple.
+///
+/// Returns `(client, reference, auth)` ready for manifest or blob pulls.
+pub fn build_oci_client(
+    registry: &str,
+    repository: &str,
+    tag: &str,
+) -> (
+    oci_distribution::Client,
+    Reference,
+    oci_distribution::secrets::RegistryAuth,
+) {
+    let config = ClientConfig {
+        protocol: ClientProtocol::Https,
+        ..ClientConfig::default()
+    };
+    let client = oci_distribution::Client::new(config);
+    let oci_ref = Reference::with_tag(registry.to_owned(), repository.to_owned(), tag.to_owned());
+    let auth = build_registry_auth(registry);
+    (client, oci_ref, auth)
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_full_ref() {
+        let (reg, repo, tag) =
+            parse_template_ref("ghcr.io/devcontainers/templates/rust:5.0.0").unwrap();
+        assert_eq!(reg, "ghcr.io");
+        assert_eq!(repo, "devcontainers/templates/rust");
+        assert_eq!(tag, "5.0.0");
+    }
+
+    #[test]
+    fn parse_ref_no_tag_defaults_to_latest() {
+        let (reg, repo, tag) = parse_template_ref("ghcr.io/devcontainers/templates/rust").unwrap();
+        assert_eq!(reg, "ghcr.io");
+        assert_eq!(repo, "devcontainers/templates/rust");
+        assert_eq!(tag, "latest");
+    }
+
+    #[test]
+    fn parse_ref_invalid_returns_error() {
+        assert!(parse_template_ref("noslash").is_err());
+    }
+
+    #[test]
+    fn parse_ref_tag_with_slash_treated_as_no_tag() {
+        // A "tag" containing a slash is not a tag — treat as tagless (latest).
+        let (reg, repo, tag) =
+            parse_template_ref("ghcr.io/devcontainers/templates/rust:repo/path").unwrap();
+        assert_eq!(reg, "ghcr.io");
+        assert_eq!(repo, "devcontainers/templates/rust:repo/path");
+        assert_eq!(tag, "latest");
+    }
+}


### PR DESCRIPTION
Stacked on #130 (templates apply) — base will retarget to main when that merges.

Adds `cella templates metadata <templateId>`, a drop-in for `devcontainer templates metadata`: fetches the OCI manifest (no blob download), reads the `dev.containers.metadata` annotation, and prints the parsed JSON to stdout. Missing ref, missing annotation, or unparseable annotation all print `{}` to stdout with warnings on stderr and exit 1, matching the official CLI exactly.

Also dedupes `parse_template_ref` and the OCI client construction into a shared `oci_ref` module — they'd been copy-pasted between fetcher.rs and the new metadata.rs. Handles both image manifests and image indexes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)