### PR TITLE
fix: skip updateRemoteUserUID remap on non-Linux hosts

### DIFF
--- a/crates/cella-backend/src/uid_image.rs
+++ b/crates/cella-backend/src/uid_image.rs
@@ -66,6 +66,15 @@ fn skip_remap_for_remote_user(remote_user: &str) -> bool {
         || (!remote_user.is_empty() && remote_user.bytes().all(|b| b.is_ascii_digit()))
 }
 
+/// Whether UID remap is unsupported on the given host OS.
+///
+/// The official CLI only remaps on Linux: on macOS/Windows the Docker Desktop
+/// VM mediates bind-mount file ownership, so there is no host UID to align the
+/// container user with (`updateRemoteUserUIDOnMacOS` is hardcoded `false`).
+fn remap_unsupported_on_host(host_os: &str) -> bool {
+    host_os != "linux"
+}
+
 /// Build a UID-remapped image on top of `base_image`.
 ///
 /// Returns `Ok(Some(uid_image_name))` when a new image was built, or
@@ -85,6 +94,14 @@ pub async fn build_uid_remap_image(
     toolchain: BuildToolchain<'_>,
     progress: &ProgressSender,
 ) -> Result<Option<String>, Box<dyn std::error::Error + Send + Sync>> {
+    if remap_unsupported_on_host(std::env::consts::OS) {
+        debug!(
+            "Skipping UID remap: host OS is {} (Docker Desktop mediates file ownership off Linux)",
+            std::env::consts::OS
+        );
+        return Ok(None);
+    }
+
     if skip_remap_for_remote_user(remote_user) {
         debug!("Skipping UID remap: remote user is root or numeric ({remote_user})");
         return Ok(None);
@@ -193,5 +210,13 @@ mod tests {
         assert!(!skip_remap_for_remote_user("node"));
         // Empty string is not numeric per /^\d+$/ (requires >=1 digit).
         assert!(!skip_remap_for_remote_user(""));
+    }
+
+    #[test]
+    fn remap_only_on_linux_host() {
+        assert!(!remap_unsupported_on_host("linux"));
+        // Off Linux, Docker Desktop's VM handles bind-mount ownership.
+        assert!(remap_unsupported_on_host("macos"));
+        assert!(remap_unsupported_on_host("windows"));
     }
 }

--- a/crates/cella-backend/src/uid_image.rs
+++ b/crates/cella-backend/src/uid_image.rs
@@ -78,7 +78,11 @@ fn remap_unsupported_on_host(host_os: &str) -> bool {
 /// Build a UID-remapped image on top of `base_image`.
 ///
 /// Returns `Ok(Some(uid_image_name))` when a new image was built, or
-/// `Ok(None)` when remapping was skipped (root user, UID 0, etc.).
+/// `Ok(None)` when remapping was skipped for any of the following reasons:
+/// - The host OS is not Linux (Docker Desktop's VM mediates file ownership
+///   on macOS/Windows, so there is no host UID to align with).
+/// - The remote user is `root` or an all-numeric UID.
+/// - The host UID is 0 (root).
 ///
 /// On build failure, logs a warning and returns `Ok(None)` so the caller
 /// can fall back to the unmodified base image.


### PR DESCRIPTION
`updateRemoteUserUID` remaps the container remote user's UID/GID to match the host user so bind-mounted files have correct ownership. The official CLI only does this on **Linux** — on macOS/Windows the Docker Desktop VM mediates file ownership and there's no meaningful host UID to align with (`updateRemoteUserUIDOnMacOS` is hardcoded `false` in the CLI).

cella had no platform guard, and `nix::unistd::getuid()` runs fine on macOS, so on a Mac cella would build an unnecessary UID-remap derived image keyed off the macOS host UID — wasted work and a wrong-for-the-platform layer. Now skipped when the host OS isn't Linux, via a guard in `build_uid_remap_image` (the shared entry point for both the single-container and compose paths). A pure `remap_unsupported_on_host` helper makes it unit-testable on the Linux CI host.

Follow-ups noted from the same analysis (not in this PR): the UID-remap `docker build` doesn't pass `--platform` from the image's inspected arch (could pick the wrong arch on multi-arch hosts — needs `ImageDetails` os/arch/variant fields), and Podman needs a `localhost/` prefix on the base image. Both are lower-impact and more involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)