### PR TITLE
fix: --id-label repeatable and validated on exec/install/read-configuration

### DIFF
--- a/crates/cella-cli/src/commands/exec.rs
+++ b/crates/cella-cli/src/commands/exec.rs
@@ -304,3 +304,34 @@ async fn build_exec_env(
     }
     env
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn id_label_is_repeatable() {
+        use clap::Parser;
+        let cli = crate::Cli::try_parse_from([
+            "cella",
+            "exec",
+            "--id-label",
+            "a=1",
+            "--id-label",
+            "b=2",
+            "--",
+            "true",
+        ])
+        .expect("two --id-label values must parse");
+        let crate::commands::Command::Exec(args) = &cli.command else {
+            panic!("expected exec subcommand");
+        };
+        assert_eq!(args.id_label, ["a=1", "b=2"]);
+    }
+
+    #[test]
+    fn id_label_rejects_missing_value() {
+        use clap::Parser;
+        let r =
+            crate::Cli::try_parse_from(["cella", "exec", "--id-label", "novalue", "--", "true"]);
+        assert!(r.is_err(), "--id-label without '=value' must be rejected");
+    }
+}

--- a/crates/cella-cli/src/commands/exec.rs
+++ b/crates/cella-cli/src/commands/exec.rs
@@ -30,9 +30,9 @@ pub struct ExecArgs {
     #[arg(long)]
     container_name: Option<String>,
 
-    /// Target container by label.
-    #[arg(long)]
-    id_label: Option<String>,
+    /// Target container by label(s) of the form `name=value` (repeatable).
+    #[arg(long, value_parser = crate::commands::parse_id_label)]
+    id_label: Vec<String>,
 
     /// Target a specific compose service (defaults to primary service).
     #[arg(long)]
@@ -82,7 +82,7 @@ impl ExecArgs {
         let target = ContainerTarget {
             container_id: self.container_id,
             container_name: self.container_name,
-            id_labels: self.id_label.into_iter().collect(),
+            id_labels: self.id_label,
             workspace_folder: self.workspace_folder,
         };
 

--- a/crates/cella-cli/src/commands/install.rs
+++ b/crates/cella-cli/src/commands/install.rs
@@ -37,9 +37,9 @@ pub struct InstallArgs {
     #[arg(long)]
     container_name: Option<String>,
 
-    /// Target container by label.
-    #[arg(long)]
-    id_label: Option<String>,
+    /// Target container by label(s) of the form `name=value` (repeatable).
+    #[arg(long, value_parser = crate::commands::parse_id_label)]
+    id_label: Vec<String>,
 
     /// Target a specific compose service (defaults to primary service).
     #[arg(long)]
@@ -61,7 +61,7 @@ impl InstallArgs {
         let target = ContainerTarget {
             container_id: self.container_id,
             container_name: self.container_name,
-            id_labels: self.id_label.into_iter().collect(),
+            id_labels: self.id_label,
             workspace_folder: self.workspace_folder,
         };
 

--- a/crates/cella-cli/src/commands/install.rs
+++ b/crates/cella-cli/src/commands/install.rs
@@ -321,6 +321,31 @@ mod tests {
     use super::*;
 
     #[test]
+    fn id_label_is_repeatable() {
+        use clap::Parser;
+        let cli = crate::Cli::try_parse_from([
+            "cella",
+            "install",
+            "--id-label",
+            "a=1",
+            "--id-label",
+            "b=2",
+        ])
+        .expect("two --id-label values must parse");
+        let crate::commands::Command::Install(args) = &cli.command else {
+            panic!("expected install subcommand");
+        };
+        assert_eq!(args.id_label, ["a=1", "b=2"]);
+    }
+
+    #[test]
+    fn id_label_rejects_missing_value() {
+        use clap::Parser;
+        let r = crate::Cli::try_parse_from(["cella", "install", "--id-label", "novalue"]);
+        assert!(r.is_err(), "--id-label without '=value' must be rejected");
+    }
+
+    #[test]
     fn resolve_tool_args_valid_names() {
         let args = vec!["claude-code".to_string(), "nvim".to_string()];
         let result = resolve_tool_args(&args, &[]).unwrap();

--- a/crates/cella-cli/src/commands/read_configuration.rs
+++ b/crates/cella-cli/src/commands/read_configuration.rs
@@ -35,9 +35,9 @@ pub struct ReadConfigurationArgs {
     #[arg(long = "override-config")]
     override_config: Option<PathBuf>,
 
-    /// Target container by label.
-    #[arg(long = "id-label")]
-    id_label: Option<String>,
+    /// Target container by label(s) of the form `name=value` (repeatable).
+    #[arg(long = "id-label", value_parser = crate::commands::parse_id_label)]
+    id_label: Vec<String>,
 
     /// Target container by ID.
     #[arg(long = "container-id")]
@@ -50,7 +50,7 @@ pub struct ReadConfigurationArgs {
 
 impl ReadConfigurationArgs {
     pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let has_container_target = self.id_label.is_some() || self.container_id.is_some();
+        let has_container_target = !self.id_label.is_empty() || self.container_id.is_some();
 
         let config_path = self.override_config.as_deref().or(self.config.as_deref());
 
@@ -59,7 +59,7 @@ impl ReadConfigurationArgs {
             let target = ContainerTarget {
                 container_id: self.container_id.clone(),
                 container_name: None,
-                id_labels: self.id_label.iter().cloned().collect(),
+                id_labels: self.id_label.clone(),
                 workspace_folder: self.workspace_folder.clone(),
             };
             let container = target.resolve(&*client, false).await?;
@@ -231,6 +231,37 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn id_label_is_repeatable_and_validated() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct Cli {
+            #[command(flatten)]
+            args: ReadConfigurationArgs,
+        }
+
+        // Repeatable: two --id-label flags collect into the Vec.
+        let cli = Cli::try_parse_from([
+            "read-configuration",
+            "--id-label",
+            "a=1",
+            "--id-label",
+            "b=2",
+        ])
+        .expect("two id-labels must parse");
+        assert_eq!(
+            cli.args.id_label,
+            vec!["a=1".to_string(), "b=2".to_string()]
+        );
+
+        // Validated: a malformed label (no `=`) is rejected.
+        assert!(
+            Cli::try_parse_from(["read-configuration", "--id-label", "noequals"]).is_err(),
+            "malformed --id-label must be rejected"
+        );
+    }
 
     #[test]
     fn apply_feature_config_sets_mounts() {
@@ -408,7 +439,7 @@ mod tests {
             include_merged_configuration: false,
             include_features_configuration: false,
             override_config: None,
-            id_label: None,
+            id_label: Vec::new(),
             container_id: None,
             additional_features: None,
         };
@@ -429,7 +460,7 @@ mod tests {
             include_merged_configuration: false,
             include_features_configuration: false,
             override_config: Some(override_path),
-            id_label: None,
+            id_label: Vec::new(),
             container_id: None,
             additional_features: None,
         };
@@ -447,7 +478,7 @@ mod tests {
             include_merged_configuration: false,
             include_features_configuration: false,
             override_config: None,
-            id_label: None,
+            id_label: Vec::new(),
             container_id: None,
             additional_features: Some(
                 r#"{"ghcr.io/devcontainers/features/git:1": {}}"#.to_string(),
@@ -467,7 +498,7 @@ mod tests {
             include_merged_configuration: false,
             include_features_configuration: false,
             override_config: None,
-            id_label: None,
+            id_label: Vec::new(),
             container_id: None,
             additional_features: Some("not valid json".to_string()),
         };
@@ -486,7 +517,7 @@ mod tests {
             include_merged_configuration: false,
             include_features_configuration: false,
             override_config: None,
-            id_label: None,
+            id_label: Vec::new(),
             container_id: None,
             additional_features: Some(r#"["not", "an", "object"]"#.to_string()),
         };
@@ -505,7 +536,7 @@ mod tests {
             include_merged_configuration: true,
             include_features_configuration: false,
             override_config: None,
-            id_label: None,
+            id_label: Vec::new(),
             container_id: None,
             additional_features: None,
         };


### PR DESCRIPTION
`exec`, `install`, and `read-configuration` declared `--id-label` as a single `Option<String>` with no format validation, whereas `up`/`run-user-commands` (and the official CLI across all commands) accept it **repeatably** and validate the `name=value` shape. Consequences:
- passing two `--id-label` flags to `exec`/`read-configuration` produced a clap "unexpected argument" error instead of AND-matching both labels;
- a malformed `--id-label noequals` was accepted and passed to Docker as a bare-key label filter that never matches anything, instead of erroring.

All three now use `Vec<String>` with the shared `parse_id_label` validator, so multiple labels AND-combine in the container lookup exactly like `up`. A clap test asserts both repeatability and rejection of a malformed value.

Note (separate follow-up, not in this PR): the **default** container-reuse lookup still filters by the cella-specific `dev.cella.workspace_path` label rather than the spec's `devcontainer.local_folder`+`devcontainer.config_file` (both of which cella does stamp). Switching that for full VS Code/official-CLI reuse interop is entangled with the lexical-vs-canonical path normalization (see the devcontainerId fix) and is higher blast-radius, so it's tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)