### PR TITLE
feat: forward host:port (compose cross-service) ports

### DIFF
--- a/crates/cella-agent/src/control.rs
+++ b/crates/cella-agent/src/control.rs
@@ -211,12 +211,18 @@ async fn run_reader_loop(
             DaemonMessage::TunnelRequest {
                 connection_id,
                 target_port,
+                target_host,
             } => {
                 if let Some(ref config) = tunnel_config {
                     let config = config.clone();
                     tokio::spawn(async move {
-                        crate::tunnel::handle_tunnel_request(connection_id, target_port, &config)
-                            .await;
+                        crate::tunnel::handle_tunnel_request(
+                            connection_id,
+                            target_port,
+                            target_host,
+                            &config,
+                        )
+                        .await;
                     });
                 }
             }

--- a/crates/cella-agent/src/tunnel.rs
+++ b/crates/cella-agent/src/tunnel.rs
@@ -15,8 +15,18 @@ pub struct TunnelConfig {
 
 /// Handle a single `TunnelRequest` by connecting back to the daemon and relaying
 /// to the local service.
-pub async fn handle_tunnel_request(connection_id: u64, target_port: u16, config: &TunnelConfig) {
-    debug!("Tunnel request: connection_id={connection_id} target_port={target_port}");
+///
+/// `target_host` overrides the hostname to connect to inside the container.
+/// `None` uses `localhost` (the existing numeric-port path — byte-identical
+/// behaviour).
+pub async fn handle_tunnel_request(
+    connection_id: u64,
+    target_port: u16,
+    target_host: Option<String>,
+    config: &TunnelConfig,
+) {
+    let host = target_host.as_deref().unwrap_or("localhost");
+    debug!("Tunnel request: connection_id={connection_id} target={host}:{target_port}");
 
     let tunnel_result = TcpStream::connect(&config.daemon_addr).await;
     let mut tunnel = match tunnel_result {
@@ -48,16 +58,16 @@ pub async fn handle_tunnel_request(connection_id: u64, target_port: u16, config:
         return;
     }
 
-    let local_result = TcpStream::connect(("localhost", target_port)).await;
+    let local_result = TcpStream::connect((host, target_port)).await;
     let mut local = match local_result {
         Ok(s) => s,
         Err(e) => {
-            warn!("Tunnel local connect to localhost:{target_port} failed: {e}");
+            warn!("Tunnel local connect to {host}:{target_port} failed: {e}");
             return;
         }
     };
 
-    debug!("Tunnel {connection_id}: connected to localhost:{target_port}");
+    debug!("Tunnel {connection_id}: connected to {host}:{target_port}");
     let _ = copy_bidirectional(&mut tunnel, &mut local).await;
     debug!("Tunnel connection {connection_id} closed");
 }
@@ -99,6 +109,16 @@ mod tests {
             auth_token: "token".to_string(),
         };
         // Should not panic — just logs a warning.
-        handle_tunnel_request(1, 3000, &config).await;
+        handle_tunnel_request(1, 3000, None, &config).await;
+    }
+
+    #[tokio::test]
+    async fn handle_tunnel_request_with_target_host_fails_gracefully() {
+        let config = TunnelConfig {
+            daemon_addr: "127.0.0.1:1".to_string(),
+            auth_token: "token".to_string(),
+        };
+        // target_host path should also fail gracefully on unreachable daemon.
+        handle_tunnel_request(2, 5432, Some("db".to_string()), &config).await;
     }
 }

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -701,6 +701,7 @@ async fn handle_port_open(
             ProxyStartTarget::AgentTunnel {
                 container_name: name.to_string(),
                 port: target_port,
+                target_host: None,
             }
         } else {
             warn!("No container name for tunnel proxy, skipping port {port}");
@@ -4994,6 +4995,7 @@ branch refs/heads/feat-b
             tx.send(DaemonMessage::TunnelRequest {
                 connection_id: 1,
                 target_port: 45973,
+                target_host: None,
             })
             .await
             .is_ok(),

--- a/crates/cella-daemon/src/control_server.rs
+++ b/crates/cella-daemon/src/control_server.rs
@@ -4877,6 +4877,25 @@ branch refs/heads/feat-b
         (h.agent_tx.is_some(), h.agent_tx_generation)
     }
 
+    /// Poll the shared handle until `agent_tx.is_some()` matches `want`, or the
+    /// deadline passes. Agent connect/disconnect cleanup runs in a spawned task,
+    /// so the observable state lags the socket event by an unbounded amount under
+    /// load (coverage instrumentation on CI in particular). Polling makes these
+    /// ownership assertions deterministic instead of racing a fixed sleep.
+    async fn wait_for_agent_tx(handles: &Arc<Mutex<HashMap<String, ContainerHandle>>>, want: bool) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if get_handle_state(&*handles.lock().await).0 == want {
+                return;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timed out waiting for agent_tx.is_some() == {want}"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    }
+
     #[tokio::test]
     async fn transient_connect_does_not_set_agent_tx() {
         use tokio::io::AsyncWriteExt;
@@ -4904,17 +4923,13 @@ branch refs/heads/feat-b
     async fn persistent_connect_sets_and_clears_agent_tx() {
         let srv = start_ownership_test_server(None, 0).await;
         let stream = agent_handshake(srv.addr, false).await;
-        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        wait_for_agent_tx(&srv.handles, true).await;
 
-        let (has_tx, generation) = get_handle_state(&*srv.handles.lock().await);
-        assert!(has_tx, "persistent connect must set agent_tx");
+        let generation = get_handle_state(&*srv.handles.lock().await).1;
         assert!(generation > 0, "persistent connect must bump generation");
 
         drop(stream);
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-        let (has_tx, _) = get_handle_state(&*srv.handles.lock().await);
-        assert!(!has_tx, "persistent disconnect must clear agent_tx");
+        wait_for_agent_tx(&srv.handles, false).await;
         let _ = srv.shutdown_tx.send(true);
     }
 
@@ -4923,15 +4938,27 @@ branch refs/heads/feat-b
         let srv = start_ownership_test_server(None, 0).await;
 
         let stream1 = agent_handshake(srv.addr, false).await;
-        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        wait_for_agent_tx(&srv.handles, true).await;
         let gen1 = get_handle_state(&*srv.handles.lock().await).1;
 
         let stream2 = agent_handshake(srv.addr, false).await;
-        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-        let gen2 = get_handle_state(&*srv.handles.lock().await).1;
-        assert!(gen2 > gen1, "second connect must bump generation");
+        // Wait until the second connection has taken ownership (generation bumped).
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let gen2 = loop {
+            let (has_tx, g) = get_handle_state(&*srv.handles.lock().await);
+            if has_tx && g > gen1 {
+                break g;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timed out waiting for second connect to bump generation"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        };
 
-        // Disconnect #1 — stale cleanup must NOT clear #2's agent_tx.
+        // Disconnect #1 — stale cleanup must NOT clear #2's agent_tx. The
+        // generation guard makes this a no-op, so the state stays stable; a
+        // brief settle gives the stale cleanup task a chance to (wrongly) run.
         drop(stream1);
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
@@ -4941,10 +4968,7 @@ branch refs/heads/feat-b
 
         // Disconnect #2 — owning cleanup should clear.
         drop(stream2);
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-
-        let (has_tx, _) = get_handle_state(&*srv.handles.lock().await);
-        assert!(!has_tx, "owning disconnect must clear agent_tx");
+        wait_for_agent_tx(&srv.handles, false).await;
         let _ = srv.shutdown_tx.send(true);
     }
 
@@ -4956,11 +4980,7 @@ branch refs/heads/feat-b
 
         // Persistent agent connects.
         let persistent = agent_handshake(srv.addr, false).await;
-        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-        assert!(
-            get_handle_state(&*srv.handles.lock().await).0,
-            "persistent must set agent_tx"
-        );
+        wait_for_agent_tx(&srv.handles, true).await;
 
         // Transient browser-open connects, sends, disconnects.
         let mut transient = agent_handshake(srv.addr, true).await;

--- a/crates/cella-daemon/src/management.rs
+++ b/crates/cella-daemon/src/management.rs
@@ -507,94 +507,154 @@ async fn preload_forward_ports(
         .remove_container(container_id);
 
     for &port in forward_ports {
-        let host_port = {
-            let mut pm = ctx.port_manager.lock().await;
-            pm.handle_port_open(container_id, port, cella_protocol::PortProtocol::Tcp, None)
-        };
-        let Some(host_port) = host_port else { continue };
-
-        let use_direct_ip = cfg!(target_os = "linux") || ctx.is_orbstack;
-        let target = if use_direct_ip {
-            if let Some(ip) = container_ip {
-                crate::proxy::ProxyStartTarget::DirectIp {
-                    ip: ip.to_string(),
-                    port,
-                }
-            } else {
-                warn!("No container IP for direct proxy, skipping forwardPort {port}");
-                ctx.port_manager
-                    .lock()
-                    .await
-                    .handle_port_closed(container_id, port);
-                continue;
-            }
-        } else {
-            crate::proxy::ProxyStartTarget::AgentTunnel {
-                container_name: container_name.to_string(),
-                port,
-                target_host: None,
-            }
-        };
-
-        if !crate::control_server::start_port_proxy(host_port, target, &ctx.proxy_cmd_tx).await {
-            ctx.port_manager
-                .lock()
-                .await
-                .handle_port_closed(container_id, port);
-            continue;
-        }
-
-        let route = ctx
-            .port_manager
-            .lock()
-            .await
-            .hostname_route_for(container_id, port);
-        if let Some(route) = route {
-            let mut rt = ctx.hostname_route_table.write().await;
-            rt.insert(
-                cella_proxy::router::RouteKey {
-                    project: route.project.clone(),
-                    branch: route.branch.clone(),
-                    port: route.container_port,
-                },
-                cella_proxy::router::BackendTarget {
-                    container_id: container_id.to_string(),
-                    container_name: container_name.to_string(),
-                    target_port: route.host_port,
-                    mode: cella_proxy::router::ProxyMode::Localhost,
-                },
-            );
-            rt.set_default_port_if_absent(&route.project, &route.branch, route.container_port);
-        }
+        preload_numeric_forward(ctx, container_id, container_name, container_ip, port).await;
     }
 
     // host:port entries always use AgentTunnel — DNS names like "db" are only
     // resolvable inside the workspace container, so DirectIp cannot work here.
+    // Each (host, port) is a distinct forward with its own host port: `db:5432`
+    // and `analytics-db:5432` must not collapse into one mapping.
     for hfp in forward_host_ports {
-        let host_port = {
-            let mut pm = ctx.port_manager.lock().await;
-            pm.handle_port_open(
-                container_id,
-                hfp.port,
-                cella_protocol::PortProtocol::Tcp,
-                None,
-            )
-        };
-        let Some(host_port) = host_port else { continue };
+        preload_host_forward(ctx, container_id, container_name, hfp).await;
+    }
+}
 
-        let target = crate::proxy::ProxyStartTarget::AgentTunnel {
-            container_name: container_name.to_string(),
-            port: hfp.port,
-            target_host: Some(hfp.host.clone()),
-        };
+/// Preload a single numeric `forwardPorts` entry: allocate a host port, start
+/// its proxy, and register the hostname route.
+async fn preload_numeric_forward(
+    ctx: &ManagementContext,
+    container_id: &str,
+    container_name: &str,
+    container_ip: Option<&str>,
+    port: u16,
+) {
+    let Some(host_port) = ctx.port_manager.lock().await.handle_port_open(
+        container_id,
+        port,
+        cella_protocol::PortProtocol::Tcp,
+        None,
+    ) else {
+        return;
+    };
 
-        if !crate::control_server::start_port_proxy(host_port, target, &ctx.proxy_cmd_tx).await {
+    let use_direct_ip = cfg!(target_os = "linux") || ctx.is_orbstack;
+    let target = if use_direct_ip {
+        if let Some(ip) = container_ip {
+            crate::proxy::ProxyStartTarget::DirectIp {
+                ip: ip.to_string(),
+                port,
+            }
+        } else {
+            warn!("No container IP for direct proxy, skipping forwardPort {port}");
             ctx.port_manager
                 .lock()
                 .await
-                .handle_port_closed(container_id, hfp.port);
+                .handle_port_closed(container_id, port);
+            return;
         }
+    } else {
+        crate::proxy::ProxyStartTarget::AgentTunnel {
+            container_name: container_name.to_string(),
+            port,
+            target_host: None,
+        }
+    };
+
+    if !crate::control_server::start_port_proxy(host_port, target, &ctx.proxy_cmd_tx).await {
+        ctx.port_manager
+            .lock()
+            .await
+            .handle_port_closed(container_id, port);
+        return;
     }
+
+    let route = ctx
+        .port_manager
+        .lock()
+        .await
+        .hostname_route_for(container_id, port);
+    if let Some(route) = route {
+        let mut rt = ctx.hostname_route_table.write().await;
+        rt.insert(
+            cella_proxy::router::RouteKey {
+                project: route.project.clone(),
+                branch: route.branch.clone(),
+                port: route.container_port,
+            },
+            cella_proxy::router::BackendTarget {
+                container_id: container_id.to_string(),
+                container_name: container_name.to_string(),
+                target_port: route.host_port,
+                mode: cella_proxy::router::ProxyMode::Localhost,
+            },
+        );
+        rt.set_default_port_if_absent(&route.project, &route.branch, route.container_port);
+    }
+}
+
+/// Preload a single `host:port` cross-service forward through the agent tunnel.
+async fn preload_host_forward(
+    ctx: &ManagementContext,
+    container_id: &str,
+    container_name: &str,
+    hfp: &cella_protocol::HostForwardPort,
+) {
+    let (host_port, route) = {
+        let mut pm = ctx.port_manager.lock().await;
+        let host_port = pm.handle_forward_open(
+            container_id,
+            hfp.port,
+            Some(&hfp.host),
+            cella_protocol::PortProtocol::Tcp,
+            None,
+        );
+        (host_port, pm.hostname_route_for(container_id, hfp.port))
+    };
+    let Some(host_port) = host_port else { return };
+
+    let target = crate::proxy::ProxyStartTarget::AgentTunnel {
+        container_name: container_name.to_string(),
+        port: hfp.port,
+        target_host: Some(hfp.host.clone()),
+    };
+
+    if !crate::control_server::start_port_proxy(host_port, target, &ctx.proxy_cmd_tx).await {
+        ctx.port_manager.lock().await.handle_forward_closed(
+            container_id,
+            hfp.port,
+            Some(&hfp.host),
+        );
+        return;
+    }
+
+    // Advertise a hostname route so `<port>.<branch>.<project>.localhost`
+    // resolves to this forward's localhost proxy. The hostname scheme keys on
+    // the container port alone and cannot encode the cross-service host, so
+    // register only if the key is still free — a numeric forward (or an earlier
+    // host:port forward) on the same port keeps ownership, and this forward
+    // stays reachable at `localhost:<host_port>` regardless.
+    let Some(route) = route else { return };
+    let mut rt = ctx.hostname_route_table.write().await;
+    if rt
+        .lookup(&route.project, &route.branch, route.container_port)
+        .is_some()
+    {
+        return;
+    }
+    rt.insert(
+        cella_proxy::router::RouteKey {
+            project: route.project.clone(),
+            branch: route.branch.clone(),
+            port: route.container_port,
+        },
+        cella_proxy::router::BackendTarget {
+            container_id: container_id.to_string(),
+            container_name: container_name.to_string(),
+            target_port: host_port,
+            mode: cella_proxy::router::ProxyMode::Localhost,
+        },
+    );
+    rt.set_default_port_if_absent(&route.project, &route.branch, route.container_port);
 }
 
 /// Handle container deregistration.
@@ -909,6 +969,99 @@ mod tests {
         assert_eq!(
             ports[0].hostname.as_deref(),
             Some("http://3000.feature-auth.myapp.localhost:49180")
+        );
+    }
+
+    #[tokio::test]
+    async fn host_forward_registers_hostname_route() {
+        // Regression: a host:port forward (web:3000) must register a hostname
+        // route so `3000.<branch>.<project>.localhost` resolves instead of
+        // returning the no-route page.
+        let (ctx, _srx) = test_management_context(0);
+        ctx.port_manager.lock().await.register_container(
+            crate::port_manager::ContainerRegistrationInfo {
+                container_id: "c1".to_string(),
+                container_name: "test-container".to_string(),
+                container_ip: Some("172.20.0.5".to_string()),
+                ports_attributes: vec![],
+                other_ports_attributes: None,
+                project_name: Some("myapp".to_string()),
+                branch: Some("main".to_string()),
+            },
+        );
+
+        preload_forward_ports(
+            &ctx,
+            "c1",
+            "test-container",
+            Some("172.20.0.5"),
+            &[],
+            &[cella_protocol::HostForwardPort {
+                host: "web".to_string(),
+                port: 3000,
+            }],
+        )
+        .await;
+
+        let is_localhost_route = {
+            let rt = ctx.hostname_route_table.read().await;
+            rt.lookup("myapp", "main", 3000)
+                .map(|target| matches!(target.mode, cella_proxy::router::ProxyMode::Localhost))
+        };
+        assert_eq!(
+            is_localhost_route,
+            Some(true),
+            "host:port forward must register a localhost hostname route"
+        );
+    }
+
+    #[tokio::test]
+    async fn host_forward_does_not_clobber_numeric_route() {
+        // A bare numeric forward owns the hostname route for its port; a
+        // host:port forward sharing that port must not overwrite it (the
+        // hostname scheme cannot disambiguate the cross-service host).
+        let (ctx, _srx) = test_management_context(0);
+        ctx.port_manager.lock().await.register_container(
+            crate::port_manager::ContainerRegistrationInfo {
+                container_id: "c1".to_string(),
+                container_name: "test-container".to_string(),
+                container_ip: Some("172.20.0.5".to_string()),
+                ports_attributes: vec![],
+                other_ports_attributes: None,
+                project_name: Some("myapp".to_string()),
+                branch: Some("main".to_string()),
+            },
+        );
+
+        // A numeric 3000 forward and a host:port web:3000 forward share the
+        // container port. The numeric forward is processed first and owns the
+        // route; the host:port forward gets its own (distinct) host port and
+        // must not overwrite the route.
+        preload_forward_ports(
+            &ctx,
+            "c1",
+            "test-container",
+            Some("172.20.0.5"),
+            &[3000],
+            &[cella_protocol::HostForwardPort {
+                host: "web".to_string(),
+                port: 3000,
+            }],
+        )
+        .await;
+
+        // The host:port forward received its own distinct host port.
+        let forward_count = ctx.port_manager.lock().await.all_forwarded_ports().len();
+        assert_eq!(forward_count, 2, "two distinct forwards expected");
+
+        let route_target_port = {
+            let rt = ctx.hostname_route_table.read().await;
+            rt.lookup("myapp", "main", 3000).map(|t| t.target_port)
+        };
+        assert_eq!(
+            route_target_port,
+            Some(3000),
+            "numeric forward (native host port 3000) must keep route ownership"
         );
     }
 

--- a/crates/cella-daemon/src/management.rs
+++ b/crates/cella-daemon/src/management.rs
@@ -404,6 +404,7 @@ struct ContainerRegistration {
     ports_attributes: Vec<PortAttributes>,
     other_ports_attributes: Option<PortAttributes>,
     forward_ports: Vec<u16>,
+    forward_host_ports: Vec<cella_protocol::HostForwardPort>,
     backend_kind: Option<String>,
     docker_host: Option<String>,
     project_name: Option<String>,
@@ -419,6 +420,7 @@ impl From<cella_protocol::ContainerRegistrationData> for ContainerRegistration {
             ports_attributes: data.ports_attributes,
             other_ports_attributes: data.other_ports_attributes,
             forward_ports: data.forward_ports,
+            forward_host_ports: data.forward_host_ports,
             backend_kind: data.backend_kind,
             docker_host: data.docker_host,
             project_name: data.project_name,
@@ -482,6 +484,7 @@ async fn handle_register(
         &container_name,
         container_ip_clone.as_deref(),
         &reg.forward_ports,
+        &reg.forward_host_ports,
     )
     .await;
 
@@ -496,6 +499,7 @@ async fn preload_forward_ports(
     container_name: &str,
     container_ip: Option<&str>,
     forward_ports: &[u16],
+    forward_host_ports: &[cella_protocol::HostForwardPort],
 ) {
     ctx.hostname_route_table
         .write()
@@ -528,6 +532,7 @@ async fn preload_forward_ports(
             crate::proxy::ProxyStartTarget::AgentTunnel {
                 container_name: container_name.to_string(),
                 port,
+                target_host: None,
             }
         };
 
@@ -560,6 +565,34 @@ async fn preload_forward_ports(
                 },
             );
             rt.set_default_port_if_absent(&route.project, &route.branch, route.container_port);
+        }
+    }
+
+    // host:port entries always use AgentTunnel — DNS names like "db" are only
+    // resolvable inside the workspace container, so DirectIp cannot work here.
+    for hfp in forward_host_ports {
+        let host_port = {
+            let mut pm = ctx.port_manager.lock().await;
+            pm.handle_port_open(
+                container_id,
+                hfp.port,
+                cella_protocol::PortProtocol::Tcp,
+                None,
+            )
+        };
+        let Some(host_port) = host_port else { continue };
+
+        let target = crate::proxy::ProxyStartTarget::AgentTunnel {
+            container_name: container_name.to_string(),
+            port: hfp.port,
+            target_host: Some(hfp.host.clone()),
+        };
+
+        if !crate::control_server::start_port_proxy(host_port, target, &ctx.proxy_cmd_tx).await {
+            ctx.port_manager
+                .lock()
+                .await
+                .handle_port_closed(container_id, hfp.port);
         }
     }
 }
@@ -788,6 +821,7 @@ mod tests {
                     ports_attributes: vec![],
                     other_ports_attributes: None,
                     forward_ports: vec![],
+                    forward_host_ports: vec![],
                     shutdown_action: None,
                     backend_kind: Some("docker".to_string()),
                     docker_host: None,
@@ -1220,6 +1254,7 @@ mod tests {
                     ports_attributes: vec![],
                     other_ports_attributes: None,
                     forward_ports: vec![],
+                    forward_host_ports: vec![],
                     shutdown_action: None,
                     backend_kind: Some("docker".to_string()),
                     docker_host: None,

--- a/crates/cella-daemon/src/port_manager.rs
+++ b/crates/cella-daemon/src/port_manager.rs
@@ -45,6 +45,11 @@ struct DetectedPort {
     protocol: PortProtocol,
     process: Option<String>,
     host_port: Option<u16>,
+    /// Cross-service target host for `host:port` forwards (e.g. `db` in
+    /// `db:5432`). `None` for ordinary forwards reached on the workspace
+    /// container itself. Part of a detected port's identity: `db:5432` and a
+    /// bare `5432` are distinct forwards that each need their own host port.
+    target_host: Option<String>,
 }
 
 /// Data needed to register a container for port management.
@@ -249,10 +254,32 @@ impl PortManager {
         protocol: PortProtocol,
         process: Option<String>,
     ) -> Option<u16> {
-        // Duplicate guard: if this container+port is already detected, return
-        // the existing mapping. Handles agent reconnections re-reporting ports.
+        self.handle_forward_open(container_id, port, None, protocol, process)
+    }
+
+    /// Handle a forward becoming active, optionally bound to a cross-service
+    /// `target_host` (the `host` in a `host:port` forward).
+    ///
+    /// A detected port's identity is `(port, target_host)`: `db:5432` and a
+    /// bare `5432` — or `db:5432` and `analytics-db:5432` — are distinct
+    /// forwards that each receive their own host port, rather than aliasing to
+    /// one mapping.
+    pub fn handle_forward_open(
+        &mut self,
+        container_id: &str,
+        port: u16,
+        target_host: Option<&str>,
+        protocol: PortProtocol,
+        process: Option<String>,
+    ) -> Option<u16> {
+        // Duplicate guard: if this exact forward (container + port + target
+        // host) is already detected, return the existing mapping. Handles agent
+        // reconnections re-reporting ports.
         if let Some(container) = self.containers.get(container_id)
-            && let Some(existing) = container.detected_ports.iter().find(|d| d.port == port)
+            && let Some(existing) = container
+                .detected_ports
+                .iter()
+                .find(|d| d.port == port && d.target_host.as_deref() == target_host)
         {
             return existing.host_port;
         }
@@ -284,6 +311,7 @@ impl PortManager {
             protocol,
             process,
             host_port: Some(host_port),
+            target_host: target_host.map(str::to_string),
         };
 
         if let Some(container) = self.containers.get_mut(container_id) {
@@ -305,15 +333,31 @@ impl PortManager {
     ///
     /// Returns the host port that was released, if any.
     pub fn handle_port_closed(&mut self, container_id: &str, port: u16) -> Option<u16> {
+        self.handle_forward_closed(container_id, port, None)
+    }
+
+    /// Close a single forward identified by `(port, target_host)`, releasing
+    /// only that forward's host port. Closing `db:5432` must not tear down a
+    /// bare `5432` (or vice versa) that happens to share the container port.
+    ///
+    /// Returns the host port that was released, if any.
+    pub fn handle_forward_closed(
+        &mut self,
+        container_id: &str,
+        port: u16,
+        target_host: Option<&str>,
+    ) -> Option<u16> {
         let host_port = self.containers.get(container_id).and_then(|c| {
             c.detected_ports
                 .iter()
-                .find(|p| p.port == port)
+                .find(|p| p.port == port && p.target_host.as_deref() == target_host)
                 .and_then(|p| p.host_port)
         });
 
         if let Some(container) = self.containers.get_mut(container_id) {
-            container.detected_ports.retain(|p| p.port != port);
+            container
+                .detected_ports
+                .retain(|p| !(p.port == port && p.target_host.as_deref() == target_host));
         }
 
         if let Some(hp) = host_port {
@@ -347,6 +391,7 @@ impl PortManager {
                         branch: container.branch.clone(),
                         project_slug: container.project_slug.clone(),
                         branch_slug: container.branch_slug.clone(),
+                        target_host: detected.target_host.clone(),
                     });
                 }
             }
@@ -384,6 +429,9 @@ pub struct ForwardedPortInfo {
     pub branch: Option<String>,
     pub project_slug: Option<String>,
     pub branch_slug: Option<String>,
+    /// Cross-service target host for `host:port` forwards. `None` for forwards
+    /// reached on the workspace container itself.
+    pub target_host: Option<String>,
 }
 
 /// Metadata needed to add/remove a hostname route.
@@ -568,6 +616,7 @@ mod tests {
             branch: None,
             project_slug: None,
             branch_slug: None,
+            target_host: None,
         };
         // url() always returns localhost
         assert_eq!(info.url(), "localhost:3000");
@@ -592,6 +641,7 @@ mod tests {
             branch: None,
             project_slug: None,
             branch_slug: None,
+            target_host: None,
         };
         assert_eq!(info.orb_url(), None);
     }
@@ -610,6 +660,7 @@ mod tests {
             branch: None,
             project_slug: None,
             branch_slug: None,
+            target_host: None,
         };
         assert_eq!(info.url(), "localhost:3001");
     }
@@ -766,5 +817,104 @@ mod tests {
     fn update_container_ip_unknown_container() {
         let mut pm = PortManager::new(false);
         assert!(!pm.update_container_ip("unknown", Some("1.2.3.4".to_string())));
+    }
+
+    #[test]
+    fn host_forwards_sharing_a_port_get_distinct_host_ports() {
+        // Regression: two host:port forwards on the same container port
+        // (db:5432, analytics-db:5432) must not alias to one host port. The
+        // dedup guard is keyed on (port, target_host), so each is distinct.
+        let mut pm = PortManager::new(false);
+        pm.register_container(ContainerRegistrationInfo {
+            container_id: "c1".to_string(),
+            container_name: "test".to_string(),
+            container_ip: None,
+            ports_attributes: vec![],
+            other_ports_attributes: None,
+            project_name: None,
+            branch: None,
+        });
+
+        let db = pm.handle_forward_open("c1", 5432, Some("db"), PortProtocol::Tcp, None);
+        let analytics =
+            pm.handle_forward_open("c1", 5432, Some("analytics-db"), PortProtocol::Tcp, None);
+        let numeric = pm.handle_port_open("c1", 5432, PortProtocol::Tcp, None);
+
+        assert!(db.is_some() && analytics.is_some() && numeric.is_some());
+        assert_ne!(db, analytics, "distinct hosts must get distinct host ports");
+        assert_ne!(db, numeric, "host:port and bare port must not alias");
+        assert_ne!(analytics, numeric);
+        assert_eq!(pm.all_forwarded_ports().len(), 3);
+    }
+
+    #[test]
+    fn re_opening_same_host_forward_reuses_host_port() {
+        // The dedup guard still coalesces a re-reported identical forward.
+        let mut pm = PortManager::new(false);
+        pm.register_container(ContainerRegistrationInfo {
+            container_id: "c1".to_string(),
+            container_name: "test".to_string(),
+            container_ip: None,
+            ports_attributes: vec![],
+            other_ports_attributes: None,
+            project_name: None,
+            branch: None,
+        });
+
+        let first = pm.handle_forward_open("c1", 5432, Some("db"), PortProtocol::Tcp, None);
+        let again = pm.handle_forward_open("c1", 5432, Some("db"), PortProtocol::Tcp, None);
+        assert_eq!(first, again);
+        assert_eq!(pm.all_forwarded_ports().len(), 1);
+    }
+
+    #[test]
+    fn closing_one_host_forward_leaves_the_other_intact() {
+        // Regression: closing db:5432 must not tear down a bare 5432 (or the
+        // other host:port forward) sharing the container port.
+        let mut pm = PortManager::new(false);
+        pm.register_container(ContainerRegistrationInfo {
+            container_id: "c1".to_string(),
+            container_name: "test".to_string(),
+            container_ip: None,
+            ports_attributes: vec![],
+            other_ports_attributes: None,
+            project_name: None,
+            branch: None,
+        });
+
+        let db = pm
+            .handle_forward_open("c1", 5432, Some("db"), PortProtocol::Tcp, None)
+            .unwrap();
+        let numeric = pm
+            .handle_port_open("c1", 5432, PortProtocol::Tcp, None)
+            .unwrap();
+
+        // Close only the host:port forward.
+        let released = pm.handle_forward_closed("c1", 5432, Some("db"));
+        assert_eq!(released, Some(db));
+
+        let remaining = pm.all_forwarded_ports();
+        assert_eq!(remaining.len(), 1, "bare 5432 must survive db:5432 closing");
+        assert_eq!(remaining[0].host_port, numeric);
+        assert!(remaining[0].target_host.is_none());
+    }
+
+    #[test]
+    fn host_forward_carries_target_host_in_forwarded_info() {
+        let mut pm = PortManager::new(false);
+        pm.register_container(ContainerRegistrationInfo {
+            container_id: "c1".to_string(),
+            container_name: "test".to_string(),
+            container_ip: None,
+            ports_attributes: vec![],
+            other_ports_attributes: None,
+            project_name: None,
+            branch: None,
+        });
+        pm.handle_forward_open("c1", 5432, Some("db"), PortProtocol::Tcp, None);
+
+        let ports = pm.all_forwarded_ports();
+        assert_eq!(ports.len(), 1);
+        assert_eq!(ports[0].target_host.as_deref(), Some("db"));
     }
 }

--- a/crates/cella-daemon/src/proxy.rs
+++ b/crates/cella-daemon/src/proxy.rs
@@ -32,7 +32,15 @@ pub enum ProxyStartTarget {
     /// Connect directly to an `IP:port` (`OrbStack`, Linux native).
     DirectIp { ip: String, port: u16 },
     /// Tunnel through the agent via a reverse TCP connection.
-    AgentTunnel { container_name: String, port: u16 },
+    ///
+    /// `target_host` overrides the hostname the agent connects to inside the
+    /// container. `None` means `localhost` (the existing numeric-port path).
+    /// Set to a Compose service name (e.g. `"db"`) for cross-service forwarding.
+    AgentTunnel {
+        container_name: String,
+        port: u16,
+        target_host: Option<String>,
+    },
 }
 
 /// Handle to a running TCP proxy task.
@@ -97,12 +105,14 @@ async fn start_tunnel_proxy(
     host_port: u16,
     container_name: String,
     target_port: u16,
+    target_host: Option<String>,
     broker: Arc<TunnelBroker>,
     container_handles: Arc<Mutex<HashMap<String, ContainerHandle>>>,
 ) -> Result<ProxyHandle, io::Error> {
     let listener = TcpListener::bind(("127.0.0.1", host_port)).await?;
+    let host_label = target_host.as_deref().unwrap_or("localhost");
     debug!(
-        "Tunnel proxy listening on 127.0.0.1:{host_port} -> agent:{container_name}:{target_port}"
+        "Tunnel proxy listening on 127.0.0.1:{host_port} -> agent:{container_name}:{host_label}:{target_port}"
     );
 
     let handle = tokio::spawn(async move {
@@ -118,6 +128,7 @@ async fn start_tunnel_proxy(
             let broker = broker.clone();
             let handles = container_handles.clone();
             let name = container_name.clone();
+            let host = target_host.clone();
             debug!("Tunnel proxy connection from {peer} on port {host_port}");
 
             tokio::spawn(async move {
@@ -125,6 +136,7 @@ async fn start_tunnel_proxy(
                     &mut inbound,
                     &name,
                     target_port,
+                    host,
                     &broker,
                     &handles,
                 )
@@ -144,6 +156,7 @@ async fn handle_tunnel_proxy_connection(
     inbound: &mut TcpStream,
     container_name: &str,
     target_port: u16,
+    target_host: Option<String>,
     broker: &TunnelBroker,
     container_handles: &Arc<Mutex<HashMap<String, ContainerHandle>>>,
 ) -> Result<(), io::Error> {
@@ -166,6 +179,7 @@ async fn handle_tunnel_proxy_connection(
         .send(DaemonMessage::TunnelRequest {
             connection_id,
             target_port,
+            target_host,
         })
         .await
         .is_err()
@@ -224,12 +238,14 @@ pub async fn run_proxy_coordinator(
                     ProxyStartTarget::AgentTunnel {
                         container_name,
                         port,
+                        target_host,
                     } => {
                         if let Some(ref ctx) = ctx {
                             start_tunnel_proxy(
                                 host_port,
                                 container_name,
                                 port,
+                                target_host,
                                 ctx.tunnel_broker.clone(),
                                 ctx.container_handles.clone(),
                             )
@@ -315,10 +331,33 @@ mod tests {
         let target = ProxyStartTarget::AgentTunnel {
             container_name: "cella-test".into(),
             port: 3000,
+            target_host: None,
         };
         let dbg = format!("{target:?}");
         assert!(dbg.contains("cella-test"));
         assert!(dbg.contains("3000"));
+    }
+
+    #[test]
+    fn proxy_start_target_agent_tunnel_with_host() {
+        let target = ProxyStartTarget::AgentTunnel {
+            container_name: "cella-test".into(),
+            port: 5432,
+            target_host: Some("db".to_string()),
+        };
+        let dbg = format!("{target:?}");
+        assert!(dbg.contains("cella-test"));
+        assert!(dbg.contains("5432"));
+        assert!(dbg.contains("db"));
+        // target_host is carried through clone correctly.
+        assert!(matches!(
+            target,
+            ProxyStartTarget::AgentTunnel {
+                ref target_host,
+                port: 5432,
+                ..
+            } if target_host.as_deref() == Some("db")
+        ));
     }
 
     // -- ProxyCommand construction --

--- a/crates/cella-orchestrator/src/daemon_registration.rs
+++ b/crates/cella-orchestrator/src/daemon_registration.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use cella_backend::{BACKEND_LABEL, ContainerInfo};
-use cella_protocol::ContainerRegistrationData;
+use cella_protocol::{ContainerRegistrationData, HostForwardPort};
 
 use crate::forward_ports::forward_port_number;
 
@@ -25,6 +25,7 @@ pub fn from_devcontainer_config(
         ports_attributes: crate::config_map::ports::parse_ports_attributes(config),
         other_ports_attributes: crate::config_map::ports::parse_other_ports_attributes(config),
         forward_ports: parse_forward_ports(config),
+        forward_host_ports: parse_forward_host_ports(config),
         shutdown_action: config
             .get("shutdownAction")
             .and_then(|v| v.as_str())
@@ -55,6 +56,7 @@ pub fn from_container_labels(
         ports_attributes,
         other_ports_attributes,
         forward_ports: Vec::new(),
+        forward_host_ports: Vec::new(),
         shutdown_action: container.labels.get("dev.cella.shutdown_action").cloned(),
         backend_kind: container.labels.get(BACKEND_LABEL).cloned(),
         docker_host,
@@ -102,6 +104,38 @@ fn parse_forward_ports(config: &serde_json::Value) -> Vec<u16> {
         .unwrap_or_default()
 }
 
+/// Extract `host:port` entries from `forwardPorts`.
+///
+/// Only string values matching `<host>:<port>` where host contains
+/// `[A-Za-z0-9._-]+` and port is a valid `u16` are returned. Bare numbers,
+/// numeric strings, and malformed entries are excluded (handled by
+/// `parse_forward_ports`).
+pub(crate) fn parse_forward_host_ports(config: &serde_json::Value) -> Vec<HostForwardPort> {
+    config
+        .get("forwardPorts")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().filter_map(forward_host_port).collect())
+        .unwrap_or_default()
+}
+
+fn forward_host_port(value: &serde_json::Value) -> Option<HostForwardPort> {
+    let s = value.as_str()?;
+    let (host, port_str) = s.rsplit_once(':')?;
+    // Host must be non-empty and contain only valid DNS label characters.
+    if host.is_empty()
+        || !host
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_')
+    {
+        return None;
+    }
+    let port: u16 = port_str.parse().ok()?;
+    Some(HostForwardPort {
+        host: host.to_string(),
+        port,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -122,6 +156,68 @@ mod tests {
         assert_eq!(forward_port_number(&json!("localhost:3000")), None);
         // Non-numeric junk.
         assert_eq!(forward_port_number(&json!("abc")), None);
+    }
+
+    #[test]
+    fn forward_host_port_parses_service_colon_port() {
+        assert_eq!(
+            forward_host_port(&json!("db:5432")),
+            Some(HostForwardPort {
+                host: "db".to_string(),
+                port: 5432,
+            })
+        );
+        assert_eq!(
+            forward_host_port(&json!("localhost:3000")),
+            Some(HostForwardPort {
+                host: "localhost".to_string(),
+                port: 3000,
+            })
+        );
+        assert_eq!(
+            forward_host_port(&json!("my-service.internal:8080")),
+            Some(HostForwardPort {
+                host: "my-service.internal".to_string(),
+                port: 8080,
+            })
+        );
+    }
+
+    #[test]
+    fn forward_host_port_rejects_bare_numbers_and_junk() {
+        // Bare numbers → handled by parse_forward_ports, not here.
+        assert_eq!(forward_host_port(&json!(3000)), None);
+        // Numeric string → handled by parse_forward_ports.
+        assert_eq!(forward_host_port(&json!("9000")), None);
+        // Out-of-range port in host:port form.
+        assert_eq!(forward_host_port(&json!("db:70000")), None);
+        // Empty host.
+        assert_eq!(forward_host_port(&json!(":5432")), None);
+        // No colon — not a host:port.
+        assert_eq!(forward_host_port(&json!("abc")), None);
+        // Invalid host characters.
+        assert_eq!(forward_host_port(&json!("my service:80")), None);
+    }
+
+    #[test]
+    fn parse_forward_host_ports_extracts_host_port_entries() {
+        let config = json!({
+            "forwardPorts": [3000, "9000", "db:5432", "cache:6379", "70000", "localhost:3001"]
+        });
+        let result = parse_forward_host_ports(&config);
+        assert_eq!(result.len(), 3);
+        assert!(result.contains(&HostForwardPort {
+            host: "db".to_string(),
+            port: 5432,
+        }));
+        assert!(result.contains(&HostForwardPort {
+            host: "cache".to_string(),
+            port: 6379,
+        }));
+        assert!(result.contains(&HostForwardPort {
+            host: "localhost".to_string(),
+            port: 3001,
+        }));
     }
 
     #[test]
@@ -152,6 +248,14 @@ mod tests {
         // Numeric strings ("9000") are accepted; out-of-range (70000) and
         // "host:port" forms ("db:5432") are dropped by the number-only path.
         assert_eq!(data.forward_ports, vec![3000, 8080, 9000]);
+        // "db:5432" is extracted into forward_host_ports.
+        assert_eq!(
+            data.forward_host_ports,
+            vec![HostForwardPort {
+                host: "db".to_string(),
+                port: 5432
+            }]
+        );
         assert_eq!(data.shutdown_action.as_deref(), Some("none"));
         assert_eq!(data.backend_kind.as_deref(), Some("docker"));
         assert_eq!(

--- a/crates/cella-orchestrator/src/daemon_registration.rs
+++ b/crates/cella-orchestrator/src/daemon_registration.rs
@@ -106,8 +106,8 @@ fn parse_forward_ports(config: &serde_json::Value) -> Vec<u16> {
 
 /// Extract `host:port` entries from `forwardPorts`.
 ///
-/// Only string values matching `<host>:<port>` where host contains
-/// `[A-Za-z0-9._-]+` and port is a valid `u16` are returned. Bare numbers,
+/// Only string values matching the devcontainer schema's `host:port` pattern
+/// (`^([a-z0-9-]+):(\d{1,5})$`) with a `u16` port are returned. Bare numbers,
 /// numeric strings, and malformed entries are excluded (handled by
 /// `parse_forward_ports`).
 pub(crate) fn parse_forward_host_ports(config: &serde_json::Value) -> Vec<HostForwardPort> {
@@ -120,12 +120,15 @@ pub(crate) fn parse_forward_host_ports(config: &serde_json::Value) -> Vec<HostFo
 
 fn forward_host_port(value: &serde_json::Value) -> Option<HostForwardPort> {
     let s = value.as_str()?;
-    let (host, port_str) = s.rsplit_once(':')?;
-    // Host must be non-empty and contain only valid DNS label characters.
+    let (host, port_str) = s.split_once(':')?;
+    // Match the devcontainer schema's `host:port` host charset exactly
+    // (`[a-z0-9-]+`): lowercase alphanumerics and dashes. VS Code and the
+    // official CLI reject other characters (uppercase, `_`, `.`) as invalid
+    // hostnames, so accepting them here would diverge from the spec.
     if host.is_empty()
         || !host
             .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_')
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
     {
         return None;
     }
@@ -175,9 +178,9 @@ mod tests {
             })
         );
         assert_eq!(
-            forward_host_port(&json!("my-service.internal:8080")),
+            forward_host_port(&json!("my-service:8080")),
             Some(HostForwardPort {
-                host: "my-service.internal".to_string(),
+                host: "my-service".to_string(),
                 port: 8080,
             })
         );
@@ -195,8 +198,14 @@ mod tests {
         assert_eq!(forward_host_port(&json!(":5432")), None);
         // No colon — not a host:port.
         assert_eq!(forward_host_port(&json!("abc")), None);
-        // Invalid host characters.
+        // Invalid host characters (the schema host charset is `[a-z0-9-]`).
         assert_eq!(forward_host_port(&json!("my service:80")), None);
+        // Uppercase, dots, and underscores are not in the schema host charset.
+        assert_eq!(forward_host_port(&json!("MyService:80")), None);
+        assert_eq!(forward_host_port(&json!("my.service:80")), None);
+        assert_eq!(forward_host_port(&json!("my_service:80")), None);
+        // Multiple colons (extra `:` is not a valid host character).
+        assert_eq!(forward_host_port(&json!("a:b:80")), None);
     }
 
     #[test]

--- a/crates/cella-protocol/src/lib.rs
+++ b/crates/cella-protocol/src/lib.rs
@@ -246,6 +246,14 @@ pub enum AgentMessage {
 // Management protocol (CLI ↔ daemon via ~/.cella/daemon.sock)
 // ---------------------------------------------------------------------------
 
+/// A `host:port` entry from `forwardPorts` — a port reachable via the named
+/// DNS host from inside the workspace container (e.g. a Compose service name).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostForwardPort {
+    pub host: String,
+    pub port: u16,
+}
+
 /// Data for a container registration request.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContainerRegistrationData {
@@ -257,6 +265,10 @@ pub struct ContainerRegistrationData {
     /// Ports from `forwardPorts` in devcontainer.json (pre-allocate on registration).
     #[serde(default)]
     pub forward_ports: Vec<u16>,
+    /// `host:port` entries from `forwardPorts` — DNS names only resolvable from
+    /// inside the workspace container (e.g. Compose service names).
+    #[serde(default)]
+    pub forward_host_ports: Vec<HostForwardPort>,
     /// The `shutdownAction` from devcontainer.json (`"none"` or `"stopContainer"`).
     #[serde(default)]
     pub shutdown_action: Option<String>,
@@ -499,6 +511,10 @@ pub enum DaemonMessage {
     TunnelRequest {
         connection_id: u64,
         target_port: u16,
+        /// DNS hostname to connect to inside the container. `None` means
+        /// `localhost` (the existing numeric-port path).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        target_host: Option<String>,
     },
     /// Push the canonical `~/.claude.json` content to the agent so it can write
     /// it into the container. Only sent to agents that advertised
@@ -1073,19 +1089,85 @@ mod tests {
         let msg = DaemonMessage::TunnelRequest {
             connection_id: 99,
             target_port: 3000,
+            target_host: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         assert!(json.contains("\"type\":\"tunnel_request\""));
         assert!(json.contains("\"connection_id\":99"));
         assert!(json.contains("\"target_port\":3000"));
+        // target_host: None is skipped in serialization
+        assert!(!json.contains("target_host"));
         let decoded: DaemonMessage = serde_json::from_str(&json).unwrap();
         assert!(matches!(
             decoded,
             DaemonMessage::TunnelRequest {
                 connection_id: 99,
-                target_port: 3000
+                target_port: 3000,
+                target_host: None,
             }
         ));
+    }
+
+    #[test]
+    fn roundtrip_tunnel_request_with_target_host() {
+        let msg = DaemonMessage::TunnelRequest {
+            connection_id: 7,
+            target_port: 5432,
+            target_host: Some("db".to_string()),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("\"target_host\":\"db\""));
+        let decoded: DaemonMessage = serde_json::from_str(&json).unwrap();
+        assert!(matches!(
+            decoded,
+            DaemonMessage::TunnelRequest {
+                connection_id: 7,
+                target_port: 5432,
+                ref target_host,
+            } if target_host.as_deref() == Some("db")
+        ));
+    }
+
+    #[test]
+    fn tunnel_request_backward_compat_no_target_host() {
+        // Old wire format without target_host should deserialize with target_host=None
+        let json = r#"{"type":"tunnel_request","connection_id":1,"target_port":8080}"#;
+        let decoded: DaemonMessage = serde_json::from_str(json).unwrap();
+        assert!(matches!(
+            decoded,
+            DaemonMessage::TunnelRequest {
+                connection_id: 1,
+                target_port: 8080,
+                target_host: None,
+            }
+        ));
+    }
+
+    #[test]
+    fn host_forward_port_roundtrip() {
+        let hfp = HostForwardPort {
+            host: "db".to_string(),
+            port: 5432,
+        };
+        let json = serde_json::to_string(&hfp).unwrap();
+        let decoded: HostForwardPort = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, hfp);
+    }
+
+    #[test]
+    fn container_registration_data_backward_compat_no_forward_host_ports() {
+        // Old wire format without forward_host_ports should deserialize with empty vec
+        let json = r#"{
+            "container_id": "abc",
+            "container_name": "cella-test",
+            "container_ip": null,
+            "ports_attributes": [],
+            "other_ports_attributes": null,
+            "forward_ports": [3000]
+        }"#;
+        let data: ContainerRegistrationData = serde_json::from_str(json).unwrap();
+        assert_eq!(data.forward_ports, vec![3000]);
+        assert!(data.forward_host_ports.is_empty());
     }
 
     #[test]
@@ -1186,6 +1268,7 @@ mod tests {
             ports_attributes: vec![],
             other_ports_attributes: None,
             forward_ports: vec![],
+            forward_host_ports: vec![],
             shutdown_action: None,
             backend_kind: Some("docker".to_string()),
             docker_host: None,


### PR DESCRIPTION
Stacked on #150 — base retargets to main when that merges.

Completes `forwardPorts` support: a `"host:port"` entry (e.g. `"db:5432"`) now forwards `port` at DNS host `host` as resolved from inside the workspace container — the compose cross-service case. Previously these entries were dropped.

Design is strictly additive, so the common numeric/localhost path is byte-identical to before:
- New `HostForwardPort { host, port }` and a `forward_host_ports` field on the registration (`#[serde(default)]`); the existing `forward_ports: Vec<u16>` is untouched.
- `DaemonMessage::TunnelRequest` gains `target_host: Option<String>` (`#[serde(default, skip_serializing_if = "Option::is_none")]`) — `None` serializes to the exact pre-existing wire bytes and old/new daemon↔agent messages cross-deserialize cleanly (no `deny_unknown_fields`), so version-skew degrades gracefully to localhost rather than breaking.
- host:port entries always route through the agent tunnel (never `DirectIp`) because a DNS name like `db` only resolves inside the workspace container's network namespace; the in-container agent connects to `(host, port)`.
- `parse_forward_host_ports` is disjoint from the numeric parser — no double-forwarding. `"localhost:3000"` routes via the agent tunnel to localhost (distinct from bare `3000`'s DirectIp on Linux, consistent and tested). IPv6 literals are intentionally not accepted (spec is for DNS/service names).

Adversarially reviewed with focus on wire compatibility (the regression risk): additive invariant, forward/backward compat, agent-not-running graceful failure with a 5s timeout — all confirmed. Note: like all daemon state, host:port forwards are in-memory and not re-established after a daemon restart (same as numeric ports beyond label reconstruction).

Tests cover the parse matrix, serde round-trips, backward-compat deserialization, and the AgentTunnel target_host threading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)