### PR TITLE
fix: apply top-level and feature init to the container

### DIFF
--- a/crates/cella-backend/src/types.rs
+++ b/crates/cella-backend/src/types.rs
@@ -508,6 +508,9 @@ pub struct CreateContainerOptions {
     pub cap_add: Vec<String>,
     pub security_opt: Vec<String>,
     pub privileged: bool,
+    /// Wrap the container entrypoint with an init process (`init: true` in
+    /// devcontainer.json or a feature). OR'd with `runArgs: ["--init"]`.
+    pub init: bool,
     /// Parsed `runArgs` overrides from devcontainer.json.
     pub run_args_overrides: Option<RunArgsOverrides>,
     /// GPU request from `hostRequirements.gpu` (lower precedence than runArgs `--gpus`).

--- a/crates/cella-config/src/config_map/mod.rs
+++ b/crates/cella-config/src/config_map/mod.rs
@@ -110,6 +110,12 @@ pub fn map_config<S: std::hash::BuildHasher>(
         .unwrap_or(false)
         || feature_config.is_some_and(|fc| fc.privileged);
 
+    let init = config
+        .get("init")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+        || feature_config.is_some_and(|fc| fc.init);
+
     let gpu_request = map_gpu_device_request(config);
     let run_args_overrides = parse_run_args_from_config(config);
 
@@ -129,6 +135,7 @@ pub fn map_config<S: std::hash::BuildHasher>(
         cap_add,
         security_opt,
         privileged,
+        init,
         run_args_overrides,
         gpu_request,
     }
@@ -583,6 +590,31 @@ mod tests {
         assert!(cmd[1].contains("/usr/local/share/docker-init.sh"));
         assert!(cmd[1].contains("while sleep 1 & wait $!; do :; done"));
         assert_eq!(cmd[2], "-");
+    }
+
+    #[test]
+    fn map_config_init_from_top_level() {
+        let config = json!({ "image": "ubuntu", "init": true });
+        let opts = test_map_config(&config, None, &[]);
+        assert!(opts.init);
+    }
+
+    #[test]
+    fn map_config_init_from_feature() {
+        let config = json!({ "image": "ubuntu" });
+        let feature_config = FeatureContainerConfig {
+            init: true,
+            ..Default::default()
+        };
+        let opts = test_map_config(&config, Some(&feature_config), &[]);
+        assert!(opts.init);
+    }
+
+    #[test]
+    fn map_config_init_defaults_false() {
+        let config = json!({ "image": "ubuntu" });
+        let opts = test_map_config(&config, None, &[]);
+        assert!(!opts.init);
     }
 
     #[test]

--- a/crates/cella-container/src/backend.rs
+++ b/crates/cella-container/src/backend.rs
@@ -1400,6 +1400,7 @@ mod tests {
             cap_add: Vec::new(),
             security_opt: Vec::new(),
             privileged: false,
+            init: false,
             run_args_overrides: None,
             gpu_request: None,
         }

--- a/crates/cella-container/src/backend.rs
+++ b/crates/cella-container/src/backend.rs
@@ -1034,6 +1034,17 @@ fn build_create_args(opts: &CreateContainerOptions, networks: &[String]) -> Vec<
         args.push(cap.clone());
     }
 
+    // init: OR top-level/feature flag with runArgs --init so either source
+    // enables the tini/init process wrapper.
+    let run_args_init = opts
+        .run_args_overrides
+        .as_ref()
+        .and_then(|o| o.init)
+        .unwrap_or(false);
+    if opts.init || run_args_init {
+        args.push("--init".to_string());
+    }
+
     // runArgs overrides with native CLI equivalents.
     if let Some(ref overrides) = opts.run_args_overrides {
         push_override_args(&mut args, overrides);
@@ -1083,10 +1094,6 @@ fn push_override_args(args: &mut Vec<String>, overrides: &RunArgsOverrides) {
     {
         args.push("--shm-size".to_string());
         args.push(shm_size.to_string());
-    }
-
-    if overrides.init == Some(true) {
-        args.push("--init".to_string());
     }
 
     for ip in &overrides.dns {
@@ -1797,11 +1804,12 @@ mod tests {
 
     #[test]
     fn push_override_args_maps_resources() {
+        // init is handled at the build_create_args level (not here), so it is
+        // intentionally absent from this overrides set.
         let overrides = RunArgsOverrides {
             memory: Some(2_147_483_648),
             nano_cpus: Some(1_500_000_000),
             shm_size: Some(67_108_864),
-            init: Some(true),
             ..RunArgsOverrides::default()
         };
         let mut args = Vec::new();
@@ -1815,7 +1823,53 @@ mod tests {
         // 1.5 CPUs rounds up to 2 whole vCPUs.
         assert!(pairs.contains(&("--cpus", "2")));
         assert!(pairs.contains(&("--shm-size", "67108864")));
+        assert!(
+            !args.contains(&"--init".to_string()),
+            "--init must not appear here; it is OR-d and emitted in build_create_args"
+        );
+    }
+
+    #[test]
+    fn build_create_args_init_from_opts() {
+        // opts.init = true should emit --init even with no runArgs.
+        let mut opts = minimal_create_opts();
+        opts.init = true;
+        let args = build_create_args(&opts, &[]);
         assert!(args.contains(&"--init".to_string()));
+    }
+
+    #[test]
+    fn build_create_args_init_from_run_args() {
+        // runArgs --init alone should emit --init when opts.init is false.
+        let mut opts = minimal_create_opts();
+        opts.init = false;
+        opts.run_args_overrides = Some(RunArgsOverrides {
+            init: Some(true),
+            ..RunArgsOverrides::default()
+        });
+        let args = build_create_args(&opts, &[]);
+        assert!(args.contains(&"--init".to_string()));
+    }
+
+    #[test]
+    fn build_create_args_init_no_duplicate() {
+        // Both opts.init and runArgs init = true must not produce two --init flags.
+        let mut opts = minimal_create_opts();
+        opts.init = true;
+        opts.run_args_overrides = Some(RunArgsOverrides {
+            init: Some(true),
+            ..RunArgsOverrides::default()
+        });
+        let args = build_create_args(&opts, &[]);
+        let count = args.iter().filter(|a| a.as_str() == "--init").count();
+        assert_eq!(count, 1, "--init should appear exactly once");
+    }
+
+    #[test]
+    fn build_create_args_init_off_by_default() {
+        let opts = minimal_create_opts();
+        let args = build_create_args(&opts, &[]);
+        assert!(!args.contains(&"--init".to_string()));
     }
 
     #[test]

--- a/crates/cella-container/src/integration_tests.rs
+++ b/crates/cella-container/src/integration_tests.rs
@@ -81,6 +81,7 @@ fn minimal_create_opts(name: &str) -> CreateContainerOptions {
         cap_add: Vec::new(),
         security_opt: Vec::new(),
         privileged: false,
+        init: false,
         run_args_overrides: None,
         gpu_request: None,
     }

--- a/crates/cella-docker/src/config_map/mod.rs
+++ b/crates/cella-docker/src/config_map/mod.rs
@@ -17,6 +17,7 @@ struct MergedOverrides {
     cap_add: Vec<String>,
     security_opt: Vec<String>,
     privileged: bool,
+    init: bool,
 }
 
 /// Convert `CreateContainerOptions` (from `cella-backend`) to a bollard
@@ -41,6 +42,7 @@ pub fn to_bollard_config(opts: &CreateContainerOptions) -> ContainerCreateBody {
         Some(merged.security_opt)
     };
     host_config.privileged = Some(merged.privileged);
+    host_config.init = Some(merged.init);
 
     ContainerCreateBody {
         image: Some(opts.image.clone()),
@@ -118,6 +120,7 @@ fn apply_overrides(opts: &CreateContainerOptions, host_config: &mut HostConfig) 
     let mut extra_hosts = vec!["host.docker.internal:host-gateway".to_string()];
     let mut security_opt = opts.security_opt.clone();
     let mut privileged = opts.privileged;
+    let mut init = opts.init;
     let cap_add = opts.cap_add.clone();
     let mut labels = opts.labels.clone();
     let mut hostname = None;
@@ -128,6 +131,9 @@ fn apply_overrides(opts: &CreateContainerOptions, host_config: &mut HostConfig) 
         security_opt.extend(ra.security_opt.clone());
         if let Some(p) = ra.privileged {
             privileged = p || privileged;
+        }
+        if let Some(i) = ra.init {
+            init = i || init;
         }
         for (k, v) in &ra.labels {
             labels.insert(k.clone(), v.clone());
@@ -162,6 +168,7 @@ fn apply_overrides(opts: &CreateContainerOptions, host_config: &mut HostConfig) 
         cap_add,
         security_opt,
         privileged,
+        init,
     }
 }
 
@@ -346,9 +353,8 @@ fn apply_misc_overrides(hc: &mut HostConfig, ra: &RunArgsOverrides) {
             maximum_retry_count: max,
         });
     }
-    if let Some(v) = ra.init {
-        hc.init = Some(v);
-    }
+    // `init` is OR'd with the top-level/feature `init` in `apply_overrides`
+    // and applied to `host_config.init` there.
 }
 
 /// Convert a `GpuRequest` to a bollard `DeviceRequest`.
@@ -437,6 +443,7 @@ mod tests {
             cap_add: Vec::new(),
             security_opt: Vec::new(),
             privileged: false,
+            init: false,
             run_args_overrides: None,
             gpu_request: None,
         };
@@ -481,6 +488,7 @@ mod tests {
             cap_add: Vec::new(),
             security_opt: Vec::new(),
             privileged: false,
+            init: false,
             run_args_overrides: None,
             gpu_request: None,
         };
@@ -511,6 +519,7 @@ mod tests {
             cap_add: Vec::new(),
             security_opt: Vec::new(),
             privileged: false,
+            init: false,
             run_args_overrides: None,
             gpu_request: None,
         };
@@ -537,6 +546,7 @@ mod tests {
             cap_add: Vec::new(),
             security_opt: Vec::new(),
             privileged: false,
+            init: false,
             run_args_overrides: None,
             gpu_request: None,
         }
@@ -803,6 +813,35 @@ mod tests {
         let config = to_bollard_config(&opts);
         let hc = config.host_config.unwrap();
         assert_eq!(hc.privileged, Some(true));
+    }
+
+    #[test]
+    fn init_flag_reaches_host_config() {
+        // Top-level/feature `init: true` (CreateContainerOptions.init) must
+        // reach host_config.init even with no runArgs --init.
+        let mut opts = minimal_opts();
+        opts.init = true;
+        let config = to_bollard_config(&opts);
+        assert_eq!(config.host_config.unwrap().init, Some(true));
+    }
+
+    #[test]
+    fn init_defaults_off() {
+        let config = to_bollard_config(&minimal_opts());
+        assert_eq!(config.host_config.unwrap().init, Some(false));
+    }
+
+    #[test]
+    fn run_args_init_or_with_base() {
+        // runArgs --init alone enables init even when the base opts.init is false.
+        let mut opts = minimal_opts();
+        opts.init = false;
+        opts.run_args_overrides = Some(RunArgsOverrides {
+            init: Some(true),
+            ..Default::default()
+        });
+        let config = to_bollard_config(&opts);
+        assert_eq!(config.host_config.unwrap().init, Some(true));
     }
 
     #[test]

--- a/crates/cella-docker/src/integration_tests/claude_seed_tests.rs
+++ b/crates/cella-docker/src/integration_tests/claude_seed_tests.rs
@@ -34,6 +34,7 @@ fn minimal_opts(name: &str) -> CreateContainerOptions {
         cap_add: Vec::new(),
         security_opt: Vec::new(),
         privileged: false,
+        init: false,
         run_args_overrides: None,
         gpu_request: None,
     }


### PR DESCRIPTION
`"init": true` in devcontainer.json (and a feature's merged `init`) was parsed into the feature container config but never reached container creation — only `runArgs: ["--init"]` actually wrapped the entrypoint with an init process. So configs relying on the documented top-level `init` property silently ran without one.

Fix mirrors how `privileged` is already handled: a new `init` field on `CreateContainerOptions`, populated from the top-level property OR the feature config, applied to `host_config.init` and OR'd with the `runArgs --init` source. Centralizing it in `apply_overrides` (instead of the runArgs helper) keeps a single OR point.

Impact: Docker-in-Docker and debugger setups (which pair `init: true` with `capAdd: ["SYS_PTRACE"]`) now get the init process they expect.

Tests: top-level `init`, feature `init`, runArgs `--init`, and the default-off case all assert `host_config.init`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)