### PR TITLE
feat: resolve ${containerEnv:VAR} in remoteEnv on the compose path

### DIFF
--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -1283,8 +1283,12 @@ impl UpContext {
                 .or(probed_env)
         };
 
-        let mut lifecycle_env =
-            build_lifecycle_env(&self.resolved, remote_env, final_probed.as_ref());
+        let mut lifecycle_env = build_lifecycle_env(
+            &self.resolved,
+            &self.cli_remote_env,
+            remote_env,
+            final_probed.as_ref(),
+        );
         lifecycle_env.extend(self.lifecycle_secrets.iter().cloned());
 
         (final_probed, lifecycle_env)
@@ -2072,15 +2076,27 @@ pub async fn write_daemon_addr_to_volume(client: &dyn ContainerBackend) -> bool 
 /// single-container orchestrator path gets.
 fn build_lifecycle_env(
     resolved: &ResolvedConfig,
+    cli_remote_env: &[String],
     remote_env: &[String],
     probed_env: Option<&std::collections::HashMap<String, String>>,
 ) -> Vec<String> {
     let effective: Vec<String> = if let (Some(raw), Some(probed)) =
         (resolved.raw_remote_env.as_ref(), probed_env)
     {
+        // Re-resolve the config `remoteEnv` with live `${containerEnv:VAR}`
+        // values. `remote_env` (cli + config, pre-chained by the caller) is
+        // bypassed here, so the CLI `--remote-env` entries must be re-chained
+        // ahead of the resolved config env — same order/precedence as the
+        // single-container `lifecycle_remote_env` (cli first, config wins on
+        // collision under later-wins merge).
         let ctx = cella_config::config_map::subst_ctx(resolved).with_container_env(probed.clone());
-        ctx.substitute_remote_env(raw)
+        cli_remote_env
+            .iter()
+            .cloned()
+            .chain(ctx.substitute_remote_env(raw))
+            .collect()
     } else {
+        // Fallback path unchanged: `remote_env` already contains cli + config.
         remote_env.to_vec()
     };
     probed_env.map_or_else(
@@ -2943,7 +2959,7 @@ mod tests {
         let probed: std::collections::HashMap<String, String> =
             [("PATH".to_string(), "/usr/bin".to_string())].into();
 
-        let result = build_lifecycle_env(&resolved, &remote_env, Some(&probed));
+        let result = build_lifecycle_env(&resolved, &[], &remote_env, Some(&probed));
 
         // merge_env puts probed first then config overrides; FOO/BAZ come from config
         assert!(result.contains(&"FOO=bar".to_string()));
@@ -2958,7 +2974,7 @@ mod tests {
         let resolved = minimal_resolved(Some(raw));
         let remote_env = vec!["FOO=original".to_string()];
 
-        let result = build_lifecycle_env(&resolved, &remote_env, None);
+        let result = build_lifecycle_env(&resolved, &[], &remote_env, None);
 
         assert_eq!(result, remote_env);
     }
@@ -2973,12 +2989,36 @@ mod tests {
         let probed: std::collections::HashMap<String, String> =
             [("PATH".to_string(), "/container/bin".to_string())].into();
 
-        let result = build_lifecycle_env(&resolved, &remote_env, Some(&probed));
+        let result = build_lifecycle_env(&resolved, &[], &remote_env, Some(&probed));
 
         assert!(
             result.contains(&"MYPATH=/container/bin".to_string()),
             "expected MYPATH=/container/bin in {result:?}"
         );
+    }
+
+    /// CLI `--remote-env` survives the second-pass containerEnv resolution and
+    /// is layered ahead of the resolved config env (regression guard: the raw+
+    /// probed branch must NOT drop `cli_remote_env`).
+    #[test]
+    fn cli_remote_env_preserved_through_container_env_resolution() {
+        let raw = serde_json::json!({"MYPATH": "${containerEnv:PATH}"});
+        let resolved = minimal_resolved(Some(raw));
+        let cli = vec!["CLI_VAR=from_cli".to_string()];
+        let remote_env = vec![
+            "CLI_VAR=from_cli".to_string(),
+            "MYPATH=fallback".to_string(),
+        ];
+        let probed: std::collections::HashMap<String, String> =
+            [("PATH".to_string(), "/container/bin".to_string())].into();
+
+        let result = build_lifecycle_env(&resolved, &cli, &remote_env, Some(&probed));
+
+        assert!(
+            result.contains(&"CLI_VAR=from_cli".to_string()),
+            "cli --remote-env must survive containerEnv resolution; got {result:?}"
+        );
+        assert!(result.contains(&"MYPATH=/container/bin".to_string()));
     }
 
     /// Config remoteEnv overrides probed env (precedence: config > probe).
@@ -2990,7 +3030,7 @@ mod tests {
         let probed: std::collections::HashMap<String, String> =
             [("FOO".to_string(), "from_probe".to_string())].into();
 
-        let result = build_lifecycle_env(&resolved, &remote_env, Some(&probed));
+        let result = build_lifecycle_env(&resolved, &[], &remote_env, Some(&probed));
 
         assert!(
             result.contains(&"FOO=from_config".to_string()),

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -1283,13 +1283,9 @@ impl UpContext {
                 .or(probed_env)
         };
 
-        let mut lifecycle_env = final_probed.as_ref().map_or_else(
-            || remote_env.to_vec(),
-            |probed| cella_env::user_env_probe::merge_env(probed, remote_env),
-        );
-        if !self.lifecycle_secrets.is_empty() {
-            lifecycle_env.extend(self.lifecycle_secrets.iter().cloned());
-        }
+        let mut lifecycle_env =
+            build_lifecycle_env(&self.resolved, remote_env, final_probed.as_ref());
+        lifecycle_env.extend(self.lifecycle_secrets.iter().cloned());
 
         (final_probed, lifecycle_env)
     }
@@ -2059,6 +2055,38 @@ pub async fn write_daemon_addr_to_volume(client: &dyn ContainerBackend) -> bool 
         return false;
     }
     true
+}
+
+/// Build the lifecycle environment for a container.
+///
+/// Performs a second-pass `${containerEnv:VAR}` substitution when the config
+/// carried a raw (pre-substitution) `remoteEnv` snapshot *and* the probe
+/// captured live container env.  The resolved `remoteEnv` is then merged with
+/// `probed_env` so the container's environment forms the base layer and config
+/// values override it.  When either input is absent the behaviour is identical
+/// to the pre-substitution path (additive invariant: no `${containerEnv:...}`
+/// tokens → byte-identical output).
+///
+/// Mirrors `resolved_remote_env` in `cella-orchestrator` but also incorporates
+/// the `merge_env` step, giving the compose path the same resolution the
+/// single-container orchestrator path gets.
+fn build_lifecycle_env(
+    resolved: &ResolvedConfig,
+    remote_env: &[String],
+    probed_env: Option<&std::collections::HashMap<String, String>>,
+) -> Vec<String> {
+    let effective: Vec<String> = if let (Some(raw), Some(probed)) =
+        (resolved.raw_remote_env.as_ref(), probed_env)
+    {
+        let ctx = cella_config::config_map::subst_ctx(resolved).with_container_env(probed.clone());
+        ctx.substitute_remote_env(raw)
+    } else {
+        remote_env.to_vec()
+    };
+    probed_env.map_or_else(
+        || effective.clone(),
+        |probed| cella_env::user_env_probe::merge_env(probed, &effective),
+    )
 }
 
 #[cfg(test)]
@@ -2888,5 +2916,85 @@ mod tests {
         );
         // terminal-columns requires terminal-rows.
         assert!(crate::Cli::try_parse_from(["cella", "up", "--terminal-columns", "80"]).is_err());
+    }
+
+    // ── build_lifecycle_env ────────────────────────────────────────────────
+
+    fn minimal_resolved(raw_remote_env: Option<serde_json::Value>) -> ResolvedConfig {
+        use std::path::PathBuf;
+        ResolvedConfig {
+            config: serde_json::json!({}),
+            config_path: PathBuf::from("/dev/null"),
+            workspace_root: PathBuf::from("/workspace"),
+            config_hash: String::new(),
+            devcontainer_id: "testid".to_string(),
+            warnings: Vec::new(),
+            typed: None,
+            raw_remote_env,
+        }
+    }
+
+    /// No `${containerEnv:...}` tokens and no raw snapshot → output equals
+    /// `remote_env` unchanged (additive invariant).
+    #[test]
+    fn no_container_env_tokens_unchanged() {
+        let resolved = minimal_resolved(None);
+        let remote_env = vec!["FOO=bar".to_string(), "BAZ=qux".to_string()];
+        let probed: std::collections::HashMap<String, String> =
+            [("PATH".to_string(), "/usr/bin".to_string())].into();
+
+        let result = build_lifecycle_env(&resolved, &remote_env, Some(&probed));
+
+        // merge_env puts probed first then config overrides; FOO/BAZ come from config
+        assert!(result.contains(&"FOO=bar".to_string()));
+        assert!(result.contains(&"BAZ=qux".to_string()));
+    }
+
+    /// `raw_remote_env` present but `probed_env` absent → falls back to `remote_env`
+    /// (additive invariant: no probe, no second-pass).
+    #[test]
+    fn no_probe_falls_back_to_remote_env() {
+        let raw = serde_json::json!({"PATH": "${containerEnv:PATH}"});
+        let resolved = minimal_resolved(Some(raw));
+        let remote_env = vec!["FOO=original".to_string()];
+
+        let result = build_lifecycle_env(&resolved, &remote_env, None);
+
+        assert_eq!(result, remote_env);
+    }
+
+    /// When both raw snapshot and probe are present, `${containerEnv:VAR}`
+    /// resolves against the probed container env.
+    #[test]
+    fn container_env_token_resolves_from_probe() {
+        let raw = serde_json::json!({"MYPATH": "${containerEnv:PATH}"});
+        let resolved = minimal_resolved(Some(raw));
+        let remote_env = vec!["MYPATH=fallback".to_string()];
+        let probed: std::collections::HashMap<String, String> =
+            [("PATH".to_string(), "/container/bin".to_string())].into();
+
+        let result = build_lifecycle_env(&resolved, &remote_env, Some(&probed));
+
+        assert!(
+            result.contains(&"MYPATH=/container/bin".to_string()),
+            "expected MYPATH=/container/bin in {result:?}"
+        );
+    }
+
+    /// Config remoteEnv overrides probed env (precedence: config > probe).
+    #[test]
+    fn config_remote_env_overrides_probe() {
+        let raw = serde_json::json!({"FOO": "from_config"});
+        let resolved = minimal_resolved(Some(raw));
+        let remote_env = vec!["FOO=phase1".to_string()];
+        let probed: std::collections::HashMap<String, String> =
+            [("FOO".to_string(), "from_probe".to_string())].into();
+
+        let result = build_lifecycle_env(&resolved, &remote_env, Some(&probed));
+
+        assert!(
+            result.contains(&"FOO=from_config".to_string()),
+            "config should win over probe; got {result:?}"
+        );
     }
 }

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -2099,10 +2099,11 @@ fn build_lifecycle_env(
         // Fallback path unchanged: `remote_env` already contains cli + config.
         remote_env.to_vec()
     };
-    probed_env.map_or_else(
-        || effective.clone(),
-        |probed| cella_env::user_env_probe::merge_env(probed, &effective),
-    )
+    if let Some(probed) = probed_env {
+        cella_env::user_env_probe::merge_env(probed, &effective)
+    } else {
+        effective
+    }
 }
 
 #[cfg(test)]
@@ -2950,8 +2951,8 @@ mod tests {
         }
     }
 
-    /// No `${containerEnv:...}` tokens and no raw snapshot → output equals
-    /// `remote_env` unchanged (additive invariant).
+    /// No `${containerEnv:...}` tokens and no raw snapshot → config entries
+    /// appear in the output (merged with the probe; additive invariant).
     #[test]
     fn no_container_env_tokens_unchanged() {
         let resolved = minimal_resolved(None);

--- a/crates/cella-compose/src/orchestrate.rs
+++ b/crates/cella-compose/src/orchestrate.rs
@@ -1118,6 +1118,18 @@ async fn build_override_and_start(
 
     let managed = ctx.client.capabilities().managed_agent;
     let mut extra_env = build_extra_env(daemon_env, env_fwd, cfg.remote_env, managed);
+    // When `remoteEnv` contains `${containerEnv:VAR}` tokens, phase-1
+    // substitution collapses them to `""` (container env is unavailable at
+    // parse time).  Injecting those phase-1 values into the compose service
+    // environment pollutes the `userEnvProbe` result: the probe reads e.g.
+    // `PATH=:/opt/bin` instead of the real image PATH, so the subsequent
+    // second-pass resolution in `build_lifecycle_env` expands
+    // `${containerEnv:PATH}` from the polluted value and produces
+    // `:/opt/bin:/opt/bin` instead of `<real_PATH>:/opt/bin`.
+    //
+    // Guard: only strip when the raw snapshot actually has tokens — the
+    // common case (no `containerEnv` references) is unaffected.
+    strip_container_env_polluted_entries(&mut extra_env, cfg.resolved.raw_remote_env.as_ref());
     let mut labels = build_compose_labels(cfg, project, remote_user);
 
     let settings = cella_config::CellaConfig::load(cfg.workspace_root, Some(cfg.resolved))?;
@@ -1373,6 +1385,50 @@ fn build_extra_env(
         extra_env.extend(agent_env_vars());
     }
     extra_env
+}
+
+/// Remove from `extra_env` any `KEY=…` entries whose key appears in
+/// `raw_remote_env` with a value that contains a `${containerEnv:…}` token.
+///
+/// Phase-1 substitution collapses `${containerEnv:VAR}` to `""` because the
+/// container doesn't exist yet.  If those phase-1 values are baked into the
+/// compose service `environment:` block, the `userEnvProbe` reads corrupted
+/// values (e.g. `PATH=:/opt/bin` instead of the real image PATH).  The
+/// second-pass resolution in `build_lifecycle_env` then expands
+/// `${containerEnv:PATH}` from the corrupted probe and doubles the suffix.
+///
+/// Stripping only the affected entries leaves daemon/agent/forwarded env vars
+/// intact — the lifecycle env from `build_lifecycle_env` supplies the
+/// correctly resolved `remoteEnv` values after the probe runs.
+fn strip_container_env_polluted_entries(
+    extra_env: &mut Vec<String>,
+    raw_remote_env: Option<&serde_json::Value>,
+) {
+    let Some(obj) = raw_remote_env.and_then(serde_json::Value::as_object) else {
+        return;
+    };
+
+    // Collect keys whose raw value contains a ${containerEnv:...} token.
+    let polluted_keys: std::collections::HashSet<&str> = obj
+        .iter()
+        .filter_map(|(k, v)| {
+            let s = v.as_str()?;
+            if s.contains("${containerEnv:") {
+                Some(k.as_str())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if polluted_keys.is_empty() {
+        return;
+    }
+
+    extra_env.retain(|entry| {
+        let key = entry.split_once('=').map_or(entry.as_str(), |(k, _)| k);
+        !polluted_keys.contains(key)
+    });
 }
 
 /// Compute the mount-input fingerprint and insert it as a label on the
@@ -1878,5 +1934,60 @@ mod tests {
         assert!(daemon_idx < fwd_idx);
         assert!(fwd_idx < user_idx);
         assert!(user_idx < browser_idx);
+    }
+
+    // ── strip_container_env_polluted_entries ──────────────────────────────────
+
+    /// Keys with `${containerEnv:…}` in their raw value are stripped from
+    /// `extra_env` so the `userEnvProbe` reads the real image env instead of the
+    /// phase-1 collapsed (empty) value.
+    #[test]
+    fn strip_removes_container_env_token_keys() {
+        let raw = serde_json::json!({
+            "PATH": "${containerEnv:PATH}:/opt/bin",
+            "PLAIN": "no_token"
+        });
+        let mut extra = vec![
+            "PATH=:/opt/bin".to_string(), // phase-1 collapsed value
+            "PLAIN=no_token".to_string(),
+            "OTHER=untouched".to_string(),
+        ];
+        strip_container_env_polluted_entries(&mut extra, Some(&raw));
+        // PATH had a token → stripped; PLAIN and OTHER are clean → preserved.
+        assert!(
+            !extra.iter().any(|e| e.starts_with("PATH=")),
+            "PATH with ${{containerEnv:…}} must be stripped; got {extra:?}"
+        );
+        assert!(
+            extra.contains(&"PLAIN=no_token".to_string()),
+            "PLAIN without token must be preserved; got {extra:?}"
+        );
+        assert!(
+            extra.contains(&"OTHER=untouched".to_string()),
+            "non-remoteEnv entries must be preserved; got {extra:?}"
+        );
+    }
+
+    /// When `raw_remote_env` is absent, the function is a no-op.
+    #[test]
+    fn strip_no_op_when_raw_remote_env_absent() {
+        let mut extra = vec!["PATH=/usr/bin".to_string(), "FOO=bar".to_string()];
+        let before = extra.clone();
+        strip_container_env_polluted_entries(&mut extra, None);
+        assert_eq!(extra, before, "no-op when raw_remote_env is absent");
+    }
+
+    /// When `raw_remote_env` has no `${containerEnv:…}` tokens, nothing is
+    /// stripped (additive invariant: common case unaffected).
+    #[test]
+    fn strip_no_op_when_no_container_env_tokens() {
+        let raw = serde_json::json!({"MYVAR": "static_value"});
+        let mut extra = vec!["MYVAR=static_value".to_string(), "OTHER=x".to_string()];
+        let before = extra.clone();
+        strip_container_env_polluted_entries(&mut extra, Some(&raw));
+        assert_eq!(
+            extra, before,
+            "no-op when no ${{containerEnv:…}} tokens present"
+        );
     }
 }


### PR DESCRIPTION
Stacked on #154 (single-container containerEnv resolution) — base retargets to main when that merges.

Completes the `${containerEnv:VAR}` feature for Docker Compose. #154 resolved it against the live container env for the single-container `up` path; compose still discarded its probe result and used the phase-1 value (containerEnv collapsed to `""`).

The compose hook routes through `UpContext::post_create_setup`, which already produces the probed env — so the second-pass resolution goes there via a `build_lifecycle_env` helper. No `ComposeUpHooks` trait/signature change (an earlier attempt that tried to thread it through the trait broke the build; this localization avoids that entirely).

Precedence guard: when the raw remoteEnv + probe are both present, the helper bypasses the pre-chained `remote_env` and re-resolves the config remoteEnv with live `containerEnv` — so it **re-chains `cli_remote_env` (`--remote-env`) ahead of the resolved config env**, matching the single-container order (cli first, config wins on collision). Without this, `--remote-env` values would have been silently dropped on compose when containerEnv tokens were present. A dedicated regression test covers it. The no-token / no-probe fallback is byte-identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)