### PR TITLE
fix: parallel object-form lifecycle commands run to completion

### DIFF
--- a/crates/cella-backend/src/container_setup.rs
+++ b/crates/cella-backend/src/container_setup.rs
@@ -25,30 +25,65 @@ pub fn run_host_command(
     info!("Running {phase} on host");
 
     match value {
-        serde_json::Value::String(s) => {
-            run_single_host_command(phase, &["sh", "-c", s])?;
+        serde_json::Value::String(_) | serde_json::Value::Array(_) => {
+            run_host_command_value(phase, value)?;
         }
-        serde_json::Value::Array(arr) => {
-            run_json_array_command(phase, arr)?;
-        }
+        // Object form runs the named commands in PARALLEL (official `Promise.all`
+        // over `cliHost.ptyExec`). All entries run to completion; the first
+        // error in iteration order is surfaced.
         serde_json::Value::Object(map) => {
-            for (name, v) in map {
-                info!("{phase} [{name}]");
-                match v {
-                    serde_json::Value::String(s) => {
-                        run_single_host_command(phase, &["sh", "-c", s])?;
-                    }
-                    serde_json::Value::Array(arr) => {
-                        run_json_array_command(phase, arr)?;
-                    }
-                    _ => {}
-                }
-            }
+            run_host_object_parallel(phase, map)?;
         }
         _ => {}
     }
 
     Ok(())
+}
+
+/// Run a single host lifecycle command value: a string via `sh -c`, an array as
+/// argv (no shell). Other JSON types are a no-op.
+fn run_host_command_value(
+    phase: &str,
+    value: &serde_json::Value,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    match value {
+        serde_json::Value::String(s) => run_single_host_command(phase, &["sh", "-c", s]),
+        serde_json::Value::Array(arr) => run_json_array_command(phase, arr),
+        _ => Ok(()),
+    }
+}
+
+/// Run the named entries of an object-form host lifecycle command in parallel
+/// (one OS thread each), waiting for all to finish, then returning the first
+/// error in iteration order.
+fn run_host_object_parallel(
+    phase: &str,
+    map: &serde_json::Map<String, serde_json::Value>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    std::thread::scope(|scope| {
+        let handles: Vec<_> = map
+            .iter()
+            .map(|(name, v)| {
+                scope.spawn(move || {
+                    info!("{phase} [{name}]");
+                    run_host_command_value(phase, v)
+                })
+            })
+            .collect();
+
+        let mut first_err = None;
+        for handle in handles {
+            let outcome = handle
+                .join()
+                .unwrap_or_else(|_| Err(format!("{phase} host command thread panicked").into()));
+            if let Err(e) = outcome
+                && first_err.is_none()
+            {
+                first_err = Some(e);
+            }
+        }
+        first_err.map_or(Ok(()), Err)
+    })
 }
 
 fn run_json_array_command(
@@ -819,6 +854,33 @@ mod tests {
         let cmd = json!("false");
         let result = run_host_command("test", &cmd);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn run_host_command_object_form_surfaces_failure() {
+        let cmd = json!({"ok": "true", "bad": "false"});
+        assert!(run_host_command("test", &cmd).is_err());
+    }
+
+    #[test]
+    fn run_host_command_object_form_runs_all_despite_failure() {
+        // A slow sibling must run to completion even though another entry fails
+        // (parallel + allSettled semantics, not cancel-on-first-error).
+        let marker = std::env::temp_dir().join(format!(
+            "cella-lifecycle-parallel-{}.marker",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&marker);
+        let touch = format!("sleep 0.3 && touch '{}'", marker.display());
+        let cmd = json!({"slow": touch, "fail": "false"});
+
+        let result = run_host_command("test", &cmd);
+        assert!(result.is_err(), "the failing entry must surface an error");
+        assert!(
+            marker.exists(),
+            "the slow sibling must complete despite the failure (not be cancelled)"
+        );
+        let _ = std::fs::remove_file(&marker);
     }
 
     #[test]

--- a/crates/cella-backend/src/lifecycle.rs
+++ b/crates/cella-backend/src/lifecycle.rs
@@ -190,10 +190,14 @@ async fn run_sequential(
     Ok(())
 }
 
-/// Run named lifecycle commands in parallel, cancelling siblings on first failure.
+/// Run named lifecycle commands in parallel, letting every command finish
+/// before surfacing a failure.
 ///
-/// Uses `try_join_all` so that when any command fails, remaining in-flight
-/// commands are cancelled (their futures are dropped) per the spec requirement.
+/// Matches the official runner's `Promise.allSettled` semantics: all named
+/// commands run to completion even if a sibling fails, then the first error
+/// (in command order) is returned. Using `try_join_all` here would cancel the
+/// remaining in-flight commands on the first failure, leaving parallel setup
+/// steps half-done.
 async fn run_parallel(
     ctx: &LifecycleContext<'_>,
     phase: &str,
@@ -227,7 +231,13 @@ async fn run_parallel(
         });
     }
 
-    let results = futures_util::future::try_join_all(futures).await?;
+    // Wait for ALL commands to finish (allSettled), then surface the first
+    // error in command order; only print output on full success.
+    let settled = futures_util::future::join_all(futures).await;
+    let mut results = Vec::with_capacity(settled.len());
+    for outcome in settled {
+        results.push(outcome?);
+    }
 
     if ctx.is_text {
         print_completed_output(&results);

--- a/crates/cella-backend/src/lifecycle.rs
+++ b/crates/cella-backend/src/lifecycle.rs
@@ -231,19 +231,28 @@ async fn run_parallel(
         });
     }
 
-    // Wait for ALL commands to finish (allSettled), then surface the first
-    // error in command order; only print output on full success.
+    // Wait for ALL commands to finish (allSettled semantics), then surface
+    // the first error in command order. Print output from successful commands
+    // regardless of whether a sibling failed.
     let settled = futures_util::future::join_all(futures).await;
+    let mut first_err: Option<BackendError> = None;
     let mut results = Vec::with_capacity(settled.len());
     for outcome in settled {
-        results.push(outcome?);
+        match outcome {
+            Ok(r) => results.push(r),
+            Err(e) => {
+                if first_err.is_none() {
+                    first_err = Some(e);
+                }
+            }
+        }
     }
 
     if ctx.is_text {
         print_completed_output(&results);
     }
 
-    Ok(())
+    first_err.map_or(Ok(()), Err)
 }
 
 /// Check an exec result exit code, returning `LifecycleFailed` on non-zero.


### PR DESCRIPTION
The object form of a lifecycle hook — `{"name1": "cmd1", "name2": "cmd2"}` — runs the named commands in parallel. cella diverged from the official runner in two ways:

1. **In-container** (`run_parallel`) used `try_join_all`, which drops (cancels) the remaining in-flight commands the instant one fails. The official runner uses `Promise.allSettled` — every parallel command runs to completion, then the first rejection is thrown. With cella's old behavior, a failure in one parallel command could abandon a sibling mid-run (e.g. a half-finished install). Now uses `join_all` and surfaces the first error in command order only after all have settled.

2. **Host `initializeCommand`** object form ran the named entries *sequentially*. The official runner runs them in parallel (`Promise.all` over `cliHost.ptyExec`). Now each entry runs on its own thread, all are joined, and the first error in iteration order is returned.

String form (`sh -c`) and array form (argv, no shell) were already correct and are unchanged.

A regression test proves a slow sibling completes (touches a marker file after a sleep) even when another entry fails immediately — i.e. siblings are no longer cancelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)