### PR TITLE
feat: regex and host:port keys in portsAttributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,6 +713,7 @@ dependencies = [
 name = "cella-protocol"
 version = "0.4.0"
 dependencies = [
+ "regex",
  "serde",
  "serde_json",
 ]

--- a/crates/cella-config/src/config_map/ports.rs
+++ b/crates/cella-config/src/config_map/ports.rs
@@ -249,7 +249,7 @@ pub fn parse_other_ports_attributes(config: &serde_json::Value) -> Option<PortAt
 /// Parse a single port key + attributes object.
 fn parse_single_port_attributes(key: &str, value: &serde_json::Value) -> Option<PortAttributes> {
     let obj = value.as_object()?;
-    let port = parse_port_pattern(key)?;
+    let port = parse_port_pattern(key);
 
     let on_auto_forward = obj
         .get("onAutoForward")
@@ -284,20 +284,67 @@ fn parse_single_port_attributes(key: &str, value: &serde_json::Value) -> Option<
     })
 }
 
+/// VS Code `HOST_AND_PORT` pattern: `^([a-z0-9-]+):(\d{1,5})$`.
+///
+/// Matches `"db:5432"`, `"localhost:3000"`, etc.
+/// Only lowercase host names are accepted, matching the devcontainer schema.
+fn is_host_port(key: &str) -> Option<(String, u16)> {
+    let (host, port_str) = key.split_once(':')?;
+    // host must be non-empty and match [a-z0-9-]+
+    if host.is_empty() || port_str.is_empty() || port_str.len() > 5 {
+        return None;
+    }
+    if !host
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    {
+        return None;
+    }
+    if !port_str.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    let port: u16 = port_str.parse().ok()?;
+    Some((host.to_string(), port))
+}
+
 /// Parse a port key into a `PortPattern`.
 ///
 /// Supports:
-/// - `"3000"` -> Single(3000)
-/// - `"3000-3010"` -> Range(3000, 3010)
-fn parse_port_pattern(key: &str) -> Option<PortPattern> {
-    if let Some((start, end)) = key.split_once('-') {
-        let start: u16 = start.trim().parse().ok()?;
-        let end: u16 = end.trim().parse().ok()?;
-        Some(PortPattern::Range(start, end))
-    } else {
-        let port: u16 = key.trim().parse().ok()?;
-        Some(PortPattern::Single(port))
+/// - `"3000"` → `Single(3000)`
+/// - `"3000-3010"` → `Range(3000, 3010)`
+/// - `"db:5432"` / `"localhost:3000"` → `HostPort { host, port }`
+/// - any other string → `Regex(key)` (invalid regex becomes a never-matching entry)
+///
+/// Always succeeds: an unrecognized key falls through to `Regex`.
+fn parse_port_pattern(key: &str) -> PortPattern {
+    // Bare port number?
+    if let Ok(port) = key.trim().parse::<u16>() {
+        return PortPattern::Single(port);
     }
+
+    // Range "N-N"?  Only if both sides are pure digits after trimming (avoids
+    // treating regex alternation like "3000|4000" as a failed range).
+    if let Some((start_str, end_str)) = key.split_once('-') {
+        let start_trimmed = start_str.trim();
+        let end_trimmed = end_str.trim();
+        if start_trimmed.chars().all(|c| c.is_ascii_digit())
+            && end_trimmed.chars().all(|c| c.is_ascii_digit())
+        {
+            if let (Ok(start), Ok(end)) = (start_trimmed.parse::<u16>(), end_trimmed.parse::<u16>())
+            {
+                return PortPattern::Range(start, end);
+            }
+        }
+    }
+
+    // Host:port?
+    if let Some((host, port)) = is_host_port(key) {
+        return PortPattern::HostPort { host, port };
+    }
+
+    // Treat as regex.  Even an invalid pattern is kept — the Regex variant
+    // always returns false from matches(), never panics.
+    PortPattern::Regex(key.to_string())
 }
 
 /// Parse `onAutoForward` string value to enum.
@@ -364,19 +411,61 @@ mod tests {
 
     #[test]
     fn parse_single_port() {
-        let pattern = parse_port_pattern("3000").unwrap();
+        let pattern = parse_port_pattern("3000");
         assert_eq!(pattern, PortPattern::Single(3000));
     }
 
     #[test]
     fn parse_range_port() {
-        let pattern = parse_port_pattern("3000-3010").unwrap();
+        let pattern = parse_port_pattern("3000-3010");
         assert_eq!(pattern, PortPattern::Range(3000, 3010));
     }
 
     #[test]
-    fn parse_invalid_port() {
-        assert!(parse_port_pattern("abc").is_none());
+    fn parse_unknown_key_becomes_regex() {
+        // Previously-dropped keys are now Regex variants.
+        let pattern = parse_port_pattern("abc");
+        assert!(matches!(pattern, PortPattern::Regex(_)));
+    }
+
+    #[test]
+    fn parse_host_port_key() {
+        let pattern = parse_port_pattern("db:5432");
+        assert_eq!(
+            pattern,
+            PortPattern::HostPort {
+                host: "db".to_string(),
+                port: 5432
+            }
+        );
+    }
+
+    #[test]
+    fn parse_localhost_host_port_key() {
+        let pattern = parse_port_pattern("localhost:3000");
+        assert_eq!(
+            pattern,
+            PortPattern::HostPort {
+                host: "localhost".to_string(),
+                port: 3000
+            }
+        );
+    }
+
+    #[test]
+    fn parse_regex_key() {
+        let pattern = parse_port_pattern("^30\\d\\d$");
+        assert!(matches!(pattern, PortPattern::Regex(_)));
+    }
+
+    // regression: uppercase host name must NOT be parsed as HostPort (spec: [a-z0-9-]+)
+    #[test]
+    fn uppercase_host_falls_through_to_regex() {
+        let pattern = parse_port_pattern("DB:5432");
+        assert!(
+            matches!(pattern, PortPattern::Regex(_)),
+            "uppercase host names are not valid per spec and must fall through to Regex"
+        );
     }
 
     #[test]
@@ -704,6 +793,116 @@ mod tests {
         assert_eq!(
             bindings["3000/tcp"][0].host_ip.as_deref(),
             Some("127.0.0.1")
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Regex key tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn regex_key_matches_in_range() {
+        // "^30\d\d$" should match 3000–3099 but not 4000 or 30000
+        let p = PortPattern::Regex(r"^30\d\d$".to_string());
+        assert!(p.matches(3000));
+        assert!(p.matches(3099));
+        assert!(!p.matches(4000));
+        assert!(!p.matches(30_000));
+    }
+
+    #[test]
+    fn regex_key_plain_single_still_single() {
+        let p = parse_port_pattern("3000");
+        assert_eq!(p, PortPattern::Single(3000));
+        assert!(p.matches(3000));
+        assert!(!p.matches(3001));
+    }
+
+    #[test]
+    fn regex_key_range_still_range() {
+        let p = parse_port_pattern("3000-3010");
+        assert_eq!(p, PortPattern::Range(3000, 3010));
+        assert!(p.matches(3000));
+        assert!(p.matches(3010));
+        assert!(!p.matches(3011));
+    }
+
+    #[test]
+    fn host_port_key_matches_port_only() {
+        let p = parse_port_pattern("db:5432");
+        assert!(p.matches(5432));
+        assert!(!p.matches(5433));
+    }
+
+    #[test]
+    fn invalid_regex_never_matches_no_panic() {
+        // A syntactically invalid regex pattern must not panic, just never match.
+        let p = PortPattern::Regex("[invalid".to_string());
+        assert!(!p.matches(3000));
+        assert!(!p.matches(0));
+    }
+
+    #[test]
+    fn regex_serde_roundtrip() {
+        let attrs = vec![PortAttributes {
+            port: PortPattern::Regex(r"^30\d\d$".to_string()),
+            on_auto_forward: OnAutoForward::Silent,
+            ..PortAttributes::default()
+        }];
+        let label = serialize_ports_attributes_label(&attrs, None);
+        let (deserialized, _) = deserialize_ports_attributes_label(&label);
+        assert_eq!(deserialized.len(), 1);
+        assert!(matches!(&deserialized[0].port, PortPattern::Regex(p) if p == r"^30\d\d$"));
+        // And it still matches correctly after round-trip
+        assert!(deserialized[0].port.matches(3000));
+        assert!(!deserialized[0].port.matches(4000));
+    }
+
+    #[test]
+    fn host_port_serde_roundtrip() {
+        let attrs = vec![PortAttributes {
+            port: PortPattern::HostPort {
+                host: "db".to_string(),
+                port: 5432,
+            },
+            on_auto_forward: OnAutoForward::Ignore,
+            ..PortAttributes::default()
+        }];
+        let label = serialize_ports_attributes_label(&attrs, None);
+        let (deserialized, _) = deserialize_ports_attributes_label(&label);
+        assert_eq!(deserialized.len(), 1);
+        assert!(matches!(
+            &deserialized[0].port,
+            PortPattern::HostPort { host, port: 5432 } if host == "db"
+        ));
+    }
+
+    #[test]
+    fn regex_keys_in_ports_attributes_not_dropped() {
+        let config = json!({
+            "portsAttributes": {
+                "3000": {"onAutoForward": "silent"},
+                "^30\\d\\d$": {"onAutoForward": "ignore"},
+                "db:5432": {"onAutoForward": "notify"},
+            }
+        });
+        let attrs = parse_ports_attributes(&config);
+        // All three keys must survive — previously the regex and host:port were silently dropped
+        assert_eq!(attrs.len(), 3);
+        assert!(
+            attrs
+                .iter()
+                .any(|a| matches!(a.port, PortPattern::Single(3000)))
+        );
+        assert!(
+            attrs
+                .iter()
+                .any(|a| matches!(&a.port, PortPattern::Regex(_)))
+        );
+        assert!(
+            attrs
+                .iter()
+                .any(|a| matches!(&a.port, PortPattern::HostPort { .. }))
         );
     }
 }

--- a/crates/cella-config/src/config_map/ports.rs
+++ b/crates/cella-config/src/config_map/ports.rs
@@ -324,17 +324,14 @@ fn parse_port_pattern(key: &str) -> PortPattern {
 
     // Range "N-N"?  Only if both sides are pure digits after trimming (avoids
     // treating regex alternation like "3000|4000" as a failed range).
-    if let Some((start_str, end_str)) = key.split_once('-') {
-        let start_trimmed = start_str.trim();
-        let end_trimmed = end_str.trim();
-        if start_trimmed.chars().all(|c| c.is_ascii_digit())
-            && end_trimmed.chars().all(|c| c.is_ascii_digit())
-        {
-            if let (Ok(start), Ok(end)) = (start_trimmed.parse::<u16>(), end_trimmed.parse::<u16>())
-            {
-                return PortPattern::Range(start, end);
-            }
-        }
+    if let Some((start_str, end_str)) = key.split_once('-')
+        && let start_trimmed = start_str.trim()
+        && let end_trimmed = end_str.trim()
+        && start_trimmed.chars().all(|c| c.is_ascii_digit())
+        && end_trimmed.chars().all(|c| c.is_ascii_digit())
+        && let (Ok(start), Ok(end)) = (start_trimmed.parse::<u16>(), end_trimmed.parse::<u16>())
+    {
+        return PortPattern::Range(start, end);
     }
 
     // Host:port?

--- a/crates/cella-protocol/Cargo.toml
+++ b/crates/cella-protocol/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 

--- a/crates/cella-protocol/src/lib.rs
+++ b/crates/cella-protocol/src/lib.rs
@@ -711,7 +711,7 @@ pub enum PortPattern {
     Regex(String),
 }
 
-impl<'de> serde::Deserialize<'de> for PortPattern {
+impl<'de> Deserialize<'de> for PortPattern {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let raw = serde_json::Value::deserialize(deserializer)?;
 
@@ -729,7 +729,7 @@ impl<'de> serde::Deserialize<'de> for PortPattern {
 }
 
 /// Internal helper — mirrors `PortPattern` with the adjacent-tag serde layout.
-#[derive(serde::Deserialize)]
+#[derive(Deserialize)]
 #[serde(tag = "type", content = "value", rename_all = "snake_case")]
 enum PortPatternTagged {
     Single(u16),
@@ -751,7 +751,7 @@ impl From<PortPatternTagged> for PortPattern {
 
 /// Legacy external-tag format: `{"Single":3000}` / `{"Range":[3000,3010]}`.
 /// Only `Single` and `Range` existed before `HostPort`/`Regex` were added.
-#[derive(serde::Deserialize)]
+#[derive(Deserialize)]
 enum PortPatternLegacy {
     Single(u16),
     Range(u16, u16),

--- a/crates/cella-protocol/src/lib.rs
+++ b/crates/cella-protocol/src/lib.rs
@@ -674,19 +674,28 @@ impl Default for PortAttributes {
 /// - `"3000"` — exact port number → [`Single`](PortPattern::Single)
 /// - `"3000-3010"` — inclusive range → [`Range`](PortPattern::Range)
 /// - `"hostname:3000"` — host-qualified port; cella matches on port number only → [`HostPort`](PortPattern::HostPort)
-/// - anything else — treated as a JavaScript-compatible regular expression tested
+/// - anything else — treated as a Rust regex (RE2-like syntax) tested
 ///   against the port number string (e.g. `"^30\\d\\d$"` matches 3000–3099).
 ///
 /// ## Regex semantics
 ///
-/// VS Code's `tunnelModel.ts` tests regex keys against the **process command line**
-/// of the port (`commandLine ? value.key.test(commandLine) : false`).  cella's daemon
-/// does not yet expose per-port process metadata at match time, so we test the regex
-/// against the decimal port-number string instead (e.g. port 3000 → `"3000"`).
-/// This is the correct adaptation for cella's number-based port model.
+/// The devcontainer spec (VS Code `tunnelModel.ts`) tests regex keys against the
+/// **process command line** of the port.  cella's daemon does not yet expose
+/// per-port process metadata at match time, so we test against the decimal
+/// port-number string instead (e.g. port 3000 → `"3000"`).
+///
+/// Note: the Rust `regex` crate uses RE2-like syntax — look-around and
+/// backreferences are not supported.
 ///
 /// Invalid regex patterns compile to a never-matching variant — they never panic.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// ## Serialization
+///
+/// Serializes with an adjacent tag (`{"type":"single","value":3000}`).
+/// Deserialization additionally accepts the legacy externally-tagged format
+/// (`{"Single":3000}`) written by cella versions prior to `HostPort`/`Regex`
+/// support, so existing container labels remain readable after an upgrade.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(tag = "type", content = "value", rename_all = "snake_case")]
 pub enum PortPattern {
     /// Exact port number (e.g. `"3000"`).
@@ -695,11 +704,66 @@ pub enum PortPattern {
     Range(u16, u16),
     /// Host-qualified port key (e.g. `"db:5432"`).  Matched on port number only.
     HostPort { host: String, port: u16 },
-    /// Regex pattern tested against the decimal port-number string.
+    /// Rust RE2-like regex pattern tested against the decimal port-number string.
     ///
     /// Stores the original source pattern so the value survives serde round-trips.
     /// An invalid pattern stored here will always return `false` from [`matches`](Self::matches).
     Regex(String),
+}
+
+impl<'de> serde::Deserialize<'de> for PortPattern {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = serde_json::Value::deserialize(deserializer)?;
+
+        // Try the current adjacent-tag format first.
+        if let Ok(p) = serde_json::from_value::<PortPatternTagged>(raw.clone()) {
+            return Ok(p.into());
+        }
+
+        // Fall back to the legacy external-tag format written before HostPort/Regex
+        // were introduced: {"Single":3000} or {"Range":[3000,3010]}.
+        serde_json::from_value::<PortPatternLegacy>(raw)
+            .map(Into::into)
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+/// Internal helper — mirrors `PortPattern` with the adjacent-tag serde layout.
+#[derive(serde::Deserialize)]
+#[serde(tag = "type", content = "value", rename_all = "snake_case")]
+enum PortPatternTagged {
+    Single(u16),
+    Range(u16, u16),
+    HostPort { host: String, port: u16 },
+    Regex(String),
+}
+
+impl From<PortPatternTagged> for PortPattern {
+    fn from(t: PortPatternTagged) -> Self {
+        match t {
+            PortPatternTagged::Single(p) => Self::Single(p),
+            PortPatternTagged::Range(lo, hi) => Self::Range(lo, hi),
+            PortPatternTagged::HostPort { host, port } => Self::HostPort { host, port },
+            PortPatternTagged::Regex(s) => Self::Regex(s),
+        }
+    }
+}
+
+/// Legacy external-tag format: `{"Single":3000}` / `{"Range":[3000,3010]}`.
+/// Only `Single` and `Range` existed before `HostPort`/`Regex` were added.
+#[derive(serde::Deserialize)]
+enum PortPatternLegacy {
+    Single(u16),
+    Range(u16, u16),
+}
+
+impl From<PortPatternLegacy> for PortPattern {
+    fn from(l: PortPatternLegacy) -> Self {
+        match l {
+            PortPatternLegacy::Single(p) => Self::Single(p),
+            PortPatternLegacy::Range(lo, hi) => Self::Range(lo, hi),
+        }
+    }
 }
 
 impl PortPattern {
@@ -2201,5 +2265,35 @@ mod tests {
             decoded,
             ManagementResponse::PhantomTokenValues { tokens } if tokens.is_empty()
         ));
+    }
+
+    // ── PortPattern backward-compat deserialization ───────────────────────────
+
+    /// Labels written before `HostPort`/`Regex` were introduced used serde's
+    /// default external-tag format: `{"Single":3000}` / `{"Range":[3000,3010]}`.
+    /// Upgrading the daemon must not drop those settings.
+    #[test]
+    fn port_pattern_deserialize_legacy_single() {
+        let p: PortPattern = serde_json::from_str(r#"{"Single":3000}"#).unwrap();
+        assert_eq!(p, PortPattern::Single(3000));
+    }
+
+    #[test]
+    fn port_pattern_deserialize_legacy_range() {
+        let p: PortPattern = serde_json::from_str(r#"{"Range":[3000,3010]}"#).unwrap();
+        assert_eq!(p, PortPattern::Range(3000, 3010));
+    }
+
+    /// New format must still round-trip correctly.
+    #[test]
+    fn port_pattern_serialize_uses_new_format() {
+        let p = PortPattern::Single(8080);
+        let json = serde_json::to_string(&p).unwrap();
+        assert!(
+            json.contains("\"type\""),
+            "should use adjacent-tag format: {json}"
+        );
+        let p2: PortPattern = serde_json::from_str(&json).unwrap();
+        assert_eq!(p, p2);
     }
 }

--- a/crates/cella-protocol/src/lib.rs
+++ b/crates/cella-protocol/src/lib.rs
@@ -669,20 +669,51 @@ impl Default for PortAttributes {
 }
 
 /// A port pattern for matching detected ports.
+///
+/// Keys in `portsAttributes` can be:
+/// - `"3000"` — exact port number → [`Single`](PortPattern::Single)
+/// - `"3000-3010"` — inclusive range → [`Range`](PortPattern::Range)
+/// - `"hostname:3000"` — host-qualified port; cella matches on port number only → [`HostPort`](PortPattern::HostPort)
+/// - anything else — treated as a JavaScript-compatible regular expression tested
+///   against the port number string (e.g. `"^30\\d\\d$"` matches 3000–3099).
+///
+/// ## Regex semantics
+///
+/// VS Code's `tunnelModel.ts` tests regex keys against the **process command line**
+/// of the port (`commandLine ? value.key.test(commandLine) : false`).  cella's daemon
+/// does not yet expose per-port process metadata at match time, so we test the regex
+/// against the decimal port-number string instead (e.g. port 3000 → `"3000"`).
+/// This is the correct adaptation for cella's number-based port model.
+///
+/// Invalid regex patterns compile to a never-matching variant — they never panic.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "value", rename_all = "snake_case")]
 pub enum PortPattern {
-    /// Exact port number.
+    /// Exact port number (e.g. `"3000"`).
     Single(u16),
-    /// Range of ports (inclusive).
+    /// Inclusive port range (e.g. `"3000-3010"`).
     Range(u16, u16),
+    /// Host-qualified port key (e.g. `"db:5432"`).  Matched on port number only.
+    HostPort { host: String, port: u16 },
+    /// Regex pattern tested against the decimal port-number string.
+    ///
+    /// Stores the original source pattern so the value survives serde round-trips.
+    /// An invalid pattern stored here will always return `false` from [`matches`](Self::matches).
+    Regex(String),
 }
 
 impl PortPattern {
     /// Check if a port number matches this pattern.
-    pub const fn matches(&self, port: u16) -> bool {
+    ///
+    /// For [`Regex`](Self::Regex): tests the compiled regex against the decimal
+    /// string of `port`.  An invalid stored pattern never matches (returns `false`).
+    pub fn matches(&self, port: u16) -> bool {
         match self {
-            Self::Single(p) => *p == port,
+            Self::Single(p) | Self::HostPort { port: p, .. } => *p == port,
             Self::Range(lo, hi) => port >= *lo && port <= *hi,
+            Self::Regex(pattern) => {
+                regex::Regex::new(pattern).is_ok_and(|re| re.is_match(&port.to_string()))
+            }
         }
     }
 }
@@ -1039,6 +1070,41 @@ mod tests {
         assert!(p.matches(3010));
         assert!(!p.matches(2999));
         assert!(!p.matches(3011));
+    }
+
+    #[test]
+    fn port_pattern_host_port_match() {
+        let p = PortPattern::HostPort {
+            host: "db".to_string(),
+            port: 5432,
+        };
+        assert!(p.matches(5432));
+        assert!(!p.matches(5433));
+    }
+
+    #[test]
+    fn port_pattern_regex_anchored_match() {
+        // "^30\d\d$" matches 3000–3099, not 4000, not 30000
+        let p = PortPattern::Regex(r"^30\d\d$".to_string());
+        assert!(p.matches(3000));
+        assert!(p.matches(3099));
+        assert!(!p.matches(4000));
+        assert!(!p.matches(30_000));
+    }
+
+    #[test]
+    fn port_pattern_invalid_regex_no_panic() {
+        let p = PortPattern::Regex("[bad".to_string());
+        assert!(!p.matches(3000));
+    }
+
+    #[test]
+    fn port_pattern_regex_serde_roundtrip() {
+        let p = PortPattern::Regex(r"^30\d\d$".to_string());
+        let json = serde_json::to_string(&p).unwrap();
+        let p2: PortPattern = serde_json::from_str(&json).unwrap();
+        assert_eq!(p, p2);
+        assert!(p2.matches(3000));
     }
 
     #[test]


### PR DESCRIPTION
`portsAttributes`/`otherPortsAttributes` keys can be a port number, a `"host:port"` value, a range, or a regular expression (per spec). cella only handled `"N"` and `"N-N"` — regex and host:port keys were silently dropped, so their attributes never applied.

- Adds `PortPattern::Regex(String)` and `PortPattern::HostPort { host, port }` to cella-protocol; `parse_port_pattern` now recognizes `"db:5432"`/`"localhost:3000"` and falls through to a regex for anything else instead of dropping it.
- The official matching lives in VS Code (closed-source) — its `tunnelModel.ts` tests regex keys against the process command line with a non-anchored `.test()`. cella's daemon forwards by port number and has no per-port process cmdline at match time, so the regex is tested (substring, matching VS Code's `.test()` semantics) against the port-number string. This is a documented adaptation to cella's model; users anchor their patterns (`^30\d\d$`) as needed.
- Invalid regex patterns are kept but never match and never panic. `matches` is no longer `const` (regex needs runtime compile).
- HostPort keys match on the numeric port (cella's forwarding unit).

Tests cover regex match/non-match, invalid-regex-never-matches, host:port parsing, serde round-trip, and that plain/range keys still parse as `Single`/`Range`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)