### PR TITLE
feat: resolve ${containerEnv:VAR} in remoteEnv against the live container

### DIFF
--- a/crates/cella-cli/src/commands/features/test.rs
+++ b/crates/cella-cli/src/commands/features/test.rs
@@ -832,6 +832,7 @@ async fn bring_up_test_container(
         resolved: &resolved,
         container_name: &container_name,
         remote_env: &empty_vec,
+        raw_remote_env: None,
         cli_remote_env: &empty_vec,
         workspace_folder_from_config: None,
         default_workspace_folder: &default_workspace_folder,

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -1484,6 +1484,7 @@ impl UpContext {
             resolved: &self.resolved,
             container_name: &self.container_nm,
             remote_env: &self.remote_env,
+            raw_remote_env: self.resolved.raw_remote_env.as_ref(),
             cli_remote_env: &self.cli_remote_env,
             workspace_folder_from_config: self.workspace_folder(),
             default_workspace_folder: &self.default_workspace_folder,

--- a/crates/cella-compose/src/orchestrate.rs
+++ b/crates/cella-compose/src/orchestrate.rs
@@ -1681,6 +1681,7 @@ mod tests {
             devcontainer_id: String::new(),
             warnings: vec![],
             typed: None,
+            raw_remote_env: None,
         };
         let cfg = ComposeUpConfig {
             resolved: &resolved,
@@ -1748,6 +1749,7 @@ mod tests {
             devcontainer_id: String::new(),
             warnings: vec![],
             typed: None,
+            raw_remote_env: None,
         };
         let cfg = ComposeUpConfig {
             resolved: &resolved,

--- a/crates/cella-config/src/cella_config/mod.rs
+++ b/crates/cella-config/src/cella_config/mod.rs
@@ -123,6 +123,7 @@ mod tests {
             devcontainer_id: String::new(),
             warnings: vec![],
             typed,
+            raw_remote_env: None,
         }
     }
 

--- a/crates/cella-config/src/devcontainer/resolve.rs
+++ b/crates/cella-config/src/devcontainer/resolve.rs
@@ -29,6 +29,14 @@ pub struct ResolvedConfig {
     pub warnings: Vec<Diagnostic>,
     /// Typed representation of the merged config, if validation succeeded.
     pub typed: Option<crate::schema::DevContainer>,
+    /// The raw (pre-substitution) `remoteEnv` object from the merged config.
+    ///
+    /// Captured before the phase-1 substitution pass so the orchestrator can
+    /// perform a second-pass resolution after `userEnvProbe` has captured the
+    /// container's live environment, enabling `${containerEnv:VAR}` in
+    /// `remoteEnv` to resolve against the actual running container.  `None`
+    /// when the merged config has no `remoteEnv` key.
+    pub raw_remote_env: Option<serde_json::Value>,
 }
 
 impl ResolvedConfig {
@@ -281,6 +289,12 @@ pub fn config_with_override(
         &devcontainer_id,
         env,
     );
+
+    // Snapshot raw remoteEnv BEFORE phase-1 substitution so the orchestrator
+    // can perform a second pass after userEnvProbe, resolving
+    // ${containerEnv:VAR} against the live container environment.
+    let raw_remote_env = config.get("remoteEnv").cloned();
+
     ctx.substitute_value(&mut config);
 
     // Deprecation warnings for legacy properties
@@ -320,6 +334,7 @@ pub fn config_with_override(
         devcontainer_id,
         warnings,
         typed,
+        raw_remote_env,
     })
 }
 
@@ -351,6 +366,9 @@ pub fn from_config_value(
         devcontainer_id,
         warnings: Vec::new(),
         typed,
+        // Config sourced from a container label is already substituted — no
+        // raw snapshot is available for a second-pass containerEnv resolution.
+        raw_remote_env: None,
     }
 }
 

--- a/crates/cella-config/src/devcontainer/subst.rs
+++ b/crates/cella-config/src/devcontainer/subst.rs
@@ -53,7 +53,7 @@ impl SubstitutionContext {
         }
     }
 
-    /// Return a clone of this context with `container_env` populated.
+    /// Consume this context and return it with `container_env` populated.
     ///
     /// Used for the second-pass `remoteEnv` resolution after container start,
     /// where `${containerEnv:VAR}` should resolve against the live container
@@ -119,10 +119,11 @@ impl SubstitutionContext {
     /// and returns one `KEY=value` string per entry, with all `${...}`
     /// expressions in the values resolved by this context.
     ///
-    /// Non-object or `null` input returns an empty vec.  This is the canonical
-    /// place to resolve `remoteEnv` — both the config-time pass and the
-    /// post-start second pass go through here so ordering and formatting are
-    /// consistent.
+    /// Non-object or `null` input returns an empty vec.  Used for the
+    /// post-start second pass where `container_env` is populated so that
+    /// `${containerEnv:VAR}` tokens resolve against the live container
+    /// environment.  Config-time `remoteEnv` is handled separately by
+    /// `config_map::env::map_remote_env`.
     #[must_use]
     pub fn substitute_remote_env(&self, raw_remote_env: &serde_json::Value) -> Vec<String> {
         let Some(obj) = raw_remote_env.as_object() else {
@@ -666,5 +667,29 @@ mod tests {
             "/projects/myapp"
         );
         assert_eq!(ctx.substitute_str("${containerEnv:FOO}"), "bar");
+    }
+
+    /// Regression: when `remoteEnv` contains no `${containerEnv:` tokens, the
+    /// second-pass substitution must produce byte-identical output to the
+    /// phase-1 pass regardless of whether `container_env` is populated.  This
+    /// is the invariant that lets `resolved_remote_env` in the orchestrator
+    /// skip the second pass cheaply.
+    #[test]
+    fn substitute_remote_env_no_container_env_tokens_is_idempotent() {
+        let raw = serde_json::json!({
+            "EDITOR": "vim",
+            "HOME": "${localEnv:HOME}",
+            "WS": "${containerWorkspaceFolder}"
+        });
+        let ctx_empty = test_ctx();
+        let first_pass = ctx_empty.substitute_remote_env(&raw);
+
+        let mut cenv = HashMap::new();
+        cenv.insert("HOME".to_string(), "/container/home".to_string());
+        let ctx_live = test_ctx().with_container_env(cenv);
+        let second_pass = ctx_live.substitute_remote_env(&raw);
+
+        // No ${containerEnv:…} tokens → both passes must agree
+        assert_eq!(first_pass, second_pass);
     }
 }

--- a/crates/cella-config/src/devcontainer/subst.rs
+++ b/crates/cella-config/src/devcontainer/subst.rs
@@ -15,6 +15,12 @@ pub struct SubstitutionContext {
     local_workspace_folder_basename: String,
     container_workspace_folder: String,
     devcontainer_id: String,
+    /// Live container environment for `${containerEnv:VAR}` resolution.
+    ///
+    /// Empty by default (config-parse time). Populated for the second-pass
+    /// `remoteEnv` resolution after `userEnvProbe` has captured the container's
+    /// actual env.
+    container_env: HashMap<String, String>,
 }
 
 impl SubstitutionContext {
@@ -43,7 +49,19 @@ impl SubstitutionContext {
             local_workspace_folder_basename: basename,
             container_workspace_folder: container_wf,
             devcontainer_id: devcontainer_id.to_string(),
+            container_env: HashMap::new(),
         }
+    }
+
+    /// Return a clone of this context with `container_env` populated.
+    ///
+    /// Used for the second-pass `remoteEnv` resolution after container start,
+    /// where `${containerEnv:VAR}` should resolve against the live container
+    /// environment captured by `userEnvProbe`.
+    #[must_use]
+    pub fn with_container_env(mut self, container_env: HashMap<String, String>) -> Self {
+        self.container_env = container_env;
+        self
     }
 
     /// Substitute all `${...}` expressions in a string.
@@ -95,6 +113,29 @@ impl SubstitutionContext {
         }
     }
 
+    /// Resolve a raw `remoteEnv` JSON object into `KEY=value` strings.
+    ///
+    /// Accepts the pre-substitution `remoteEnv` value (a `{"K":"V"}` object)
+    /// and returns one `KEY=value` string per entry, with all `${...}`
+    /// expressions in the values resolved by this context.
+    ///
+    /// Non-object or `null` input returns an empty vec.  This is the canonical
+    /// place to resolve `remoteEnv` — both the config-time pass and the
+    /// post-start second pass go through here so ordering and formatting are
+    /// consistent.
+    #[must_use]
+    pub fn substitute_remote_env(&self, raw_remote_env: &serde_json::Value) -> Vec<String> {
+        let Some(obj) = raw_remote_env.as_object() else {
+            return Vec::new();
+        };
+        obj.iter()
+            .map(|(k, v)| {
+                let raw_val = v.as_str().unwrap_or("");
+                format!("{k}={}", self.substitute_str(raw_val))
+            })
+            .collect()
+    }
+
     /// Resolve a single expression (the content between `${` and `}`).
     fn resolve_expr(&self, expr: &str) -> String {
         // Split into at most 3 parts: keyword, name, default
@@ -111,10 +152,15 @@ impl SubstitutionContext {
                     .unwrap_or_else(|| default.to_string())
             }
             "containerEnv" => {
-                // Container not running at resolve time — use default or empty
-                parts.next(); // advance past var name to reach default
+                let var_name = parts.next().unwrap_or("");
                 let default = parts.next().unwrap_or("");
-                default.to_string()
+                // When container_env is populated (second pass after container
+                // start), resolve against the live env. At config-parse time
+                // container_env is empty, so we fall through to `default` or ""
+                // — identical to today's behaviour.
+                self.container_env
+                    .get(var_name)
+                    .map_or_else(|| default.to_string(), Clone::clone)
             }
             "localWorkspaceFolder" => self.local_workspace_folder.clone(),
             "containerWorkspaceFolder" => self.container_workspace_folder.clone(),
@@ -146,6 +192,7 @@ mod tests {
             local_workspace_folder_basename: "myapp".to_string(),
             container_workspace_folder: "/workspaces/myapp".to_string(),
             devcontainer_id: "abc123".to_string(),
+            container_env: HashMap::new(),
         }
     }
 
@@ -493,5 +540,131 @@ mod tests {
             ctx.substitute_str("${localEnv:TRICKY}"),
             "${localWorkspaceFolder}"
         );
+    }
+
+    // --- with_container_env / substitute_remote_env tests ---
+
+    fn ctx_with_container_env() -> SubstitutionContext {
+        let mut local = HashMap::new();
+        local.insert("HOME".to_string(), "/home/testuser".to_string());
+        let mut cenv = HashMap::new();
+        cenv.insert(
+            "PATH".to_string(),
+            "/usr/local/bin:/usr/bin:/bin".to_string(),
+        );
+        cenv.insert("SHELL".to_string(), "/bin/bash".to_string());
+        SubstitutionContext {
+            local_env: local,
+            local_workspace_folder: "/projects/myapp".to_string(),
+            local_workspace_folder_basename: "myapp".to_string(),
+            container_workspace_folder: "/workspaces/myapp".to_string(),
+            devcontainer_id: "abc123".to_string(),
+            container_env: cenv,
+        }
+    }
+
+    #[test]
+    fn with_container_env_resolves_container_env_var() {
+        let ctx = ctx_with_container_env();
+        assert_eq!(
+            ctx.substitute_str("${containerEnv:PATH}"),
+            "/usr/local/bin:/usr/bin:/bin"
+        );
+    }
+
+    #[test]
+    fn with_container_env_appends_to_existing_path() {
+        let ctx = ctx_with_container_env();
+        assert_eq!(
+            ctx.substitute_str("${containerEnv:PATH}:/extra/bin"),
+            "/usr/local/bin:/usr/bin:/bin:/extra/bin"
+        );
+    }
+
+    #[test]
+    fn with_container_env_missing_var_falls_back_to_default() {
+        let ctx = ctx_with_container_env();
+        assert_eq!(
+            ctx.substitute_str("${containerEnv:NONEXISTENT:fallback}"),
+            "fallback"
+        );
+    }
+
+    #[test]
+    fn with_container_env_missing_var_no_default_is_empty() {
+        let ctx = ctx_with_container_env();
+        assert_eq!(ctx.substitute_str("${containerEnv:NONEXISTENT}"), "");
+    }
+
+    /// Prove additive invariant: empty `container_env` produces identical output
+    /// to the pre-feature behaviour.
+    #[test]
+    fn empty_container_env_collapses_to_default() {
+        let ctx = test_ctx(); // container_env is empty
+        assert_eq!(ctx.substitute_str("${containerEnv:PATH}"), "");
+        assert_eq!(
+            ctx.substitute_str("${containerEnv:PATH:/usr/bin}"),
+            "/usr/bin"
+        );
+    }
+
+    #[test]
+    fn substitute_remote_env_resolves_mixed_entries() {
+        let ctx = ctx_with_container_env();
+        let raw = serde_json::json!({
+            "PATH": "${containerEnv:PATH}:/extra/bin",
+            "HOME": "${localEnv:HOME}",
+            "LITERAL": "plain-value"
+        });
+        let result = ctx.substitute_remote_env(&raw);
+        assert!(result.contains(&"PATH=/usr/local/bin:/usr/bin:/bin:/extra/bin".to_string()));
+        assert!(result.contains(&"HOME=/home/testuser".to_string()));
+        assert!(result.contains(&"LITERAL=plain-value".to_string()));
+        assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn substitute_remote_env_non_object_returns_empty() {
+        let ctx = test_ctx();
+        assert!(
+            ctx.substitute_remote_env(&serde_json::json!(null))
+                .is_empty()
+        );
+        assert!(
+            ctx.substitute_remote_env(&serde_json::json!("str"))
+                .is_empty()
+        );
+        assert!(ctx.substitute_remote_env(&serde_json::json!([])).is_empty());
+    }
+
+    #[test]
+    fn substitute_remote_env_without_container_env_uses_defaults() {
+        // Proves the non-containerEnv path is unchanged: same output regardless
+        // of whether container_env is populated.
+        let ctx_empty = test_ctx();
+        let raw = serde_json::json!({
+            "EDITOR": "vim",
+            "HOME": "${localEnv:HOME}"
+        });
+        let result_empty = ctx_empty.substitute_remote_env(&raw);
+        // Now with container_env populated — same entries should be equal
+        let ctx_live = ctx_with_container_env();
+        let result_live = ctx_live.substitute_remote_env(&raw);
+        assert_eq!(result_empty, result_live);
+    }
+
+    #[test]
+    fn with_container_env_builder_leaves_other_fields_intact() {
+        let base = test_ctx();
+        let mut cenv = HashMap::new();
+        cenv.insert("FOO".to_string(), "bar".to_string());
+        let ctx = base.with_container_env(cenv);
+        // Other substitutions still work after with_container_env
+        assert_eq!(ctx.substitute_str("${localEnv:HOME}"), "/home/testuser");
+        assert_eq!(
+            ctx.substitute_str("${localWorkspaceFolder}"),
+            "/projects/myapp"
+        );
+        assert_eq!(ctx.substitute_str("${containerEnv:FOO}"), "bar");
     }
 }

--- a/crates/cella-orchestrator/src/config.rs
+++ b/crates/cella-orchestrator/src/config.rs
@@ -106,6 +106,13 @@ pub struct UpConfig<'a> {
     /// Remote environment entries from config (`remoteEnv`). Used for lifecycle
     /// command env AND persisted in the `dev.cella.remote_env` metadata label.
     pub remote_env: &'a [String],
+    /// Raw (pre-substitution) `remoteEnv` JSON value from the merged config.
+    ///
+    /// `Some` when the config was read from disk and has a `remoteEnv` key;
+    /// `None` when the config was reconstructed from a container label (already
+    /// substituted) or when `remoteEnv` was absent.  Used by the orchestrator
+    /// for the second-pass containerEnv resolution after `userEnvProbe`.
+    pub raw_remote_env: Option<&'a serde_json::Value>,
     /// Remote environment entries from the CLI `--remote-env` flag. Applied to
     /// lifecycle command env ONLY (config `remote_env` wins on key collision);
     /// runtime-only — must NOT enter labels, image layers, or `containerEnv`.

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -380,7 +380,8 @@ impl EnsureUpContext<'_> {
                 .or(probed_env)
         };
 
-        let combined_remote_env = self.lifecycle_remote_env(self.config.remote_env);
+        let resolved_remote_env = resolved_remote_env(self.config, final_probed.as_ref());
+        let combined_remote_env = self.lifecycle_remote_env(&resolved_remote_env);
         let mut lifecycle_env = final_probed.as_ref().map_or_else(
             || combined_remote_env.clone(),
             |probed| cella_env::user_env_probe::merge_env(probed, &combined_remote_env),
@@ -1242,7 +1243,6 @@ impl EnsureUpContext<'_> {
         remote_user: &str,
         env_fwd: &cella_env::EnvForwarding,
         settings: &cella_config::CellaConfig,
-        remote_env: &[String],
     ) -> (
         Option<std::collections::HashMap<String, String>>,
         Vec<String>,
@@ -1339,15 +1339,8 @@ impl EnsureUpContext<'_> {
                 .await;
         }
 
-        self.install_tools_and_probe_env(
-            container_id,
-            remote_user,
-            settings,
-            &shell,
-            probed_env,
-            remote_env,
-        )
-        .await
+        self.install_tools_and_probe_env(container_id, remote_user, settings, &shell, probed_env)
+            .await
     }
 
     async fn install_tools_and_probe_env(
@@ -1357,7 +1350,6 @@ impl EnsureUpContext<'_> {
         settings: &cella_config::CellaConfig,
         shell: &str,
         probed_env: Option<std::collections::HashMap<String, String>>,
-        remote_env: &[String],
     ) -> (
         Option<std::collections::HashMap<String, String>>,
         Vec<String>,
@@ -1404,9 +1396,11 @@ impl EnsureUpContext<'_> {
                 .or(probed_env)
         };
 
+        let resolved = resolved_remote_env(self.config, final_probed.as_ref());
+        let effective_remote_env = self.lifecycle_remote_env(&resolved);
         let mut lifecycle_env = final_probed.as_ref().map_or_else(
-            || remote_env.to_vec(),
-            |probed| cella_env::user_env_probe::merge_env(probed, remote_env),
+            || effective_remote_env.clone(),
+            |probed| cella_env::user_env_probe::merge_env(probed, &effective_remote_env),
         );
         if !self.config.lifecycle_secrets.is_empty() {
             lifecycle_env.extend_from_slice(self.config.lifecycle_secrets);
@@ -1942,15 +1936,8 @@ impl EnsureUpContext<'_> {
 
         self.start_and_notify(&container_id).await?;
 
-        let create_lifecycle_remote_env = self.lifecycle_remote_env(&create_opts.remote_env);
         let (_probed_env, lifecycle_env) = self
-            .post_create_setup(
-                &container_id,
-                &remote_user,
-                &env_fwd,
-                &settings,
-                &create_lifecycle_remote_env,
-            )
+            .post_create_setup(&container_id, &remote_user, &env_fwd, &settings)
             .await;
 
         let lifecycle_err = self
@@ -2348,14 +2335,31 @@ fn injected_proxy_config(post_start: &cella_env::PostStartInjection) -> bool {
         .any(|upload| upload.container_path == cella_env::PROXY_CONFIG_PATH)
 }
 
-/// Restart the in-container agent daemon.
+/// Resolve `remoteEnv` to a `KEY=value` vec for lifecycle command injection.
 ///
-/// Kills only the `cella-agent daemon` process (not credential or browser
-/// helpers that exec the same binary), waits briefly for the entrypoint
-/// restart loop to respawn it, and only explicitly starts a replacement
-/// if nothing came back. This avoids double-launching the daemon on
-/// containers with the restart loop while remaining backward compatible
-/// with containers created before it was introduced.
+/// When both `raw_remote_env` (the pre-substitution snapshot from config
+/// parse) and `probed_env` (the live container env from `userEnvProbe`) are
+/// available, performs a second-pass substitution so that
+/// `${containerEnv:VAR}` tokens in `remoteEnv` resolve against the actual
+/// running container environment — matching the official CLI's
+/// `containerSubstitute` pass.
+///
+/// Falls back to `config.remote_env` (the phase-1-substituted slice) when
+/// either input is absent, preserving identical behaviour for all existing
+/// callers that have no `${containerEnv:...}` tokens.
+fn resolved_remote_env(
+    config: &UpConfig<'_>,
+    probed_env: Option<&std::collections::HashMap<String, String>>,
+) -> Vec<String> {
+    if let (Some(raw), Some(probed)) = (config.raw_remote_env, probed_env) {
+        let ctx =
+            cella_config::config_map::subst_ctx(config.resolved).with_container_env(probed.clone());
+        ctx.substitute_remote_env(raw)
+    } else {
+        config.remote_env.to_vec()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -2339,25 +2339,26 @@ fn injected_proxy_config(post_start: &cella_env::PostStartInjection) -> bool {
 ///
 /// When both `raw_remote_env` (the pre-substitution snapshot from config
 /// parse) and `probed_env` (the live container env from `userEnvProbe`) are
-/// available, performs a second-pass substitution so that
-/// `${containerEnv:VAR}` tokens in `remoteEnv` resolve against the actual
-/// running container environment — matching the official CLI's
+/// available **and** at least one value contains a `${containerEnv:` token,
+/// performs a second-pass substitution so that those tokens resolve against
+/// the actual running container environment — matching the official CLI's
 /// `containerSubstitute` pass.
 ///
 /// Falls back to `config.remote_env` (the phase-1-substituted slice) when
-/// either input is absent, preserving identical behaviour for all existing
-/// callers that have no `${containerEnv:...}` tokens.
+/// either input is absent or no `${containerEnv:` tokens are present,
+/// preserving identical behaviour for configs that don't use them.
 fn resolved_remote_env(
     config: &UpConfig<'_>,
     probed_env: Option<&std::collections::HashMap<String, String>>,
 ) -> Vec<String> {
-    if let (Some(raw), Some(probed)) = (config.raw_remote_env, probed_env) {
+    if let (Some(raw), Some(probed)) = (config.raw_remote_env, probed_env)
+        && raw.to_string().contains("${containerEnv:")
+    {
         let ctx =
             cella_config::config_map::subst_ctx(config.resolved).with_container_env(probed.clone());
-        ctx.substitute_remote_env(raw)
-    } else {
-        config.remote_env.to_vec()
+        return ctx.substitute_remote_env(raw);
     }
+    config.remote_env.to_vec()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
`${containerEnv:VAR}` in `remoteEnv` collapsed to `""` at config-parse time, so a common pattern like `"PATH": "${containerEnv:PATH}:/extra/bin"` resolved to `":/extra/bin"` — a broken PATH. The official CLI resolves `containerEnv` against the live container environment after start (its `containerSubstitute` pass).

This adds that second pass for the single-container `up` path, strictly additively:
- `SubstitutionContext` gains a `container_env` map (`with_container_env`); the `containerEnv` arm resolves from it, falling back to the `:default`/`""` exactly as before when the map is empty — so every existing caller is unchanged.
- `ResolvedConfig` snapshots the **raw** `remoteEnv` (before phase-1 substitution) so the unresolved `${containerEnv:…}` tokens survive.
- After `userEnvProbe` yields the live container env, `remoteEnv` is re-resolved from the raw value with that env and used for lifecycle/exec injection. When the probe is unavailable (`userEnvProbe: none` / `--skip-post-create`) or there are no containerEnv tokens, it falls back to the phase-1 value — byte-identical to before.

Adversarially reviewed (focus on silent env regressions): the additive invariant holds — remoteEnv without containerEnv tokens produces identical lifecycle env, same ordering/precedence (cli > config > probed). NO critical findings.

**Scope:** single-container path only. The Docker Compose path still collapses `containerEnv` to `""` (unchanged — not a regression); wiring it needs a `post_create_setup` hook-signature change because compose computes the lifecycle env before its probe runs, so it's a separate follow-up. The `run-user-commands`/exec path (reads the already-substituted value from the container label) is likewise deferred.

Tests prove the additive invariant, live resolution, PATH-append, and default fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)