### PR TITLE
fix: parse external from object-form mounts

### DIFF
--- a/crates/cella-codegen/src/snapshots/cella_codegen__tests__full_devcontainer_schema.snap
+++ b/crates/cella-codegen/src/snapshots/cella_codegen__tests__full_devcontainer_schema.snap
@@ -35,6 +35,10 @@ pub enum MountType {
 }
 #[derive(Debug, Clone)]
 pub struct Mount {
+    ///Whether the volume is externally managed (pre-existing). When true, the tooling will not create or remove the volume.
+    pub external: Option<bool>,
+    ///Whether the mount is read-only.
+    pub read_only: Option<bool>,
     ///Mount source.
     pub source: Option<String>,
     ///Mount target.
@@ -471,6 +475,48 @@ impl Mount {
                     kind: ValidationErrorKind::MissingRequired,
                 });
         }
+        let external = if let Some(v) = obj.get("external") {
+            let field_path = format!("{path}/{}", "external");
+            match v
+                .as_bool()
+                .ok_or_else(|| {
+                    vec![
+                        ValidationError { path : field_path.to_string(), message :
+                        "expected boolean".to_string(), kind :
+                        ValidationErrorKind::TypeError, }
+                    ]
+                })
+            {
+                Ok(val) => Some(val),
+                Err(mut e) => {
+                    errors.append(&mut e);
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        let read_only = if let Some(v) = obj.get("readOnly") {
+            let field_path = format!("{path}/{}", "readOnly");
+            match v
+                .as_bool()
+                .ok_or_else(|| {
+                    vec![
+                        ValidationError { path : field_path.to_string(), message :
+                        "expected boolean".to_string(), kind :
+                        ValidationErrorKind::TypeError, }
+                    ]
+                })
+            {
+                Ok(val) => Some(val),
+                Err(mut e) => {
+                    errors.append(&mut e);
+                    None
+                }
+            }
+        } else {
+            None
+        };
         let source = if let Some(v) = obj.get("source") {
             let field_path = format!("{path}/{}", "source");
             match v
@@ -528,7 +574,9 @@ impl Mount {
             None
         };
         for key in obj.keys() {
-            if !["source", "target", "type"].contains(&key.as_str()) {
+            if !["external", "readOnly", "source", "target", "type"]
+                .contains(&key.as_str())
+            {
                 errors
                     .push(ValidationError {
                         path: format!("{path}/{key}"),
@@ -539,6 +587,8 @@ impl Mount {
         }
         if errors.is_empty() {
             Ok(Self {
+                external,
+                read_only,
                 source,
                 target: target.unwrap(),
                 r#type: r#type.unwrap(),

--- a/crates/cella-config/schemas/devContainer.base.schema.json
+++ b/crates/cella-config/schemas/devContainer.base.schema.json
@@ -720,6 +720,14 @@
 				"target": {
 					"type": "string",
 					"description": "Mount target."
+				},
+				"external": {
+					"type": "boolean",
+					"description": "Whether the volume is externally managed (pre-existing). When true, the tooling will not create or remove the volume."
+				},
+				"readOnly": {
+					"type": "boolean",
+					"description": "Whether the mount is read-only."
 				}
 			},
 			"required": [

--- a/crates/cella-config/src/config_map/mounts.rs
+++ b/crates/cella-config/src/config_map/mounts.rs
@@ -64,6 +64,13 @@ pub fn map_additional_mounts(config: &serde_json::Value) -> Vec<MountConfig> {
                     .get("readOnly")
                     .and_then(serde_json::Value::as_bool)
                     .unwrap_or(false);
+                // `external: true` marks a pre-existing volume (don't auto-create);
+                // part of the official `Mount` object schema, same as the string
+                // form's `external=true`.
+                let external = obj
+                    .get("external")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false);
 
                 if target.is_empty() {
                     return None;
@@ -75,7 +82,7 @@ pub fn map_additional_mounts(config: &serde_json::Value) -> Vec<MountConfig> {
                     target,
                     consistency: None,
                     read_only,
-                    external: false,
+                    external,
                 })
             }
             _ => None,
@@ -247,6 +254,31 @@ mod tests {
     }
 
     // ── external field ────────────────────────────────────────────
+
+    #[test]
+    fn map_additional_mounts_honors_external_object() {
+        let config = json!({
+            "mounts": [
+                {"type": "volume", "source": "myvol", "target": "/data", "external": true}
+            ]
+        });
+        let mounts = map_additional_mounts(&config);
+        assert_eq!(mounts.len(), 1);
+        assert!(
+            mounts[0].external,
+            "object-form external:true must propagate to MountConfig"
+        );
+    }
+
+    #[test]
+    fn map_additional_mounts_external_defaults_false_object() {
+        let config = json!({
+            "mounts": [{"type": "volume", "source": "myvol", "target": "/data"}]
+        });
+        let mounts = map_additional_mounts(&config);
+        assert_eq!(mounts.len(), 1);
+        assert!(!mounts[0].external, "absent external must default to false");
+    }
 
     #[test]
     fn parse_mount_string_external_true() {


### PR DESCRIPTION
The official `Mount` object schema is `{ type, source?, target, external? }`. cella read `external` from the string form (`source=vol,target=/data,external=true`) but hardcoded `external: false` for the object form:

```json
"mounts": [{ "type": "volume", "source": "myvol", "target": "/data", "external": true }]
```

So an externally-managed volume declared in object form would be treated as cella-created. `MountConfig.external` already exists and flows through; this just reads the key from the object like `readOnly`. Tests cover object-form `external: true`, the default-false case, and the existing string-form behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)