### PR TITLE
feat: feature lockfile + upgrade command

### DIFF
--- a/crates/cella-backend/src/lifecycle.rs
+++ b/crates/cella-backend/src/lifecycle.rs
@@ -1517,6 +1517,7 @@ mod tests {
                 ..Default::default()
             },
             metadata_label: String::new(),
+            lockfile: None,
         }
     }
 

--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -108,6 +108,9 @@ impl BuildArgs {
                 env_files: self.env_file.clone(),
                 pull_policy: self.pull_policy.as_ref().map(|p| p.as_str().to_string()),
                 secrets: secrets.clone(),
+                // Match the single-container build path: update the lockfile when
+                // features are present (`cella build` has no --no-lockfile flag yet).
+                lockfile_policy: cella_features::LockfilePolicy::Update,
             };
             let result = cella_orchestrator::compose_build::compose_build(
                 client.as_ref(),

--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -142,6 +142,8 @@ impl BuildArgs {
             // `--omit-config-remote-env-from-metadata` is wired on `up` only;
             // `cella build` keeps the full metadata label.
             omit_remote_env_from_metadata: false,
+            // `cella build` updates the lockfile when features are present.
+            lockfile_policy: cella_features::LockfilePolicy::Update,
             progress: &sender,
         };
         let result = cella_orchestrator::image::ensure_image(&input).await;

--- a/crates/cella-cli/src/commands/compose_up.rs
+++ b/crates/cella-cli/src/commands/compose_up.rs
@@ -46,6 +46,7 @@ pub async fn compose_ensure_up(
         gpu_availability: ctx.gpu_availability(),
         update_remote_user_uid_default: ctx.update_remote_user_uid_default(),
         omit_remote_env_from_metadata: ctx.omit_remote_env_from_metadata(),
+        lockfile_policy: ctx.lockfile_policy,
         dotfiles: cella_orchestrator::compose_up::DotfilesConfig {
             repository: ctx.dotfiles.repository.clone(),
             install_command: ctx.dotfiles.install_command.clone(),

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -26,6 +26,7 @@ mod status;
 mod switch;
 pub mod templates;
 pub mod up;
+mod upgrade;
 
 use std::io::IsTerminal;
 
@@ -262,6 +263,8 @@ pub enum Command {
     Templates(templates::TemplatesArgs),
     /// Manage devcontainer features.
     Features(features::FeaturesArgs),
+    /// Upgrade the feature lockfile to the latest digests.
+    Upgrade(upgrade::UpgradeArgs),
     /// Show current and available versions.
     Outdated(outdated::OutdatedArgs),
     /// Initialize cella in the current repository.
@@ -390,6 +393,7 @@ impl Command {
             Self::Config(args) => args.execute().map_err(boxed_err_to_report),
             Self::Templates(args) => args.execute().await.map_err(boxed_err_to_report),
             Self::Features(args) => args.execute(progress).await.map_err(boxed_err_to_report),
+            Self::Upgrade(args) => args.execute().await.map_err(boxed_err_to_report),
             Self::Outdated(args) => args.execute().await.map_err(boxed_err_to_report),
             Self::Init(args) => args.execute(progress).await.map_err(boxed_err_to_report),
             Self::Completion(args) => {

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -338,7 +338,8 @@ impl Command {
     /// The `--log-level` value, if the subcommand carries one.
     ///
     /// `up` (and `code`, which embeds the `up` arg surface), `run-user-commands`,
-    /// and `features package` expose `--log-level`; every other variant returns
+    /// `set-up`, `templates`, `features`, and `upgrade` expose `--log-level`;
+    /// every other variant returns
     /// `None`. main.rs reads this once, before subcommand dispatch, to seed the
     /// global tracing filter — the level can't be applied inside `execute()`
     /// because the subscriber is already installed by then.
@@ -350,6 +351,7 @@ impl Command {
             Self::SetUp(args) => args.compat.log_level,
             Self::Templates(args) => args.apply_log_level(),
             Self::Features(args) => args.log_level(),
+            Self::Upgrade(args) => Some(args.log_level),
             _ => None,
         }
     }

--- a/crates/cella-cli/src/commands/read_configuration.rs
+++ b/crates/cella-cli/src/commands/read_configuration.rs
@@ -160,9 +160,16 @@ pub async fn resolve_merged_config(
         // omit-remote-env flag does not apply here.
         omit_remote_env: false,
     };
-    let rf =
-        cella_features::resolve_features(config, config_path, &platform, &cache, &base_ctx, false)
-            .await?;
+    let rf = cella_features::resolve_features(
+        config,
+        config_path,
+        &platform,
+        &cache,
+        &base_ctx,
+        false,
+        cella_features::LockfilePolicy::NoLockfile,
+    )
+    .await?;
 
     let mut merged = config.clone();
     apply_feature_config(&mut merged, &rf.container_config);

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -157,22 +157,21 @@ pub struct UpResultArgs {
     pub(crate) omit_config_remote_env_from_metadata: bool,
 }
 
-/// Feature-lockfile flags. cella does not use feature lockfiles; these are
-/// accepted for devcontainer-CLI compatibility and are no-ops.
+/// Feature-lockfile flags for controlling lockfile read/write behavior.
 #[derive(Args)]
 pub struct UpLockfileArgs {
-    /// Disable lockfile generation and verification (compatibility no-op).
+    /// Disable lockfile generation and pinning.
     #[arg(
         long,
         conflicts_with_all = ["frozen_lockfile", "experimental_lockfile", "experimental_frozen_lockfile"],
     )]
     pub(crate) no_lockfile: bool,
 
-    /// Ensure the lockfile remains unchanged (compatibility no-op).
+    /// Require the lockfile to exist and match resolved digests; fail if missing or different.
     #[arg(long)]
     pub(crate) frozen_lockfile: bool,
 
-    /// Deprecated alias for lockfile writing (compatibility no-op).
+    /// Deprecated: lockfile is now written by default.
     #[arg(long, hide = true)]
     pub(crate) experimental_lockfile: bool,
 }
@@ -239,7 +238,7 @@ pub struct UpCompatArgs {
     #[arg(long = "terminal-rows", requires = "terminal_columns")]
     pub(crate) terminal_rows: Option<u16>,
 
-    /// Ensure the lockfile exists and remains unchanged (compatibility no-op).
+    /// Deprecated alias for --frozen-lockfile.
     #[arg(long, hide = true)]
     pub(crate) experimental_frozen_lockfile: bool,
 
@@ -359,7 +358,6 @@ impl UpArgs {
     fn acknowledge_compat_flags(&self) {
         let ci = &self.config_inputs;
         let c = &self.compat;
-        let lf = &self.lockfile;
         debug!(
             skip_feature_auto_mapping = ci.skip_feature_auto_mapping,
             terminal_columns = ?c.terminal_columns,
@@ -368,13 +366,35 @@ impl UpArgs {
             container_system_data_folder = ?c.container_system_data_folder,
             container_session_data_folder = ?c.container_session_data_folder,
             user_data_folder = ?c.user_data_folder,
-            no_lockfile = lf.no_lockfile,
-            frozen_lockfile = lf.frozen_lockfile,
-            experimental_lockfile = lf.experimental_lockfile,
-            experimental_frozen_lockfile = c.experimental_frozen_lockfile,
             omit_syntax_directive = c.omit_syntax_directive,
             "up: accepted devcontainer-CLI compatibility no-op flags"
         );
+    }
+}
+
+/// Derive the lockfile policy from the CLI lockfile flags.
+///
+/// Deprecated aliases emit a warning to stderr before delegating.
+fn derive_lockfile_policy(
+    lf: &UpLockfileArgs,
+    compat: &UpCompatArgs,
+) -> cella_features::LockfilePolicy {
+    if lf.experimental_lockfile {
+        eprintln!(
+            "warning: --experimental-lockfile is deprecated; lockfile is now written by default"
+        );
+    }
+    if compat.experimental_frozen_lockfile {
+        eprintln!(
+            "warning: --experimental-frozen-lockfile is deprecated; use --frozen-lockfile instead"
+        );
+    }
+    if lf.no_lockfile {
+        cella_features::LockfilePolicy::NoLockfile
+    } else if lf.frozen_lockfile || compat.experimental_frozen_lockfile {
+        cella_features::LockfilePolicy::Frozen
+    } else {
+        cella_features::LockfilePolicy::Update
     }
 }
 
@@ -619,6 +639,9 @@ pub struct UpContext {
     /// (owner/repo shorthand expanded) at construction so both the
     /// single-container and compose paths receive a clone-ready value.
     pub(crate) dotfiles: cella_orchestrator::config::DotfilesConfig,
+    /// Lockfile policy derived from the `--no-lockfile` / `--frozen-lockfile`
+    /// flags.
+    pub(crate) lockfile_policy: cella_features::LockfilePolicy,
 }
 
 /// Normalize a `--dotfiles-repository` value to a clone-ready form.
@@ -895,6 +918,7 @@ impl UpContext {
             ),
             omit_remote_env_from_metadata: args.result.omit_config_remote_env_from_metadata,
             dotfiles: build_dotfiles_config(&args.dotfiles),
+            lockfile_policy: derive_lockfile_policy(&args.lockfile, &args.compat),
         })
     }
 
@@ -1045,6 +1069,8 @@ impl UpContext {
             omit_remote_env_from_metadata: false,
             // Branch/auto-up never installs dotfiles (no --dotfiles-* flags).
             dotfiles: cella_orchestrator::config::DotfilesConfig::default(),
+            // Branch/auto-up uses default lockfile policy (Update).
+            lockfile_policy: cella_features::LockfilePolicy::default(),
         })
     }
 
@@ -1509,6 +1535,7 @@ impl UpContext {
                 omit_remote_env: self.omit_remote_env_from_metadata,
             },
             dotfiles: self.dotfiles.clone(),
+            lockfile_policy: self.lockfile_policy,
         };
 
         let result =

--- a/crates/cella-cli/src/commands/upgrade.rs
+++ b/crates/cella-cli/src/commands/upgrade.rs
@@ -27,6 +27,10 @@ pub struct UpgradeArgs {
     /// Print the new lockfile to stdout without writing it.
     #[arg(long)]
     pub dry_run: bool,
+
+    /// Log verbosity level.
+    #[arg(long, value_enum, default_value_t = crate::commands::LogLevel::Info)]
+    pub log_level: crate::commands::LogLevel,
 }
 
 impl UpgradeArgs {

--- a/crates/cella-cli/src/commands/upgrade.rs
+++ b/crates/cella-cli/src/commands/upgrade.rs
@@ -1,0 +1,123 @@
+//! `cella upgrade` — refresh the feature lockfile without starting a container.
+
+use std::path::{Path, PathBuf};
+
+use clap::Args;
+
+use cella_features::{
+    BaseImageContext, FeatureCache, LockfilePolicy,
+    lockfile::{lockfile_path, write_lockfile},
+    oci::detect_platform,
+};
+
+/// Upgrade (refresh) the devcontainer feature lockfile.
+///
+/// Resolves all OCI features fresh from the registry and writes an updated
+/// `devcontainer-lock.json`. Does not require a running Docker daemon.
+#[derive(Args)]
+pub struct UpgradeArgs {
+    /// Workspace folder path (defaults to current directory).
+    #[arg(long)]
+    pub workspace_folder: Option<PathBuf>,
+
+    /// Path to devcontainer.json (overrides auto-discovery).
+    #[arg(long)]
+    pub config: Option<PathBuf>,
+
+    /// Print the new lockfile to stdout without writing it.
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+impl UpgradeArgs {
+    /// Execute the upgrade command.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if config discovery, parsing, or feature resolution fails.
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let config_path =
+            resolve_config_path(self.workspace_folder.as_ref(), self.config.as_ref())?;
+        let config_json = read_config_json(&config_path)?;
+        let platform = detect_platform(std::env::consts::OS, std::env::consts::ARCH);
+        let cache = FeatureCache::new();
+        let base_image = config_json
+            .get("image")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let base_ctx = BaseImageContext {
+            base_image,
+            image_user: "root",
+            metadata: None,
+            omit_remote_env: false,
+        };
+
+        let resolved = cella_features::resolve_features(
+            &config_json,
+            &config_path,
+            &platform,
+            &cache,
+            &base_ctx,
+            false,
+            LockfilePolicy::Upgrade,
+        )
+        .await
+        .map_err(|e| format!("feature resolution failed: {e}"))?;
+
+        let Some(lockfile) = &resolved.lockfile else {
+            eprintln!("No OCI features found; lockfile not updated.");
+            return Ok(());
+        };
+
+        if self.dry_run {
+            let mut json = serde_json::to_string_pretty(lockfile)?;
+            json.push('\n');
+            print!("{json}");
+        } else {
+            write_lockfile(&config_path, lockfile)
+                .map_err(|e| format!("failed to write lockfile: {e}"))?;
+            eprintln!("Wrote {}", lockfile_path(&config_path).display());
+        }
+
+        Ok(())
+    }
+}
+
+fn resolve_config_path(
+    workspace_folder: Option<&PathBuf>,
+    config_override: Option<&PathBuf>,
+) -> Result<PathBuf, Box<dyn std::error::Error + Send + Sync>> {
+    if let Some(config) = config_override {
+        return Ok(config.clone());
+    }
+
+    let workspace = workspace_folder.cloned().map_or_else(
+        || {
+            std::env::current_dir()
+                .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })
+        },
+        Ok,
+    )?;
+
+    let candidates = [
+        workspace.join(".devcontainer").join("devcontainer.json"),
+        workspace.join(".devcontainer.json"),
+    ];
+
+    for candidate in &candidates {
+        if candidate.exists() {
+            return Ok(candidate.clone());
+        }
+    }
+
+    Err(format!("no devcontainer.json found under {}", workspace.display()).into())
+}
+
+fn read_config_json(
+    config_path: &Path,
+) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
+    let raw = std::fs::read_to_string(config_path)?;
+    let stripped = cella_jsonc::strip(&raw).map_err(|e| e.to_string())?;
+    let value = serde_json::from_str(&stripped)?;
+    Ok(value)
+}

--- a/crates/cella-compose/src/build_features.rs
+++ b/crates/cella-compose/src/build_features.rs
@@ -35,6 +35,8 @@ pub struct ComposeBuildConfig<'a> {
     pub pull_policy: Option<String>,
     /// `BuildKit` secrets forwarded to compose builds.
     pub secrets: Vec<BuildSecret>,
+    /// Feature lockfile policy derived from `--no-lockfile` / `--frozen-lockfile`.
+    pub lockfile_policy: cella_features::LockfilePolicy,
 }
 
 /// Run the compose build pipeline: resolve features, write override, build.
@@ -75,6 +77,7 @@ pub async fn compose_build(
         // `cella build` does not yet expose --omit-config-remote-env-from-metadata
         // (it's wired on the `up` path only); keep the full metadata label here.
         false,
+        cfg.lockfile_policy,
         progress,
     )
     .await?;

--- a/crates/cella-compose/src/combined_dockerfile_build.rs
+++ b/crates/cella-compose/src/combined_dockerfile_build.rs
@@ -157,6 +157,7 @@ pub async fn resolve_compose_features(
                 omit_remote_env: omit_remote_env_from_metadata,
             },
             true, // compose builds use named content source via additional_contexts
+            cella_features::LockfilePolicy::NoLockfile,
         )
         .await
         .map_err(|e| format!("feature resolution failed: {e}"))

--- a/crates/cella-compose/src/combined_dockerfile_build.rs
+++ b/crates/cella-compose/src/combined_dockerfile_build.rs
@@ -62,6 +62,7 @@ pub async fn resolve_compose_features(
     config_path: &Path,
     project: &ComposeProject,
     omit_remote_env_from_metadata: bool,
+    lockfile_policy: cella_features::LockfilePolicy,
     progress: &ProgressSender,
 ) -> Result<Option<ComposeFeaturesBuild>, Box<dyn std::error::Error + Send + Sync>> {
     // 1. Check if features are present
@@ -157,7 +158,7 @@ pub async fn resolve_compose_features(
                 omit_remote_env: omit_remote_env_from_metadata,
             },
             true, // compose builds use named content source via additional_contexts
-            cella_features::LockfilePolicy::NoLockfile,
+            lockfile_policy,
         )
         .await
         .map_err(|e| format!("feature resolution failed: {e}"))

--- a/crates/cella-compose/src/orchestrate.rs
+++ b/crates/cella-compose/src/orchestrate.rs
@@ -76,6 +76,10 @@ pub struct ComposeUpConfig<'a> {
     /// generated `devcontainer.metadata` label. Does NOT affect the runtime
     /// `dev.cella.remote_env` label.
     pub omit_remote_env_from_metadata: bool,
+    /// Feature lockfile policy derived from `--no-lockfile` / `--frozen-lockfile`.
+    /// Threaded into compose feature resolution so dockerCompose devcontainers
+    /// write/validate `devcontainer-lock.json` like single-container builds.
+    pub lockfile_policy: cella_features::LockfilePolicy,
     /// Dotfiles install inputs (`--dotfiles-repository` / `-install-command` /
     /// `-target-path`). Installed via [`ComposeUpHooks::install_dotfiles`] in
     /// the post-create flow, between `postCreateCommand` and `postStartCommand`,
@@ -495,6 +499,7 @@ async fn prepare_and_start(
         cfg.config_path,
         project,
         cfg.omit_remote_env_from_metadata,
+        cfg.lockfile_policy,
         progress,
     )
     .await?;
@@ -1697,6 +1702,7 @@ mod tests {
             gpu_availability: cella_backend::GpuAvailability::default(),
             update_remote_user_uid_default: cella_backend::UpdateRemoteUserUidDefault::default(),
             omit_remote_env_from_metadata: false,
+            lockfile_policy: cella_features::LockfilePolicy::default(),
             dotfiles: DotfilesConfig::default(),
         };
         let project = ComposeProject {
@@ -1763,6 +1769,7 @@ mod tests {
             gpu_availability: cella_backend::GpuAvailability::default(),
             update_remote_user_uid_default: cella_backend::UpdateRemoteUserUidDefault::default(),
             omit_remote_env_from_metadata: false,
+            lockfile_policy: cella_features::LockfilePolicy::default(),
             dotfiles: DotfilesConfig::default(),
         };
         let project = ComposeProject {

--- a/crates/cella-features/src/error.rs
+++ b/crates/cella-features/src/error.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use crate::lockfile::LockfileError;
+
 use miette::Diagnostic;
 use thiserror::Error;
 
@@ -73,6 +75,11 @@ pub enum FeatureError {
     #[error("invalid feature reference: {reference}: {reason}")]
     #[diagnostic(code(cella::features::invalid_reference))]
     InvalidReference { reference: String, reason: String },
+
+    /// Lockfile validation failed.
+    #[error(transparent)]
+    #[diagnostic(code(cella::features::lockfile))]
+    Lockfile(#[from] LockfileError),
 
     /// Generic I/O error.
     #[error(transparent)]

--- a/crates/cella-features/src/lib.rs
+++ b/crates/cella-features/src/lib.rs
@@ -5,6 +5,7 @@ pub mod docs;
 mod error;
 pub mod fetch;
 pub mod graph;
+pub mod lockfile;
 pub mod merge;
 pub mod metadata;
 pub mod oci;
@@ -24,6 +25,10 @@ pub use dockerfile::{
 };
 pub use error::{FeatureError, FeatureWarning};
 pub use fetch::{HttpFetcher, LocalFetcher};
+pub use lockfile::{
+    Lockfile, LockfileEntry, LockfileError, LockfilePolicy, compare_lockfile, generate_lockfile,
+    lockfile_key, lockfile_path, read_lockfile, write_lockfile,
+};
 pub use merge::{
     ImageMetadataUserInfo, merge_features, merge_with_devcontainer, parse_image_metadata,
     validate_options,
@@ -130,6 +135,7 @@ pub async fn resolve_features(
     cache: &FeatureCache,
     base_image_ctx: &BaseImageContext<'_>,
     use_named_content_source: bool,
+    lockfile_policy: LockfilePolicy,
 ) -> Result<ResolvedFeatures, FeatureError> {
     // Step 1: Extract the "features" object from the config.
     let features_obj = match config.get("features").and_then(|v| v.as_object()) {
@@ -153,22 +159,42 @@ pub async fn resolve_features(
     let config_hash = compute_config_hash(features_obj);
     let build_context = cache.build_context_path(&config_hash);
 
-    // Step 4: Fetch all concurrently.
-    let artifact_paths = fetch_all(&parsed_entries, platform, cache).await?;
+    // Step 4: Read locked digests (no-op for NoLockfile/Upgrade).
+    let (existing_lockfile, locked_digests) =
+        read_locked_digests(config_path, &parsed_entries, lockfile_policy)?;
 
-    // Step 5: Parse metadata and validate options.
+    // Step 5: Fetch all concurrently (OCI uses digest pinning when available).
+    let fetch_results =
+        fetch_all_with_results(&parsed_entries, platform, cache, &locked_digests).await?;
+
+    // Step 5a: Extract artifact paths for metadata parsing.
+    let artifact_paths: Vec<PathBuf> = fetch_results
+        .iter()
+        .map(|r| r.artifact_dir().clone())
+        .collect();
+
+    // Step 6: Parse metadata and validate options.
     let mut feature_entries = parse_metadata_and_validate(&parsed_entries, &artifact_paths)?;
 
-    // Step 5b: Expand the install set with transitive `dependsOn` features.
+    // Step 6b: Expand the install set with transitive `dependsOn` features.
     expand_depends_on(&mut feature_entries, workspace_root, platform, cache).await?;
 
-    // Step 6: Compute install order.
+    // Step 7: Compute install order.
     let ordered_ids = compute_order(&feature_entries, config, workspace_root)?;
 
-    // Step 7: Assemble resolved features in install order.
+    // Step 8: Assemble resolved features in install order.
     let resolved = assemble_resolved(&feature_entries, &ordered_ids);
 
-    // Step 8: Generate Dockerfile and build context.
+    // Step 9: Build and apply lockfile policy.
+    let generated_lockfile = build_lockfile_from_results(&parsed_entries, &fetch_results);
+    let final_lockfile = apply_lockfile_policy(
+        lockfile_policy,
+        config_path,
+        existing_lockfile,
+        generated_lockfile,
+    )?;
+
+    // Step 10: Generate Dockerfile and build context.
     let dockerfile = generate_and_write_build_context(
         &build_context,
         &resolved,
@@ -179,7 +205,7 @@ pub async fn resolve_features(
         use_named_content_source,
     )?;
 
-    // Step 9: Merge feature metadata and generate label.
+    // Step 11: Merge feature metadata and generate label.
     let container_config = merge_all_metadata(&resolved, config, base_image_ctx.metadata);
     let metadata_label = generate_metadata_label(
         &resolved,
@@ -200,6 +226,7 @@ pub async fn resolve_features(
         build_context,
         container_config,
         metadata_label,
+        lockfile: final_lockfile,
     })
 }
 
@@ -286,6 +313,7 @@ fn resolve_empty_features(
         build_context,
         container_config,
         metadata_label: generate_metadata_label(&[], config, base_image_metadata, omit_remote_env),
+        lockfile: None,
     })
 }
 
@@ -371,12 +399,28 @@ fn parse_and_normalize(
     Ok(parsed_entries)
 }
 
-/// Fetch all features concurrently, returning their artifact paths.
-async fn fetch_all(
+/// Result of fetching a single feature — OCI fetches carry digest metadata,
+/// other fetchers return only the artifact path.
+enum FetchResult {
+    Oci(oci::OciFetchResult),
+    Other(PathBuf),
+}
+
+impl FetchResult {
+    const fn artifact_dir(&self) -> &PathBuf {
+        match self {
+            Self::Oci(r) => &r.artifact_dir,
+            Self::Other(p) => p,
+        }
+    }
+}
+
+async fn fetch_all_with_results(
     parsed_entries: &[(String, NormalizedRef, serde_json::Value)],
     platform: &Platform,
     cache: &FeatureCache,
-) -> Result<Vec<PathBuf>, FeatureError> {
+    locked_digests: &HashMap<String, String>,
+) -> Result<Vec<FetchResult>, FeatureError> {
     let oci_fetcher = OciFetcher::default();
     let http_fetcher = HttpFetcher;
     let local_fetcher = LocalFetcher;
@@ -384,26 +428,136 @@ async fn fetch_all(
     let fetch_futures: Vec<_> = parsed_entries
         .iter()
         .map(|(key, norm_ref, _)| {
-            fetch_one(
-                key,
+            let locked = locked_digests.get(key.as_str()).map(String::as_str);
+            fetch_one_with_digest(
                 norm_ref,
                 platform,
                 cache,
                 &oci_fetcher,
                 &http_fetcher,
+                locked,
                 &local_fetcher,
             )
         })
         .collect();
 
-    let fetch_results = join_all(fetch_futures).await;
+    let results = join_all(fetch_futures).await;
+    let mut fetch_results = Vec::with_capacity(parsed_entries.len());
+    for result in results {
+        fetch_results.push(result?);
+    }
+    Ok(fetch_results)
+}
 
-    let mut artifact_paths = Vec::with_capacity(parsed_entries.len());
-    for result in fetch_results {
-        artifact_paths.push(result?);
+async fn fetch_one_with_digest(
+    norm_ref: &NormalizedRef,
+    platform: &Platform,
+    cache: &FeatureCache,
+    oci_fetcher: &OciFetcher,
+    http_fetcher: &HttpFetcher,
+    locked_digest: Option<&str>,
+    local_fetcher: &LocalFetcher,
+) -> Result<FetchResult, FeatureError> {
+    debug!("fetching feature from {norm_ref}");
+    match norm_ref {
+        NormalizedRef::OciTarget { .. } => {
+            let result = oci_fetcher
+                .fetch_oci_with_digest(norm_ref, cache, locked_digest)
+                .await?;
+            Ok(FetchResult::Oci(result))
+        }
+        NormalizedRef::HttpTarget { .. } => {
+            let path = http_fetcher.fetch(norm_ref, platform, cache).await?;
+            Ok(FetchResult::Other(path))
+        }
+        NormalizedRef::LocalTarget { .. } => {
+            let path = local_fetcher.fetch(norm_ref, platform, cache).await?;
+            Ok(FetchResult::Other(path))
+        }
+    }
+}
+
+fn read_locked_digests(
+    config_path: &Path,
+    parsed_entries: &[(String, NormalizedRef, serde_json::Value)],
+    policy: LockfilePolicy,
+) -> Result<(Option<Lockfile>, HashMap<String, String>), FeatureError> {
+    if matches!(policy, LockfilePolicy::NoLockfile | LockfilePolicy::Upgrade) {
+        return Ok((None, HashMap::new()));
     }
 
-    Ok(artifact_paths)
+    let existing = read_lockfile(config_path);
+
+    if matches!(policy, LockfilePolicy::Frozen) && existing.is_none() {
+        return Err(FeatureError::Lockfile(LockfileError::Missing));
+    }
+
+    let locked_digests = existing.as_ref().map_or_else(HashMap::new, |lf| {
+        parsed_entries
+            .iter()
+            .filter_map(|(key, norm_ref, _)| {
+                if matches!(norm_ref, NormalizedRef::OciTarget { .. }) {
+                    let lock_key = lockfile_key(key);
+                    lf.features
+                        .get(&lock_key)
+                        .map(|e| (key.clone(), e.integrity.clone()))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    });
+
+    Ok((existing, locked_digests))
+}
+
+fn build_lockfile_from_results(
+    parsed_entries: &[(String, NormalizedRef, serde_json::Value)],
+    fetch_results: &[FetchResult],
+) -> Lockfile {
+    let data: Vec<_> = parsed_entries
+        .iter()
+        .zip(fetch_results.iter())
+        .filter_map(|((key, _, _), result)| {
+            if let FetchResult::Oci(r) = result {
+                let lock_key = lockfile_key(key);
+                let resolved = format!("{}/{}@{}", r.registry, r.repository, r.digest);
+                Some((
+                    lock_key,
+                    r.version.clone(),
+                    resolved,
+                    r.digest.clone(),
+                    vec![],
+                ))
+            } else {
+                None
+            }
+        })
+        .collect();
+    generate_lockfile(&data)
+}
+
+fn apply_lockfile_policy(
+    policy: LockfilePolicy,
+    config_path: &Path,
+    existing: Option<Lockfile>,
+    generated: Lockfile,
+) -> Result<Option<Lockfile>, FeatureError> {
+    if generated.features.is_empty() {
+        return Ok(None);
+    }
+    match policy {
+        LockfilePolicy::NoLockfile => Ok(None),
+        LockfilePolicy::Update | LockfilePolicy::Upgrade => {
+            write_lockfile(config_path, &generated)?;
+            Ok(Some(generated))
+        }
+        LockfilePolicy::Frozen => {
+            let existing = existing.ok_or(FeatureError::Lockfile(LockfileError::Missing))?;
+            compare_lockfile(&existing, &generated).map_err(FeatureError::Lockfile)?;
+            Ok(Some(existing))
+        }
+    }
 }
 
 /// Parse metadata from fetched artifacts and validate user options.
@@ -972,6 +1126,8 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), FeatureError> {
 mod tests {
     use std::collections::{HashMap, HashSet};
 
+    use crate::LockfilePolicy;
+
     use serde_json::json;
 
     use super::*;
@@ -1177,6 +1333,7 @@ mod tests {
                 omit_remote_env: false,
             },
             false,
+            LockfilePolicy::NoLockfile,
         )
         .await
         .unwrap();
@@ -1206,6 +1363,7 @@ mod tests {
                 omit_remote_env: false,
             },
             false,
+            LockfilePolicy::NoLockfile,
         )
         .await
         .unwrap();
@@ -1259,6 +1417,7 @@ mod tests {
                 omit_remote_env: false,
             },
             false,
+            LockfilePolicy::NoLockfile,
         )
         .await
         .unwrap();
@@ -1375,6 +1534,7 @@ mod tests {
                 omit_remote_env: false,
             },
             false,
+            LockfilePolicy::NoLockfile,
         )
         .await
         .unwrap();
@@ -1440,6 +1600,7 @@ mod tests {
                 omit_remote_env: false,
             },
             false,
+            LockfilePolicy::NoLockfile,
         )
         .await
         .unwrap();
@@ -1484,6 +1645,7 @@ mod tests {
                 omit_remote_env: false,
             },
             false,
+            LockfilePolicy::NoLockfile,
         )
         .await;
 
@@ -1528,6 +1690,7 @@ mod tests {
                 omit_remote_env: false,
             },
             false,
+            LockfilePolicy::NoLockfile,
         )
         .await;
         let resolved = result.expect("resolve_features should succeed");
@@ -1661,6 +1824,7 @@ mod tests {
                 omit_remote_env: false,
             },
             false,
+            LockfilePolicy::NoLockfile,
         )
         .await
         .unwrap();
@@ -1749,6 +1913,7 @@ mod tests {
                 omit_remote_env: false,
             },
             false,
+            LockfilePolicy::NoLockfile,
         )
         .await
         .unwrap();
@@ -1815,6 +1980,7 @@ mod tests {
                 omit_remote_env: false,
             },
             false,
+            LockfilePolicy::NoLockfile,
         )
         .await
         .unwrap();
@@ -1878,6 +2044,7 @@ mod tests {
                 omit_remote_env: false,
             },
             false,
+            LockfilePolicy::NoLockfile,
         )
         .await
         .unwrap();
@@ -1954,6 +2121,7 @@ mod tests {
                 omit_remote_env: false,
             },
             false,
+            LockfilePolicy::NoLockfile,
         )
         .await
         .unwrap_err();
@@ -2017,6 +2185,7 @@ mod tests {
                 omit_remote_env: false,
             },
             false,
+            LockfilePolicy::NoLockfile,
         )
         .await
         .unwrap_err();

--- a/crates/cella-features/src/lib.rs
+++ b/crates/cella-features/src/lib.rs
@@ -548,10 +548,13 @@ fn apply_lockfile_policy(
     }
     match policy {
         LockfilePolicy::NoLockfile => Ok(None),
-        LockfilePolicy::Update | LockfilePolicy::Upgrade => {
+        LockfilePolicy::Update => {
             write_lockfile(config_path, &generated)?;
             Ok(Some(generated))
         }
+        // `upgrade` regenerates the lockfile but the caller decides whether to
+        // write it (so `upgrade --dry-run` can print without touching disk).
+        LockfilePolicy::Upgrade => Ok(Some(generated)),
         LockfilePolicy::Frozen => {
             let existing = existing.ok_or(FeatureError::Lockfile(LockfileError::Missing))?;
             compare_lockfile(&existing, &generated).map_err(FeatureError::Lockfile)?;

--- a/crates/cella-features/src/lib.rs
+++ b/crates/cella-features/src/lib.rs
@@ -27,7 +27,7 @@ pub use error::{FeatureError, FeatureWarning};
 pub use fetch::{HttpFetcher, LocalFetcher};
 pub use lockfile::{
     Lockfile, LockfileEntry, LockfileError, LockfilePolicy, compare_lockfile, generate_lockfile,
-    lockfile_key, lockfile_path, read_lockfile, write_lockfile,
+    lockfile_path, read_lockfile, write_lockfile,
 };
 pub use merge::{
     ImageMetadataUserInfo, merge_features, merge_with_devcontainer, parse_image_metadata,
@@ -88,6 +88,20 @@ pub struct BaseImageContext<'a> {
     pub omit_remote_env: bool,
 }
 
+/// OCI digest metadata captured for a feature so it can be pinned in the
+/// lockfile. Present only for OCI-sourced features (HTTP / local have no
+/// digest to lock).
+struct OciLockInfo {
+    /// The OCI tag that was fetched (e.g. `"1"`, `"latest"`).
+    version: String,
+    /// The OCI registry hostname.
+    registry: String,
+    /// The OCI repository path.
+    repository: String,
+    /// The resolved manifest digest, e.g. `"sha256:abc..."`.
+    digest: String,
+}
+
 /// Intermediate representation of a parsed feature before ordering.
 struct FeatureEntry {
     /// Unique install identity = `(normalized_ref, options)`.
@@ -103,6 +117,10 @@ struct FeatureEntry {
     /// The raw reference the user (or a `dependsOn` key) wrote, kept for
     /// display and surfaced on the [`ResolvedFeature`].
     original_ref: String,
+    /// OCI pin metadata, present only when this entry was fetched from an OCI
+    /// registry. Drives lockfile generation, including transitive `dependsOn`
+    /// features (which are appended to the install set during expansion).
+    oci: Option<OciLockInfo>,
 }
 
 /// Build the unique install identity for a feature instance.
@@ -159,25 +177,30 @@ pub async fn resolve_features(
     let config_hash = compute_config_hash(features_obj);
     let build_context = cache.build_context_path(&config_hash);
 
-    // Step 4: Read locked digests (no-op for NoLockfile/Upgrade).
-    let (existing_lockfile, locked_digests) =
-        read_locked_digests(config_path, &parsed_entries, lockfile_policy)?;
+    // Step 4: Read the existing lockfile (no-op for NoLockfile/Upgrade). Its
+    // pinned digests, keyed by verbatim feature ref, drive digest pinning for
+    // both top-level and transitive `dependsOn` features.
+    let existing_lockfile = read_existing_lockfile(config_path, lockfile_policy)?;
 
-    // Step 5: Fetch all concurrently (OCI uses digest pinning when available).
+    // Step 5: Fetch all top-level features concurrently (OCI pins to the locked
+    // digest when one exists for that ref).
     let fetch_results =
-        fetch_all_with_results(&parsed_entries, platform, cache, &locked_digests).await?;
+        fetch_all_with_results(&parsed_entries, platform, cache, existing_lockfile.as_ref())
+            .await?;
 
-    // Step 5a: Extract artifact paths for metadata parsing.
-    let artifact_paths: Vec<PathBuf> = fetch_results
-        .iter()
-        .map(|r| r.artifact_dir().clone())
-        .collect();
+    // Step 6: Parse metadata, validate options, and capture OCI pin metadata.
+    let mut feature_entries = parse_metadata_and_validate(&parsed_entries, &fetch_results)?;
 
-    // Step 6: Parse metadata and validate options.
-    let mut feature_entries = parse_metadata_and_validate(&parsed_entries, &artifact_paths)?;
-
-    // Step 6b: Expand the install set with transitive `dependsOn` features.
-    expand_depends_on(&mut feature_entries, workspace_root, platform, cache).await?;
+    // Step 6b: Expand the install set with transitive `dependsOn` features,
+    // pinning them to the lockfile too.
+    expand_depends_on(
+        &mut feature_entries,
+        workspace_root,
+        platform,
+        cache,
+        existing_lockfile.as_ref(),
+    )
+    .await?;
 
     // Step 7: Compute install order.
     let ordered_ids = compute_order(&feature_entries, config, workspace_root)?;
@@ -185,8 +208,10 @@ pub async fn resolve_features(
     // Step 8: Assemble resolved features in install order.
     let resolved = assemble_resolved(&feature_entries, &ordered_ids);
 
-    // Step 9: Build and apply lockfile policy.
-    let generated_lockfile = build_lockfile_from_results(&parsed_entries, &fetch_results);
+    // Step 9: Build and apply lockfile policy. The lockfile is generated from
+    // the full install set (top-level + expanded `dependsOn`), so transitive
+    // OCI dependencies are pinned and surfaced via each entry's `dependsOn`.
+    let generated_lockfile = build_lockfile_from_entries(&feature_entries);
     let final_lockfile = apply_lockfile_policy(
         lockfile_policy,
         config_path,
@@ -413,13 +438,38 @@ impl FetchResult {
             Self::Other(p) => p,
         }
     }
+
+    /// OCI pin metadata for this fetch, if it came from an OCI registry.
+    fn oci_lock_info(&self) -> Option<OciLockInfo> {
+        match self {
+            Self::Oci(r) => Some(OciLockInfo {
+                version: r.version.clone(),
+                registry: r.registry.clone(),
+                repository: r.repository.clone(),
+                digest: r.digest.clone(),
+            }),
+            Self::Other(_) => None,
+        }
+    }
+}
+
+/// Look up the locked manifest digest for a verbatim feature ref.
+///
+/// The lockfile is keyed by the ref exactly as authored (tag included), so the
+/// lookup is a direct map hit — a ref whose tag changed (`:1` → `:2`) simply
+/// misses and is re-resolved against the registry, matching the official CLI.
+fn locked_digest_for<'a>(existing: Option<&'a Lockfile>, raw_ref: &str) -> Option<&'a str> {
+    existing?
+        .features
+        .get(raw_ref)
+        .map(|e| e.integrity.as_str())
 }
 
 async fn fetch_all_with_results(
     parsed_entries: &[(String, NormalizedRef, serde_json::Value)],
     platform: &Platform,
     cache: &FeatureCache,
-    locked_digests: &HashMap<String, String>,
+    existing_lockfile: Option<&Lockfile>,
 ) -> Result<Vec<FetchResult>, FeatureError> {
     let oci_fetcher = OciFetcher::default();
     let http_fetcher = HttpFetcher;
@@ -428,7 +478,7 @@ async fn fetch_all_with_results(
     let fetch_futures: Vec<_> = parsed_entries
         .iter()
         .map(|(key, norm_ref, _)| {
-            let locked = locked_digests.get(key.as_str()).map(String::as_str);
+            let locked = locked_digest_for(existing_lockfile, key);
             fetch_one_with_digest(
                 norm_ref,
                 platform,
@@ -477,61 +527,65 @@ async fn fetch_one_with_digest(
     }
 }
 
-fn read_locked_digests(
+/// Read the existing lockfile from disk, honoring the policy.
+///
+/// Returns `Ok(None)` when no lockfile is consulted (`NoLockfile` / `Upgrade`)
+/// or when the file is genuinely absent. A corrupt or unreadable lockfile is
+/// surfaced as an error rather than treated as missing. Under
+/// [`LockfilePolicy::Frozen`] an absent file is a hard [`LockfileError::Missing`].
+fn read_existing_lockfile(
     config_path: &Path,
-    parsed_entries: &[(String, NormalizedRef, serde_json::Value)],
     policy: LockfilePolicy,
-) -> Result<(Option<Lockfile>, HashMap<String, String>), FeatureError> {
+) -> Result<Option<Lockfile>, FeatureError> {
     if matches!(policy, LockfilePolicy::NoLockfile | LockfilePolicy::Upgrade) {
-        return Ok((None, HashMap::new()));
+        return Ok(None);
     }
 
-    let existing = read_lockfile(config_path);
+    let existing = read_lockfile(config_path).map_err(FeatureError::Lockfile)?;
 
     if matches!(policy, LockfilePolicy::Frozen) && existing.is_none() {
         return Err(FeatureError::Lockfile(LockfileError::Missing));
     }
 
-    let locked_digests = existing.as_ref().map_or_else(HashMap::new, |lf| {
-        parsed_entries
-            .iter()
-            .filter_map(|(key, norm_ref, _)| {
-                if matches!(norm_ref, NormalizedRef::OciTarget { .. }) {
-                    let lock_key = lockfile_key(key);
-                    lf.features
-                        .get(&lock_key)
-                        .map(|e| (key.clone(), e.integrity.clone()))
-                } else {
-                    None
-                }
-            })
-            .collect()
-    });
-
-    Ok((existing, locked_digests))
+    Ok(existing)
 }
 
-fn build_lockfile_from_results(
-    parsed_entries: &[(String, NormalizedRef, serde_json::Value)],
-    fetch_results: &[FetchResult],
-) -> Lockfile {
-    let data: Vec<_> = parsed_entries
+/// Build a lockfile from the full resolved install set.
+///
+/// Each OCI feature (top-level or pulled in transitively via `dependsOn`)
+/// becomes one entry keyed by its verbatim ref. The `dependsOn` array lists the
+/// raw refs of an entry's hard dependencies that resolved to OCI features, so
+/// transitive pins are recorded and `--frozen-lockfile` validates them.
+fn build_lockfile_from_entries(feature_entries: &[FeatureEntry]) -> Lockfile {
+    // Refs that resolved to an OCI feature; a dependsOn edge is only recorded
+    // when its target is itself lockable (OCI), matching the official CLI.
+    let oci_refs: HashSet<&str> = feature_entries
         .iter()
-        .zip(fetch_results.iter())
-        .filter_map(|((key, _, _), result)| {
-            if let FetchResult::Oci(r) = result {
-                let lock_key = lockfile_key(key);
-                let resolved = format!("{}/{}@{}", r.registry, r.repository, r.digest);
-                Some((
-                    lock_key,
-                    r.version.clone(),
-                    resolved,
-                    r.digest.clone(),
-                    vec![],
-                ))
-            } else {
-                None
-            }
+        .filter(|e| e.oci.is_some())
+        .map(|e| e.original_ref.as_str())
+        .collect();
+
+    let data: Vec<_> = feature_entries
+        .iter()
+        .filter_map(|entry| {
+            let oci = entry.oci.as_ref()?;
+            let resolved = format!("{}/{}@{}", oci.registry, oci.repository, oci.digest);
+            let mut depends_on: Vec<String> = entry
+                .metadata
+                .depends_on
+                .keys()
+                .filter(|dep| oci_refs.contains(dep.as_str()))
+                .cloned()
+                .collect();
+            depends_on.sort();
+            depends_on.dedup();
+            Some((
+                entry.original_ref.clone(),
+                oci.version.clone(),
+                resolved,
+                oci.digest.clone(),
+                depends_on,
+            ))
         })
         .collect();
     generate_lockfile(&data)
@@ -566,12 +620,13 @@ fn apply_lockfile_policy(
 /// Parse metadata from fetched artifacts and validate user options.
 fn parse_metadata_and_validate(
     parsed_entries: &[(String, NormalizedRef, serde_json::Value)],
-    artifact_paths: &[PathBuf],
+    fetch_results: &[FetchResult],
 ) -> Result<Vec<FeatureEntry>, FeatureError> {
     let mut entries = Vec::with_capacity(parsed_entries.len());
 
     for (i, (key, normalized, options_value)) in parsed_entries.iter().enumerate() {
-        let artifact_dir = &artifact_paths[i];
+        let fetch_result = &fetch_results[i];
+        let artifact_dir = fetch_result.artifact_dir();
         let metadata_path = artifact_dir.join("devcontainer-feature.json");
         let metadata_json =
             std::fs::read_to_string(&metadata_path).map_err(|e| FeatureError::InvalidMetadata {
@@ -598,6 +653,7 @@ fn parse_metadata_and_validate(
             artifact_dir: artifact_dir.clone(),
             user_options,
             original_ref: key.clone(),
+            oci: fetch_result.oci_lock_info(),
         });
     }
 
@@ -888,6 +944,7 @@ async fn expand_depends_on(
     workspace_root: &Path,
     platform: &Platform,
     cache: &FeatureCache,
+    existing_lockfile: Option<&Lockfile>,
 ) -> Result<(), FeatureError> {
     let oci_fetcher = OciFetcher::default();
     let http_fetcher = HttpFetcher;
@@ -944,17 +1001,20 @@ async fn expand_depends_on(
         // as the `visited` key so option variants of one ref stay distinct.
         let install_id = install_identity(&normalized.to_string(), &opts_json);
 
-        // Fetch the artifact.
-        let artifact_dir = fetch_one(
-            &dep_ref,
+        // Fetch the artifact, pinning to the locked digest (keyed by the
+        // verbatim dependsOn ref) when the lockfile has one.
+        let locked = locked_digest_for(existing_lockfile, &dep_ref);
+        let fetch_result = fetch_one_with_digest(
             &normalized,
             platform,
             cache,
             &oci_fetcher,
             &http_fetcher,
+            locked,
             &local_fetcher,
         )
         .await?;
+        let artifact_dir = fetch_result.artifact_dir().clone();
 
         // Parse metadata.
         let metadata_path = artifact_dir.join("devcontainer-feature.json");
@@ -989,6 +1049,7 @@ async fn expand_depends_on(
             artifact_dir,
             user_options,
             original_ref: dep_ref,
+            oci: fetch_result.oci_lock_info(),
         });
     }
 
@@ -1065,25 +1126,6 @@ fn log_option_warning(key: &str, w: &FeatureWarning) {
             warn!("{key}: option '{option}' value '{value}' not in allowed set: {allowed:?}");
         }
         _ => {}
-    }
-}
-
-/// Dispatch a single fetch to the appropriate fetcher based on the normalized ref.
-async fn fetch_one(
-    key: &str,
-    norm_ref: &NormalizedRef,
-    platform: &Platform,
-    cache: &FeatureCache,
-    oci_fetcher: &OciFetcher,
-    http_fetcher: &HttpFetcher,
-    local_fetcher: &LocalFetcher,
-) -> Result<PathBuf, FeatureError> {
-    debug!("fetching feature {key} from {norm_ref}");
-
-    match norm_ref {
-        NormalizedRef::OciTarget { .. } => oci_fetcher.fetch(norm_ref, platform, cache).await,
-        NormalizedRef::HttpTarget { .. } => http_fetcher.fetch(norm_ref, platform, cache).await,
-        NormalizedRef::LocalTarget { .. } => local_fetcher.fetch(norm_ref, platform, cache).await,
     }
 }
 
@@ -2197,5 +2239,151 @@ mod tests {
             matches!(err, FeatureError::CyclicDependsOn { .. }),
             "expected CyclicDependsOn error for transitive cycle, got: {err:?}"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // lockfile generation from the resolved install set
+    // -----------------------------------------------------------------------
+
+    /// Build a minimal OCI-backed [`FeatureEntry`] for lockfile tests.
+    fn oci_entry(
+        original_ref: &str,
+        registry: &str,
+        repo: &str,
+        tag: &str,
+        digest: &str,
+    ) -> FeatureEntry {
+        FeatureEntry {
+            install_id: install_identity(original_ref, "{}"),
+            metadata: FeatureMetadata {
+                id: repo.rsplit('/').next().unwrap_or(repo).to_string(),
+                ..Default::default()
+            },
+            artifact_dir: PathBuf::from("/tmp/feature"),
+            user_options: HashMap::new(),
+            original_ref: original_ref.to_string(),
+            oci: Some(OciLockInfo {
+                version: tag.to_string(),
+                registry: registry.to_string(),
+                repository: repo.to_string(),
+                digest: digest.to_string(),
+            }),
+        }
+    }
+
+    #[test]
+    fn lockfile_keys_on_verbatim_ref_including_tag() {
+        // Per the devcontainer spec the lockfile key is the ref exactly as
+        // authored — the `:1` tag is part of the key, never stripped.
+        let entries = vec![oci_entry(
+            "ghcr.io/devcontainers/features/node:1",
+            "ghcr.io",
+            "devcontainers/features/node",
+            "1",
+            "sha256:abc",
+        )];
+        let lf = build_lockfile_from_entries(&entries);
+        assert!(
+            lf.features
+                .contains_key("ghcr.io/devcontainers/features/node:1")
+        );
+        let entry = &lf.features["ghcr.io/devcontainers/features/node:1"];
+        assert_eq!(entry.version, "1");
+        assert_eq!(entry.integrity, "sha256:abc");
+        assert_eq!(
+            entry.resolved,
+            "ghcr.io/devcontainers/features/node@sha256:abc"
+        );
+    }
+
+    #[test]
+    fn lockfile_records_transitive_depends_on() {
+        // A feature whose `dependsOn` names another OCI feature must record
+        // that dependency both as its own lockfile entry and in the parent's
+        // `dependsOn` array — keyed by the verbatim dep ref.
+        let mut parent = oci_entry("ghcr.io/x/parent:1", "ghcr.io", "x/parent", "1", "sha256:p");
+        parent
+            .metadata
+            .depends_on
+            .insert("ghcr.io/x/child".to_string(), json!({}));
+        let child = oci_entry(
+            "ghcr.io/x/child",
+            "ghcr.io",
+            "x/child",
+            "latest",
+            "sha256:c",
+        );
+
+        let lf = build_lockfile_from_entries(&[parent, child]);
+
+        assert_eq!(
+            lf.features.len(),
+            2,
+            "both parent and transitive dep recorded"
+        );
+        assert!(lf.features.contains_key("ghcr.io/x/child"));
+        assert_eq!(
+            lf.features["ghcr.io/x/parent:1"].depends_on,
+            vec!["ghcr.io/x/child".to_string()]
+        );
+        // The transitive dep has no further deps.
+        assert!(lf.features["ghcr.io/x/child"].depends_on.is_empty());
+    }
+
+    #[test]
+    fn lockfile_depends_on_excludes_non_oci_targets() {
+        // A dependsOn edge to a non-OCI (local) feature is not lockable, so it
+        // must not appear in the parent's dependsOn array.
+        let mut parent = oci_entry("ghcr.io/x/parent:1", "ghcr.io", "x/parent", "1", "sha256:p");
+        parent
+            .metadata
+            .depends_on
+            .insert("./local-feature".to_string(), json!({}));
+        let lf = build_lockfile_from_entries(&[parent]);
+        assert!(lf.features["ghcr.io/x/parent:1"].depends_on.is_empty());
+    }
+
+    #[test]
+    fn lockfile_skips_non_oci_features() {
+        // HTTP / local features carry no digest and produce no lockfile entry.
+        let entry = FeatureEntry {
+            install_id: install_identity("./local", "{}"),
+            metadata: FeatureMetadata {
+                id: "local".to_string(),
+                ..Default::default()
+            },
+            artifact_dir: PathBuf::from("/tmp/local"),
+            user_options: HashMap::new(),
+            original_ref: "./local".to_string(),
+            oci: None,
+        };
+        let lf = build_lockfile_from_entries(&[entry]);
+        assert!(lf.features.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // locked_digest_for
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn locked_digest_lookup_uses_verbatim_ref() {
+        let lf = generate_lockfile(&[(
+            "ghcr.io/x/y:1".to_string(),
+            "1".to_string(),
+            "ghcr.io/x/y@sha256:aa".to_string(),
+            "sha256:aa".to_string(),
+            vec![],
+        )]);
+        // Exact tagged ref hits.
+        assert_eq!(
+            locked_digest_for(Some(&lf), "ghcr.io/x/y:1"),
+            Some("sha256:aa")
+        );
+        // A changed tag (`:1` -> `:2`) misses, so resolution re-fetches `:2`.
+        assert_eq!(locked_digest_for(Some(&lf), "ghcr.io/x/y:2"), None);
+        // Untagged form misses too — the key is verbatim.
+        assert_eq!(locked_digest_for(Some(&lf), "ghcr.io/x/y"), None);
+        // No lockfile -> never pinned.
+        assert_eq!(locked_digest_for(None, "ghcr.io/x/y:1"), None);
     }
 }

--- a/crates/cella-features/src/lockfile.rs
+++ b/crates/cella-features/src/lockfile.rs
@@ -60,7 +60,9 @@ pub enum LockfilePolicy {
     NoLockfile,
     /// Require the lockfile to match; fail if missing or different.
     Frozen,
-    /// Resolve fresh and write a new lockfile (for `upgrade` command).
+    /// Resolve fresh (ignoring any locked digests) and return the regenerated
+    /// lockfile WITHOUT writing it — the `upgrade` command writes or prints it
+    /// itself so `--dry-run` never touches disk.
     Upgrade,
 }
 

--- a/crates/cella-features/src/lockfile.rs
+++ b/crates/cella-features/src/lockfile.rs
@@ -51,9 +51,10 @@ pub enum LockfileError {
 }
 
 /// Controls how the lockfile is read and written during feature resolution.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum LockfilePolicy {
     /// Write/update the lockfile after resolution (default).
+    #[default]
     Update,
     /// Skip reading and writing the lockfile entirely.
     NoLockfile,

--- a/crates/cella-features/src/lockfile.rs
+++ b/crates/cella-features/src/lockfile.rs
@@ -48,6 +48,13 @@ pub enum LockfileError {
     /// The generated lockfile does not match the one on disk.
     #[error("Lockfile does not match.")]
     Mismatch,
+    /// The lockfile exists but could not be read or parsed.
+    ///
+    /// Distinct from [`LockfileError::Missing`] so a corrupt or unreadable
+    /// lockfile is never silently treated as absent (which would, under
+    /// `--frozen-lockfile`, mis-report it as "does not exist").
+    #[error("Lockfile is unreadable: {reason}")]
+    Corrupt { reason: String },
 }
 
 /// Controls how the lockfile is read and written during feature resolution.
@@ -97,13 +104,33 @@ pub fn lockfile_path(config_path: &Path) -> PathBuf {
 // Read / write
 // ---------------------------------------------------------------------------
 
-/// Read and deserialize a lockfile.  Returns `None` on any error (missing,
-/// I/O failure, malformed JSON).
-#[must_use]
-pub fn read_lockfile(config_path: &Path) -> Option<Lockfile> {
+/// Read and deserialize a lockfile.
+///
+/// Returns `Ok(None)` only when the file is genuinely absent. An I/O error
+/// (e.g. permissions) or malformed JSON yields [`LockfileError::Corrupt`] so
+/// callers can surface the real problem instead of conflating it with a
+/// missing file.
+///
+/// # Errors
+///
+/// Returns [`LockfileError::Corrupt`] when the lockfile exists but cannot be
+/// read or parsed.
+pub fn read_lockfile(config_path: &Path) -> Result<Option<Lockfile>, LockfileError> {
     let path = lockfile_path(config_path);
-    let contents = std::fs::read_to_string(path).ok()?;
-    serde_json::from_str(&contents).ok()
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => {
+            return Err(LockfileError::Corrupt {
+                reason: format!("cannot read {}: {e}", path.display()),
+            });
+        }
+    };
+    serde_json::from_str(&contents)
+        .map(Some)
+        .map_err(|e| LockfileError::Corrupt {
+            reason: format!("invalid JSON in {}: {e}", path.display()),
+        })
 }
 
 /// Serialize and write a lockfile to disk, with a trailing newline.
@@ -149,23 +176,6 @@ pub fn generate_lockfile(
         );
     }
     Lockfile { features }
-}
-
-/// Strip the `:version` suffix from a raw feature reference string.
-///
-/// `"ghcr.io/devcontainers/features/git:1"` → `"ghcr.io/devcontainers/features/git"`
-///
-/// Only strips the trailing component when it contains no `'/'` (i.e. it
-/// looks like a tag, not a registry path segment).
-#[must_use]
-pub fn lockfile_key(raw_ref: &str) -> String {
-    if let Some(pos) = raw_ref.rfind(':') {
-        let suffix = &raw_ref[pos + 1..];
-        if !suffix.contains('/') {
-            return raw_ref[..pos].to_string();
-        }
-    }
-    raw_ref.to_string()
 }
 
 // ---------------------------------------------------------------------------
@@ -337,31 +347,40 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // lockfile_key
+    // read_lockfile
     // -----------------------------------------------------------------------
 
     #[test]
-    fn lockfile_key_strips_version() {
-        assert_eq!(
-            lockfile_key("ghcr.io/devcontainers/features/git:1"),
-            "ghcr.io/devcontainers/features/git"
-        );
+    fn read_lockfile_absent_is_ok_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = tmp.path().join("devcontainer.json");
+        assert!(matches!(read_lockfile(&config), Ok(None)));
     }
 
     #[test]
-    fn lockfile_key_no_version() {
-        assert_eq!(
-            lockfile_key("ghcr.io/devcontainers/features/git"),
-            "ghcr.io/devcontainers/features/git"
-        );
+    fn read_lockfile_malformed_is_corrupt() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = tmp.path().join("devcontainer.json");
+        std::fs::write(lockfile_path(&config), "{ this is not json").unwrap();
+        assert!(matches!(
+            read_lockfile(&config),
+            Err(LockfileError::Corrupt { .. })
+        ));
     }
 
     #[test]
-    fn lockfile_key_port_not_stripped() {
-        assert_eq!(
-            lockfile_key("localhost:5000/features/git"),
-            "localhost:5000/features/git"
-        );
+    fn read_lockfile_valid_round_trips() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = tmp.path().join("devcontainer.json");
+        let lf = generate_lockfile(&[(
+            "ghcr.io/x/y:1".to_string(),
+            "1".to_string(),
+            "ghcr.io/x/y@sha256:aa".to_string(),
+            "sha256:aa".to_string(),
+            vec![],
+        )]);
+        write_lockfile(&config, &lf).unwrap();
+        assert_eq!(read_lockfile(&config).unwrap(), Some(lf));
     }
 
     // -----------------------------------------------------------------------

--- a/crates/cella-features/src/lockfile.rs
+++ b/crates/cella-features/src/lockfile.rs
@@ -26,7 +26,7 @@ pub struct LockfileEntry {
     /// Manifest digest, e.g. `"sha256:abc..."`.
     pub integrity: String,
     /// Keys of other features in the lockfile this one depends on.
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[serde(rename = "dependsOn", skip_serializing_if = "Vec::is_empty", default)]
     pub depends_on: Vec<String>,
 }
 
@@ -172,17 +172,14 @@ pub fn lockfile_key(raw_ref: &str) -> String {
 
 /// Compare an existing lockfile against a freshly-generated one.
 ///
-/// Returns `Ok(())` when they match, or:
-/// - [`LockfileError::Missing`] when `existing` has no entries, or
-/// - [`LockfileError::Mismatch`] when the two differ.
+/// Returns `Ok(())` when they match, or [`LockfileError::Mismatch`] when they
+/// differ. The missing-file case is handled by the caller before this point
+/// (a `read_lockfile` returning `None`), so this only compares structure.
 ///
 /// # Errors
 ///
-/// Returns [`LockfileError`] on mismatch or empty existing lockfile.
+/// Returns [`LockfileError::Mismatch`] when `existing` differs from `generated`.
 pub fn compare_lockfile(existing: &Lockfile, generated: &Lockfile) -> Result<(), LockfileError> {
-    if existing.features.is_empty() {
-        return Err(LockfileError::Missing);
-    }
     if existing == generated {
         Ok(())
     } else {
@@ -307,8 +304,12 @@ mod tests {
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(
-            json.contains("depends_on") || json.contains("dependsOn"),
-            "non-empty depends_on must be serialized"
+            json.contains("dependsOn"),
+            "non-empty depends_on must serialize as the camelCase `dependsOn` key"
+        );
+        assert!(
+            !json.contains("depends_on"),
+            "must not leak the snake_case field name"
         );
     }
 
@@ -400,7 +401,10 @@ mod tests {
     }
 
     #[test]
-    fn compare_empty_existing_returns_missing() {
+    fn compare_empty_present_lockfile_against_nonempty_is_mismatch() {
+        // A present-but-empty lockfile differs from what resolution produced:
+        // that is a Mismatch, not Missing (Missing is only for an absent file,
+        // handled by the caller before compare_lockfile is reached).
         let empty = Lockfile::default();
         let generated = generate_lockfile(&[(
             "ghcr.io/x/y".to_string(),
@@ -411,7 +415,13 @@ mod tests {
         )]);
         assert!(matches!(
             compare_lockfile(&empty, &generated),
-            Err(LockfileError::Missing)
+            Err(LockfileError::Mismatch)
         ));
+    }
+
+    #[test]
+    fn compare_two_empty_lockfiles_matches() {
+        let empty = Lockfile::default();
+        assert!(compare_lockfile(&empty, &Lockfile::default()).is_ok());
     }
 }

--- a/crates/cella-features/src/lockfile.rs
+++ b/crates/cella-features/src/lockfile.rs
@@ -1,0 +1,416 @@
+//! Devcontainer feature lockfile support.
+//!
+//! Implements reading, writing, generating, and comparing the
+//! `devcontainer-lock.json` / `.devcontainer-lock.json` file used to pin
+//! OCI feature digests across builds.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::FeatureError;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// A single feature entry inside the lockfile.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LockfileEntry {
+    /// Resolved version (OCI tag, e.g. `"1"` or `"latest"`).
+    pub version: String,
+    /// Full resolved reference with manifest digest, e.g.
+    /// `"ghcr.io/devcontainers/features/node@sha256:abc..."`.
+    pub resolved: String,
+    /// Manifest digest, e.g. `"sha256:abc..."`.
+    pub integrity: String,
+    /// Keys of other features in the lockfile this one depends on.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub depends_on: Vec<String>,
+}
+
+/// The contents of a `devcontainer-lock.json` file.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct Lockfile {
+    /// Map from feature key (OCI ref without version suffix) to entry.
+    ///
+    /// Uses [`BTreeMap`] so keys are always serialized in alphabetical order.
+    pub features: BTreeMap<String, LockfileEntry>,
+}
+
+/// Errors specific to lockfile validation.
+#[derive(Debug, thiserror::Error)]
+pub enum LockfileError {
+    /// The lockfile does not exist on disk.
+    #[error("Lockfile does not exist.")]
+    Missing,
+    /// The generated lockfile does not match the one on disk.
+    #[error("Lockfile does not match.")]
+    Mismatch,
+}
+
+/// Controls how the lockfile is read and written during feature resolution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LockfilePolicy {
+    /// Write/update the lockfile after resolution (default).
+    Update,
+    /// Skip reading and writing the lockfile entirely.
+    NoLockfile,
+    /// Require the lockfile to match; fail if missing or different.
+    Frozen,
+    /// Resolve fresh and write a new lockfile (for `upgrade` command).
+    Upgrade,
+}
+
+// ---------------------------------------------------------------------------
+// Path derivation
+// ---------------------------------------------------------------------------
+
+/// Derive the lockfile path from the devcontainer config path.
+///
+/// If the config filename starts with `'.'` (e.g. `.devcontainer.json`) the
+/// lockfile is `.devcontainer-lock.json`; otherwise it is
+/// `devcontainer-lock.json`. The lockfile is always placed in the **same
+/// directory** as the config.
+#[must_use]
+pub fn lockfile_path(config_path: &Path) -> PathBuf {
+    let dir = config_path.parent().unwrap_or_else(|| Path::new("."));
+    let filename = config_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("devcontainer.json");
+
+    let lock_name = if filename.starts_with('.') {
+        ".devcontainer-lock.json"
+    } else {
+        "devcontainer-lock.json"
+    };
+
+    dir.join(lock_name)
+}
+
+// ---------------------------------------------------------------------------
+// Read / write
+// ---------------------------------------------------------------------------
+
+/// Read and deserialize a lockfile.  Returns `None` on any error (missing,
+/// I/O failure, malformed JSON).
+#[must_use]
+pub fn read_lockfile(config_path: &Path) -> Option<Lockfile> {
+    let path = lockfile_path(config_path);
+    let contents = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&contents).ok()
+}
+
+/// Serialize and write a lockfile to disk, with a trailing newline.
+///
+/// # Errors
+///
+/// Returns [`FeatureError::Io`] on I/O failure.
+pub fn write_lockfile(config_path: &Path, lockfile: &Lockfile) -> Result<(), FeatureError> {
+    let path = lockfile_path(config_path);
+    let mut json = serde_json::to_string_pretty(lockfile)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    json.push('\n');
+    std::fs::write(path, json)?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Generation
+// ---------------------------------------------------------------------------
+
+/// Generate a [`Lockfile`] from a list of resolved OCI features.
+///
+/// Each tuple is `(key, version, resolved_full, integrity, depends_on)` where:
+/// - `key` — feature ID with any `:version` / `@digest` suffix stripped
+/// - `version` — the OCI tag that was fetched
+/// - `resolved_full` — `"registry/repository@digest"`
+/// - `integrity` — the manifest digest (`"sha256:..."`)
+/// - `depends_on` — keys of features this one depends on (may be empty)
+#[must_use]
+pub fn generate_lockfile(
+    resolved_oci_features: &[(String, String, String, String, Vec<String>)],
+) -> Lockfile {
+    let mut features = BTreeMap::new();
+    for (key, version, resolved, integrity, depends_on) in resolved_oci_features {
+        features.insert(
+            key.clone(),
+            LockfileEntry {
+                version: version.clone(),
+                resolved: resolved.clone(),
+                integrity: integrity.clone(),
+                depends_on: depends_on.clone(),
+            },
+        );
+    }
+    Lockfile { features }
+}
+
+/// Strip the `:version` suffix from a raw feature reference string.
+///
+/// `"ghcr.io/devcontainers/features/git:1"` → `"ghcr.io/devcontainers/features/git"`
+///
+/// Only strips the trailing component when it contains no `'/'` (i.e. it
+/// looks like a tag, not a registry path segment).
+#[must_use]
+pub fn lockfile_key(raw_ref: &str) -> String {
+    if let Some(pos) = raw_ref.rfind(':') {
+        let suffix = &raw_ref[pos + 1..];
+        if !suffix.contains('/') {
+            return raw_ref[..pos].to_string();
+        }
+    }
+    raw_ref.to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Comparison
+// ---------------------------------------------------------------------------
+
+/// Compare an existing lockfile against a freshly-generated one.
+///
+/// Returns `Ok(())` when they match, or:
+/// - [`LockfileError::Missing`] when `existing` has no entries, or
+/// - [`LockfileError::Mismatch`] when the two differ.
+///
+/// # Errors
+///
+/// Returns [`LockfileError`] on mismatch or empty existing lockfile.
+pub fn compare_lockfile(existing: &Lockfile, generated: &Lockfile) -> Result<(), LockfileError> {
+    if existing.features.is_empty() {
+        return Err(LockfileError::Missing);
+    }
+    if existing == generated {
+        Ok(())
+    } else {
+        Err(LockfileError::Mismatch)
+    }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------------
+    // lockfile_path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn lockfile_path_devcontainer_dir() {
+        let config = Path::new("/workspace/.devcontainer/devcontainer.json");
+        let lock = lockfile_path(config);
+        assert_eq!(
+            lock,
+            Path::new("/workspace/.devcontainer/devcontainer-lock.json")
+        );
+    }
+
+    #[test]
+    fn lockfile_path_root_dotfile() {
+        let config = Path::new("/workspace/.devcontainer.json");
+        let lock = lockfile_path(config);
+        assert_eq!(lock, Path::new("/workspace/.devcontainer-lock.json"));
+    }
+
+    #[test]
+    fn lockfile_path_named_config() {
+        let config = Path::new("/workspace/.devcontainer/my.json");
+        let lock = lockfile_path(config);
+        assert_eq!(
+            lock,
+            Path::new("/workspace/.devcontainer/devcontainer-lock.json")
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // serde round-trip
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn serde_round_trip_sorted_keys() {
+        let mut features = BTreeMap::new();
+        features.insert(
+            "ghcr.io/devcontainers/features/node".to_string(),
+            LockfileEntry {
+                version: "1".to_string(),
+                resolved: "ghcr.io/devcontainers/features/node@sha256:aabbcc".to_string(),
+                integrity: "sha256:aabbcc".to_string(),
+                depends_on: vec![],
+            },
+        );
+        features.insert(
+            "ghcr.io/devcontainers/features/git".to_string(),
+            LockfileEntry {
+                version: "1".to_string(),
+                resolved: "ghcr.io/devcontainers/features/git@sha256:112233".to_string(),
+                integrity: "sha256:112233".to_string(),
+                depends_on: vec![],
+            },
+        );
+        let lockfile = Lockfile { features };
+
+        let json = serde_json::to_string_pretty(&lockfile).unwrap();
+
+        // Keys must be alphabetically sorted (BTreeMap guarantees this).
+        let git_pos = json.find("features/git").unwrap();
+        let node_pos = json.find("features/node").unwrap();
+        assert!(git_pos < node_pos, "keys must be sorted: git before node");
+
+        // Trailing newline after write.
+        let tmp = tempfile::tempdir().unwrap();
+        let config = tmp.path().join("devcontainer.json");
+        write_lockfile(&config, &lockfile).unwrap();
+        let raw = std::fs::read_to_string(lockfile_path(&config)).unwrap();
+        assert!(
+            raw.ends_with('\n'),
+            "written lockfile must end with newline"
+        );
+
+        // Round-trip.
+        let recovered: Lockfile = serde_json::from_str(&json).unwrap();
+        assert_eq!(recovered, lockfile);
+    }
+
+    #[test]
+    fn depends_on_omitted_when_empty() {
+        let entry = LockfileEntry {
+            version: "1".to_string(),
+            resolved: "ghcr.io/x/y@sha256:00".to_string(),
+            integrity: "sha256:00".to_string(),
+            depends_on: vec![],
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(
+            !json.contains("depends_on"),
+            "empty depends_on must be omitted"
+        );
+        assert!(
+            !json.contains("dependsOn"),
+            "empty depends_on must be omitted"
+        );
+    }
+
+    #[test]
+    fn depends_on_present_when_non_empty() {
+        let entry = LockfileEntry {
+            version: "1".to_string(),
+            resolved: "ghcr.io/x/y@sha256:00".to_string(),
+            integrity: "sha256:00".to_string(),
+            depends_on: vec!["ghcr.io/x/z".to_string()],
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(
+            json.contains("depends_on") || json.contains("dependsOn"),
+            "non-empty depends_on must be serialized"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // generate_lockfile
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn generate_lockfile_from_synthetic_data() {
+        let data = vec![(
+            "ghcr.io/devcontainers/features/git".to_string(),
+            "1".to_string(),
+            "ghcr.io/devcontainers/features/git@sha256:deadbeef".to_string(),
+            "sha256:deadbeef".to_string(),
+            vec![],
+        )];
+        let lf = generate_lockfile(&data);
+        assert_eq!(lf.features.len(), 1);
+        let entry = &lf.features["ghcr.io/devcontainers/features/git"];
+        assert_eq!(entry.version, "1");
+        assert_eq!(entry.integrity, "sha256:deadbeef");
+        assert!(entry.depends_on.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // lockfile_key
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn lockfile_key_strips_version() {
+        assert_eq!(
+            lockfile_key("ghcr.io/devcontainers/features/git:1"),
+            "ghcr.io/devcontainers/features/git"
+        );
+    }
+
+    #[test]
+    fn lockfile_key_no_version() {
+        assert_eq!(
+            lockfile_key("ghcr.io/devcontainers/features/git"),
+            "ghcr.io/devcontainers/features/git"
+        );
+    }
+
+    #[test]
+    fn lockfile_key_port_not_stripped() {
+        assert_eq!(
+            lockfile_key("localhost:5000/features/git"),
+            "localhost:5000/features/git"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // compare_lockfile
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn compare_matching_lockfiles_ok() {
+        let lf = generate_lockfile(&[(
+            "ghcr.io/x/y".to_string(),
+            "1".to_string(),
+            "ghcr.io/x/y@sha256:aa".to_string(),
+            "sha256:aa".to_string(),
+            vec![],
+        )]);
+        assert!(compare_lockfile(&lf, &lf).is_ok());
+    }
+
+    #[test]
+    fn compare_mismatch_returns_error() {
+        let lf1 = generate_lockfile(&[(
+            "ghcr.io/x/y".to_string(),
+            "1".to_string(),
+            "ghcr.io/x/y@sha256:aa".to_string(),
+            "sha256:aa".to_string(),
+            vec![],
+        )]);
+        let lf2 = generate_lockfile(&[(
+            "ghcr.io/x/y".to_string(),
+            "1".to_string(),
+            "ghcr.io/x/y@sha256:bb".to_string(),
+            "sha256:bb".to_string(),
+            vec![],
+        )]);
+        assert!(matches!(
+            compare_lockfile(&lf1, &lf2),
+            Err(LockfileError::Mismatch)
+        ));
+    }
+
+    #[test]
+    fn compare_empty_existing_returns_missing() {
+        let empty = Lockfile::default();
+        let generated = generate_lockfile(&[(
+            "ghcr.io/x/y".to_string(),
+            "1".to_string(),
+            "ghcr.io/x/y@sha256:aa".to_string(),
+            "sha256:aa".to_string(),
+            vec![],
+        )]);
+        assert!(matches!(
+            compare_lockfile(&empty, &generated),
+            Err(LockfileError::Missing)
+        ));
+    }
+}

--- a/crates/cella-features/src/oci.rs
+++ b/crates/cella-features/src/oci.rs
@@ -287,8 +287,15 @@ impl OciFetcher {
             });
         }
 
-        let oci_ref =
-            Reference::with_tag(registry.to_owned(), repository.to_owned(), tag.to_owned());
+        // Request the manifest by the pinned digest directly (not the mutable
+        // tag) so a moved tag can never substitute different content: the
+        // registry serves the exact `@sha256:...` artifact or 404s. This
+        // matches the official CLI's locked-build behavior.
+        let oci_ref = Reference::with_digest(
+            registry.to_owned(),
+            repository.to_owned(),
+            digest.to_owned(),
+        );
         let auth = build_registry_auth(registry);
         let (manifest, resolved_digest) = self
             .pull_manifest(&oci_ref, &auth, registry, repository, tag)
@@ -323,6 +330,13 @@ impl OciFetcher {
     }
 
     /// Fetch by OCI tag (no pinning).
+    ///
+    /// Always resolves the manifest digest from the registry first, then keys
+    /// the cache lookup on that **content-addressed** digest. A tag-addressed
+    /// cache entry is never trusted on its own: if the tag has moved, returning
+    /// the stale tag directory paired with the freshly-resolved digest would
+    /// produce an [`OciFetchResult`] whose artifact and digest disagree (and
+    /// thus a wrong lockfile). Digest-addressed entries can never drift.
     async fn fetch_by_tag(
         &self,
         registry: &str,
@@ -330,22 +344,6 @@ impl OciFetcher {
         tag: &str,
         cache: &FeatureCache,
     ) -> Result<OciFetchResult, FeatureError> {
-        if let Some(cached) = cache.get_oci(registry, repository, tag) {
-            let oci_ref =
-                Reference::with_tag(registry.to_owned(), repository.to_owned(), tag.to_owned());
-            let auth = build_registry_auth(registry);
-            let (_, digest) = self
-                .pull_manifest(&oci_ref, &auth, registry, repository, tag)
-                .await?;
-            return Ok(OciFetchResult {
-                artifact_dir: cached,
-                digest,
-                version: tag.to_owned(),
-                registry: registry.to_owned(),
-                repository: repository.to_owned(),
-            });
-        }
-
         let oci_ref =
             Reference::with_tag(registry.to_owned(), repository.to_owned(), tag.to_owned());
         let auth = build_registry_auth(registry);
@@ -354,6 +352,7 @@ impl OciFetcher {
             .await?;
 
         if let Some(cached) = cache.get_oci(registry, repository, &digest) {
+            debug!("cache hit by digest {digest} for {registry}/{repository}:{tag}");
             return Ok(OciFetchResult {
                 artifact_dir: cached,
                 digest,

--- a/crates/cella-features/src/oci.rs
+++ b/crates/cella-features/src/oci.rs
@@ -68,6 +68,20 @@ impl Default for OciFetcher {
     }
 }
 
+/// Result of an OCI feature fetch that includes the manifest digest.
+pub struct OciFetchResult {
+    /// Local filesystem path to the extracted feature artifact.
+    pub artifact_dir: PathBuf,
+    /// Manifest digest, e.g. `"sha256:abcdef..."`.
+    pub digest: String,
+    /// The OCI tag that was fetched (e.g. `"1"`, `"latest"`).
+    pub version: String,
+    /// The OCI registry hostname.
+    pub registry: String,
+    /// The OCI repository path.
+    pub repository: String,
+}
+
 /// Find the first extractable layer in a manifest, or return an error listing available types.
 fn find_feature_layer<'a>(
     manifest: &'a oci_distribution::manifest::OciImageManifest,
@@ -217,6 +231,156 @@ impl OciFetcher {
         verify_blob_digest(&blob, &layer.digest, oci_ref.repository())?;
 
         Ok(blob)
+    }
+}
+
+impl OciFetcher {
+    /// Fetch an OCI feature and return full digest metadata alongside the path.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FeatureError`] if the reference is not an OCI target, if the
+    /// registry fetch fails, or if the digest does not match the locked value.
+    pub async fn fetch_oci_with_digest(
+        &self,
+        reference: &NormalizedRef,
+        cache: &FeatureCache,
+        locked_digest: Option<&str>,
+    ) -> Result<OciFetchResult, FeatureError> {
+        let NormalizedRef::OciTarget {
+            registry,
+            repository,
+            tag,
+        } = reference
+        else {
+            return Err(FeatureError::InvalidReference {
+                reference: reference.to_string(),
+                reason: "OciFetcher only handles OCI targets".to_owned(),
+            });
+        };
+
+        if let Some(digest) = locked_digest {
+            return self
+                .fetch_by_locked_digest(registry, repository, tag, digest, cache)
+                .await;
+        }
+
+        self.fetch_by_tag(registry, repository, tag, cache).await
+    }
+
+    /// Fetch by a known locked digest (pinning mode).
+    async fn fetch_by_locked_digest(
+        &self,
+        registry: &str,
+        repository: &str,
+        tag: &str,
+        digest: &str,
+        cache: &FeatureCache,
+    ) -> Result<OciFetchResult, FeatureError> {
+        if let Some(cached) = cache.get_oci(registry, repository, digest) {
+            return Ok(OciFetchResult {
+                artifact_dir: cached,
+                digest: digest.to_owned(),
+                version: tag.to_owned(),
+                registry: registry.to_owned(),
+                repository: repository.to_owned(),
+            });
+        }
+
+        let oci_ref =
+            Reference::with_tag(registry.to_owned(), repository.to_owned(), tag.to_owned());
+        let auth = build_registry_auth(registry);
+        let (manifest, resolved_digest) = self
+            .pull_manifest(&oci_ref, &auth, registry, repository, tag)
+            .await?;
+
+        if resolved_digest != digest {
+            return Err(FeatureError::DigestMismatch {
+                feature_id: format!("{registry}/{repository}"),
+                expected: digest.to_owned(),
+                actual: resolved_digest,
+            });
+        }
+
+        let layer = find_feature_layer(&manifest, registry, repository, tag)?;
+        let blob = self.pull_layer_blob(&oci_ref, layer, registry).await?;
+        let artifact_dir = extract_and_commit(
+            &blob,
+            &layer.media_type,
+            cache,
+            registry,
+            repository,
+            tag,
+            &resolved_digest,
+        )?;
+        Ok(OciFetchResult {
+            artifact_dir,
+            digest: resolved_digest,
+            version: tag.to_owned(),
+            registry: registry.to_owned(),
+            repository: repository.to_owned(),
+        })
+    }
+
+    /// Fetch by OCI tag (no pinning).
+    async fn fetch_by_tag(
+        &self,
+        registry: &str,
+        repository: &str,
+        tag: &str,
+        cache: &FeatureCache,
+    ) -> Result<OciFetchResult, FeatureError> {
+        if let Some(cached) = cache.get_oci(registry, repository, tag) {
+            let oci_ref =
+                Reference::with_tag(registry.to_owned(), repository.to_owned(), tag.to_owned());
+            let auth = build_registry_auth(registry);
+            let (_, digest) = self
+                .pull_manifest(&oci_ref, &auth, registry, repository, tag)
+                .await?;
+            return Ok(OciFetchResult {
+                artifact_dir: cached,
+                digest,
+                version: tag.to_owned(),
+                registry: registry.to_owned(),
+                repository: repository.to_owned(),
+            });
+        }
+
+        let oci_ref =
+            Reference::with_tag(registry.to_owned(), repository.to_owned(), tag.to_owned());
+        let auth = build_registry_auth(registry);
+        let (manifest, digest) = self
+            .pull_manifest(&oci_ref, &auth, registry, repository, tag)
+            .await?;
+
+        if let Some(cached) = cache.get_oci(registry, repository, &digest) {
+            return Ok(OciFetchResult {
+                artifact_dir: cached,
+                digest,
+                version: tag.to_owned(),
+                registry: registry.to_owned(),
+                repository: repository.to_owned(),
+            });
+        }
+
+        let layer = find_feature_layer(&manifest, registry, repository, tag)?;
+        let blob = self.pull_layer_blob(&oci_ref, layer, registry).await?;
+        let artifact_dir = extract_and_commit(
+            &blob,
+            &layer.media_type,
+            cache,
+            registry,
+            repository,
+            tag,
+            &digest,
+        )?;
+        Ok(OciFetchResult {
+            artifact_dir,
+            digest,
+            version: tag.to_owned(),
+            registry: registry.to_owned(),
+            repository: repository.to_owned(),
+        })
     }
 }
 

--- a/crates/cella-features/src/types.rs
+++ b/crates/cella-features/src/types.rs
@@ -112,4 +112,6 @@ pub struct ResolvedFeatures {
     pub build_context: PathBuf,
     pub container_config: FeatureContainerConfig,
     pub metadata_label: String,
+    /// The lockfile written or validated during feature resolution, if any.
+    pub lockfile: Option<crate::lockfile::Lockfile>,
 }

--- a/crates/cella-orchestrator/src/config.rs
+++ b/crates/cella-orchestrator/src/config.rs
@@ -164,6 +164,8 @@ pub struct UpConfig<'a> {
     /// `-target-path`). Installed in the post-create flow when armed and the
     /// lifecycle gate permits (after `postCreateCommand`, before `postStart`).
     pub dotfiles: DotfilesConfig,
+    /// Lockfile policy for feature resolution (default: Update).
+    pub lockfile_policy: cella_features::LockfilePolicy,
 }
 
 /// How the up pipeline should handle the container image.

--- a/crates/cella-orchestrator/src/image.rs
+++ b/crates/cella-orchestrator/src/image.rs
@@ -327,6 +327,7 @@ async fn resolve_and_build_features(
             omit_remote_env: input.omit_remote_env_from_metadata,
         },
         false, // non-compose: build context IS the features dir, bare COPY works
+        cella_features::LockfilePolicy::Update,
     )
     .await
     .map_err(|e| format!("feature resolution failed: {e}"))?;

--- a/crates/cella-orchestrator/src/image.rs
+++ b/crates/cella-orchestrator/src/image.rs
@@ -112,6 +112,8 @@ pub struct EnsureImageInput<'a> {
     /// `--omit-config-remote-env-from-metadata`: strip `remoteEnv` from the
     /// generated `devcontainer.metadata` label baked into the built image.
     pub omit_remote_env_from_metadata: bool,
+    /// Lockfile policy for feature resolution.
+    pub lockfile_policy: cella_features::LockfilePolicy,
     pub progress: &'a ProgressSender,
 }
 
@@ -159,6 +161,7 @@ pub async fn ensure_image(
         no_cache: input.no_cache,
         build_tuning: input.build_tuning,
         omit_remote_env_from_metadata: input.omit_remote_env_from_metadata,
+        lockfile_policy: input.lockfile_policy,
         progress: input.progress,
     };
     let (features_image, resolved) = resolve_and_build_features(&features_input).await?;
@@ -298,6 +301,7 @@ struct FeaturesBuildInput<'a> {
     no_cache: bool,
     build_tuning: crate::config::BuildTuning<'a>,
     omit_remote_env_from_metadata: bool,
+    lockfile_policy: cella_features::LockfilePolicy,
     progress: &'a ProgressSender,
 }
 
@@ -327,7 +331,7 @@ async fn resolve_and_build_features(
             omit_remote_env: input.omit_remote_env_from_metadata,
         },
         false, // non-compose: build context IS the features dir, bare COPY works
-        cella_features::LockfilePolicy::Update,
+        input.lockfile_policy,
     )
     .await
     .map_err(|e| format!("feature resolution failed: {e}"))?;

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -1882,6 +1882,7 @@ impl EnsureUpContext<'_> {
                 secrets: &self.config.build_secrets,
                 build_tuning: self.config.build_tuning,
                 omit_remote_env_from_metadata: self.config.metadata_options.omit_remote_env,
+                lockfile_policy: self.config.lockfile_policy,
                 progress: &self.progress,
             })
             .await?;


### PR DESCRIPTION
Stacked on #141 (dependsOn install) — base retargets to main as parents merge.

Implements the devcontainer feature lockfile and the top-level `cella upgrade` command — the last official devcontainer CLI command cella was missing. This reverses the prior "lockfiles are no-ops" stance for true drop-in parity.

**Lockfile** (`devcontainer-lock.json`, or `.devcontainer-lock.json` when the config name starts with a dot — sibling to devcontainer.json):
- Schema matches the official CLI exactly: `{"features": {"<ref-without-tag>": {"version", "resolved": "<ref>@sha256:…", "integrity": "sha256:…", "dependsOn"?: [...]}}}`, keys sorted, pretty-printed with trailing newline. `integrity` is the OCI manifest digest.
- Written/updated by default during `up` and `build`. Only OCI features are recorded (local-path features excluded).

**Flags** (now real, previously no-ops): `--no-lockfile` skips read+write; `--frozen-lockfile` requires the lockfile to exist and match (errors `Lockfile does not exist.` / `Lockfile does not match.`, non-zero exit, no write); `--experimental-lockfile`/`--experimental-frozen-lockfile` are deprecated and warn. `--no-lockfile` conflicts with the others.

**Pinning**: when a lockfile entry exists, the OCI manifest is fetched by the locked digest (not the tag) and verified — a digest mismatch is a hard error.

**`cella upgrade`**: re-resolves all features fresh (no pinning) to the latest versions allowed by the devcontainer.json refs and rewrites the lockfile. `--dry-run` prints the regenerated lockfile to stdout without touching disk. No Docker daemon required.

Verified live against `ghcr.io/devcontainers/features/git:1`: `upgrade --dry-run` prints the resolved digest and writes nothing; `upgrade` writes the lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)