### PR TITLE
feat: install dependsOn features during up

### DIFF
--- a/crates/cella-cli/src/commands/features/resolve_dependencies.rs
+++ b/crates/cella-cli/src/commands/features/resolve_dependencies.rs
@@ -264,7 +264,12 @@ fn compute_order_with_metadata(
         compute_install_order(&order_input, override_order, &mut depends_on_cycle);
 
     if let Some(cycle) = depends_on_cycle {
-        return Err(format!("cyclic dependsOn detected: {}", cycle.join(" -> ")));
+        // `cycle` is the set of features in the cycle, not an ordered path —
+        // render comma-separated so arrows don't imply a traversal order.
+        return Err(format!(
+            "cyclic dependsOn among features: {}",
+            cycle.join(", ")
+        ));
     }
 
     for w in &warnings {
@@ -310,7 +315,9 @@ fn compute_order_declared_only(
         compute_install_order(&order_input, override_order, &mut depends_on_cycle);
 
     if let Some(cycle) = depends_on_cycle {
-        return Err(format!("cyclic dependsOn detected: {}", cycle.join(" -> ")).into());
+        // `cycle` is the set of features in the cycle, not an ordered path —
+        // render comma-separated so arrows don't imply a traversal order.
+        return Err(format!("cyclic dependsOn among features: {}", cycle.join(", ")).into());
     }
 
     for w in &warnings {

--- a/crates/cella-cli/src/commands/features/resolve_dependencies.rs
+++ b/crates/cella-cli/src/commands/features/resolve_dependencies.rs
@@ -259,7 +259,13 @@ fn compute_order_with_metadata(
     let order_input: Vec<(String, &FeatureMetadata)> =
         metas.iter().map(|(id, m)| (id.clone(), m)).collect();
 
-    let (ordered_ids, warnings) = compute_install_order(&order_input, override_order);
+    let mut depends_on_cycle: Option<Vec<String>> = None;
+    let (ordered_ids, warnings) =
+        compute_install_order(&order_input, override_order, &mut depends_on_cycle);
+
+    if let Some(cycle) = depends_on_cycle {
+        return Err(format!("cyclic dependsOn detected: {}", cycle.join(" -> ")));
+    }
 
     for w in &warnings {
         if let FeatureWarning::CyclicDependency { features } = w {
@@ -299,7 +305,13 @@ fn compute_order_declared_only(
     let order_input: Vec<(String, &FeatureMetadata)> =
         metas.iter().map(|(id, m)| (id.clone(), m)).collect();
 
-    let (ordered_ids, warnings) = compute_install_order(&order_input, override_order);
+    let mut depends_on_cycle: Option<Vec<String>> = None;
+    let (ordered_ids, warnings) =
+        compute_install_order(&order_input, override_order, &mut depends_on_cycle);
+
+    if let Some(cycle) = depends_on_cycle {
+        return Err(format!("cyclic dependsOn detected: {}", cycle.join(" -> ")).into());
+    }
 
     for w in &warnings {
         if let FeatureWarning::CyclicDependency { features } = w {

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -369,7 +369,7 @@ impl Command {
 
     pub async fn execute(self, progress: Progress) -> miette::Result<()> {
         match self {
-            Self::Code(args) => args.execute(progress).await,
+            Self::Code(args) => Box::pin(args.execute(progress)).await,
             Self::Up(args) => args.execute(progress).await.map_err(boxed_err_to_report),
             Self::Down(args) => args.execute().await.map_err(boxed_err_to_report),
             Self::Shell(args) => args.execute().await.map_err(boxed_err_to_report),

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -1668,7 +1668,7 @@ impl UpArgs {
 
         // Docker Compose branch: if dockerComposeFile is present, delegate to compose flow
         if ctx.config().get("dockerComposeFile").is_some() {
-            return super::compose_up::compose_up(ctx, &self.result).await;
+            return Box::pin(super::compose_up::compose_up(ctx, &self.result)).await;
         }
 
         let mut result = ctx

--- a/crates/cella-features/src/error.rs
+++ b/crates/cella-features/src/error.rs
@@ -36,6 +36,11 @@ pub enum FeatureError {
     #[diagnostic(code(cella::features::cyclic_dependency))]
     CyclicDependency { features: Vec<String> },
 
+    /// Cyclic hard dependency (`dependsOn`) detected — fatal.
+    #[error("cyclic dependsOn detected: {}", cycle.join(" -> "))]
+    #[diagnostic(code(cella::features::cyclic_depends_on))]
+    CyclicDependsOn { cycle: Vec<String> },
+
     /// Feature install script failed during container build.
     #[error("feature build failed for {feature_id}: {message}")]
     #[diagnostic(code(cella::features::build_failed))]

--- a/crates/cella-features/src/error.rs
+++ b/crates/cella-features/src/error.rs
@@ -37,7 +37,11 @@ pub enum FeatureError {
     CyclicDependency { features: Vec<String> },
 
     /// Cyclic hard dependency (`dependsOn`) detected — fatal.
-    #[error("cyclic dependsOn detected: {}", cycle.join(" -> "))]
+    ///
+    /// `cycle` holds the *set* of features caught in the cycle (not an ordered
+    /// traversal path), so it is rendered comma-separated rather than with
+    /// arrows that would imply a specific path.
+    #[error("cyclic dependsOn among features: {}", cycle.join(", "))]
     #[diagnostic(code(cella::features::cyclic_depends_on))]
     CyclicDependsOn { cycle: Vec<String> },
 

--- a/crates/cella-features/src/lib.rs
+++ b/crates/cella-features/src/lib.rs
@@ -583,18 +583,28 @@ async fn expand_depends_on(
     let http_fetcher = HttpFetcher;
     let local_fetcher = LocalFetcher;
 
-    // Visited set: (normalised_ref_string, options_json) to implement spec
-    // identity semantics.  Pre-populate with user-declared entries.
+    // Normalize a raw ref string for identity keying, ignoring parse errors
+    // (invalid refs are caught later during fetch).
+    let normalize_key = |raw: &str| -> String {
+        FeatureRef::parse(raw)
+            .and_then(|r| r.normalize(workspace_root))
+            .map_or_else(|_| raw.to_owned(), |(n, _)| n.to_string())
+    };
+
+    // Visited set: (normalised_ref_string, options_json) — spec identity
+    // semantics.  Pre-populate with user-declared entries using their
+    // NORMALISED ref so that spelling variants of the same OCI ref
+    // (e.g. shorthand vs. fully-qualified) deduplicate correctly.
     let mut visited: std::collections::HashSet<(String, String)> = feature_entries
         .iter()
         .map(|e| {
-            // Reconstruct the canonical key from the original_ref.
+            let norm_key = normalize_key(&e.original_ref);
             let opts = serde_json::to_string(&e.user_options).unwrap_or_default();
-            (e.original_ref.clone(), opts)
+            (norm_key, opts)
         })
         .collect();
 
-    // Worklist: (feature_ref_string, options_value) pairs to process.
+    // Worklist: (raw_ref_string, options_value) pairs to process.
     // Pre-populate from the dependsOn of already-fetched entries.
     let mut worklist: Vec<(String, serde_json::Value)> = feature_entries
         .iter()
@@ -607,21 +617,22 @@ async fn expand_depends_on(
         .collect();
 
     while let Some((dep_ref, dep_opts)) = worklist.pop() {
-        let opts_json = serde_json::to_string(&dep_opts).unwrap_or_default();
-        let visit_key = (dep_ref.clone(), opts_json);
-
-        if visited.contains(&visit_key) {
-            continue;
-        }
-        visited.insert(visit_key);
-
-        // Parse and normalise the reference.
+        // Parse and normalise the reference first so we can deduplicate on
+        // the canonical identity, not the raw string the author wrote.
         let feature_ref = FeatureRef::parse(&dep_ref)?;
         let (normalized, warning) = feature_ref.normalize(workspace_root)?;
         if let Some(w) = warning {
             warn!("{dep_ref}: deprecated feature reference in dependsOn ({w:?})");
             let _ = w;
         }
+
+        let opts_json = serde_json::to_string(&dep_opts).unwrap_or_default();
+        let visit_key = (normalized.to_string(), opts_json);
+
+        if visited.contains(&visit_key) {
+            continue;
+        }
+        visited.insert(visit_key);
 
         // Fetch the artifact.
         let artifact_dir = fetch_one(
@@ -651,10 +662,12 @@ async fn expand_depends_on(
             log_option_warning(&dep_ref, w);
         }
 
-        // Enqueue this entry's own dependsOn for further expansion.
+        // Enqueue this entry's own dependsOn for further expansion,
+        // pre-filtering with the normalised key to avoid redundant fetches.
         for (transitive_ref, transitive_opts) in &metadata.depends_on {
+            let t_norm = normalize_key(transitive_ref);
             let t_opts_json = serde_json::to_string(transitive_opts).unwrap_or_default();
-            let t_key = (transitive_ref.clone(), t_opts_json);
+            let t_key = (t_norm, t_opts_json);
             if !visited.contains(&t_key) {
                 worklist.push((transitive_ref.clone(), transitive_opts.clone()));
             }
@@ -1780,6 +1793,69 @@ mod tests {
         assert!(
             matches!(err, FeatureError::CyclicDependsOn { .. }),
             "expected CyclicDependsOn error, got: {err:?}"
+        );
+    }
+
+    /// Regression: transitive cycle discovered during dependsOn expansion where
+    /// only the root feature is user-declared.
+    ///
+    /// User declares only A.  A dependsOn B (not declared).  B dependsOn A
+    /// (back-edge, completing the cycle).  `resolve_features` must return
+    /// `CyclicDependsOn`, not loop or silently mis-order.
+    #[tokio::test]
+    async fn depends_on_transitive_cycle_not_user_declared_returns_error() {
+        let feature_dir = tempfile::tempdir().unwrap();
+
+        let a_ref = "./feat-a".to_string();
+        let b_ref = "./feat-b".to_string();
+
+        // A depends on B (B is not in the user's features list).
+        make_local_feature(
+            feature_dir.path(),
+            "feat-a",
+            &[(&b_ref, serde_json::json!({}))],
+            true,
+        );
+        // B depends back on A — completes the cycle.
+        make_local_feature(
+            feature_dir.path(),
+            "feat-b",
+            &[(&a_ref, serde_json::json!({}))],
+            true,
+        );
+
+        let cache_dir = tempfile::tempdir().unwrap();
+        let cache = FeatureCache::with_root(cache_dir.path().join("features"));
+        let config_path = feature_dir.path().join("devcontainer.json");
+        // Only feat-a is declared — B is auto-injected via dependsOn expansion.
+        let config = json!({
+            "image": "ubuntu:22.04",
+            "features": { "./feat-a": {} }
+        });
+        let platform = Platform {
+            os: "linux".to_string(),
+            architecture: "amd64".to_string(),
+        };
+
+        let err = resolve_features(
+            &config,
+            &config_path,
+            &platform,
+            &cache,
+            &BaseImageContext {
+                base_image: "ubuntu:22.04",
+                image_user: "root",
+                metadata: None,
+                omit_remote_env: false,
+            },
+            false,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, FeatureError::CyclicDependsOn { .. }),
+            "expected CyclicDependsOn error for transitive cycle, got: {err:?}"
         );
     }
 }

--- a/crates/cella-features/src/lib.rs
+++ b/crates/cella-features/src/lib.rs
@@ -138,10 +138,13 @@ pub async fn resolve_features(
     let artifact_paths = fetch_all(&parsed_entries, platform, cache).await?;
 
     // Step 5: Parse metadata and validate options.
-    let feature_entries = parse_metadata_and_validate(&parsed_entries, &artifact_paths)?;
+    let mut feature_entries = parse_metadata_and_validate(&parsed_entries, &artifact_paths)?;
+
+    // Step 5b: Expand the install set with transitive `dependsOn` features.
+    expand_depends_on(&mut feature_entries, workspace_root, platform, cache).await?;
 
     // Step 6: Compute install order.
-    let ordered_ids = compute_order(&feature_entries, config);
+    let ordered_ids = compute_order(&feature_entries, config)?;
 
     // Step 7: Assemble resolved features in install order.
     let resolved = assemble_resolved(&feature_entries, &ordered_ids);
@@ -422,7 +425,15 @@ fn parse_metadata_and_validate(
 }
 
 /// Compute install order from feature entries and config overrides.
-fn compute_order(feature_entries: &[FeatureEntry], config: &serde_json::Value) -> Vec<String> {
+///
+/// # Errors
+///
+/// Returns [`FeatureError::CyclicDependsOn`] when a hard `dependsOn` cycle
+/// is detected.
+fn compute_order(
+    feature_entries: &[FeatureEntry],
+    config: &serde_json::Value,
+) -> Result<Vec<String>, FeatureError> {
     let order_input: Vec<(String, &FeatureMetadata)> = feature_entries
         .iter()
         .map(|entry| (entry.key.clone(), &entry.metadata))
@@ -437,14 +448,22 @@ fn compute_order(feature_entries: &[FeatureEntry], config: &serde_json::Value) -
                 .collect::<Vec<_>>()
         });
 
-    let (ordered_ids, order_warnings) =
-        compute_install_order(&order_input, override_order.as_deref());
+    let mut depends_on_cycle: Option<Vec<String>> = None;
+    let (ordered_ids, order_warnings) = compute_install_order(
+        &order_input,
+        override_order.as_deref(),
+        &mut depends_on_cycle,
+    );
+
+    if let Some(cycle) = depends_on_cycle {
+        return Err(FeatureError::CyclicDependsOn { cycle });
+    }
 
     for w in &order_warnings {
         warn!("install order: {w:?}");
     }
 
-    ordered_ids
+    Ok(ordered_ids)
 }
 
 /// Assemble `ResolvedFeature` structs in install order.
@@ -528,6 +547,126 @@ fn prepare_build_context(
 
     if let Some(script) = entrypoint_script {
         std::fs::write(build_context.join("docker-init.sh"), script)?;
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// dependsOn expansion
+// ---------------------------------------------------------------------------
+
+/// Recursively expand `dependsOn` references into `feature_entries`.
+///
+/// Starting from the already-fetched user-declared features, this function
+/// performs a worklist BFS over every `dependsOn` key found in each feature's
+/// metadata.  For each referenced feature not yet in the install set it:
+///
+/// 1. Parses and normalises the reference (reusing the same path as
+///    user-declared features).
+/// 2. Fetches the artifact (OCI / HTTP / local) via the same fetchers.
+/// 3. Parses its `devcontainer-feature.json` and validates options.
+/// 4. Pushes the new entry onto `feature_entries` and enqueues its own
+///    `dependsOn` keys for further expansion.
+///
+/// Identity / dedup semantics per spec: two references are the same feature
+/// when their normalised reference string **and** their options JSON are
+/// identical.  Same feature with different options = two separate install
+/// entries (not merged).
+async fn expand_depends_on(
+    feature_entries: &mut Vec<FeatureEntry>,
+    workspace_root: &Path,
+    platform: &Platform,
+    cache: &FeatureCache,
+) -> Result<(), FeatureError> {
+    let oci_fetcher = OciFetcher::default();
+    let http_fetcher = HttpFetcher;
+    let local_fetcher = LocalFetcher;
+
+    // Visited set: (normalised_ref_string, options_json) to implement spec
+    // identity semantics.  Pre-populate with user-declared entries.
+    let mut visited: std::collections::HashSet<(String, String)> = feature_entries
+        .iter()
+        .map(|e| {
+            // Reconstruct the canonical key from the original_ref.
+            let opts = serde_json::to_string(&e.user_options).unwrap_or_default();
+            (e.original_ref.clone(), opts)
+        })
+        .collect();
+
+    // Worklist: (feature_ref_string, options_value) pairs to process.
+    // Pre-populate from the dependsOn of already-fetched entries.
+    let mut worklist: Vec<(String, serde_json::Value)> = feature_entries
+        .iter()
+        .flat_map(|e| {
+            e.metadata
+                .depends_on
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+        })
+        .collect();
+
+    while let Some((dep_ref, dep_opts)) = worklist.pop() {
+        let opts_json = serde_json::to_string(&dep_opts).unwrap_or_default();
+        let visit_key = (dep_ref.clone(), opts_json);
+
+        if visited.contains(&visit_key) {
+            continue;
+        }
+        visited.insert(visit_key);
+
+        // Parse and normalise the reference.
+        let feature_ref = FeatureRef::parse(&dep_ref)?;
+        let (normalized, warning) = feature_ref.normalize(workspace_root)?;
+        if let Some(w) = warning {
+            warn!("{dep_ref}: deprecated feature reference in dependsOn ({w:?})");
+            let _ = w;
+        }
+
+        // Fetch the artifact.
+        let artifact_dir = fetch_one(
+            &dep_ref,
+            &normalized,
+            platform,
+            cache,
+            &oci_fetcher,
+            &http_fetcher,
+            &local_fetcher,
+        )
+        .await?;
+
+        // Parse metadata.
+        let metadata_path = artifact_dir.join("devcontainer-feature.json");
+        let metadata_json =
+            std::fs::read_to_string(&metadata_path).map_err(|e| FeatureError::InvalidMetadata {
+                feature_id: dep_ref.clone(),
+                reason: format!("cannot read devcontainer-feature.json: {e}"),
+            })?;
+        let metadata = parse_feature_metadata(&metadata_json)?;
+
+        // Parse and validate user options.
+        let user_options = parse_user_options(&dep_opts);
+        let warnings = validate_options(&dep_ref, &user_options, &metadata.options);
+        for w in &warnings {
+            log_option_warning(&dep_ref, w);
+        }
+
+        // Enqueue this entry's own dependsOn for further expansion.
+        for (transitive_ref, transitive_opts) in &metadata.depends_on {
+            let t_opts_json = serde_json::to_string(transitive_opts).unwrap_or_default();
+            let t_key = (transitive_ref.clone(), t_opts_json);
+            if !visited.contains(&t_key) {
+                worklist.push((transitive_ref.clone(), transitive_opts.clone()));
+            }
+        }
+
+        feature_entries.push(FeatureEntry {
+            key: dep_ref.clone(),
+            metadata,
+            artifact_dir,
+            user_options,
+            original_ref: dep_ref,
+        });
     }
 
     Ok(())
@@ -1368,6 +1507,279 @@ mod tests {
                 .any(|m| m.contains("${devcontainerId}")),
             "mounts should contain raw ${{devcontainerId}} before orchestrator substitution: {:?}",
             result.container_config.mounts
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // resolve_features: dependsOn expansion
+    // -----------------------------------------------------------------------
+
+    /// Build a minimal local feature dir with optional dependsOn and install.sh.
+    fn make_local_feature(
+        base: &Path,
+        name: &str,
+        depends_on: &[(&str, serde_json::Value)],
+        has_install: bool,
+    ) {
+        let path = base.join(name);
+        std::fs::create_dir_all(&path).unwrap();
+        let mut meta = serde_json::json!({
+            "id": name,
+            "version": "1.0.0"
+        });
+        if !depends_on.is_empty() {
+            let deps: serde_json::Map<String, serde_json::Value> = depends_on
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), v.clone()))
+                .collect();
+            meta.as_object_mut()
+                .unwrap()
+                .insert("dependsOn".to_string(), serde_json::Value::Object(deps));
+        }
+        std::fs::write(path.join("devcontainer-feature.json"), meta.to_string()).unwrap();
+        if has_install {
+            std::fs::write(path.join("install.sh"), "#!/bin/sh\necho ok").unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn depends_on_transitive_dep_auto_added_and_ordered_first() {
+        // Feature "child" depends on "parent". Only "child" is declared in
+        // devcontainer.json. After expansion both should be resolved, and
+        // "parent" must appear before "child".
+        let feature_dir = tempfile::tempdir().unwrap();
+
+        make_local_feature(feature_dir.path(), "parent", &[], true);
+        // child declares dependsOn on ./parent
+        let child_dep_ref = "./parent".to_string();
+        make_local_feature(
+            feature_dir.path(),
+            "child",
+            &[(&child_dep_ref, serde_json::json!({}))],
+            true,
+        );
+
+        let cache_dir = tempfile::tempdir().unwrap();
+        let cache = FeatureCache::with_root(cache_dir.path().join("features"));
+        let config_path = feature_dir.path().join("devcontainer.json");
+        let config = json!({
+            "image": "ubuntu:22.04",
+            "features": { "./child": {} }
+        });
+        let platform = Platform {
+            os: "linux".to_string(),
+            architecture: "amd64".to_string(),
+        };
+
+        let result = resolve_features(
+            &config,
+            &config_path,
+            &platform,
+            &cache,
+            &BaseImageContext {
+                base_image: "ubuntu:22.04",
+                image_user: "root",
+                metadata: None,
+                omit_remote_env: false,
+            },
+            false,
+        )
+        .await
+        .unwrap();
+
+        let ids: Vec<&str> = result.features.iter().map(|f| f.id.as_str()).collect();
+        assert_eq!(ids.len(), 2, "both child and parent should be resolved");
+        assert!(ids.contains(&"parent"));
+        assert!(ids.contains(&"child"));
+
+        let parent_pos = ids.iter().position(|&x| x == "parent").unwrap();
+        let child_pos = ids.iter().position(|&x| x == "child").unwrap();
+        assert!(
+            parent_pos < child_pos,
+            "parent must be installed before child, got order: {ids:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn depends_on_dedup_same_ref_same_options() {
+        // Two features both declare dependsOn on the same "shared" feature with
+        // the same options. It should only appear once in the install set.
+        let feature_dir = tempfile::tempdir().unwrap();
+
+        make_local_feature(feature_dir.path(), "shared", &[], true);
+
+        let shared_ref = "./shared".to_string();
+        make_local_feature(
+            feature_dir.path(),
+            "feat-a",
+            &[(&shared_ref, serde_json::json!({}))],
+            true,
+        );
+        make_local_feature(
+            feature_dir.path(),
+            "feat-b",
+            &[(&shared_ref, serde_json::json!({}))],
+            true,
+        );
+
+        let cache_dir = tempfile::tempdir().unwrap();
+        let cache = FeatureCache::with_root(cache_dir.path().join("features"));
+        let config_path = feature_dir.path().join("devcontainer.json");
+        let config = json!({
+            "image": "ubuntu:22.04",
+            "features": {
+                "./feat-a": {},
+                "./feat-b": {}
+            }
+        });
+        let platform = Platform {
+            os: "linux".to_string(),
+            architecture: "amd64".to_string(),
+        };
+
+        let result = resolve_features(
+            &config,
+            &config_path,
+            &platform,
+            &cache,
+            &BaseImageContext {
+                base_image: "ubuntu:22.04",
+                image_user: "root",
+                metadata: None,
+                omit_remote_env: false,
+            },
+            false,
+        )
+        .await
+        .unwrap();
+
+        let ids: Vec<&str> = result.features.iter().map(|f| f.id.as_str()).collect();
+        assert_eq!(
+            ids.iter().filter(|&&x| x == "shared").count(),
+            1,
+            "shared should appear exactly once, got: {ids:?}"
+        );
+        assert_eq!(ids.len(), 3, "feat-a, feat-b, shared: {ids:?}");
+    }
+
+    #[tokio::test]
+    async fn depends_on_same_ref_different_options_two_entries() {
+        // Same feature referenced with different options = two separate entries.
+        let feature_dir = tempfile::tempdir().unwrap();
+
+        make_local_feature(feature_dir.path(), "base-tool", &[], true);
+
+        // feat-a depends on base-tool with version="1"
+        let base_ref = "./base-tool".to_string();
+        make_local_feature(
+            feature_dir.path(),
+            "feat-a",
+            &[(&base_ref, serde_json::json!({"version": "1"}))],
+            true,
+        );
+        // feat-b depends on base-tool with version="2"
+        make_local_feature(
+            feature_dir.path(),
+            "feat-b",
+            &[(&base_ref, serde_json::json!({"version": "2"}))],
+            true,
+        );
+
+        let cache_dir = tempfile::tempdir().unwrap();
+        let cache = FeatureCache::with_root(cache_dir.path().join("features"));
+        let config_path = feature_dir.path().join("devcontainer.json");
+        let config = json!({
+            "image": "ubuntu:22.04",
+            "features": {
+                "./feat-a": {},
+                "./feat-b": {}
+            }
+        });
+        let platform = Platform {
+            os: "linux".to_string(),
+            architecture: "amd64".to_string(),
+        };
+
+        let result = resolve_features(
+            &config,
+            &config_path,
+            &platform,
+            &cache,
+            &BaseImageContext {
+                base_image: "ubuntu:22.04",
+                image_user: "root",
+                metadata: None,
+                omit_remote_env: false,
+            },
+            false,
+        )
+        .await
+        .unwrap();
+
+        let ids: Vec<&str> = result.features.iter().map(|f| f.id.as_str()).collect();
+        // Per spec: same feature with different options = different entries.
+        assert_eq!(
+            ids.iter().filter(|&&x| x == "base-tool").count(),
+            2,
+            "base-tool with different options should appear twice, got: {ids:?}"
+        );
+        assert_eq!(ids.len(), 4);
+    }
+
+    #[tokio::test]
+    async fn depends_on_cycle_returns_error() {
+        // Feature A depends on B, B depends on A → fatal error.
+        let feature_dir = tempfile::tempdir().unwrap();
+
+        let a_ref = "./feat-a".to_string();
+        let b_ref = "./feat-b".to_string();
+        make_local_feature(
+            feature_dir.path(),
+            "feat-a",
+            &[(&b_ref, serde_json::json!({}))],
+            true,
+        );
+        make_local_feature(
+            feature_dir.path(),
+            "feat-b",
+            &[(&a_ref, serde_json::json!({}))],
+            true,
+        );
+
+        let cache_dir = tempfile::tempdir().unwrap();
+        let cache = FeatureCache::with_root(cache_dir.path().join("features"));
+        let config_path = feature_dir.path().join("devcontainer.json");
+        let config = json!({
+            "image": "ubuntu:22.04",
+            "features": {
+                "./feat-a": {},
+                "./feat-b": {}
+            }
+        });
+        let platform = Platform {
+            os: "linux".to_string(),
+            architecture: "amd64".to_string(),
+        };
+
+        let err = resolve_features(
+            &config,
+            &config_path,
+            &platform,
+            &cache,
+            &BaseImageContext {
+                base_image: "ubuntu:22.04",
+                image_user: "root",
+                metadata: None,
+                omit_remote_env: false,
+            },
+            false,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, FeatureError::CyclicDependsOn { .. }),
+            "expected CyclicDependsOn error, got: {err:?}"
         );
     }
 }

--- a/crates/cella-features/src/lib.rs
+++ b/crates/cella-features/src/lib.rs
@@ -33,7 +33,7 @@ pub use ordering::compute_install_order;
 pub use reference::{FeatureRef, NormalizedRef};
 pub use types::*;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 /// Parse lifecycle commands for a phase from a `devcontainer.metadata` label.
@@ -84,11 +84,29 @@ pub struct BaseImageContext<'a> {
 
 /// Intermediate representation of a parsed feature before ordering.
 struct FeatureEntry {
-    key: String,
+    /// Unique install identity = `(normalized_ref, options)`.
+    ///
+    /// The same feature pulled in twice with **different** options is two
+    /// distinct installs per the spec, so a raw ref alone is not a unique key:
+    /// it would collapse the two variants in any map keyed by it (ordering,
+    /// assembly). `install_id` keeps them apart — see [`install_identity`].
+    install_id: String,
     metadata: FeatureMetadata,
     artifact_dir: PathBuf,
     user_options: HashMap<String, serde_json::Value>,
+    /// The raw reference the user (or a `dependsOn` key) wrote, kept for
+    /// display and surfaced on the [`ResolvedFeature`].
     original_ref: String,
+}
+
+/// Build the unique install identity for a feature instance.
+///
+/// Two installs are the same feature iff their **normalized reference** and
+/// their **options** match (devcontainer spec identity). The two parts are
+/// joined with a NUL byte, which cannot appear in a ref or in serialized JSON
+/// text, so the composite is unambiguous and stable.
+fn install_identity(normalized_ref: &str, options_json: &str) -> String {
+    format!("{normalized_ref}\u{0}{options_json}")
 }
 
 // ---------------------------------------------------------------------------
@@ -144,7 +162,7 @@ pub async fn resolve_features(
     expand_depends_on(&mut feature_entries, workspace_root, platform, cache).await?;
 
     // Step 6: Compute install order.
-    let ordered_ids = compute_order(&feature_entries, config)?;
+    let ordered_ids = compute_order(&feature_entries, config, workspace_root)?;
 
     // Step 7: Assemble resolved features in install order.
     let resolved = assemble_resolved(&feature_entries, &ordered_ids);
@@ -394,7 +412,7 @@ fn parse_metadata_and_validate(
 ) -> Result<Vec<FeatureEntry>, FeatureError> {
     let mut entries = Vec::with_capacity(parsed_entries.len());
 
-    for (i, (key, _, options_value)) in parsed_entries.iter().enumerate() {
+    for (i, (key, normalized, options_value)) in parsed_entries.iter().enumerate() {
         let artifact_dir = &artifact_paths[i];
         let metadata_path = artifact_dir.join("devcontainer-feature.json");
         let metadata_json =
@@ -412,8 +430,12 @@ fn parse_metadata_and_validate(
             log_option_warning(key, w);
         }
 
+        // Identity keys on the NORMALIZED ref so shorthand and fully-qualified
+        // spellings of the same feature deduplicate together, and on the raw
+        // options value so option variants stay distinct.
+        let options_json = serde_json::to_string(options_value).unwrap_or_default();
         entries.push(FeatureEntry {
-            key: key.clone(),
+            install_id: install_identity(&normalized.to_string(), &options_json),
             metadata,
             artifact_dir: artifact_dir.clone(),
             user_options,
@@ -426,6 +448,12 @@ fn parse_metadata_and_validate(
 
 /// Compute install order from feature entries and config overrides.
 ///
+/// The ordering graph is keyed by each entry's unique [`FeatureEntry::install_id`]
+/// (not the raw ref), so two installs of the same feature with different
+/// options stay distinct. Each entry's `dependsOn` / `installsAfter` edges are
+/// resolved from raw refs to the matching install identities before sorting,
+/// so an edge points at the specific option-variant instance it names.
+///
 /// # Errors
 ///
 /// Returns [`FeatureError::CyclicDependsOn`] when a hard `dependsOn` cycle
@@ -433,20 +461,15 @@ fn parse_metadata_and_validate(
 fn compute_order(
     feature_entries: &[FeatureEntry],
     config: &serde_json::Value,
+    workspace_root: &Path,
 ) -> Result<Vec<String>, FeatureError> {
-    let order_input: Vec<(String, &FeatureMetadata)> = feature_entries
+    let order_metadata = build_order_metadata(feature_entries, workspace_root);
+    let order_input: Vec<(String, &FeatureMetadata)> = order_metadata
         .iter()
-        .map(|entry| (entry.key.clone(), &entry.metadata))
+        .map(|(id, meta)| (id.clone(), meta))
         .collect();
 
-    let override_order = config
-        .get("overrideFeatureInstallOrder")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(String::from))
-                .collect::<Vec<_>>()
-        });
+    let override_order = resolve_override_order(config, feature_entries, workspace_root);
 
     let mut depends_on_cycle: Option<Vec<String>> = None;
     let (ordered_ids, order_warnings) = compute_install_order(
@@ -466,7 +489,131 @@ fn compute_order(
     Ok(ordered_ids)
 }
 
+/// Normalize a raw feature reference for identity matching, falling back to the
+/// raw string when it cannot be parsed (invalid refs surface elsewhere).
+fn normalize_ref_for_identity(raw: &str, workspace_root: &Path) -> String {
+    FeatureRef::parse(raw)
+        .and_then(|r| r.normalize(workspace_root))
+        .map_or_else(|_| raw.to_owned(), |(n, _)| n.to_string())
+}
+
+/// Build per-entry ordering metadata keyed by `install_id`, with `dependsOn`
+/// and `installsAfter` edges rewritten from raw refs to the matching
+/// `install_id`s.
+///
+/// - `dependsOn` matches on `(normalized_ref, options)` — the full identity, so
+///   it targets the exact option-variant instance it names.
+/// - `installsAfter` matches on `normalized_ref` only (the spec gives it no
+///   options); it therefore expands to **every** option-variant of that ref.
+fn build_order_metadata(
+    feature_entries: &[FeatureEntry],
+    workspace_root: &Path,
+) -> Vec<(String, FeatureMetadata)> {
+    // Set of valid install identities, for dependsOn resolution.
+    let identities: HashSet<&str> = feature_entries
+        .iter()
+        .map(|e| e.install_id.as_str())
+        .collect();
+    let by_ref = index_by_ref(feature_entries);
+
+    feature_entries
+        .iter()
+        .map(|entry| {
+            let mut meta = entry.metadata.clone();
+
+            // Rewrite hard (dependsOn) edges to matching install identities.
+            let depends_on = std::mem::take(&mut meta.depends_on);
+            meta.depends_on = depends_on
+                .into_iter()
+                .filter_map(|(dep_ref, opts)| {
+                    let norm = normalize_ref_for_identity(&dep_ref, workspace_root);
+                    let opts_json = serde_json::to_string(&opts).unwrap_or_default();
+                    let id = install_identity(&norm, &opts_json);
+                    identities.contains(id.as_str()).then_some((id, opts))
+                })
+                .collect();
+
+            // Rewrite soft (installsAfter) edges; one ref may fan out to
+            // several option-variant installs.
+            let installs_after = std::mem::take(&mut meta.installs_after);
+            meta.installs_after = installs_after
+                .into_iter()
+                .flat_map(|after_ref| {
+                    let norm = normalize_ref_for_identity(&after_ref, workspace_root);
+                    by_ref
+                        .get(norm.as_str())
+                        .into_iter()
+                        .flatten()
+                        .map(|id| (*id).to_string())
+                        .collect::<Vec<_>>()
+                })
+                .collect();
+
+            (entry.install_id.clone(), meta)
+        })
+        .collect()
+}
+
+/// Index install identities by their normalized ref.
+///
+/// One ref may map to several identities when the same feature is installed
+/// more than once with different options. Used to resolve option-agnostic
+/// references (`installsAfter`, `overrideFeatureInstallOrder`) to the concrete
+/// install identities they cover.
+fn index_by_ref(feature_entries: &[FeatureEntry]) -> HashMap<&str, Vec<&str>> {
+    let mut by_ref: HashMap<&str, Vec<&str>> = HashMap::new();
+    for entry in feature_entries {
+        // The install_id is `normalized_ref \0 options_json`; the ref is the
+        // part before the NUL separator.
+        let normalized_ref = entry
+            .install_id
+            .split('\u{0}')
+            .next()
+            .unwrap_or(&entry.install_id);
+        by_ref
+            .entry(normalized_ref)
+            .or_default()
+            .push(entry.install_id.as_str());
+    }
+    by_ref
+}
+
+/// Resolve `overrideFeatureInstallOrder` (raw refs) to install identities.
+///
+/// Each override ref names a feature without options, so it expands to every
+/// matching option-variant install, preserving the override's declared order.
+fn resolve_override_order(
+    config: &serde_json::Value,
+    feature_entries: &[FeatureEntry],
+    workspace_root: &Path,
+) -> Option<Vec<String>> {
+    let raw = config
+        .get("overrideFeatureInstallOrder")
+        .and_then(|v| v.as_array())?;
+
+    let by_ref = index_by_ref(feature_entries);
+
+    let resolved: Vec<String> = raw
+        .iter()
+        .filter_map(serde_json::Value::as_str)
+        .flat_map(|ref_str| {
+            let norm = normalize_ref_for_identity(ref_str, workspace_root);
+            by_ref
+                .get(norm.as_str())
+                .into_iter()
+                .flatten()
+                .map(|id| (*id).to_string())
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    Some(resolved)
+}
+
 /// Assemble `ResolvedFeature` structs in install order.
+///
+/// `ordered_ids` are unique [`FeatureEntry::install_id`]s, so the lookup never
+/// collapses two option-variants of the same ref onto one entry.
 fn assemble_resolved(
     feature_entries: &[FeatureEntry],
     ordered_ids: &[String],
@@ -474,13 +621,18 @@ fn assemble_resolved(
     let entry_map: HashMap<&str, usize> = feature_entries
         .iter()
         .enumerate()
-        .map(|(i, entry)| (entry.key.as_str(), i))
+        .map(|(i, entry)| (entry.install_id.as_str(), i))
         .collect();
 
     let mut resolved = Vec::with_capacity(ordered_ids.len());
 
     for id in ordered_ids {
-        let idx = entry_map[id.as_str()];
+        let Some(&idx) = entry_map.get(id.as_str()) else {
+            // An ordered id with no backing entry would be a logic bug in the
+            // ordering step; skip rather than panic.
+            warn!("install order produced unknown id {id:?}; skipping");
+            continue;
+        };
         let entry = &feature_entries[idx];
 
         let has_install = entry.artifact_dir.join("install.sh").is_file();
@@ -496,7 +648,7 @@ fn assemble_resolved(
 
         debug!(
             "resolved feature {} -> {} (install_script={})",
-            entry.key, entry.metadata.id, has_install
+            entry.original_ref, entry.metadata.id, has_install
         );
     }
 
@@ -585,17 +737,13 @@ async fn expand_depends_on(
 
     // Normalize a raw ref string for identity keying, ignoring parse errors
     // (invalid refs are caught later during fetch).
-    let normalize_key = |raw: &str| -> String {
-        FeatureRef::parse(raw)
-            .and_then(|r| r.normalize(workspace_root))
-            .map_or_else(|_| raw.to_owned(), |(n, _)| n.to_string())
-    };
+    let normalize_key = |raw: &str| normalize_ref_for_identity(raw, workspace_root);
 
     // Visited set: (normalised_ref_string, options_json) — spec identity
     // semantics.  Pre-populate with user-declared entries using their
     // NORMALISED ref so that spelling variants of the same OCI ref
     // (e.g. shorthand vs. fully-qualified) deduplicate correctly.
-    let mut visited: std::collections::HashSet<(String, String)> = feature_entries
+    let mut visited: HashSet<(String, String)> = feature_entries
         .iter()
         .map(|e| {
             let norm_key = normalize_key(&e.original_ref);
@@ -627,12 +775,16 @@ async fn expand_depends_on(
         }
 
         let opts_json = serde_json::to_string(&dep_opts).unwrap_or_default();
-        let visit_key = (normalized.to_string(), opts_json);
+        let visit_key = (normalized.to_string(), opts_json.clone());
 
         if visited.contains(&visit_key) {
             continue;
         }
         visited.insert(visit_key);
+
+        // Unique install identity for this expanded instance — same composite
+        // as the `visited` key so option variants of one ref stay distinct.
+        let install_id = install_identity(&normalized.to_string(), &opts_json);
 
         // Fetch the artifact.
         let artifact_dir = fetch_one(
@@ -674,7 +826,7 @@ async fn expand_depends_on(
         }
 
         feature_entries.push(FeatureEntry {
-            key: dep_ref.clone(),
+            install_id,
             metadata,
             artifact_dir,
             user_options,
@@ -817,7 +969,7 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), FeatureError> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
 
     use serde_json::json;
 
@@ -1737,6 +1889,21 @@ mod tests {
             "base-tool with different options should appear twice, got: {ids:?}"
         );
         assert_eq!(ids.len(), 4);
+
+        // Regression (unique-key fix): the two base-tool installs must keep
+        // their DISTINCT options. With a non-unique key both collapsed onto one
+        // entry and the surviving copy carried the wrong option set.
+        let base_versions: HashSet<Option<&str>> = result
+            .features
+            .iter()
+            .filter(|f| f.id == "base-tool")
+            .map(|f| f.user_options.get("version").and_then(|v| v.as_str()))
+            .collect();
+        assert_eq!(
+            base_versions,
+            HashSet::from([Some("1"), Some("2")]),
+            "both base-tool option variants must survive distinctly, got: {base_versions:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/cella-features/src/ordering.rs
+++ b/crates/cella-features/src/ordering.rs
@@ -7,9 +7,22 @@
 //! 1. Official `ghcr.io/devcontainers/features/*` features sort first.
 //! 2. Among equal-priority features, declaration order is preserved.
 //! 3. `overrideFeatureInstallOrder` takes precedence over computed order.
+//!
+//! `dependsOn` edges are hard ordering constraints — a feature cannot be
+//! emitted until ALL its `dependsOn` targets appear earlier in the result.
+//! Cycles in `dependsOn` edges are surfaced via the `depends_on_cycle`
+//! out-parameter so callers can return a fatal error. `installsAfter` cycles
+//! are merely soft hints: they are reported as a non-fatal warning and the
+//! affected features fall back to declaration order.
+//!
+//! Hard and soft cycles are detected independently. A hard cycle is determined
+//! solely from the `dependsOn`-only graph, so a soft `installsAfter` edge that
+//! merely *participates* in a loop with otherwise-acyclic `dependsOn` edges
+//! (e.g. `A dependsOn B`, `B installsAfter A` — satisfiable by installing `B`
+//! first) is never misclassified as a fatal `dependsOn` cycle.
 
 use std::cmp::Reverse;
-use std::collections::{BTreeSet, BinaryHeap, HashMap, HashSet};
+use std::collections::{BinaryHeap, HashMap, HashSet};
 
 use crate::error::FeatureWarning;
 use crate::types::FeatureMetadata;
@@ -17,7 +30,25 @@ use crate::types::FeatureMetadata;
 /// Prefix for official devcontainer features in the OCI namespace.
 const OFFICIAL_PREFIX: &str = "ghcr.io/devcontainers/features/";
 
-/// Priority bucket for tiebreaking in the topological sort.
+/// Adjacency lists plus degree counters for a Kahn sort.
+///
+/// Hard (`dependsOn`) and soft (`installsAfter`) edges are kept apart so the
+/// scheduler can apply both while cycle detection reasons about the hard graph
+/// in isolation. All edges flow prerequisite → dependent (emit prereq first).
+struct DepGraph {
+    /// Hard-edge adjacency: `hard_adj[prereq]` lists dependents that
+    /// `dependsOn` `prereq`.
+    hard_adj: Vec<Vec<usize>>,
+    /// Soft-edge adjacency: `soft_adj[prereq]` lists dependents that
+    /// `installsAfter` `prereq`.
+    soft_adj: Vec<Vec<usize>>,
+    /// Combined (hard + soft) in-degree used by the scheduling Kahn pass.
+    in_degree: Vec<usize>,
+    /// Hard-only in-degree, used to seed the hard-cycle detection pass.
+    hard_in_degree: Vec<usize>,
+}
+
+/// Priority bucket for tiebreaking in the topological sort (no override).
 ///
 /// Lower numeric value = higher priority (installed first).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -25,6 +56,23 @@ struct SortKey {
     /// 0 for official features, 1 for third-party.
     tier: u8,
     /// Index in the original declaration order.
+    declaration_index: usize,
+}
+
+/// Extended sort key used when `overrideFeatureInstallOrder` is active.
+///
+/// Override-listed features get `override_tier = 0` and sort by their
+/// position in the override list.  Unlisted features get `override_tier = 1`
+/// and fall back to the standard official-first + declaration-order tiebreak.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct OverrideSortKey {
+    /// 0 = in override list, 1 = not in override list.
+    override_tier: u8,
+    /// Position in the override list (only meaningful when `override_tier == 0`).
+    override_pos: usize,
+    /// 0 = official, 1 = third-party (only meaningful when `override_tier == 1`).
+    official_tier: u8,
+    /// Declaration index tiebreaker (only meaningful when `override_tier == 1`).
     declaration_index: usize,
 }
 
@@ -40,22 +88,25 @@ fn build_id_index<'a>(features: &'a [(String, &FeatureMetadata)]) -> HashMap<&'a
 /// Compute the install order for a set of features.
 ///
 /// Takes features in their declaration order and returns them reordered
-/// according to `installsAfter` dependencies, official-first tiebreaking,
-/// and any explicit override.
+/// according to `dependsOn` (hard) and `installsAfter` (soft) dependencies,
+/// official-first tiebreaking, and any explicit override.
 ///
 /// # Arguments
 ///
 /// * `features` - Pairs of `(feature_id, metadata)` in declaration order.
 /// * `override_order` - Optional explicit ordering from `overrideFeatureInstallOrder`.
+/// * `depends_on_cycle` - Set to the cycle members when a hard `dependsOn`
+///   cycle is detected; caller should return a fatal error in that case.
 ///
 /// # Returns
 ///
 /// A tuple of `(ordered_ids, warnings)`. Warnings are emitted for cyclic
-/// dependencies. On cycle detection, affected features fall back to
-/// declaration order.
+/// `installsAfter` soft deps only. Cyclic `dependsOn` hard deps are
+/// signalled via `depends_on_cycle` instead.
 pub fn compute_install_order(
     features: &[(String, &FeatureMetadata)],
     override_order: Option<&[String]>,
+    depends_on_cycle: &mut Option<Vec<String>>,
 ) -> (Vec<String>, Vec<FeatureWarning>) {
     if features.is_empty() {
         return (Vec::new(), Vec::new());
@@ -78,53 +129,79 @@ pub fn compute_install_order(
             overrides,
             &id_to_index,
             has_official,
+            depends_on_cycle,
             &mut warnings,
         );
     }
 
     // No override — run full topological sort.
-    topological_sort(features, &id_to_index, has_official, &mut warnings)
+    topological_sort(
+        features,
+        &id_to_index,
+        has_official,
+        depends_on_cycle,
+        &mut warnings,
+    )
 }
 
-/// Apply `overrideFeatureInstallOrder`: listed features go first in override
-/// order (ignoring `installsAfter`), unlisted features are appended in
-/// default topological sort order.
+/// Apply `overrideFeatureInstallOrder` as a **priority hint** inside the
+/// topological sort.
+///
+/// Per the devcontainer spec, `overrideFeatureInstallOrder` controls which
+/// `in_degree == 0` candidate is picked first in each Kahn round.  It does
+/// NOT bypass `dependsOn` hard constraints — a feature that `dependsOn`
+/// another must still wait for that prerequisite regardless of its position in
+/// the override list.
+///
+/// Override-listed features use `OverrideSortKey` tier 0 (highest priority)
+/// with their override position as tiebreak, and have their own
+/// `installsAfter` soft edges ignored.  Unlisted features fall back to the
+/// standard official-first + declaration-order tiebreak (tier 1).
 fn apply_override(
     features: &[(String, &FeatureMetadata)],
     overrides: &[String],
     id_to_index: &HashMap<&str, usize>,
     has_official: bool,
+    depends_on_cycle: &mut Option<Vec<String>>,
     warnings: &mut Vec<FeatureWarning>,
 ) -> (Vec<String>, Vec<FeatureWarning>) {
-    let override_set: HashSet<&str> = overrides.iter().map(String::as_str).collect();
-
-    // Listed features in override order (skip any that aren't in our feature set).
-    let mut result: Vec<String> = overrides
+    let override_position: HashMap<&str, usize> = overrides
         .iter()
-        .filter(|id| id_to_index.contains_key(id.as_str()))
-        .cloned()
+        .enumerate()
+        .filter(|(_, id)| id_to_index.contains_key(id.as_str()))
+        .map(|(pos, id)| (id.as_str(), pos))
         .collect();
 
-    // Unlisted features: topological sort among themselves only.
-    let unlisted: Vec<(String, &FeatureMetadata)> = features
-        .iter()
-        .filter(|(id, _)| !override_set.contains(id.as_str()))
-        .cloned()
-        .collect();
+    let graph = build_graph(features, id_to_index, Some(&override_position));
+    let ext_key = |id: &str| override_sort_key(id, &override_position, id_to_index, has_official);
 
-    if !unlisted.is_empty() {
-        let unlisted_id_to_index = build_id_index(&unlisted);
+    let mut in_degree = graph.in_degree.clone();
+    let mut heap: BinaryHeap<Reverse<(OverrideSortKey, usize)>> = BinaryHeap::new();
+    for (local_idx, (id, _)) in features.iter().enumerate() {
+        if in_degree[local_idx] == 0 {
+            heap.push(Reverse((ext_key(id), local_idx)));
+        }
+    }
 
-        // For unlisted features, only consider dependencies among unlisted features.
-        // Use the original declaration order for tiebreaking.
-        let (unlisted_order, mut unlisted_warnings) = topological_sort_with_original_indices(
-            &unlisted,
-            &unlisted_id_to_index,
-            id_to_index,
-            has_official,
-        );
-        result.extend(unlisted_order);
-        warnings.append(&mut unlisted_warnings);
+    let mut result = Vec::with_capacity(features.len());
+    while let Some(Reverse((_, local_idx))) = heap.pop() {
+        result.push(features[local_idx].0.clone());
+        // Iterate adjacency slices by reference — no per-pop clone needed.
+        for &dep in graph.hard_adj[local_idx]
+            .iter()
+            .chain(&graph.soft_adj[local_idx])
+        {
+            in_degree[dep] -= 1;
+            if in_degree[dep] == 0 {
+                heap.push(Reverse((ext_key(&features[dep].0), dep)));
+            }
+        }
+    }
+
+    if let Some(fallback) =
+        finish_with_cycle_detection(features, &graph, &result, depends_on_cycle, warnings)
+    {
+        result.extend(fallback);
     }
 
     (result, warnings.clone())
@@ -135,105 +212,203 @@ fn topological_sort(
     features: &[(String, &FeatureMetadata)],
     id_to_index: &HashMap<&str, usize>,
     has_official: bool,
+    depends_on_cycle: &mut Option<Vec<String>>,
     warnings: &mut Vec<FeatureWarning>,
 ) -> (Vec<String>, Vec<FeatureWarning>) {
-    topological_sort_with_original_indices(features, id_to_index, id_to_index, has_official)
-        .pipe_warnings(warnings)
+    topological_sort_with_original_indices(
+        features,
+        id_to_index,
+        id_to_index,
+        has_official,
+        depends_on_cycle,
+    )
+    .pipe_warnings(warnings)
 }
 
 /// Inner topological sort that accepts separate index maps for adjacency
 /// lookup vs. tiebreaking (needed when sorting a subset of features while
 /// preserving original declaration order).
+///
+/// Both `dependsOn` (hard) and `installsAfter` (soft) edges contribute to
+/// `in_degree`.  Cycle detection reasons about the hard graph in isolation so
+/// hard cycles are signalled via `depends_on_cycle` while soft-only cycles
+/// emit a warning and fall back to declaration order.
 fn topological_sort_with_original_indices(
     features: &[(String, &FeatureMetadata)],
     local_id_to_index: &HashMap<&str, usize>,
     original_id_to_index: &HashMap<&str, usize>,
     has_official: bool,
+    depends_on_cycle: &mut Option<Vec<String>>,
 ) -> (Vec<String>, Vec<FeatureWarning>) {
-    let n = features.len();
     let mut warnings = Vec::new();
 
-    // Adjacency: edge from prerequisite -> dependent. If feature X must be
-    // installed after Y (Y is a prerequisite of X), then Y comes first, so we
-    // record the edge Y -> X.
-    //
-    // Both edge sources impose the same install-before constraint:
-    //   - `dependsOn` keys  — hard dependencies (must install before)
-    //   - `installsAfter`   — soft ordering hints
-    // Matching the official CLI, a round can only install a node once *every*
-    // hard- and soft-dependency has been installed, so both feed the sort.
-    let mut adj: Vec<Vec<usize>> = vec![Vec::new(); n];
-    let mut in_degree: Vec<usize> = vec![0; n];
-
-    for (local_idx, (_, meta)) in features.iter().enumerate() {
-        // Deduplicate prerequisites so a dependency declared in both
-        // `dependsOn` and `installsAfter` (or repeated) counts once — otherwise
-        // the inflated in-degree would never reach zero and stall the sort.
-        // `BTreeSet` keeps the adjacency build deterministic.
-        let mut prerequisites: BTreeSet<usize> = BTreeSet::new();
-        let dep_ids = meta.depends_on.keys().map(String::as_str);
-        let after_ids = meta.installs_after.iter().map(String::as_str);
-        for dep_id in dep_ids.chain(after_ids) {
-            if let Some(&dep_local_idx) = local_id_to_index.get(dep_id) {
-                prerequisites.insert(dep_local_idx);
-            }
-            // Dependencies on features not in our set are ignored.
-        }
-        for dep_local_idx in prerequisites {
-            adj[dep_local_idx].push(local_idx);
-            in_degree[local_idx] += 1;
-        }
-    }
+    let graph = build_graph(features, local_id_to_index, None);
+    let mut in_degree = graph.in_degree.clone();
 
     // Priority queue: smallest SortKey wins (installed first).
     // BinaryHeap is max-heap, so wrap in Reverse.
     let mut heap: BinaryHeap<Reverse<(SortKey, usize)>> = BinaryHeap::new();
-
     for (local_idx, (id, _)) in features.iter().enumerate() {
         if in_degree[local_idx] == 0 {
-            let key = sort_key(id, original_id_to_index, has_official);
-            heap.push(Reverse((key, local_idx)));
+            heap.push(Reverse((
+                sort_key(id, original_id_to_index, has_official),
+                local_idx,
+            )));
         }
     }
 
-    let mut result = Vec::with_capacity(n);
-
+    let mut result = Vec::with_capacity(features.len());
     while let Some(Reverse((_, local_idx))) = heap.pop() {
-        let id = &features[local_idx].0;
-        result.push(id.clone());
+        result.push(features[local_idx].0.clone());
 
-        for &neighbor in &adj[local_idx] {
-            in_degree[neighbor] -= 1;
-            if in_degree[neighbor] == 0 {
-                let neighbor_id = &features[neighbor].0;
-                let key = sort_key(neighbor_id, original_id_to_index, has_official);
-                heap.push(Reverse((key, neighbor)));
+        // Both edge kinds impose the same install-before constraint, so a
+        // dependent only becomes schedulable once every hard AND soft
+        // prerequisite has been emitted. Iterating the adjacency slices by
+        // reference avoids cloning them on every pop.
+        for &dependent in graph.hard_adj[local_idx]
+            .iter()
+            .chain(&graph.soft_adj[local_idx])
+        {
+            in_degree[dependent] -= 1;
+            if in_degree[dependent] == 0 {
+                heap.push(Reverse((
+                    sort_key(&features[dependent].0, original_id_to_index, has_official),
+                    dependent,
+                )));
             }
         }
     }
 
-    // Cycle detection: if we couldn't process all nodes, remaining form a cycle.
-    if result.len() < n {
-        let processed: HashSet<String> = result.iter().cloned().collect();
-        let cycle_members: Vec<String> = features
-            .iter()
-            .filter(|(id, _)| !processed.contains(id.as_str()))
-            .map(|(id, _)| id.clone())
-            .collect();
-
-        warnings.push(FeatureWarning::CyclicDependency {
-            features: cycle_members,
-        });
-
-        // Append cyclic features in declaration order as fallback.
-        for (id, _) in features {
-            if !processed.contains(id.as_str()) {
-                result.push(id.clone());
-            }
-        }
+    if let Some(fallback) =
+        finish_with_cycle_detection(features, &graph, &result, depends_on_cycle, &mut warnings)
+    {
+        result.extend(fallback);
     }
 
     (result, warnings)
+}
+
+/// Build hard/soft adjacency lists and degree counters for the Kahn passes.
+///
+/// Hard (`dependsOn`) edges are always included.  Soft (`installsAfter`) edges
+/// are included for every feature, except — when `override_position` is
+/// provided — for features that appear in the override list (their soft
+/// ordering hints are deliberately ignored so the override wins).
+fn build_graph(
+    features: &[(String, &FeatureMetadata)],
+    id_to_index: &HashMap<&str, usize>,
+    override_position: Option<&HashMap<&str, usize>>,
+) -> DepGraph {
+    let n = features.len();
+    let mut graph = DepGraph {
+        hard_adj: vec![Vec::new(); n],
+        soft_adj: vec![Vec::new(); n],
+        in_degree: vec![0; n],
+        hard_in_degree: vec![0; n],
+    };
+
+    for (local_idx, (id, meta)) in features.iter().enumerate() {
+        // Hard edges: dependsOn (dep must be installed BEFORE local_idx).
+        // Option values on the dependsOn key form part of the dependency's
+        // identity, but the install set has already been expanded to one entry
+        // per (ref, options) pair upstream, so matching by feature id here
+        // lands on the correct instance.
+        for dep_id in meta.depends_on.keys() {
+            if let Some(&prereq_idx) = id_to_index.get(dep_id.as_str()) {
+                graph.hard_adj[prereq_idx].push(local_idx);
+                graph.in_degree[local_idx] += 1;
+                graph.hard_in_degree[local_idx] += 1;
+            }
+            // dependsOn targets outside the current set were already injected
+            // by resolve_features; any remaining unknowns are ignored here.
+        }
+
+        // Soft edges: installsAfter (dep should be installed BEFORE local_idx).
+        // Skipped for override-listed features so the override order wins.
+        let suppress_soft = override_position.is_some_and(|p| p.contains_key(id.as_str()));
+        if !suppress_soft {
+            for dep_id in &meta.installs_after {
+                if let Some(&prereq_idx) = id_to_index.get(dep_id.as_str()) {
+                    graph.soft_adj[prereq_idx].push(local_idx);
+                    graph.in_degree[local_idx] += 1;
+                }
+            }
+        }
+    }
+
+    graph
+}
+
+/// Run Kahn's algorithm on the **hard-only** (`dependsOn`) graph and return the
+/// members of any hard cycle — i.e. nodes that can never be scheduled when
+/// only `dependsOn` edges are considered.
+///
+/// This is the authoritative hard-cycle test: it ignores soft `installsAfter`
+/// edges entirely, so a satisfiable-but-tangled case like `A dependsOn B`,
+/// `B installsAfter A` reports *no* hard cycle (the `dependsOn` graph `B → A`
+/// is acyclic) even though the combined graph stalls.
+fn hard_cycle_members(features: &[(String, &FeatureMetadata)], graph: &DepGraph) -> Vec<String> {
+    let n = features.len();
+    let mut hard_in_degree = graph.hard_in_degree.clone();
+    let mut queue: Vec<usize> = (0..n).filter(|&i| hard_in_degree[i] == 0).collect();
+    let mut processed = vec![false; n];
+
+    while let Some(idx) = queue.pop() {
+        processed[idx] = true;
+        for &dependent in &graph.hard_adj[idx] {
+            hard_in_degree[dependent] -= 1;
+            if hard_in_degree[dependent] == 0 {
+                queue.push(dependent);
+            }
+        }
+    }
+
+    features
+        .iter()
+        .zip(processed)
+        .filter(|(_, done)| !done)
+        .map(|((id, _), _)| id.clone())
+        .collect()
+}
+
+/// Classify the outcome of the scheduling Kahn pass.
+///
+/// - Complete schedule → `None` (nothing more to do).
+/// - Hard (`dependsOn`) cycle → sets `depends_on_cycle` and returns `None`
+///   (the caller surfaces a fatal error; no fallback is appended).
+/// - Soft-only (`installsAfter`) cycle → pushes a non-fatal warning and
+///   returns `Some(leftover)` — the unscheduled features in declaration order
+///   for the caller to append as a best-effort fallback.
+fn finish_with_cycle_detection(
+    features: &[(String, &FeatureMetadata)],
+    graph: &DepGraph,
+    scheduled: &[String],
+    depends_on_cycle: &mut Option<Vec<String>>,
+    warnings: &mut Vec<FeatureWarning>,
+) -> Option<Vec<String>> {
+    if scheduled.len() == features.len() {
+        return None;
+    }
+
+    // A hard cycle is determined purely from the dependsOn-only graph.
+    let hard_cycle = hard_cycle_members(features, graph);
+    if !hard_cycle.is_empty() {
+        *depends_on_cycle = Some(hard_cycle);
+        return None;
+    }
+
+    // Soft-only (installsAfter) cycle: warn and fall back to declaration order.
+    let processed: HashSet<&str> = scheduled.iter().map(String::as_str).collect();
+    let leftover: Vec<String> = features
+        .iter()
+        .filter(|(id, _)| !processed.contains(id.as_str()))
+        .map(|(id, _)| id.clone())
+        .collect();
+
+    warnings.push(FeatureWarning::CyclicDependency {
+        features: leftover.clone(),
+    });
+    Some(leftover)
 }
 
 /// Compute the sort key for tiebreaking.
@@ -244,6 +419,31 @@ fn sort_key(id: &str, original_id_to_index: &HashMap<&str, usize>, has_official:
     SortKey {
         tier,
         declaration_index,
+    }
+}
+
+/// Compute the `OverrideSortKey` for a feature id.
+fn override_sort_key(
+    id: &str,
+    override_position: &HashMap<&str, usize>,
+    id_to_index: &HashMap<&str, usize>,
+    has_official: bool,
+) -> OverrideSortKey {
+    if let Some(&pos) = override_position.get(id) {
+        OverrideSortKey {
+            override_tier: 0,
+            override_pos: pos,
+            official_tier: 0,
+            declaration_index: 0,
+        }
+    } else {
+        let is_third_party = !(has_official && id.starts_with(OFFICIAL_PREFIX));
+        OverrideSortKey {
+            override_tier: 1,
+            override_pos: 0,
+            official_tier: u8::from(is_third_party),
+            declaration_index: id_to_index.get(id).copied().unwrap_or(usize::MAX),
+        }
     }
 }
 
@@ -273,7 +473,7 @@ mod tests {
         }
     }
 
-    /// Helper to build a `FeatureMetadata` with `depends_on` (hard) deps set.
+    /// Helper to build a `FeatureMetadata` with `depends_on` (hard deps) set.
     /// Each key maps to an arbitrary option value (`true`).
     fn meta_depends(id: &str, depends_on: &[&str]) -> FeatureMetadata {
         FeatureMetadata {
@@ -304,7 +504,7 @@ mod tests {
         ];
         let features = feature_list(&items);
 
-        let (order, warnings) = compute_install_order(&features, None);
+        let (order, warnings) = compute_install_order(&features, None, &mut None);
 
         assert!(warnings.is_empty());
         assert_eq!(order, vec!["alpha", "beta", "gamma"]);
@@ -323,7 +523,7 @@ mod tests {
         ];
         let features = feature_list(&items);
 
-        let (order, warnings) = compute_install_order(&features, None);
+        let (order, warnings) = compute_install_order(&features, None, &mut None);
 
         assert!(warnings.is_empty());
         assert_eq!(order, vec!["c", "b", "a"]);
@@ -344,7 +544,7 @@ mod tests {
         ];
         let features = feature_list(&items);
 
-        let (order, warnings) = compute_install_order(&features, None);
+        let (order, warnings) = compute_install_order(&features, None, &mut None);
 
         assert!(warnings.is_empty());
         // Official sorts first despite being declared second.
@@ -373,7 +573,7 @@ mod tests {
         ];
         let features = feature_list(&items);
 
-        let (order, warnings) = compute_install_order(&features, None);
+        let (order, warnings) = compute_install_order(&features, None, &mut None);
 
         assert!(warnings.is_empty());
         assert_eq!(
@@ -398,7 +598,7 @@ mod tests {
         ];
         let features = feature_list(&items);
 
-        let (order, warnings) = compute_install_order(&features, None);
+        let (order, warnings) = compute_install_order(&features, None, &mut None);
 
         assert_eq!(warnings.len(), 1);
         match &warnings[0] {
@@ -425,7 +625,7 @@ mod tests {
         ];
         let features = feature_list(&items);
 
-        let (order, warnings) = compute_install_order(&features, None);
+        let (order, warnings) = compute_install_order(&features, None, &mut None);
 
         assert_eq!(warnings.len(), 1);
         // x has no cycle, gets processed first.
@@ -448,7 +648,7 @@ mod tests {
         let features = feature_list(&items);
         let overrides = vec!["c".to_string(), "a".to_string(), "b".to_string()];
 
-        let (order, warnings) = compute_install_order(&features, Some(&overrides));
+        let (order, warnings) = compute_install_order(&features, Some(&overrides), &mut None);
 
         assert!(warnings.is_empty());
         assert_eq!(order, vec!["c", "a", "b"]);
@@ -469,7 +669,7 @@ mod tests {
         let features = feature_list(&items);
         let overrides = vec!["c".to_string(), "a".to_string()];
 
-        let (order, warnings) = compute_install_order(&features, Some(&overrides));
+        let (order, warnings) = compute_install_order(&features, Some(&overrides), &mut None);
 
         assert!(warnings.is_empty());
         // c, a listed first; b, d unlisted in declaration order.
@@ -490,7 +690,7 @@ mod tests {
         let features = feature_list(&items);
         let overrides = vec!["a".to_string(), "b".to_string()];
 
-        let (order, warnings) = compute_install_order(&features, Some(&overrides));
+        let (order, warnings) = compute_install_order(&features, Some(&overrides), &mut None);
 
         assert!(warnings.is_empty());
         // Override order takes precedence over installsAfter.
@@ -511,7 +711,7 @@ mod tests {
         let features = feature_list(&items);
         let overrides = vec!["listed".to_string()];
 
-        let (order, warnings) = compute_install_order(&features, Some(&overrides));
+        let (order, warnings) = compute_install_order(&features, Some(&overrides), &mut None);
 
         assert!(warnings.is_empty());
         // listed first (override), then y before x (dependency).
@@ -536,7 +736,7 @@ mod tests {
         ];
         let features = feature_list(&items);
 
-        let (order, warnings) = compute_install_order(&features, None);
+        let (order, warnings) = compute_install_order(&features, None, &mut None);
 
         assert!(warnings.is_empty());
         // official sorts first (tier 0), then another (tier 1, index 2),
@@ -551,7 +751,7 @@ mod tests {
     #[test]
     fn empty_input_returns_empty() {
         let features: Vec<(String, &FeatureMetadata)> = vec![];
-        let (order, warnings) = compute_install_order(&features, None);
+        let (order, warnings) = compute_install_order(&features, None, &mut None);
         assert!(order.is_empty());
         assert!(warnings.is_empty());
     }
@@ -565,7 +765,7 @@ mod tests {
         let items = vec![("only".to_string(), meta("only", &[]))];
         let features = feature_list(&items);
 
-        let (order, warnings) = compute_install_order(&features, None);
+        let (order, warnings) = compute_install_order(&features, None, &mut None);
 
         assert!(warnings.is_empty());
         assert_eq!(order, vec!["only"]);
@@ -583,7 +783,7 @@ mod tests {
         ];
         let features = feature_list(&items);
 
-        let (order, warnings) = compute_install_order(&features, None);
+        let (order, warnings) = compute_install_order(&features, None, &mut None);
 
         assert!(warnings.is_empty());
         // a's dependency on nonexistent is ignored, so declaration order.
@@ -605,7 +805,7 @@ mod tests {
         ];
         let features = feature_list(&items);
 
-        let (order, warnings) = compute_install_order(&features, None);
+        let (order, warnings) = compute_install_order(&features, None, &mut None);
 
         assert!(warnings.is_empty());
         assert_eq!(order, vec!["b", "a"]);
@@ -613,41 +813,96 @@ mod tests {
 
     #[test]
     fn depends_on_cycle_is_fatal() {
-        // a dependsOn b, b dependsOn a → cycle must be reported, not silently
-        // ordered. Previously dependsOn edges were never added, so this cycle
-        // went undetected.
+        // a dependsOn b, b dependsOn a → hard cycle must be signalled fatally
+        // via depends_on_cycle, not silently ordered or merely warned.
         let items = vec![
             ("a".to_string(), meta_depends("a", &["b"])),
             ("b".to_string(), meta_depends("b", &["a"])),
         ];
         let features = feature_list(&items);
 
-        let (_order, warnings) = compute_install_order(&features, None);
+        let mut cycle = None;
+        let (_order, warnings) = compute_install_order(&features, None, &mut cycle);
 
-        assert_eq!(warnings.len(), 1);
-        match &warnings[0] {
-            FeatureWarning::CyclicDependency { features } => {
-                assert!(features.contains(&"a".to_string()));
-                assert!(features.contains(&"b".to_string()));
-            }
-            other => panic!("expected CyclicDependency, got {other:?}"),
-        }
+        assert!(warnings.is_empty(), "hard cycle is fatal, not a warning");
+        let members = cycle.expect("expected a hard dependsOn cycle signal");
+        assert!(members.contains(&"a".to_string()));
+        assert!(members.contains(&"b".to_string()));
     }
 
     #[test]
-    fn depends_on_and_installs_after_same_target_counted_once() {
+    fn depends_on_and_installs_after_same_target_counted_correctly() {
         // a lists b in BOTH dependsOn and installsAfter. The prerequisite must
-        // be deduplicated; otherwise the doubled in-degree would stall the sort
-        // and spuriously report a cycle.
+        // resolve cleanly; the doubled in-degree must not stall the sort or
+        // spuriously report a cycle.
         let mut a = meta_depends("a", &["b"]);
         a.installs_after = vec!["b".to_string()];
         let items = vec![("a".to_string(), a), ("b".to_string(), meta("b", &[]))];
         let features = feature_list(&items);
 
-        let (order, warnings) = compute_install_order(&features, None);
+        let mut cycle = None;
+        let (order, warnings) = compute_install_order(&features, None, &mut cycle);
 
         assert!(warnings.is_empty(), "no cycle: b is a single prerequisite");
+        assert!(cycle.is_none());
         assert_eq!(order, vec!["b", "a"]);
+    }
+
+    // ---------------------------------------------------------------
+    // P1 regression: soft installsAfter participating in a loop with an
+    // acyclic dependsOn graph must NOT be misclassified as a hard cycle.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn soft_edge_in_loop_with_acyclic_hard_graph_is_not_fatal() {
+        // a dependsOn b (hard: b before a), b installsAfter a (soft: a before b).
+        // The combined graph stalls, but the dependsOn-only graph (b → a) is
+        // acyclic and satisfiable by installing b first. This must NOT be a
+        // fatal dependsOn cycle — it should warn and fall back instead.
+        let mut b = meta("b", &["a"]); // installsAfter a
+        b.id = "b".to_string();
+        let items = vec![
+            ("a".to_string(), meta_depends("a", &["b"])),
+            ("b".to_string(), b),
+        ];
+        let features = feature_list(&items);
+
+        let mut cycle = None;
+        let (order, warnings) = compute_install_order(&features, None, &mut cycle);
+
+        assert!(
+            cycle.is_none(),
+            "soft installsAfter must not trigger a fatal dependsOn cycle, got {cycle:?}"
+        );
+        // Combined-graph stall is reported as a soft warning, not a hard error.
+        assert_eq!(warnings.len(), 1, "expected a soft-cycle warning");
+        match &warnings[0] {
+            FeatureWarning::CyclicDependency { .. } => {}
+            other => panic!("expected CyclicDependency warning, got {other:?}"),
+        }
+        // Every feature still appears in the result.
+        assert!(order.contains(&"a".to_string()));
+        assert!(order.contains(&"b".to_string()));
+    }
+
+    #[test]
+    fn override_soft_edge_in_loop_with_acyclic_hard_graph_is_not_fatal() {
+        // Same scenario as above but exercised through the override path.
+        let mut b = meta("b", &["a"]);
+        b.id = "b".to_string();
+        let items = vec![
+            ("a".to_string(), meta_depends("a", &["b"])),
+            ("b".to_string(), b),
+        ];
+        let features = feature_list(&items);
+        let overrides = vec!["a".to_string(), "b".to_string()];
+
+        let mut cycle = None;
+        let (_order, _warnings) = compute_install_order(&features, Some(&overrides), &mut cycle);
+
+        // Override suppresses soft edges for listed features, so b's
+        // installsAfter is dropped entirely; either way no hard cycle exists.
+        assert!(cycle.is_none(), "no hard cycle expected, got {cycle:?}");
     }
 
     // ---------------------------------------------------------------
@@ -664,11 +919,11 @@ mod tests {
         ];
         let features = feature_list(&items);
 
-        let (order, warnings) = compute_install_order(&features, None);
+        let (order, warnings) = compute_install_order(&features, None, &mut None);
 
         assert!(warnings.is_empty());
         // d must come before b and c; b and c before a.
-        let pos = |id: &str| order.iter().position(|x| x == id).unwrap();
+        let pos = |id: &str| order.iter().position(|x| x == id).expect("id present");
         assert!(pos("d") < pos("b"));
         assert!(pos("d") < pos("c"));
         assert!(pos("b") < pos("a"));
@@ -688,11 +943,78 @@ mod tests {
         let features = feature_list(&items);
         let overrides = vec!["nonexistent".to_string(), "b".to_string()];
 
-        let (order, warnings) = compute_install_order(&features, Some(&overrides));
+        let (order, warnings) = compute_install_order(&features, Some(&overrides), &mut None);
 
         assert!(warnings.is_empty());
         // b listed (override), a unlisted (appended).
         assert_eq!(order, vec!["b", "a"]);
+    }
+
+    // ---------------------------------------------------------------
+    // Override cannot bypass dependsOn hard constraints
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn override_respects_depends_on_hard_constraint() {
+        // child dependsOn parent — override lists child first, but parent must
+        // still be emitted before child per hard-dep semantics.
+        let items = vec![
+            ("child".to_string(), meta_depends("child", &["parent"])),
+            ("parent".to_string(), meta_depends("parent", &[])),
+        ];
+        let features = feature_list(&items);
+        let overrides = vec!["child".to_string(), "parent".to_string()];
+
+        let mut cycle = None;
+        let (order, warnings) = compute_install_order(&features, Some(&overrides), &mut cycle);
+
+        assert!(warnings.is_empty());
+        assert!(cycle.is_none(), "no cycle expected");
+        // parent must appear before child despite override listing child first.
+        let pos = |id: &str| order.iter().position(|x| x == id).expect("id present");
+        assert!(pos("parent") < pos("child"), "order was {order:?}");
+    }
+
+    // ---------------------------------------------------------------
+    // Override respects order among independent features
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn override_order_respected_for_independent_features() {
+        // c, b, a have no deps — override dictates their install order.
+        let items = vec![
+            ("a".to_string(), meta("a", &[])),
+            ("b".to_string(), meta("b", &[])),
+            ("c".to_string(), meta("c", &[])),
+        ];
+        let features = feature_list(&items);
+        let overrides = vec!["c".to_string(), "b".to_string(), "a".to_string()];
+
+        let (order, warnings) = compute_install_order(&features, Some(&overrides), &mut None);
+
+        assert!(warnings.is_empty());
+        assert_eq!(order, vec!["c", "b", "a"]);
+    }
+
+    // ---------------------------------------------------------------
+    // dependsOn cycle in override path → fatal signal
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn override_with_depends_on_cycle_signals_fatal() {
+        let items = vec![
+            ("a".to_string(), meta_depends("a", &["b"])),
+            ("b".to_string(), meta_depends("b", &["a"])),
+        ];
+        let features = feature_list(&items);
+        let overrides = vec!["a".to_string(), "b".to_string()];
+
+        let mut cycle = None;
+        let (_order, _warnings) = compute_install_order(&features, Some(&overrides), &mut cycle);
+
+        let members = cycle.expect("expected CyclicDependsOn signal");
+        assert!(members.contains(&"a".to_string()));
+        assert!(members.contains(&"b".to_string()));
     }
 
     // --- Spec compliance: feature option env var transformation ---


### PR DESCRIPTION
Stacked on #137 (features resolve-dependencies) — base retargets as parents merge.

Spec-compliance fix: features declaring `dependsOn` now get their dependencies fetched, added to the install set, and ordered before the dependent feature during `up` — previously cella parsed `dependsOn` but never installed anything from it.

- `resolve_features` BFS-expands transitive `dependsOn` refs (reusing the existing fetcher + cache), deduping by normalized ref + options per the spec (same feature with different options = separate installs; equivalent spellings of the same ref = one install).
- Ordering follows the official round-based algorithm: `dependsOn` is a hard gate (cycles are a fatal `CyclicDependsOn` error, including cycles among transitively-pulled features), `installsAfter` stays a soft hint, and `overrideFeatureInstallOrder` acts as a priority among ready nodes — it can no longer bypass a hard dependency.
- Features without `dependsOn` produce the same order as before; existing ordering tests are untouched.
- Also boxes two CLI futures that grew past the `large_futures` threshold from the expanded resolution path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)