### PR TITLE
feat: mask --secrets-file values in lifecycle output

### DIFF
--- a/crates/cella-backend/src/lib.rs
+++ b/crates/cella-backend/src/lib.rs
@@ -7,6 +7,7 @@ pub mod names;
 pub mod network;
 pub mod progress;
 pub mod resolve;
+pub mod secret_mask;
 pub mod traits;
 pub mod types;
 pub mod uid_image;
@@ -25,6 +26,7 @@ pub use names::{
 };
 pub use network::{ManagedNetwork, RemovalOutcome};
 pub use resolve::ContainerTarget;
+pub use secret_mask::SecretMasker;
 pub use traits::{BackendCapabilities, BoxFuture, ContainerBackend, Platform};
 pub use types::{
     BackendEndpoint, BackendKind, BuildOptions, BuildSecret, ContainerInfo, ContainerState,

--- a/crates/cella-backend/src/lifecycle.rs
+++ b/crates/cella-backend/src/lifecycle.rs
@@ -258,7 +258,7 @@ async fn run_sequential(
             ctx.client.exec_command(ctx.container_id, &opts).await?
         };
 
-        check_exit_code(&result, phase, None)?;
+        check_exit_code(&result, phase, None, &ctx.secret_masker)?;
     }
     Ok(())
 }
@@ -295,7 +295,7 @@ async fn run_parallel(
                 )
                 .await?;
 
-            check_exit_code(&result, &phase, Some(&name))?;
+            check_exit_code(&result, &phase, Some(&name), &ctx.secret_masker)?;
             Ok::<ExecResult, BackendError>(result)
         });
     }
@@ -314,15 +314,18 @@ fn check_exit_code(
     result: &ExecResult,
     phase: &str,
     name: Option<&str>,
+    masker: &SecretMasker,
 ) -> Result<(), BackendError> {
     if result.exit_code != 0 {
         let prefix = name.map_or(String::new(), |n| format!("[{n}] "));
+        // The failing command's stderr is embedded in the error message, which
+        // surfaces in the JSON error envelope — mask secrets before it does.
         return Err(BackendError::LifecycleFailed {
             phase: phase.to_string(),
             message: format!(
                 "{prefix}exit code {}: {}",
                 result.exit_code,
-                result.stderr.trim()
+                masker.mask(result.stderr.trim())
             ),
         });
     }
@@ -1406,7 +1409,9 @@ mod tests {
             stdout: String::new(),
             stderr: String::new(),
         };
-        assert!(check_exit_code(&result, "postCreateCommand", None).is_ok());
+        assert!(
+            check_exit_code(&result, "postCreateCommand", None, &SecretMasker::default()).is_ok()
+        );
     }
 
     #[test]
@@ -1416,7 +1421,8 @@ mod tests {
             stdout: String::new(),
             stderr: "command not found".to_string(),
         };
-        let err = check_exit_code(&result, "onCreateCommand", None).unwrap_err();
+        let err = check_exit_code(&result, "onCreateCommand", None, &SecretMasker::default())
+            .unwrap_err();
         let msg = format!("{err}");
         assert!(
             msg.contains("onCreateCommand"),
@@ -1431,7 +1437,8 @@ mod tests {
             stdout: String::new(),
             stderr: "sh: npm: not found".to_string(),
         };
-        let err = check_exit_code(&result, "postCreateCommand", None).unwrap_err();
+        let err = check_exit_code(&result, "postCreateCommand", None, &SecretMasker::default())
+            .unwrap_err();
         let msg = format!("{err}");
         assert!(
             msg.contains("127"),
@@ -1446,7 +1453,13 @@ mod tests {
             stdout: "some output\n".to_string(),
             stderr: "fatal error occurred\n".to_string(),
         };
-        let err = check_exit_code(&result, "updateContentCommand", None).unwrap_err();
+        let err = check_exit_code(
+            &result,
+            "updateContentCommand",
+            None,
+            &SecretMasker::default(),
+        )
+        .unwrap_err();
         let msg = format!("{err}");
         assert!(
             msg.contains("fatal error occurred"),
@@ -1461,7 +1474,13 @@ mod tests {
             stdout: String::new(),
             stderr: "failed".to_string(),
         };
-        let err = check_exit_code(&result, "postStartCommand", Some("setup")).unwrap_err();
+        let err = check_exit_code(
+            &result,
+            "postStartCommand",
+            Some("setup"),
+            &SecretMasker::default(),
+        )
+        .unwrap_err();
         let msg = format!("{err}");
         assert!(
             msg.contains("[setup]"),
@@ -1476,7 +1495,7 @@ mod tests {
             stdout: String::new(),
             stderr: "err".to_string(),
         };
-        let err = check_exit_code(&result, "phase", None).unwrap_err();
+        let err = check_exit_code(&result, "phase", None, &SecretMasker::default()).unwrap_err();
         let msg = format!("{err}");
         assert!(
             !msg.contains('['),
@@ -1491,7 +1510,7 @@ mod tests {
             stdout: "done".to_string(),
             stderr: String::new(),
         };
-        assert!(check_exit_code(&result, "phase", Some("task")).is_ok());
+        assert!(check_exit_code(&result, "phase", Some("task"), &SecretMasker::default()).is_ok());
     }
 
     #[test]
@@ -1501,13 +1520,27 @@ mod tests {
             stdout: String::new(),
             stderr: "  whitespace  \n".to_string(),
         };
-        let err = check_exit_code(&result, "phase", None).unwrap_err();
+        let err = check_exit_code(&result, "phase", None, &SecretMasker::default()).unwrap_err();
         let msg = format!("{err}");
         assert!(
             msg.contains("whitespace"),
             "expected trimmed stderr in message, got: {msg}"
         );
         assert!(!msg.ends_with('\n'), "stderr should be trimmed, got: {msg}");
+    }
+
+    #[test]
+    fn check_exit_code_masks_secret_in_stderr() {
+        let result = ExecResult {
+            exit_code: 1,
+            stdout: String::new(),
+            stderr: "failed: leaked s3cr3t".to_string(),
+        };
+        let masker = SecretMasker::new(&["TOKEN=s3cr3t".to_string()]);
+        let err = check_exit_code(&result, "phase", None, &masker).unwrap_err();
+        let msg = format!("{err}");
+        assert!(!msg.contains("s3cr3t"), "secret leaked into error: {msg}");
+        assert!(msg.contains("********"), "expected mask, got: {msg}");
     }
 
     #[test]

--- a/crates/cella-backend/src/lifecycle.rs
+++ b/crates/cella-backend/src/lifecycle.rs
@@ -11,6 +11,7 @@ use tracing::{debug, info};
 
 use crate::error::BackendError;
 use crate::progress::{ProgressSender, format_elapsed};
+use crate::secret_mask::SecretMasker;
 use crate::traits::ContainerBackend;
 use crate::types::{ExecOptions, ExecResult};
 
@@ -85,19 +86,26 @@ pub struct LifecycleContext<'a> {
     /// When set, sequential lifecycle output is written through this callback
     /// (e.g., indented under an active spinner) instead of directly to stderr.
     pub on_output: Option<OutputCallback<'a>>,
+    /// Masker applied to all lifecycle output before it reaches any sink.
+    ///
+    /// Built from `--secrets-file` `KEY=VALUE` entries. When no secrets are
+    /// configured the masker is a cheap no-op passthrough.
+    pub secret_masker: SecretMasker,
 }
 
-/// A `Write` adapter that buffers lines and forwards each complete line
-/// through a callback with indentation.
+/// A `Write` adapter that buffers lines, masks secret values, and forwards
+/// each complete line through a callback with indentation.
 struct CallbackWriter<'a> {
     callback: &'a (dyn Fn(&str) + Send + Sync),
+    masker: &'a SecretMasker,
     buf: Vec<u8>,
 }
 
 impl<'a> CallbackWriter<'a> {
-    fn new(callback: &'a (dyn Fn(&str) + Send + Sync)) -> Self {
+    fn new(callback: &'a (dyn Fn(&str) + Send + Sync), masker: &'a SecretMasker) -> Self {
         Self {
             callback,
+            masker,
             buf: Vec::with_capacity(256),
         }
     }
@@ -106,7 +114,8 @@ impl<'a> CallbackWriter<'a> {
         while let Some(pos) = self.buf.iter().position(|&b| b == b'\n') {
             let line = String::from_utf8_lossy(&self.buf[..pos]);
             if !line.trim().is_empty() {
-                (self.callback)(&format!("      {line}"));
+                let masked = self.masker.mask(&line);
+                (self.callback)(&format!("      {masked}"));
             }
             self.buf.drain(..=pos);
         }
@@ -116,7 +125,8 @@ impl<'a> CallbackWriter<'a> {
         if !self.buf.is_empty() {
             let line = String::from_utf8_lossy(&self.buf);
             if !line.trim().is_empty() {
-                (self.callback)(&format!("      {line}"));
+                let masked = self.masker.mask(&line);
+                (self.callback)(&format!("      {masked}"));
             }
             self.buf.clear();
         }
@@ -142,6 +152,68 @@ impl Drop for CallbackWriter<'_> {
     }
 }
 
+/// A `Write` adapter that buffers lines, masks secret values, and writes
+/// each complete line to the wrapped sink.
+///
+/// Used for the stderr fallback path in `run_sequential` so that no byte
+/// escapes to stderr unmasked.
+struct MaskingWriter<W: io::Write> {
+    inner: W,
+    masker: SecretMasker,
+    buf: Vec<u8>,
+}
+
+impl<W: io::Write> MaskingWriter<W> {
+    fn new(inner: W, masker: SecretMasker) -> Self {
+        Self {
+            inner,
+            masker,
+            buf: Vec::with_capacity(256),
+        }
+    }
+
+    fn flush_lines(&mut self) -> io::Result<()> {
+        while let Some(pos) = self.buf.iter().position(|&b| b == b'\n') {
+            let line = String::from_utf8_lossy(&self.buf[..pos]);
+            let masked = self.masker.mask(&line);
+            self.inner.write_all(masked.as_bytes())?;
+            self.inner.write_all(b"\n")?;
+            self.buf.drain(..=pos);
+        }
+        Ok(())
+    }
+
+    fn flush_remaining(&mut self) -> io::Result<()> {
+        if !self.buf.is_empty() {
+            let line = String::from_utf8_lossy(&self.buf);
+            let masked = self.masker.mask(&line);
+            self.inner.write_all(masked.as_bytes())?;
+            self.buf.clear();
+        }
+        Ok(())
+    }
+}
+
+impl<W: io::Write> io::Write for MaskingWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buf.extend_from_slice(buf);
+        self.flush_lines()?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.flush_remaining()?;
+        self.inner.flush()
+    }
+}
+
+impl<W: io::Write> Drop for MaskingWriter<W> {
+    fn drop(&mut self) {
+        // Best-effort flush on drop; ignore errors (same pattern as BufWriter).
+        let _ = self.flush_remaining();
+    }
+}
+
 /// Run sequential lifecycle commands, streaming output when `is_text`.
 async fn run_sequential(
     ctx: &LifecycleContext<'_>,
@@ -161,23 +233,24 @@ async fn run_sequential(
         };
         let result = if ctx.is_text {
             if let Some(ref on_output) = ctx.on_output {
-                // Route through progress system with indentation
+                // Route through progress system with indentation; mask secrets.
                 ctx.client
                     .exec_stream(
                         ctx.container_id,
                         &opts,
-                        Box::new(CallbackWriter::new(on_output.as_ref())),
-                        Box::new(CallbackWriter::new(on_output.as_ref())),
+                        Box::new(CallbackWriter::new(on_output.as_ref(), &ctx.secret_masker)),
+                        Box::new(CallbackWriter::new(on_output.as_ref(), &ctx.secret_masker)),
                     )
                     .await?
             } else {
-                // Fallback: stream directly to stderr
+                // Fallback: stream to stderr through masking writer so no
+                // secret bytes reach the terminal unmasked.
                 ctx.client
                     .exec_stream(
                         ctx.container_id,
                         &opts,
-                        Box::new(io::stderr()),
-                        Box::new(io::stderr()),
+                        Box::new(MaskingWriter::new(io::stderr(), ctx.secret_masker.clone())),
+                        Box::new(MaskingWriter::new(io::stderr(), ctx.secret_masker.clone())),
                     )
                     .await?
             }
@@ -230,7 +303,7 @@ async fn run_parallel(
     let results = futures_util::future::try_join_all(futures).await?;
 
     if ctx.is_text {
-        print_completed_output(&results);
+        print_completed_output(&results, &ctx.secret_masker);
     }
 
     Ok(())
@@ -256,14 +329,15 @@ fn check_exit_code(
     Ok(())
 }
 
-/// Print stdout/stderr from completed parallel exec results to stderr.
-fn print_completed_output(results: &[ExecResult]) {
+/// Print stdout/stderr from completed parallel exec results to stderr, masking
+/// secret values before any bytes reach the terminal.
+fn print_completed_output(results: &[ExecResult], masker: &SecretMasker) {
     for exec_result in results {
         if !exec_result.stdout.is_empty() {
-            eprint!("{}", exec_result.stdout);
+            eprint!("{}", masker.mask(&exec_result.stdout));
         }
         if !exec_result.stderr.is_empty() {
-            eprint!("{}", exec_result.stderr);
+            eprint!("{}", masker.mask(&exec_result.stderr));
         }
     }
 }
@@ -1167,7 +1241,8 @@ mod tests {
             collected.lock().unwrap().push(line.to_string());
         };
 
-        let mut writer = CallbackWriter::new(&callback);
+        let masker = SecretMasker::default();
+        let mut writer = CallbackWriter::new(&callback, &masker);
         io::Write::write_all(&mut writer, input).unwrap();
         drop(writer);
 
@@ -1180,6 +1255,25 @@ mod tests {
         assert_eq!(lines.len(), 2);
         assert_eq!(lines[0], "      first line");
         assert_eq!(lines[1], "      second line");
+    }
+
+    #[test]
+    fn callback_writer_masks_secret_values() {
+        use std::sync::Mutex;
+        let collected = Mutex::new(Vec::new());
+        let callback = |line: &str| collected.lock().unwrap().push(line.to_string());
+        let masker = SecretMasker::new(&["TOKEN=s3cr3t".to_string()]);
+        let mut writer = CallbackWriter::new(&callback, &masker);
+        io::Write::write_all(&mut writer, b"echoed s3cr3t value\n").unwrap();
+        drop(writer);
+        let lines = collected.into_inner().unwrap();
+        assert_eq!(lines.len(), 1);
+        assert!(!lines[0].contains("s3cr3t"), "secret leaked: {}", lines[0]);
+        assert!(
+            lines[0].contains("********"),
+            "expected mask in {}",
+            lines[0]
+        );
     }
 
     #[test]
@@ -1481,7 +1575,8 @@ mod tests {
             collected.lock().unwrap().push(line.to_string());
         };
 
-        let mut writer = CallbackWriter::new(&callback);
+        let masker = SecretMasker::default();
+        let mut writer = CallbackWriter::new(&callback, &masker);
         io::Write::write_all(&mut writer, b"hello ").unwrap();
         io::Write::write_all(&mut writer, b"world\n").unwrap();
         drop(writer);

--- a/crates/cella-backend/src/lifecycle.rs
+++ b/crates/cella-backend/src/lifecycle.rs
@@ -1294,6 +1294,89 @@ mod tests {
         assert_eq!(lines[1], "      another");
     }
 
+    // ── MaskingWriter tests ──────────────────────────────────────────────────
+
+    // Shared sink for MaskingWriter tests: an `io::Write` backed by an
+    // `Arc<Mutex<Vec<u8>>>` so the buffer can be recovered after the writer is
+    // dropped.
+    use std::sync::{Arc, Mutex};
+
+    struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+    impl io::Write for SharedBuf {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Write `input` into a `MaskingWriter` backed by a shared `Vec<u8>` and
+    /// return the bytes collected after the writer is dropped (which flushes
+    /// any trailing partial line).
+    fn masking_writer_bytes(input: &[u8], masker: SecretMasker) -> Vec<u8> {
+        let shared = Arc::new(Mutex::new(Vec::new()));
+        let mut writer = MaskingWriter::new(SharedBuf(Arc::clone(&shared)), masker);
+        io::Write::write_all(&mut writer, input).unwrap();
+        drop(writer);
+        Arc::try_unwrap(shared).unwrap().into_inner().unwrap()
+    }
+
+    #[test]
+    fn masking_writer_masks_on_newline() {
+        let masker = SecretMasker::new(&["TOKEN=s3cr3t".to_string()]);
+        let out = masking_writer_bytes(b"got s3cr3t value\n", masker);
+        let s = String::from_utf8(out).unwrap();
+        assert!(!s.contains("s3cr3t"), "secret leaked: {s}");
+        assert!(s.contains("********"), "mask missing: {s}");
+        assert!(s.ends_with('\n'), "newline stripped");
+    }
+
+    #[test]
+    fn masking_writer_masks_trailing_partial_line_on_drop() {
+        // No trailing newline — the remainder is flushed in Drop.
+        let masker = SecretMasker::new(&["TOKEN=s3cr3t".to_string()]);
+        let out = masking_writer_bytes(b"s3cr3t", masker);
+        let s = String::from_utf8(out).unwrap();
+        assert!(!s.contains("s3cr3t"), "secret leaked: {s}");
+        assert!(s.contains("********"), "mask missing: {s}");
+    }
+
+    #[test]
+    fn masking_writer_multiple_lines_all_masked() {
+        let masker = SecretMasker::new(&["TOKEN=s3cr3t".to_string()]);
+        let out = masking_writer_bytes(b"line1 s3cr3t\nline2 s3cr3t\n", masker);
+        let s = String::from_utf8(out).unwrap();
+        assert!(!s.contains("s3cr3t"), "secret leaked: {s}");
+        assert_eq!(s.matches("********").count(), 2);
+    }
+
+    #[test]
+    fn masking_writer_passthrough_when_no_secrets() {
+        let masker = SecretMasker::default();
+        let out = masking_writer_bytes(b"hello world\n", masker);
+        assert_eq!(out, b"hello world\n");
+    }
+
+    #[test]
+    fn masking_writer_split_write_masks_correctly() {
+        // Secret split across two writes — the buffer holds incomplete bytes
+        // until the newline arrives, then masks the full line.
+        let masker = SecretMasker::new(&["TOKEN=s3cr3t".to_string()]);
+        let shared = Arc::new(Mutex::new(Vec::new()));
+        let mut writer = MaskingWriter::new(SharedBuf(Arc::clone(&shared)), masker);
+        io::Write::write_all(&mut writer, b"s3cr").unwrap();
+        io::Write::write_all(&mut writer, b"3t\n").unwrap();
+        drop(writer);
+        let out = Arc::try_unwrap(shared).unwrap().into_inner().unwrap();
+        let s = String::from_utf8(out).unwrap();
+        assert!(!s.contains("s3cr3t"), "secret leaked: {s}");
+        assert!(s.contains("********"), "mask missing: {s}");
+    }
+
     #[test]
     fn spec_string_command_wrapped_in_sh() {
         let value = json!("echo hello && echo world");

--- a/crates/cella-backend/src/secret_mask.rs
+++ b/crates/cella-backend/src/secret_mask.rs
@@ -28,16 +28,16 @@ impl SecretMasker {
     /// - Empty values are silently dropped (nothing to mask).
     /// - Values are deduplicated and sorted longest-first.
     pub fn new(entries: &[String]) -> Self {
+        // Output is masked per line, so a multiline secret value (e.g. a PEM
+        // key in the secrets file) is registered as its individual non-empty
+        // lines — otherwise the whole value would never match a single line and
+        // leak through.
         let mut values: Vec<String> = entries
             .iter()
-            .filter_map(|e| {
-                let (_, v) = e.split_once('=')?;
-                if v.is_empty() {
-                    None
-                } else {
-                    Some(v.to_string())
-                }
-            })
+            .filter_map(|e| e.split_once('=').map(|(_, v)| v))
+            .flat_map(str::lines)
+            .filter(|line| !line.is_empty())
+            .map(str::to_owned)
             .collect();
 
         // Dedup before sorting so identical values don't cause double-passes.
@@ -131,6 +131,16 @@ mod tests {
         let m = masker(&["EMPTY=", "REAL=hunter2"]);
         let out = m.mask("password is hunter2 and EMPTY= stays");
         assert_eq!(out, "password is ******** and EMPTY= stays");
+    }
+
+    #[test]
+    fn multiline_value_masked_per_line() {
+        // A multiline secret (e.g. a PEM key) registers each non-empty line, so
+        // per-line output masking catches it instead of leaking.
+        let m = masker(&["KEY=-----BEGIN-----\nMIIByz\n-----END-----"]);
+        assert_eq!(m.mask("-----BEGIN-----"), "********");
+        assert_eq!(m.mask("MIIByz"), "********");
+        assert_eq!(m.mask("-----END-----"), "********");
     }
 
     #[test]

--- a/crates/cella-backend/src/secret_mask.rs
+++ b/crates/cella-backend/src/secret_mask.rs
@@ -68,18 +68,19 @@ impl SecretMasker {
             return std::borrow::Cow::Borrowed(s);
         }
 
-        let mut result = s.to_string();
+        // Delay allocation until the first match so the common no-match path
+        // is zero-allocation.
+        let mut result: Option<String> = None;
         for secret in &self.values {
-            if result.contains(secret.as_str()) {
-                result = result.replace(secret.as_str(), MASK);
+            let haystack: &str = result.as_deref().unwrap_or(s);
+            if haystack.contains(secret.as_str()) {
+                result = Some(haystack.replace(secret.as_str(), MASK));
             }
         }
 
-        if result == s {
-            std::borrow::Cow::Borrowed(s)
-        } else {
-            std::borrow::Cow::Owned(result)
-        }
+        result.map_or(std::borrow::Cow::Borrowed(s), |owned| {
+            std::borrow::Cow::Owned(owned)
+        })
     }
 }
 

--- a/crates/cella-backend/src/secret_mask.rs
+++ b/crates/cella-backend/src/secret_mask.rs
@@ -1,0 +1,164 @@
+//! Secret-value masking for lifecycle command output.
+//!
+//! Matches the semantics of the official devcontainer CLI's `maskSecrets` in
+//! `src/spec-utils/log.ts`:
+//! - Replace each secret **value** (RHS of `KEY=VALUE`) with `********`.
+//! - Skip empty values.
+//! - Replace longest values first so that a short secret that is a prefix/
+//!   substring of a longer one cannot leave partial matches.
+
+/// Eight asterisks — the replacement sentinel used by the official CLI.
+const MASK: &str = "********";
+
+/// Replaces secret values in strings passed to lifecycle output sinks.
+///
+/// Constructed from the raw `KEY=VALUE` secret entries coming out of
+/// `--secrets-file`. Calling [`SecretMasker::mask`] on a string is free when
+/// there are no secrets (early-return without allocation).
+#[derive(Debug, Clone, Default)]
+pub struct SecretMasker {
+    /// Secret values sorted by descending length (longest first).
+    values: Vec<String>,
+}
+
+impl SecretMasker {
+    /// Build a masker from `KEY=VALUE` secret entries.
+    ///
+    /// - Values are extracted by splitting on the first `=`.
+    /// - Empty values are silently dropped (nothing to mask).
+    /// - Values are deduplicated and sorted longest-first.
+    pub fn new(entries: &[String]) -> Self {
+        let mut values: Vec<String> = entries
+            .iter()
+            .filter_map(|e| {
+                let (_, v) = e.split_once('=')?;
+                if v.is_empty() {
+                    None
+                } else {
+                    Some(v.to_string())
+                }
+            })
+            .collect();
+
+        // Dedup before sorting so identical values don't cause double-passes.
+        values.sort_unstable();
+        values.dedup();
+
+        // Longest first: prevents a shorter secret from being applied first
+        // when it is a prefix/substring of a longer one.
+        values.sort_by_key(|v| std::cmp::Reverse(v.len()));
+
+        Self { values }
+    }
+
+    /// Returns `true` when there are no secrets — callers can skip masking
+    /// entirely on the hot path.
+    #[inline]
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    /// Replace every secret value in `s` with `********`.
+    ///
+    /// Returns the input string unchanged (zero allocation) when no secrets are
+    /// registered or no match is found.
+    pub fn mask<'s>(&self, s: &'s str) -> std::borrow::Cow<'s, str> {
+        if self.values.is_empty() {
+            return std::borrow::Cow::Borrowed(s);
+        }
+
+        let mut result = s.to_string();
+        for secret in &self.values {
+            if result.contains(secret.as_str()) {
+                result = result.replace(secret.as_str(), MASK);
+            }
+        }
+
+        if result == s {
+            std::borrow::Cow::Borrowed(s)
+        } else {
+            std::borrow::Cow::Owned(result)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn masker(entries: &[&str]) -> SecretMasker {
+        SecretMasker::new(&entries.iter().map(ToString::to_string).collect::<Vec<_>>())
+    }
+
+    #[test]
+    fn single_value_masked() {
+        let m = masker(&["TOKEN=secret123"]);
+        assert_eq!(
+            m.mask("got TOKEN=secret123 here"),
+            "got TOKEN=******** here"
+        );
+    }
+
+    #[test]
+    fn multiple_values_all_masked() {
+        let m = masker(&["A=alpha", "B=beta"]);
+        let out = m.mask("alpha and beta");
+        assert_eq!(out, "******** and ********");
+    }
+
+    #[test]
+    fn longest_first_no_partial_match() {
+        // "pass" is a substring of "password". Masking "password" first must
+        // not leave "pass" residue from the longer replacement sentinel.
+        let m = masker(&["X=pass", "Y=password"]);
+        let out = m.mask("my password is pass");
+        // "password" → "********", then "pass" → "********"
+        assert_eq!(out, "my ******** is ********");
+    }
+
+    #[test]
+    fn longest_first_prefix_of_longer() {
+        // "abc" is prefix of "abcdef". With longest-first, "abcdef" is masked
+        // first and "abc" does not partially match inside "********".
+        let m = masker(&["S=abc", "T=abcdef"]);
+        let out = m.mask("value=abcdef");
+        assert_eq!(out, "value=********");
+    }
+
+    #[test]
+    fn empty_value_skipped() {
+        let m = masker(&["EMPTY=", "REAL=hunter2"]);
+        let out = m.mask("password is hunter2 and EMPTY= stays");
+        assert_eq!(out, "password is ******** and EMPTY= stays");
+    }
+
+    #[test]
+    fn no_secrets_passthrough() {
+        let m = SecretMasker::default();
+        let s = "no secrets here";
+        // Must return a Borrowed slice — no allocation.
+        assert!(matches!(m.mask(s), std::borrow::Cow::Borrowed(_)));
+        assert_eq!(m.mask(s), s);
+    }
+
+    #[test]
+    fn no_match_returns_borrowed() {
+        let m = masker(&["KEY=secret"]);
+        let s = "nothing to mask";
+        assert!(matches!(m.mask(s), std::borrow::Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn value_appearing_multiple_times() {
+        let m = masker(&["K=tok"]);
+        assert_eq!(m.mask("tok and tok again"), "******** and ******** again");
+    }
+
+    #[test]
+    fn no_key_entry_skipped() {
+        // An entry without '=' has no value to extract — skip it gracefully.
+        let m = masker(&["NOKEYVALUE"]);
+        assert!(m.is_empty());
+    }
+}

--- a/crates/cella-cli/src/commands/run_user_commands.rs
+++ b/crates/cella-cli/src/commands/run_user_commands.rs
@@ -310,6 +310,7 @@ impl RunUserCommandsArgs {
             working_dir: Some(&workspace_folder),
             is_text: false,
             on_output: None,
+            secret_masker: cella_backend::SecretMasker::new(&secrets),
         };
         let input = orchestrator::RunUserCommandsInput {
             config: &config,

--- a/crates/cella-cli/src/commands/set_up.rs
+++ b/crates/cella-cli/src/commands/set_up.rs
@@ -209,6 +209,7 @@ impl SetUpArgs {
                 working_dir: Some(&workspace_folder),
                 is_text: false,
                 on_output: None,
+                secret_masker: cella_backend::SecretMasker::new(&secrets),
             };
             let input = orchestrator::RunUserCommandsInput {
                 config: &config,

--- a/crates/cella-compose/src/orchestrate.rs
+++ b/crates/cella-compose/src/orchestrate.rs
@@ -1588,6 +1588,9 @@ fn build_lifecycle_ctx<'a>(
         working_dir,
         is_text: true,
         on_output: Some(Box::new(move |line| p.println(line))),
+        // Compose has no lifecycle `--secrets-file` plumbing yet, so there are
+        // no secret values to mask here (empty masker = passthrough).
+        secret_masker: cella_backend::SecretMasker::default(),
     }
 }
 

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -199,6 +199,7 @@ impl EnsureUpContext<'_> {
             ),
             is_text: true,
             on_output: Some(Box::new(move |line| progress.println(line))),
+            secret_masker: cella_backend::SecretMasker::new(self.config.lifecycle_secrets),
         }
     }
 


### PR DESCRIPTION
Security parity fix. cella injects `--secrets-file` values into lifecycle command env but never masked them in the output it streams/prints — so a lifecycle script that echoes its environment (common when debugging) leaked secret values to the terminal and to the JSON error envelope. The official CLI replaces every secret value with `********` in all log output.

- New `SecretMasker` (cella-backend): extracts values from the `KEY=VALUE` secret entries, skips empties, expands multiline values (e.g. PEM keys) into their component lines, sorts longest-first to avoid partial-match shadowing, and replaces each with `********`. Empty masker is a zero-alloc passthrough.
- Applied at every lifecycle output sink: the `CallbackWriter` (spinner) path, the direct-stderr streaming fallback (new line-buffered `MaskingWriter`), `print_completed_output` (parallel results), and `check_exit_code` (a failing command's stderr is embedded in the error message → was leaking into the `--output json` error envelope).
- Threaded through `LifecycleContext` from `up` and `run-user-commands` (masker built from the `--secrets-file` values only — never the full remoteEnv). Compose has no lifecycle-secrets plumbing yet, so it passes an empty masker (no regression).
- With no secrets, every path is byte-identical to before.

Adversarially reviewed; the two findings it surfaced (error-envelope stderr leak, multiline values) are fixed here. Tests cover the masker semantics plus masking at the CallbackWriter sink and in `check_exit_code`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)