### PR TITLE
fix: derive devcontainerId from lexical path, not realpath

### DIFF
--- a/crates/cella-backend/src/names.rs
+++ b/crates/cella-backend/src/names.rs
@@ -1,7 +1,7 @@
 //! Container/image naming and label generation.
 
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 use chrono::Utc;
 use sha2::{Digest, Sha256};
@@ -105,6 +105,44 @@ pub fn image_name_with_features(
     format!("cella-img-{identifier}-{path_hash}-{feat_hash}")
 }
 
+/// Make `path` absolute and lexically normalized — the Rust equivalent of
+/// Node's `path.resolve(path)`.
+///
+/// Relative paths are resolved against the current directory (best-effort OS
+/// query; falls back to the original path when `current_dir()` fails). `.` and
+/// `..` segments are then collapsed purely textually — no symlink resolution,
+/// no existence requirement.
+///
+/// This matches the path values used by VS Code and the official devcontainer
+/// CLI when computing `devcontainerId`, which hash the lexical workspace and
+/// config paths rather than their canonicalized (symlink-resolved) targets.
+pub fn lexical_absolute(path: &Path) -> PathBuf {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir().map_or_else(|_| path.to_path_buf(), |cwd| cwd.join(path))
+    };
+
+    let mut out = PathBuf::new();
+    for component in absolute.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                // Pop only a real path segment; never ascend past the root.
+                if out
+                    .components()
+                    .next_back()
+                    .is_some_and(|c| matches!(c, Component::Normal(_)))
+                {
+                    out.pop();
+                }
+            }
+            other => out.push(other),
+        }
+    }
+    out
+}
+
 /// Label key for the container backend kind.
 pub const BACKEND_LABEL: &str = "dev.cella.backend";
 
@@ -119,14 +157,14 @@ pub fn container_labels(
     config_hash: &str,
     runtime_label: &str,
 ) -> HashMap<String, String> {
-    let canonical_workspace = workspace_root
-        .canonicalize()
-        .unwrap_or_else(|_| workspace_root.to_path_buf());
-    let canonical_config = config_path
-        .canonicalize()
-        .unwrap_or_else(|_| config_path.to_path_buf());
-    let workspace_str = canonical_workspace.to_string_lossy().to_string();
-    let config_str = canonical_config.to_string_lossy().to_string();
+    // Use lexical (non-symlink-resolving) paths to match the values hashed by
+    // `devcontainer_id` and by VS Code / the official CLI. Canonicalization
+    // would resolve symlinks (e.g. macOS /tmp → /private/tmp, bind mounts) and
+    // make the labels disagree with the ID in symlinked-workspace scenarios.
+    let workspace_str = lexical_absolute(workspace_root)
+        .to_string_lossy()
+        .to_string();
+    let config_str = lexical_absolute(config_path).to_string_lossy().to_string();
 
     let mut labels = HashMap::new();
 

--- a/crates/cella-compose/src/orchestrate.rs
+++ b/crates/cella-compose/src/orchestrate.rs
@@ -19,7 +19,7 @@ use cella_backend::lifecycle::{lifecycle_entries_for_phase, run_lifecycle_entrie
 use cella_backend::progress::ProgressSender;
 use cella_backend::{
     ContainerBackend, ContainerInfo, ContainerState, LifecycleContext, MountSpec,
-    SshAgentProxyStatus, agent_env_vars, run_lifecycle_phase,
+    SshAgentProxyStatus, agent_env_vars, names::lexical_absolute, run_lifecycle_phase,
 };
 use cella_config::devcontainer::resolve::ResolvedConfig;
 
@@ -1288,16 +1288,14 @@ fn build_compose_labels(
     project: &ComposeProject,
     remote_user: &str,
 ) -> BTreeMap<String, String> {
-    let workspace_str = cfg
-        .workspace_root
-        .canonicalize()
-        .unwrap_or_else(|_| cfg.workspace_root.to_path_buf())
+    // Use lexical (non-symlink-resolving) paths to match the values hashed by
+    // `devcontainer_id` and by VS Code / the official CLI. Canonicalization
+    // would resolve symlinks (e.g. macOS /tmp → /private/tmp, bind mounts) and
+    // make the labels disagree with the ID in symlinked-workspace scenarios.
+    let workspace_str = lexical_absolute(cfg.workspace_root)
         .to_string_lossy()
         .to_string();
-    let config_str = cfg
-        .config_path
-        .canonicalize()
-        .unwrap_or_else(|_| cfg.config_path.to_path_buf())
+    let config_str = lexical_absolute(cfg.config_path)
         .to_string_lossy()
         .to_string();
 

--- a/crates/cella-config/src/devcontainer/resolve.rs
+++ b/crates/cella-config/src/devcontainer/resolve.rs
@@ -1,7 +1,7 @@
 //! Config resolution: discover, parse, merge layers, compute hash.
 
 use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use sha2::{Digest, Sha256};
 use tracing::debug;
@@ -112,23 +112,55 @@ impl ResolvedConfig {
 /// Per <https://containers.dev/implementors/spec/#devcontainerid>:
 /// SHA-256 of the sorted JSON label object, base-32 encoded, left-padded to 52 chars.
 pub fn devcontainer_id(workspace_root: &Path, config_path: &Path) -> String {
-    let canonical_workspace = workspace_root
-        .canonicalize()
-        .unwrap_or_else(|_| workspace_root.to_path_buf());
-    let canonical_config = config_path
-        .canonicalize()
-        .unwrap_or_else(|_| config_path.to_path_buf());
-
+    // Match the official CLI's label values, which use a LEXICAL absolute path
+    // (Node's `path.resolve`) — it collapses `.`/`..` but never follows
+    // symlinks. Using `canonicalize()` here would resolve symlinks (e.g. macOS
+    // `/tmp` -> `/private/tmp`, bind mounts) and produce a different id than VS
+    // Code / the official CLI, breaking cross-tool container reuse and shared
+    // volume names.
     let mut labels = BTreeMap::new();
     labels.insert(
         "devcontainer.local_folder".to_string(),
-        canonical_workspace.to_string_lossy().to_string(),
+        lexical_absolute(workspace_root)
+            .to_string_lossy()
+            .to_string(),
     );
     labels.insert(
         "devcontainer.config_file".to_string(),
-        canonical_config.to_string_lossy().to_string(),
+        lexical_absolute(config_path).to_string_lossy().to_string(),
     );
     spec_devcontainer_id(&labels)
+}
+
+/// Make `path` absolute and lexically normalized — the Rust equivalent of
+/// Node's `path.resolve(path)`. Relative paths are resolved against the current
+/// directory; `.` and `..` segments are collapsed purely textually, WITHOUT
+/// touching the filesystem or following symlinks.
+fn lexical_absolute(path: &Path) -> PathBuf {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir().map_or_else(|_| path.to_path_buf(), |cwd| cwd.join(path))
+    };
+
+    let mut out = PathBuf::new();
+    for component in absolute.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                // Pop only a real path segment; never ascend past the root.
+                if out
+                    .components()
+                    .next_back()
+                    .is_some_and(|c| matches!(c, Component::Normal(_)))
+                {
+                    out.pop();
+                }
+            }
+            other => out.push(other),
+        }
+    }
+    out
 }
 
 fn spec_devcontainer_id(labels: &BTreeMap<String, String>) -> String {
@@ -595,6 +627,39 @@ mod tests {
 
     // --- Spec: devcontainerId computation ---
     // Reference: https://containers.dev/implementors/spec/#devcontainerid
+
+    #[test]
+    fn lexical_absolute_collapses_dot_dot_without_symlinks() {
+        assert_eq!(lexical_absolute(Path::new("/a/b/../c")), Path::new("/a/c"));
+        assert_eq!(lexical_absolute(Path::new("/a/./b")), Path::new("/a/b"));
+        // Cannot ascend past the root.
+        assert_eq!(lexical_absolute(Path::new("/../x")), Path::new("/x"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn devcontainer_id_does_not_follow_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let real = TempDir::new().unwrap();
+        create_devcontainer(real.path(), r#"{"image": "ubuntu"}"#);
+        let real_cfg = real.path().join(".devcontainer/devcontainer.json");
+
+        // A symlink pointing at the real workspace.
+        let link_parent = TempDir::new().unwrap();
+        let link = link_parent.path().join("link");
+        symlink(real.path(), &link).unwrap();
+        let link_cfg = link.join(".devcontainer/devcontainer.json");
+
+        // The id must derive from the symlink PATH (lexical), not its target —
+        // otherwise it wouldn't match VS Code / the official CLI, which never
+        // resolve symlinks for the id labels.
+        let via_link = devcontainer_id(&link, &link_cfg);
+        let via_real = devcontainer_id(real.path(), &real_cfg);
+        assert_ne!(via_link, via_real);
+        // And it's stable for the same (symlink) path.
+        assert_eq!(via_link, devcontainer_id(&link, &link_cfg));
+    }
 
     #[test]
     fn devcontainer_id_is_52_chars() {

--- a/crates/cella-config/src/devcontainer/resolve.rs
+++ b/crates/cella-config/src/devcontainer/resolve.rs
@@ -1,8 +1,9 @@
 //! Config resolution: discover, parse, merge layers, compute hash.
 
 use std::collections::BTreeMap;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 
+use cella_backend::names::lexical_absolute;
 use sha2::{Digest, Sha256};
 use tracing::debug;
 
@@ -130,37 +131,6 @@ pub fn devcontainer_id(workspace_root: &Path, config_path: &Path) -> String {
         lexical_absolute(config_path).to_string_lossy().to_string(),
     );
     spec_devcontainer_id(&labels)
-}
-
-/// Make `path` absolute and lexically normalized — the Rust equivalent of
-/// Node's `path.resolve(path)`. Relative paths are resolved against the current
-/// directory; `.` and `..` segments are collapsed purely textually, WITHOUT
-/// touching the filesystem or following symlinks.
-fn lexical_absolute(path: &Path) -> PathBuf {
-    let absolute = if path.is_absolute() {
-        path.to_path_buf()
-    } else {
-        std::env::current_dir().map_or_else(|_| path.to_path_buf(), |cwd| cwd.join(path))
-    };
-
-    let mut out = PathBuf::new();
-    for component in absolute.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                // Pop only a real path segment; never ascend past the root.
-                if out
-                    .components()
-                    .next_back()
-                    .is_some_and(|c| matches!(c, Component::Normal(_)))
-                {
-                    out.pop();
-                }
-            }
-            other => out.push(other),
-        }
-    }
-    out
 }
 
 fn spec_devcontainer_id(labels: &BTreeMap<String, String>) -> String {
@@ -404,6 +374,7 @@ fn home_dir() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cella_backend::names::lexical_absolute;
     use tempfile::TempDir;
 
     fn create_devcontainer(workspace: &Path, content: &str) {


### PR DESCRIPTION
`${devcontainerId}` (and the volume names / container identity derived from it) was computed by `canonicalize()`-ing the workspace and config paths, which follows symlinks. The official CLI and VS Code hash the `devcontainer.local_folder` / `devcontainer.config_file` label values produced by Node's `path.resolve` — a purely lexical absolute path that collapses `.`/`..` but never follows symlinks.

On any symlinked path (macOS `/tmp` → `/private/tmp`, bind-mounted workspaces, symlinked home dirs) cella therefore computed a **different** id than VS Code/the official CLI, so:
- `${devcontainerId}`-templated volume names (e.g. the Docker-in-Docker feature's `dind-var-lib-docker-<id>`) didn't match
- cella couldn't re-identify containers created by VS Code, and vice versa

Replaced `canonicalize()` with a `lexical_absolute` helper that mirrors `path.resolve`: makes the path absolute (against cwd if relative) and collapses `.`/`..` textually without any filesystem access. `canonicalize()` also required the path to exist and silently fell back to the raw path on failure — the lexical version is consistent regardless.

Tests: lexical collapse cases (`/a/b/../c`, can't ascend past root) and a Unix regression test asserting the id derives from a symlink's own path, not its target, and stays stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)