### PR TITLE
feat: parse devcontainer.json secrets property

### DIFF
--- a/crates/cella-config/src/devcontainer/mod.rs
+++ b/crates/cella-config/src/devcontainer/mod.rs
@@ -4,7 +4,9 @@ mod error;
 pub mod merge;
 pub mod parse;
 pub mod resolve;
+pub mod secrets;
 pub mod span;
 pub mod subst;
 
 pub use error::CellaConfigError;
+pub use secrets::SecretDeclaration;

--- a/crates/cella-config/src/devcontainer/resolve.rs
+++ b/crates/cella-config/src/devcontainer/resolve.rs
@@ -78,6 +78,28 @@ impl ResolvedConfig {
     pub fn host_requirements(&self) -> Option<&crate::schema::DevContainerCommonHostRequirements> {
         self.typed.as_ref().and_then(|t| t.host_requirements())
     }
+
+    /// Returns the declared secrets from the top-level `secrets` property.
+    ///
+    /// Each entry names an environment variable that the container expects to
+    /// have set, along with optional documentation metadata. These are
+    /// advisory — they do not inject values. Use `--secrets-file` for
+    /// value injection.
+    ///
+    /// Returns `None` when the config has no `secrets` key, or an empty map
+    /// when the key is present but empty.
+    #[must_use]
+    pub fn secrets(
+        &self,
+    ) -> Option<std::collections::HashMap<String, super::secrets::SecretDeclaration>> {
+        let raw_map = self.typed.as_ref()?.secrets()?;
+        Some(
+            raw_map
+                .iter()
+                .map(|(k, v)| (k.clone(), super::secrets::SecretDeclaration::from_value(v)))
+                .collect(),
+        )
+    }
 }
 
 /// Compute the spec-compliant `devcontainerId`.
@@ -688,5 +710,86 @@ mod tests {
         create_devcontainer(tmp.path(), r#"{"image": "ubuntu", "unknownField": true}"#);
         let resolved = config(tmp.path(), None).unwrap();
         assert!(resolved.typed.is_some());
+    }
+
+    #[test]
+    fn secrets_returns_none_when_absent() {
+        let tmp = TempDir::new().unwrap();
+        create_devcontainer(tmp.path(), r#"{"image": "ubuntu"}"#);
+        let resolved = config(tmp.path(), None).unwrap();
+        assert!(resolved.secrets().is_none());
+    }
+
+    #[test]
+    fn secrets_parses_full_declaration() {
+        let tmp = TempDir::new().unwrap();
+        create_devcontainer(
+            tmp.path(),
+            r#"{
+                "image": "ubuntu",
+                "secrets": {
+                    "GITHUB_TOKEN": {
+                        "description": "GitHub personal access token",
+                        "documentationUrl": "https://docs.github.com/en/authentication"
+                    }
+                }
+            }"#,
+        );
+        let resolved = config(tmp.path(), None).unwrap();
+        let secrets = resolved.secrets().expect("secrets should be present");
+        assert_eq!(secrets.len(), 1);
+        let decl = secrets
+            .get("GITHUB_TOKEN")
+            .expect("GITHUB_TOKEN should exist");
+        assert_eq!(
+            decl.description.as_deref(),
+            Some("GitHub personal access token")
+        );
+        assert_eq!(
+            decl.documentation_url.as_deref(),
+            Some("https://docs.github.com/en/authentication")
+        );
+    }
+
+    #[test]
+    fn secrets_parses_declaration_without_optional_fields() {
+        let tmp = TempDir::new().unwrap();
+        create_devcontainer(
+            tmp.path(),
+            r#"{
+                "image": "ubuntu",
+                "secrets": {
+                    "API_KEY": {}
+                }
+            }"#,
+        );
+        let resolved = config(tmp.path(), None).unwrap();
+        let secrets = resolved.secrets().expect("secrets should be present");
+        assert_eq!(secrets.len(), 1);
+        let decl = secrets.get("API_KEY").expect("API_KEY should exist");
+        assert!(decl.description.is_none());
+        assert!(decl.documentation_url.is_none());
+    }
+
+    #[test]
+    fn secrets_parses_multiple_declarations() {
+        let tmp = TempDir::new().unwrap();
+        create_devcontainer(
+            tmp.path(),
+            r#"{
+                "image": "ubuntu",
+                "secrets": {
+                    "GITHUB_TOKEN": { "description": "GitHub token" },
+                    "NPM_TOKEN": { "description": "npm registry token" },
+                    "DB_PASSWORD": {}
+                }
+            }"#,
+        );
+        let resolved = config(tmp.path(), None).unwrap();
+        let secrets = resolved.secrets().expect("secrets should be present");
+        assert_eq!(secrets.len(), 3);
+        assert!(secrets.contains_key("GITHUB_TOKEN"));
+        assert!(secrets.contains_key("NPM_TOKEN"));
+        assert!(secrets.contains_key("DB_PASSWORD"));
     }
 }

--- a/crates/cella-config/src/devcontainer/resolve.rs
+++ b/crates/cella-config/src/devcontainer/resolve.rs
@@ -96,7 +96,12 @@ impl ResolvedConfig {
         Some(
             raw_map
                 .iter()
-                .map(|(k, v)| (k.clone(), super::secrets::SecretDeclaration::from_value(v)))
+                // filter_map drops entries whose value does not conform to the schema
+                // (non-object or known field with wrong type). Valid but empty objects
+                // {} are retained as SecretDeclaration { description: None, documentation_url: None }.
+                .filter_map(|(k, v)| {
+                    super::secrets::SecretDeclaration::from_value(v).map(|decl| (k.clone(), decl))
+                })
                 .collect(),
         )
     }
@@ -790,6 +795,31 @@ mod tests {
         assert_eq!(secrets.len(), 3);
         assert!(secrets.contains_key("GITHUB_TOKEN"));
         assert!(secrets.contains_key("NPM_TOKEN"));
+        assert!(secrets.contains_key("GITHUB_TOKEN"));
+        assert!(secrets.contains_key("NPM_TOKEN"));
         assert!(secrets.contains_key("DB_PASSWORD"));
+    }
+
+    // Regression: secret entries with a non-object value (e.g. a plain string)
+    // must be silently dropped rather than coerced into an empty declaration.
+    #[test]
+    fn secrets_skips_malformed_non_object_entries() {
+        let tmp = TempDir::new().unwrap();
+        create_devcontainer(
+            tmp.path(),
+            r#"{
+                "image": "ubuntu",
+                "secrets": {
+                    "VALID_TOKEN": { "description": "A valid secret" },
+                    "BAD_TOKEN": "plain-string-not-allowed"
+                }
+            }"#,
+        );
+        let resolved = config(tmp.path(), None).unwrap();
+        let secrets = resolved.secrets().expect("secrets key is present");
+        // Only the valid entry survives; the malformed one is dropped.
+        assert_eq!(secrets.len(), 1);
+        assert!(secrets.contains_key("VALID_TOKEN"));
+        assert!(!secrets.contains_key("BAD_TOKEN"));
     }
 }

--- a/crates/cella-config/src/devcontainer/secrets.rs
+++ b/crates/cella-config/src/devcontainer/secrets.rs
@@ -17,23 +17,33 @@ pub struct SecretDeclaration {
 impl SecretDeclaration {
     /// Parse a `SecretDeclaration` from a `serde_json::Value`.
     ///
-    /// The value must be a JSON object. Unknown fields are ignored to match
-    /// the `additionalProperties: false` schema (which only has `description`
-    /// and `documentationUrl`).
+    /// Returns `Some` when `value` is a JSON object whose `description` and
+    /// `documentationUrl` fields, if present, are strings. Returns `None` when
+    /// the value is not an object or any known field has the wrong type —
+    /// callers should treat such entries as malformed and skip them.
+    ///
+    /// Unknown fields are silently ignored for forward compatibility.
     #[must_use]
-    pub fn from_value(value: &serde_json::Value) -> Self {
-        let description = value
-            .get("description")
-            .and_then(|v| v.as_str())
-            .map(str::to_owned);
-        let documentation_url = value
-            .get("documentationUrl")
-            .and_then(|v| v.as_str())
-            .map(str::to_owned);
-        Self {
+    pub fn from_value(value: &serde_json::Value) -> Option<Self> {
+        // The schema requires each secret entry to be a JSON object.
+        if !value.is_object() {
+            return None;
+        }
+
+        // If a known field is present but has the wrong type, reject the entry.
+        let description = match value.get("description") {
+            Some(v) => Some(v.as_str().map(str::to_owned)?),
+            None => None,
+        };
+        let documentation_url = match value.get("documentationUrl") {
+            Some(v) => Some(v.as_str().map(str::to_owned)?),
+            None => None,
+        };
+
+        Some(Self {
             description,
             documentation_url,
-        }
+        })
     }
 }
 
@@ -47,7 +57,7 @@ mod tests {
             "description": "GitHub token for API access",
             "documentationUrl": "https://docs.github.com/en/authentication"
         });
-        let decl = SecretDeclaration::from_value(&value);
+        let decl = SecretDeclaration::from_value(&value).expect("valid object");
         assert_eq!(
             decl.description.as_deref(),
             Some("GitHub token for API access")
@@ -61,7 +71,7 @@ mod tests {
     #[test]
     fn parse_description_only() {
         let value = serde_json::json!({ "description": "An API key" });
-        let decl = SecretDeclaration::from_value(&value);
+        let decl = SecretDeclaration::from_value(&value).expect("valid object");
         assert_eq!(decl.description.as_deref(), Some("An API key"));
         assert!(decl.documentation_url.is_none());
     }
@@ -69,7 +79,7 @@ mod tests {
     #[test]
     fn parse_documentation_url_only() {
         let value = serde_json::json!({ "documentationUrl": "https://example.com/secret" });
-        let decl = SecretDeclaration::from_value(&value);
+        let decl = SecretDeclaration::from_value(&value).expect("valid object");
         assert!(decl.description.is_none());
         assert_eq!(
             decl.documentation_url.as_deref(),
@@ -80,7 +90,7 @@ mod tests {
     #[test]
     fn parse_empty_object() {
         let value = serde_json::json!({});
-        let decl = SecretDeclaration::from_value(&value);
+        let decl = SecretDeclaration::from_value(&value).expect("valid object");
         assert!(decl.description.is_none());
         assert!(decl.documentation_url.is_none());
     }
@@ -91,7 +101,55 @@ mod tests {
             "description": "A secret",
             "unknownField": true
         });
-        let decl = SecretDeclaration::from_value(&value);
+        let decl = SecretDeclaration::from_value(&value).expect("valid object");
         assert_eq!(decl.description.as_deref(), Some("A secret"));
+    }
+
+    // Regression: malformed entries (non-object value) must be rejected, not
+    // silently coerced into an empty SecretDeclaration.
+    #[test]
+    fn rejects_string_value() {
+        let value = serde_json::json!("abc");
+        assert!(SecretDeclaration::from_value(&value).is_none());
+    }
+
+    #[test]
+    fn rejects_integer_value() {
+        let value = serde_json::json!(42);
+        assert!(SecretDeclaration::from_value(&value).is_none());
+    }
+
+    #[test]
+    fn rejects_boolean_value() {
+        let value = serde_json::json!(true);
+        assert!(SecretDeclaration::from_value(&value).is_none());
+    }
+
+    #[test]
+    fn rejects_array_value() {
+        let value = serde_json::json!(["a", "b"]);
+        assert!(SecretDeclaration::from_value(&value).is_none());
+    }
+
+    // Regression: a typo like `documentationURL` (wrong case) is unknown and
+    // ignored; the known field `documentationUrl` stays None.
+    #[test]
+    fn ignores_typo_field_name() {
+        let value = serde_json::json!({ "documentationURL": "https://example.com" });
+        let decl = SecretDeclaration::from_value(&value).expect("valid object");
+        assert!(decl.documentation_url.is_none());
+    }
+
+    // Regression: known field present with wrong type must be rejected.
+    #[test]
+    fn rejects_non_string_description() {
+        let value = serde_json::json!({ "description": 123 });
+        assert!(SecretDeclaration::from_value(&value).is_none());
+    }
+
+    #[test]
+    fn rejects_non_string_documentation_url() {
+        let value = serde_json::json!({ "documentationUrl": true });
+        assert!(SecretDeclaration::from_value(&value).is_none());
     }
 }

--- a/crates/cella-config/src/devcontainer/secrets.rs
+++ b/crates/cella-config/src/devcontainer/secrets.rs
@@ -1,0 +1,97 @@
+/// A declared secret entry from the top-level `secrets` property in devcontainer.json.
+///
+/// Per the devcontainer spec, `secrets` is advisory metadata — it documents
+/// what environment variables a container expects to have set, but does not
+/// provide or inject their values. Value injection is handled separately via
+/// the `--secrets-file` CLI flag.
+///
+/// Reference: <https://containers.dev/implementors/json_reference/#general-properties>
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SecretDeclaration {
+    /// A human-readable description of what this secret is for.
+    pub description: Option<String>,
+    /// A URL to documentation about the secret.
+    pub documentation_url: Option<String>,
+}
+
+impl SecretDeclaration {
+    /// Parse a `SecretDeclaration` from a `serde_json::Value`.
+    ///
+    /// The value must be a JSON object. Unknown fields are ignored to match
+    /// the `additionalProperties: false` schema (which only has `description`
+    /// and `documentationUrl`).
+    #[must_use]
+    pub fn from_value(value: &serde_json::Value) -> Self {
+        let description = value
+            .get("description")
+            .and_then(|v| v.as_str())
+            .map(str::to_owned);
+        let documentation_url = value
+            .get("documentationUrl")
+            .and_then(|v| v.as_str())
+            .map(str::to_owned);
+        Self {
+            description,
+            documentation_url,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_full_declaration() {
+        let value = serde_json::json!({
+            "description": "GitHub token for API access",
+            "documentationUrl": "https://docs.github.com/en/authentication"
+        });
+        let decl = SecretDeclaration::from_value(&value);
+        assert_eq!(
+            decl.description.as_deref(),
+            Some("GitHub token for API access")
+        );
+        assert_eq!(
+            decl.documentation_url.as_deref(),
+            Some("https://docs.github.com/en/authentication")
+        );
+    }
+
+    #[test]
+    fn parse_description_only() {
+        let value = serde_json::json!({ "description": "An API key" });
+        let decl = SecretDeclaration::from_value(&value);
+        assert_eq!(decl.description.as_deref(), Some("An API key"));
+        assert!(decl.documentation_url.is_none());
+    }
+
+    #[test]
+    fn parse_documentation_url_only() {
+        let value = serde_json::json!({ "documentationUrl": "https://example.com/secret" });
+        let decl = SecretDeclaration::from_value(&value);
+        assert!(decl.description.is_none());
+        assert_eq!(
+            decl.documentation_url.as_deref(),
+            Some("https://example.com/secret")
+        );
+    }
+
+    #[test]
+    fn parse_empty_object() {
+        let value = serde_json::json!({});
+        let decl = SecretDeclaration::from_value(&value);
+        assert!(decl.description.is_none());
+        assert!(decl.documentation_url.is_none());
+    }
+
+    #[test]
+    fn parse_ignores_unknown_fields() {
+        let value = serde_json::json!({
+            "description": "A secret",
+            "unknownField": true
+        });
+        let decl = SecretDeclaration::from_value(&value);
+        assert_eq!(decl.description.as_deref(), Some("A secret"));
+    }
+}


### PR DESCRIPTION
Recognizes the top-level `secrets` property in devcontainer.json. Per the spec it's advisory metadata — `{ "<NAME>": { "description"?, "documentationUrl"? } }` documenting which env vars a container expects — and the official CLI never injects values from it (value injection and log redaction come from `--secrets-file`, which cella already implements). I confirmed this against the official source: `maskSecrets` operates on the `--secrets-file` value map, not the declaration.

So this is the spec-faithful scope: a typed `SecretDeclaration` model plus a `ResolvedConfig::secrets()` accessor over the codegen-generated schema field, so the property is recognized and surfaced rather than unmodeled. No invented value-injection behavior.

Tests cover parsing with/without the optional fields, the absent case, and multiple declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)