### PR TITLE
fix: cap OCI blob download and decompression size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,6 +658,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
 ]
 
@@ -732,6 +733,7 @@ dependencies = [
  "dirs",
  "filetime",
  "flate2",
+ "futures-util",
  "glob",
  "hex",
  "miette",

--- a/crates/cella-features/src/fetch.rs
+++ b/crates/cella-features/src/fetch.rs
@@ -11,6 +11,7 @@
 use std::path::PathBuf;
 
 use flate2::read::GzDecoder;
+use futures_util::StreamExt as _;
 use tracing::debug;
 
 use crate::Platform;
@@ -50,7 +51,7 @@ impl FeatureFetcher for HttpFetcher {
         }
 
         // Step 2: download the tarball.
-        let bytes = reqwest::get(url)
+        let response = reqwest::get(url)
             .await
             .map_err(|e| FeatureError::FetchFailed {
                 url: url.clone(),
@@ -60,13 +61,40 @@ impl FeatureFetcher for HttpFetcher {
             .map_err(|e| FeatureError::FetchFailed {
                 url: url.clone(),
                 message: format!("HTTP error status: {e}"),
-            })?
-            .bytes()
-            .await
-            .map_err(|e| FeatureError::FetchFailed {
+            })?;
+
+        // Pre-check declared Content-Length before streaming.
+        if let Some(content_length) = response.content_length()
+            && content_length > cella_oci::MAX_BLOB_COMPRESSED_BYTES
+        {
+            return Err(FeatureError::FetchFailed {
+                url: url.clone(),
+                message: format!(
+                    "tarball download exceeds size limit: {content_length} bytes > {} bytes",
+                    cella_oci::MAX_BLOB_COMPRESSED_BYTES,
+                ),
+            });
+        }
+
+        // Stream body with a running byte counter to enforce the cap.
+        let mut stream = response.bytes_stream();
+        let mut bytes: Vec<u8> = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|e| FeatureError::FetchFailed {
                 url: url.clone(),
                 message: format!("failed to read response body: {e}"),
             })?;
+            bytes.extend_from_slice(&chunk);
+            if bytes.len() as u64 > cella_oci::MAX_BLOB_COMPRESSED_BYTES {
+                return Err(FeatureError::FetchFailed {
+                    url: url.clone(),
+                    message: format!(
+                        "tarball download exceeds size limit of {} bytes",
+                        cella_oci::MAX_BLOB_COMPRESSED_BYTES,
+                    ),
+                });
+            }
+        }
 
         debug!("downloaded {} bytes from {url}", bytes.len());
 
@@ -89,7 +117,8 @@ impl FeatureFetcher for HttpFetcher {
         })?;
 
         let gz = GzDecoder::new(&bytes[..]);
-        let mut archive = tar::Archive::new(gz);
+        let limited_gz = cella_oci::LimitedReader::new(gz, cella_oci::MAX_BLOB_DECOMPRESSED_BYTES);
+        let mut archive = tar::Archive::new(limited_gz);
         archive.unpack(&staging).map_err(|e| {
             let _ = std::fs::remove_dir_all(&staging);
             FeatureError::FetchFailed {

--- a/crates/cella-features/src/oci.rs
+++ b/crates/cella-features/src/oci.rs
@@ -182,7 +182,20 @@ impl OciFetcher {
         layer: &oci_distribution::manifest::OciDescriptor,
         registry: &str,
     ) -> Result<Vec<u8>, FeatureError> {
-        let capacity = usize::try_from(layer.size.max(0)).unwrap_or(0);
+        // Reject oversized blobs before downloading.
+        let declared_size = u64::try_from(layer.size.max(0)).unwrap_or(0);
+        if declared_size > cella_oci::MAX_BLOB_COMPRESSED_BYTES {
+            return Err(FeatureError::RegistryError {
+                registry: registry.to_owned(),
+                message: format!(
+                    "blob download exceeds size limit: {declared_size} bytes > {} bytes for {}",
+                    cella_oci::MAX_BLOB_COMPRESSED_BYTES,
+                    layer.digest,
+                ),
+            });
+        }
+
+        let capacity = usize::try_from(declared_size).unwrap_or(0);
         let mut blob = Vec::with_capacity(capacity);
         self.client
             .pull_blob(oci_ref, layer, &mut blob)
@@ -191,6 +204,20 @@ impl OciFetcher {
                 registry: registry.to_owned(),
                 message: format!("failed to pull layer blob: {e}"),
             })?;
+
+        // Enforce the cap on the actual received size too (manifests can lie).
+        let actual_size = blob.len() as u64;
+        if actual_size > cella_oci::MAX_BLOB_COMPRESSED_BYTES {
+            return Err(FeatureError::RegistryError {
+                registry: registry.to_owned(),
+                message: format!(
+                    "blob download exceeds size limit: {actual_size} bytes > {} bytes for {}",
+                    cella_oci::MAX_BLOB_COMPRESSED_BYTES,
+                    layer.digest,
+                ),
+            });
+        }
+
         debug!(
             "downloaded layer blob ({} bytes, media_type={})",
             blob.len(),

--- a/crates/cella-features/src/oci.rs
+++ b/crates/cella-features/src/oci.rs
@@ -196,27 +196,16 @@ impl OciFetcher {
         }
 
         let capacity = usize::try_from(declared_size).unwrap_or(0);
-        let mut blob = Vec::with_capacity(capacity);
+        let buf = Vec::with_capacity(capacity);
+        let mut limited = cella_oci::LimitedWriter::new(buf, cella_oci::MAX_BLOB_COMPRESSED_BYTES);
         self.client
-            .pull_blob(oci_ref, layer, &mut blob)
+            .pull_blob(oci_ref, layer, &mut limited)
             .await
             .map_err(|e| FeatureError::RegistryError {
                 registry: registry.to_owned(),
                 message: format!("failed to pull layer blob: {e}"),
             })?;
-
-        // Enforce the cap on the actual received size too (manifests can lie).
-        let actual_size = blob.len() as u64;
-        if actual_size > cella_oci::MAX_BLOB_COMPRESSED_BYTES {
-            return Err(FeatureError::RegistryError {
-                registry: registry.to_owned(),
-                message: format!(
-                    "blob download exceeds size limit: {actual_size} bytes > {} bytes for {}",
-                    cella_oci::MAX_BLOB_COMPRESSED_BYTES,
-                    layer.digest,
-                ),
-            });
-        }
+        let blob = limited.into_inner();
 
         debug!(
             "downloaded layer blob ({} bytes, media_type={})",

--- a/crates/cella-oci/Cargo.toml
+++ b/crates/cella-oci/Cargo.toml
@@ -13,10 +13,12 @@ serde.workspace = true
 serde_json.workspace = true
 tar.workspace = true
 thiserror.workspace = true
+tokio.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+tokio = { workspace = true, features = ["rt", "macros"] }
 
 [lints]
 workspace = true

--- a/crates/cella-oci/src/extract.rs
+++ b/crates/cella-oci/src/extract.rs
@@ -14,6 +14,8 @@ use oci_distribution::manifest::{
 use thiserror::Error;
 use tracing::warn;
 
+use crate::limits::{LimitedReader, MAX_BLOB_DECOMPRESSED_BYTES};
+
 /// Media type for devcontainer feature layers (plain tar).
 pub const DEVCONTAINERS_LAYER_MEDIA_TYPE: &str = "application/vnd.devcontainers.layer.v1+tar";
 
@@ -38,6 +40,18 @@ pub enum ExtractionError {
     /// crate also considers it unsafe.  We surface it as a hard error.
     #[error("tar entry '{path}' was rejected by the tar crate (would escape destination)")]
     EntrySkipped { path: String },
+
+    /// A blob's compressed download size exceeds the configured limit.
+    #[error("blob download exceeds size limit: {size} bytes > {limit} bytes for {digest}")]
+    BlobTooLarge {
+        size: u64,
+        limit: u64,
+        digest: String,
+    },
+
+    /// Decompressed output exceeded the configured cap — possible zip-bomb.
+    #[error("decompressed output exceeds limit of {limit} bytes for blob {digest}")]
+    DecompressedTooLarge { limit: u64, digest: String },
 
     /// Underlying I/O or tar error.
     #[error(transparent)]
@@ -64,25 +78,47 @@ pub fn is_extractable_layer(media_type: &str) -> bool {
 ///
 /// Sniffs the magic bytes to determine encoding regardless of `media_type`
 /// (the registry sometimes lies).  All entries are validated by
-/// [`unpack_archive`] before any file is written.
+/// [`unpack_archive`] before any file is written.  Decompressed output is
+/// capped at [`MAX_BLOB_DECOMPRESSED_BYTES`]; exceeding it returns
+/// [`ExtractionError::DecompressedTooLarge`].
 ///
 /// # Errors
 ///
 /// Returns [`ExtractionError`] if the archive contains a path-traversal or
-/// unsafe link entry, or if an I/O error occurs.
+/// unsafe link entry, if an I/O error occurs, or if the decompressed size
+/// exceeds the cap.
 pub fn extract_layer(blob: &[u8], media_type: &str, dest: &Path) -> Result<(), ExtractionError> {
+    extract_layer_with_limit(blob, media_type, dest, MAX_BLOB_DECOMPRESSED_BYTES)
+}
+
+/// Like [`extract_layer`] but with a caller-supplied decompression cap.
+///
+/// Intended for tests that need a small cap to exercise the limit path without
+/// allocating gigabytes.
+///
+/// # Errors
+///
+/// Same as [`extract_layer`].
+pub fn extract_layer_with_limit(
+    blob: &[u8],
+    media_type: &str,
+    dest: &Path,
+    decompress_limit: u64,
+) -> Result<(), ExtractionError> {
     let is_gzip = blob.len() >= 2 && blob[0] == 0x1f && blob[1] == 0x8b;
 
     if media_type.contains("gzip") || media_type == IMAGE_LAYER_GZIP_MEDIA_TYPE {
         if is_gzip {
-            unpack_archive(tar::Archive::new(GzDecoder::new(blob)), dest)
+            let limited = LimitedReader::new(GzDecoder::new(blob), decompress_limit);
+            unpack_archive(tar::Archive::new(limited), dest)
         } else {
             warn!("layer declared as gzip but does not have gzip magic; trying raw tar");
             unpack_archive(tar::Archive::new(blob), dest)
         }
     } else if is_gzip {
         warn!("layer declared as plain tar but has gzip magic; decompressing");
-        unpack_archive(tar::Archive::new(GzDecoder::new(blob)), dest)
+        let limited = LimitedReader::new(GzDecoder::new(blob), decompress_limit);
+        unpack_archive(tar::Archive::new(limited), dest)
     } else {
         unpack_archive(tar::Archive::new(blob), dest)
     }
@@ -619,5 +655,44 @@ mod tests {
         assert!(!is_extractable_layer(
             "application/vnd.oci.image.config.v1+json"
         ));
+    }
+
+    // -----------------------------------------------------------------------
+    // Decompression size caps
+    // -----------------------------------------------------------------------
+
+    /// Build a gzip-compressed tar whose decompressed size exceeds a small cap.
+    ///
+    /// The content is highly compressible (repeated zeros) to simulate a
+    /// zip-bomb: tiny compressed, large decompressed.
+    fn build_gz_tar_with_large_content(decompressed_content_size: usize) -> Vec<u8> {
+        let content = vec![0u8; decompressed_content_size];
+        gz_compress(&build_safe_tar(&[("big.bin", None, &content)]))
+    }
+
+    #[test]
+    fn decompression_cap_blocks_zip_bomb() {
+        // 2048 bytes decompressed content; cap is 1024 bytes → must error.
+        let gz_tar = build_gz_tar_with_large_content(2048);
+        let dest = dest_dir();
+        let result =
+            extract_layer_with_limit(&gz_tar, IMAGE_LAYER_GZIP_MEDIA_TYPE, dest.path(), 1024);
+        assert!(
+            result.is_err(),
+            "expected error for oversized decompressed output, got Ok"
+        );
+    }
+
+    #[test]
+    fn decompression_cap_allows_normal_archive() {
+        // Small archive well under any reasonable cap.
+        let gz_tar = build_gz_tar_with_large_content(512);
+        let dest = dest_dir();
+        extract_layer_with_limit(&gz_tar, IMAGE_LAYER_GZIP_MEDIA_TYPE, dest.path(), 64 * 1024)
+            .expect("small archive should succeed");
+        assert!(
+            dest.path().join("big.bin").exists(),
+            "big.bin should have been extracted"
+        );
     }
 }

--- a/crates/cella-oci/src/lib.rs
+++ b/crates/cella-oci/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod auth;
 pub mod cache;
 pub mod extract;
+pub mod limits;
 
 pub use auth::{DockerCredentials, resolve_credentials};
 pub use cache::{commit_staging, staging_path};
 pub use extract::{ExtractionError, extract_layer, is_extractable_layer};
+pub use limits::{LimitedReader, MAX_BLOB_COMPRESSED_BYTES, MAX_BLOB_DECOMPRESSED_BYTES};
 
 use oci_distribution::secrets::RegistryAuth;
 use tracing::debug;

--- a/crates/cella-oci/src/lib.rs
+++ b/crates/cella-oci/src/lib.rs
@@ -6,7 +6,10 @@ pub mod limits;
 pub use auth::{DockerCredentials, resolve_credentials};
 pub use cache::{commit_staging, staging_path};
 pub use extract::{ExtractionError, extract_layer, is_extractable_layer};
-pub use limits::{LimitedReader, MAX_BLOB_COMPRESSED_BYTES, MAX_BLOB_DECOMPRESSED_BYTES};
+pub use limits::{
+    LimitedReader, LimitedWriter, MAX_BLOB_COMPRESSED_BYTES, MAX_BLOB_DECOMPRESSED_BYTES,
+    MAX_COLLECTION_JSON_BYTES,
+};
 
 use oci_distribution::secrets::RegistryAuth;
 use tracing::debug;

--- a/crates/cella-oci/src/limits.rs
+++ b/crates/cella-oci/src/limits.rs
@@ -2,8 +2,16 @@
 //!
 //! [`LimitedReader`] wraps any [`Read`] and returns a hard [`io::Error`] when
 //! the byte count exceeds the configured limit — it never silently truncates.
+//!
+//! [`LimitedWriter`] wraps any [`tokio::io::AsyncWrite`] and returns a hard
+//! error when bytes written exceed the configured limit — used when streaming
+//! blobs via `pull_blob`.
 
 use std::io::{self, Read};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use tokio::io::AsyncWrite;
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -14,6 +22,9 @@ pub const MAX_BLOB_COMPRESSED_BYTES: u64 = 512 * 1024 * 1024;
 
 /// Maximum decompressed output size: 2 GiB.
 pub const MAX_BLOB_DECOMPRESSED_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+
+/// Maximum size for collection/index JSON: 64 MiB.
+pub const MAX_COLLECTION_JSON_BYTES: u64 = 64 * 1024 * 1024;
 
 // ---------------------------------------------------------------------------
 // LimitedReader
@@ -69,7 +80,6 @@ impl<R: Read> Read for LimitedReader<R> {
                     "decompressed output exceeds limit of {} bytes",
                     self.limit
                 ))),
-                Err(e) if e.kind() == io::ErrorKind::WouldBlock => Ok(0),
                 Err(e) => Err(e),
             };
         }
@@ -95,7 +105,6 @@ impl<R: Read> Read for LimitedReader<R> {
                         self.limit
                     )));
                 }
-                Err(e) if e.kind() == io::ErrorKind::WouldBlock => {}
                 Err(e) => return Err(e),
             }
         }
@@ -103,6 +112,86 @@ impl<R: Read> Read for LimitedReader<R> {
         Ok(n)
     }
 }
+
+// ---------------------------------------------------------------------------
+// LimitedWriter
+// ---------------------------------------------------------------------------
+
+/// An [`AsyncWrite`] adaptor that returns a hard error when the total bytes
+/// written exceeds `limit`.
+///
+/// Used to cap blob downloads mid-stream (e.g. `pull_blob` from
+/// `oci-distribution`) so a lying or malicious manifest cannot force
+/// unbounded memory growth.
+///
+/// When the limit is hit the error message includes the limit value so
+/// callers can surface a human-readable diagnostic.
+pub struct LimitedWriter<W> {
+    inner: W,
+    limit: u64,
+    written: u64,
+}
+
+impl<W: AsyncWrite + Unpin> LimitedWriter<W> {
+    /// Wrap `inner`, refusing to accept more than `limit` bytes in total.
+    pub const fn new(inner: W, limit: u64) -> Self {
+        Self {
+            inner,
+            limit,
+            written: 0,
+        }
+    }
+
+    /// Consume the wrapper and return the inner writer.
+    pub fn into_inner(self) -> W {
+        self.inner
+    }
+}
+
+impl<W: AsyncWrite + Unpin> AsyncWrite for LimitedWriter<W> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let remaining = self.limit.saturating_sub(self.written);
+        if remaining == 0 {
+            return Poll::Ready(Err(io::Error::other(format!(
+                "blob download exceeds limit of {} bytes",
+                self.limit
+            ))));
+        }
+
+        // Clamp the write to at most `remaining` bytes.
+        let capped_len = buf
+            .len()
+            .min(usize::try_from(remaining).unwrap_or(usize::MAX));
+
+        let result = Pin::new(&mut self.inner).poll_write(cx, &buf[..capped_len]);
+
+        if let Poll::Ready(Ok(n)) = result {
+            self.written += n as u64;
+            // If we just hit the exact limit, check whether the caller is
+            // sending more data (i.e. the next byte would overflow).  We
+            // cannot peek asynchronously here, so we simply update written
+            // and let the *next* poll_write call return the error.
+        }
+
+        result
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+// LimitedWriter is Unpin because its only non-marker field is W: Unpin, and
+// all others (u64) are always Unpin.
+impl<W: Unpin> Unpin for LimitedWriter<W> {}
 
 // ===========================================================================
 // Tests
@@ -112,7 +201,11 @@ impl<R: Read> Read for LimitedReader<R> {
 mod tests {
     use std::io::Read as _;
 
+    use tokio::io::AsyncWriteExt as _;
+
     use super::*;
+
+    // ── LimitedReader tests ─────────────────────────────────────────────────
 
     #[test]
     fn under_limit_reads_all() {
@@ -155,5 +248,39 @@ mod tests {
         let mut buf = [0u8; 1];
         let result = reader.read(&mut buf);
         assert!(result.is_err(), "limit=0 should error on first read");
+    }
+
+    // ── LimitedWriter tests ─────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn writer_exactly_at_cap_succeeds() {
+        let inner: Vec<u8> = Vec::new();
+        let mut writer = LimitedWriter::new(inner, 5);
+        writer
+            .write_all(b"12345")
+            .await
+            .expect("should succeed at cap");
+        let out = writer.into_inner();
+        assert_eq!(out, b"12345");
+    }
+
+    #[tokio::test]
+    async fn writer_over_cap_errors() {
+        let inner: Vec<u8> = Vec::new();
+        let mut writer = LimitedWriter::new(inner, 5);
+        // First 5 bytes should be accepted.
+        writer.write_all(b"12345").await.expect("first 5 bytes ok");
+        // One more byte must error.
+        let result = writer.write_all(b"6").await;
+        assert!(result.is_err(), "writing past cap should return an error");
+    }
+
+    #[tokio::test]
+    async fn writer_under_cap_succeeds() {
+        let inner: Vec<u8> = Vec::new();
+        let mut writer = LimitedWriter::new(inner, 100);
+        writer.write_all(b"hello").await.expect("well under cap");
+        let out = writer.into_inner();
+        assert_eq!(out, b"hello");
     }
 }

--- a/crates/cella-oci/src/limits.rs
+++ b/crates/cella-oci/src/limits.rs
@@ -1,0 +1,159 @@
+//! Blob size caps to defend against zip-bombs and oversized blobs.
+//!
+//! [`LimitedReader`] wraps any [`Read`] and returns a hard [`io::Error`] when
+//! the byte count exceeds the configured limit — it never silently truncates.
+
+use std::io::{self, Read};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Maximum compressed (downloaded) blob size: 512 MiB.
+pub const MAX_BLOB_COMPRESSED_BYTES: u64 = 512 * 1024 * 1024;
+
+/// Maximum decompressed output size: 2 GiB.
+pub const MAX_BLOB_DECOMPRESSED_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+
+// ---------------------------------------------------------------------------
+// LimitedReader
+// ---------------------------------------------------------------------------
+
+/// A [`Read`] adaptor that returns an error when the total bytes read exceeds
+/// `limit`.
+///
+/// Unlike [`std::io::Take`], this returns `Err` instead of EOF so callers
+/// discover the violation rather than silently reading a truncated stream.
+///
+/// When the underlying stream contains **exactly** `limit` bytes the reader
+/// returns `Ok(0)` (EOF) rather than an error.  An error is only returned when
+/// the stream contains *more* than `limit` bytes.
+pub struct LimitedReader<R> {
+    inner: R,
+    limit: u64,
+    consumed: u64,
+    /// Set to `true` once we have confirmed that the inner stream is exhausted
+    /// at exactly the limit boundary (peek returned 0 bytes).
+    at_eof: bool,
+}
+
+impl<R: Read> LimitedReader<R> {
+    /// Wrap `inner`, refusing to deliver more than `limit` bytes in total.
+    pub const fn new(inner: R, limit: u64) -> Self {
+        Self {
+            inner,
+            limit,
+            consumed: 0,
+            at_eof: false,
+        }
+    }
+}
+
+impl<R: Read> Read for LimitedReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        // Already confirmed EOF at the limit boundary.
+        if self.at_eof {
+            return Ok(0);
+        }
+
+        let remaining = self.limit.saturating_sub(self.consumed);
+        if remaining == 0 {
+            // We're at the limit; peek to decide: EOF → Ok(0), more data → Err.
+            let mut probe = [0u8; 1];
+            return match self.inner.read(&mut probe) {
+                Ok(0) => {
+                    self.at_eof = true;
+                    Ok(0)
+                }
+                Ok(_) => Err(io::Error::other(format!(
+                    "decompressed output exceeds limit of {} bytes",
+                    self.limit
+                ))),
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => Ok(0),
+                Err(e) => Err(e),
+            };
+        }
+
+        // Only ask the inner reader for `remaining` bytes at most.
+        let capped_len = buf
+            .len()
+            .min(usize::try_from(remaining).unwrap_or(usize::MAX));
+        let n = self.inner.read(&mut buf[..capped_len])?;
+        self.consumed += n as u64;
+
+        // If we've now consumed exactly `limit` bytes, peek to check for
+        // overflow on the *current* call rather than waiting for the next one.
+        if self.consumed == self.limit && n > 0 {
+            let mut probe = [0u8; 1];
+            match self.inner.read(&mut probe) {
+                Ok(0) => {
+                    self.at_eof = true;
+                }
+                Ok(_) => {
+                    return Err(io::Error::other(format!(
+                        "decompressed output exceeds limit of {} bytes",
+                        self.limit
+                    )));
+                }
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => {}
+                Err(e) => return Err(e),
+            }
+        }
+
+        Ok(n)
+    }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use std::io::Read as _;
+
+    use super::*;
+
+    #[test]
+    fn under_limit_reads_all() {
+        let data = b"hello world";
+        let mut reader = LimitedReader::new(&data[..], 64);
+        let mut out = Vec::new();
+        reader.read_to_end(&mut out).expect("read_to_end");
+        assert_eq!(out, data);
+    }
+
+    #[test]
+    fn exactly_at_limit_succeeds() {
+        let data = b"12345";
+        let mut reader = LimitedReader::new(&data[..], 5);
+        let mut out = Vec::new();
+        reader
+            .read_to_end(&mut out)
+            .expect("should succeed at limit");
+        assert_eq!(out, data);
+    }
+
+    #[test]
+    fn over_limit_errors_not_truncates() {
+        let data = b"hello world"; // 11 bytes
+        let mut reader = LimitedReader::new(&data[..], 5);
+        let mut out = Vec::new();
+        let result = reader.read_to_end(&mut out);
+        assert!(
+            result.is_err(),
+            "expected error, got Ok with {} bytes",
+            out.len()
+        );
+        // Must be an error — NOT a silently truncated Ok.
+    }
+
+    #[test]
+    fn limit_zero_errors_immediately() {
+        let data = b"x";
+        let mut reader = LimitedReader::new(&data[..], 0);
+        let mut buf = [0u8; 1];
+        let result = reader.read(&mut buf);
+        assert!(result.is_err(), "limit=0 should error on first read");
+    }
+}

--- a/crates/cella-templates/Cargo.toml
+++ b/crates/cella-templates/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 cella-jsonc.workspace = true
 dirs.workspace = true
 flate2.workspace = true
+futures-util.workspace = true
 glob.workspace = true
 hex.workspace = true
 miette.workspace = true

--- a/crates/cella-templates/src/collection.rs
+++ b/crates/cella-templates/src/collection.rs
@@ -150,14 +150,28 @@ async fn fetch_collection_json(collection_ref: &str) -> Result<String, TemplateE
             message: "no layers found in collection manifest".to_owned(),
         })?;
 
-    let mut blob = Vec::with_capacity(usize::try_from(layer.size.max(0)).unwrap_or(0));
+    // Pre-check declared size before downloading.
+    let declared_size = u64::try_from(layer.size.max(0)).unwrap_or(0);
+    if declared_size > cella_oci::MAX_COLLECTION_JSON_BYTES {
+        return Err(TemplateError::CollectionFetchFailed {
+            registry: collection_ref.to_owned(),
+            message: format!(
+                "collection JSON exceeds size limit: {declared_size} bytes > {} bytes",
+                cella_oci::MAX_COLLECTION_JSON_BYTES,
+            ),
+        });
+    }
+
+    let buf = Vec::with_capacity(usize::try_from(declared_size).unwrap_or(0));
+    let mut limited = cella_oci::LimitedWriter::new(buf, cella_oci::MAX_COLLECTION_JSON_BYTES);
     client
-        .pull_blob(&oci_ref, layer, &mut blob)
+        .pull_blob(&oci_ref, layer, &mut limited)
         .await
         .map_err(|e| TemplateError::CollectionFetchFailed {
             registry: collection_ref.to_owned(),
             message: format!("failed to pull collection blob: {e}"),
         })?;
+    let blob = limited.into_inner();
 
     String::from_utf8(blob).map_err(|e| TemplateError::CollectionFetchFailed {
         registry: collection_ref.to_owned(),

--- a/crates/cella-templates/src/fetcher.rs
+++ b/crates/cella-templates/src/fetcher.rs
@@ -76,27 +76,16 @@ pub async fn fetch_template(
     }
 
     let capacity = usize::try_from(declared_size).unwrap_or(0);
-    let mut blob = Vec::with_capacity(capacity);
+    let buf = Vec::with_capacity(capacity);
+    let mut limited = cella_oci::LimitedWriter::new(buf, cella_oci::MAX_BLOB_COMPRESSED_BYTES);
     client
-        .pull_blob(&oci_ref, layer, &mut blob)
+        .pull_blob(&oci_ref, layer, &mut limited)
         .await
         .map_err(|e| TemplateError::RegistryError {
             registry: registry.clone(),
             message: format!("failed to pull layer blob: {e}"),
         })?;
-
-    // Enforce the cap on actual received size too (manifests can lie).
-    let actual_size = blob.len() as u64;
-    if actual_size > cella_oci::MAX_BLOB_COMPRESSED_BYTES {
-        return Err(TemplateError::RegistryError {
-            registry: registry.clone(),
-            message: format!(
-                "blob download exceeds size limit: {actual_size} bytes > {} bytes for {}",
-                cella_oci::MAX_BLOB_COMPRESSED_BYTES,
-                layer.digest,
-            ),
-        });
-    }
+    let blob = limited.into_inner();
 
     // Verify digest
     let actual_digest = format!("sha256:{}", hex::encode(Sha256::digest(&blob)));

--- a/crates/cella-templates/src/fetcher.rs
+++ b/crates/cella-templates/src/fetcher.rs
@@ -62,7 +62,20 @@ pub async fn fetch_template(
 
     let layer = find_extractable_layer(&manifest, template_ref)?;
 
-    let capacity = usize::try_from(layer.size.max(0)).unwrap_or(0);
+    // Reject oversized blobs before downloading.
+    let declared_size = u64::try_from(layer.size.max(0)).unwrap_or(0);
+    if declared_size > cella_oci::MAX_BLOB_COMPRESSED_BYTES {
+        return Err(TemplateError::RegistryError {
+            registry: registry.clone(),
+            message: format!(
+                "blob download exceeds size limit: {declared_size} bytes > {} bytes for {}",
+                cella_oci::MAX_BLOB_COMPRESSED_BYTES,
+                layer.digest,
+            ),
+        });
+    }
+
+    let capacity = usize::try_from(declared_size).unwrap_or(0);
     let mut blob = Vec::with_capacity(capacity);
     client
         .pull_blob(&oci_ref, layer, &mut blob)
@@ -71,6 +84,19 @@ pub async fn fetch_template(
             registry: registry.clone(),
             message: format!("failed to pull layer blob: {e}"),
         })?;
+
+    // Enforce the cap on actual received size too (manifests can lie).
+    let actual_size = blob.len() as u64;
+    if actual_size > cella_oci::MAX_BLOB_COMPRESSED_BYTES {
+        return Err(TemplateError::RegistryError {
+            registry: registry.clone(),
+            message: format!(
+                "blob download exceeds size limit: {actual_size} bytes > {} bytes for {}",
+                cella_oci::MAX_BLOB_COMPRESSED_BYTES,
+                layer.digest,
+            ),
+        });
+    }
 
     // Verify digest
     let actual_digest = format!("sha256:{}", hex::encode(Sha256::digest(&blob)));

--- a/crates/cella-templates/src/index.rs
+++ b/crates/cella-templates/src/index.rs
@@ -7,6 +7,7 @@
 
 use std::time::{Duration, SystemTime};
 
+use futures_util::StreamExt as _;
 use sha2::{Digest, Sha256};
 use tracing::debug;
 
@@ -88,12 +89,39 @@ async fn fetch_index_json() -> Result<String, TemplateError> {
         });
     }
 
-    response
-        .text()
-        .await
-        .map_err(|e| TemplateError::IndexFetchFailed {
+    // Pre-check declared Content-Length before streaming.
+    if let Some(content_length) = response.content_length()
+        && content_length > cella_oci::MAX_COLLECTION_JSON_BYTES
+    {
+        return Err(TemplateError::IndexFetchFailed {
+            message: format!(
+                "index download exceeds size limit: {content_length} bytes > {} bytes",
+                cella_oci::MAX_COLLECTION_JSON_BYTES,
+            ),
+        });
+    }
+
+    // Stream body with a running byte counter to enforce the cap.
+    let mut stream = response.bytes_stream();
+    let mut bytes: Vec<u8> = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| TemplateError::IndexFetchFailed {
             message: format!("failed to read response body: {e}"),
-        })
+        })?;
+        bytes.extend_from_slice(&chunk);
+        if bytes.len() as u64 > cella_oci::MAX_COLLECTION_JSON_BYTES {
+            return Err(TemplateError::IndexFetchFailed {
+                message: format!(
+                    "index download exceeds size limit of {} bytes",
+                    cella_oci::MAX_COLLECTION_JSON_BYTES,
+                ),
+            });
+        }
+    }
+
+    String::from_utf8(bytes).map_err(|e| TemplateError::IndexFetchFailed {
+        message: format!("index response is not valid UTF-8: {e}"),
+    })
 }
 
 // ── Cache helpers ────────────────────────────────────────────────────


### PR DESCRIPTION
Stacked on #131 (tar path-traversal fix) — base retargets to main when that merges.

Caps the size of attacker-influenced OCI data so a huge blob or zip-bomb can't exhaust memory/disk. The official devcontainer CLI applies no limits here (there's even a TODO in its source) — cella diverges intentionally with generous named limits.

- `LimitedWriter` (async) caps `pull_blob` mid-stream — the transfer aborts the moment cumulative bytes would exceed the cap, rather than buffering the whole blob and checking after (which was the original approach's flaw). Applied to feature/template layer pulls and the collection-index fetch.
- `LimitedReader` caps gzip decompression output during tar extraction, so a small blob can't expand into gigabytes.
- The HTTP tarball fetcher (direct `.tgz` feature URLs) and the containers.dev index download now stream with a running byte cap plus a Content-Length pre-check.
- Constants: 512 MiB compressed / 2 GiB decompressed for layer blobs, 64 MiB for JSON indices. Caps are injectable in tests.
- Also removed two `WouldBlock → treat as EOF` arms in `LimitedReader` that could silently truncate a synchronous read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)