### PR TITLE
fix: pass --platform to the UID-remap build (multi-arch correctness)

### DIFF
--- a/crates/cella-backend/src/types.rs
+++ b/crates/cella-backend/src/types.rs
@@ -163,6 +163,12 @@ pub struct ImageDetails {
     pub env: Vec<String>,
     /// Raw JSON from the `devcontainer.metadata` label, if present.
     pub metadata: Option<String>,
+    /// OS reported by the image (e.g. `"linux"`).
+    pub os: Option<String>,
+    /// CPU architecture reported by the image (e.g. `"amd64"`, `"arm64"`).
+    pub architecture: Option<String>,
+    /// Architecture variant reported by the image (e.g. `"v8"`).
+    pub variant: Option<String>,
 }
 
 /// A `BuildKit` build secret (`--secret id=X,src=Y` or `--secret id=X,env=Y`).
@@ -193,6 +199,10 @@ pub struct BuildOptions {
     pub use_buildkit: bool,
     /// Path to the `docker` CLI binary. `None` defaults to `docker` on `PATH`.
     pub docker_path: Option<String>,
+    /// Target platform for the build (e.g. `linux/amd64`, `linux/arm64/v8`).
+    /// When set, emits `--platform <value>` on the docker build command.
+    /// Derived from the base image's inspected OS/architecture/variant.
+    pub platform: Option<String>,
 }
 
 impl Default for BuildOptions {
@@ -209,6 +219,7 @@ impl Default for BuildOptions {
             secrets: Vec::new(),
             use_buildkit: true,
             docker_path: None,
+            platform: None,
         }
     }
 }

--- a/crates/cella-backend/src/uid_image.rs
+++ b/crates/cella-backend/src/uid_image.rs
@@ -117,7 +117,6 @@ pub async fn build_uid_remap_image(
     image_user: &str,
     remote_user: &str,
     toolchain: BuildToolchain<'_>,
-    image_platform: Option<&str>,
     progress: &ProgressSender,
 ) -> Result<Option<String>, Box<dyn std::error::Error + Send + Sync>> {
     if remap_unsupported_on_host(std::env::consts::OS) {
@@ -140,6 +139,20 @@ pub async fn build_uid_remap_image(
         debug!("Skipping UID remap: host UID is 0 (root)");
         return Ok(None);
     }
+
+    // Inspect the base image to derive `--platform`. Failures are non-fatal:
+    // omitting `--platform` is byte-identical to the pre-platform behaviour.
+    let platform = client
+        .inspect_image_details(base_image)
+        .await
+        .ok()
+        .and_then(|d| {
+            image_platform(
+                d.os.as_deref(),
+                d.architecture.as_deref(),
+                d.variant.as_deref(),
+            )
+        });
 
     let uid_image = format!("{base_image}-uid");
 
@@ -166,7 +179,7 @@ pub async fn build_uid_remap_image(
         secrets: vec![],
         use_buildkit: toolchain.use_buildkit,
         docker_path: toolchain.docker_path.map(str::to_string),
-        platform: image_platform.map(str::to_string),
+        platform,
     };
 
     info!("Building UID remap image: {uid_image} (UID {host_uid}:{host_gid})");

--- a/crates/cella-backend/src/uid_image.rs
+++ b/crates/cella-backend/src/uid_image.rs
@@ -75,6 +75,23 @@ fn remap_unsupported_on_host(host_os: &str) -> bool {
     host_os != "linux"
 }
 
+/// Compute the platform string from image inspect fields.
+///
+/// Joins non-empty fields with `/`: `linux/amd64` or `linux/arm64/v8`.
+/// Returns `None` when os is absent or empty (platform cannot be determined).
+pub fn image_platform(
+    os: Option<&str>,
+    arch: Option<&str>,
+    variant: Option<&str>,
+) -> Option<String> {
+    let os = os.filter(|s| !s.is_empty())?;
+    let parts: Vec<&str> = std::iter::once(os)
+        .chain(arch.into_iter().filter(|s| !s.is_empty()))
+        .chain(variant.into_iter().filter(|s| !s.is_empty()))
+        .collect();
+    Some(parts.join("/"))
+}
+
 /// Build a UID-remapped image on top of `base_image`.
 ///
 /// Returns `Ok(Some(uid_image_name))` when a new image was built, or
@@ -87,6 +104,10 @@ fn remap_unsupported_on_host(host_os: &str) -> bool {
 /// On build failure, logs a warning and returns `Ok(None)` so the caller
 /// can fall back to the unmodified base image.
 ///
+/// The platform (`--platform`) is derived by inspecting `base_image` after
+/// the skip guards pass. On inspect failure the flag is omitted, which is
+/// byte-identical to the pre-platform behaviour.
+///
 /// # Errors
 ///
 /// Returns an error if the Dockerfile cannot be written to disk.
@@ -96,6 +117,7 @@ pub async fn build_uid_remap_image(
     image_user: &str,
     remote_user: &str,
     toolchain: BuildToolchain<'_>,
+    image_platform: Option<&str>,
     progress: &ProgressSender,
 ) -> Result<Option<String>, Box<dyn std::error::Error + Send + Sync>> {
     if remap_unsupported_on_host(std::env::consts::OS) {
@@ -144,6 +166,7 @@ pub async fn build_uid_remap_image(
         secrets: vec![],
         use_buildkit: toolchain.use_buildkit,
         docker_path: toolchain.docker_path.map(str::to_string),
+        platform: image_platform.map(str::to_string),
     };
 
     info!("Building UID remap image: {uid_image} (UID {host_uid}:{host_gid})");
@@ -222,5 +245,53 @@ mod tests {
         // Off Linux, Docker Desktop's VM handles bind-mount ownership.
         assert!(remap_unsupported_on_host("macos"));
         assert!(remap_unsupported_on_host("windows"));
+    }
+
+    // -----------------------------------------------------------------------
+    // image_platform
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn image_platform_linux_amd64() {
+        assert_eq!(
+            image_platform(Some("linux"), Some("amd64"), None),
+            Some("linux/amd64".to_string())
+        );
+    }
+
+    #[test]
+    fn image_platform_linux_arm64_v8() {
+        assert_eq!(
+            image_platform(Some("linux"), Some("arm64"), Some("v8")),
+            Some("linux/arm64/v8".to_string())
+        );
+    }
+
+    #[test]
+    fn image_platform_missing_os_returns_none() {
+        assert_eq!(image_platform(None, Some("amd64"), None), None);
+    }
+
+    #[test]
+    fn image_platform_empty_os_returns_none() {
+        assert_eq!(image_platform(Some(""), Some("amd64"), None), None);
+    }
+
+    #[test]
+    fn image_platform_os_only() {
+        assert_eq!(
+            image_platform(Some("linux"), None, None),
+            Some("linux".to_string())
+        );
+    }
+
+    #[test]
+    fn image_platform_empty_arch_skipped_no_trailing_slash() {
+        // OS present, ARCH is an empty string — must be filtered, not joined.
+        // Expected: "linux", not "linux/".
+        assert_eq!(
+            image_platform(Some("linux"), Some(""), None),
+            Some("linux".to_string())
+        );
     }
 }

--- a/crates/cella-compose/src/orchestrate.rs
+++ b/crates/cella-compose/src/orchestrate.rs
@@ -437,19 +437,23 @@ async fn resolve_user_and_env(
 ) -> (
     String,
     String,
+    Option<String>,
+    Option<String>,
+    Option<String>,
     cella_env::EnvForwarding,
     Option<SshAgentProxyStatus>,
 ) {
     let cfg = ctx.cfg;
     let progress = ctx.progress;
-    let (image_user, image_meta_user) = resolve_compose_image_info(
-        client,
-        project,
-        features_build,
-        cfg.docker_binaries(),
-        progress,
-    )
-    .await;
+    let (image_user, image_os, image_arch, image_variant, image_meta_user) =
+        resolve_compose_image_info(
+            client,
+            project,
+            features_build,
+            cfg.docker_binaries(),
+            progress,
+        )
+        .await;
     let remote_user = resolve_remote_user(cfg.config, image_meta_user.as_ref(), &image_user);
     let managed_agent = client.capabilities().managed_agent;
     let skip_rules = cfg.network_rule_policy == cella_network::NetworkRulePolicy::Skip;
@@ -462,7 +466,15 @@ async fn resolve_user_and_env(
         client.host_gateway(),
     )
     .await;
-    (remote_user, image_user, env_fwd, ssh_agent_proxy)
+    (
+        remote_user,
+        image_user,
+        image_os,
+        image_arch,
+        image_variant,
+        env_fwd,
+        ssh_agent_proxy,
+    )
 }
 
 /// Prepare environment, write override YAML, and start compose services.
@@ -551,8 +563,15 @@ async fn prepare_and_start(
     .await?;
 
     // 10. Resolve remote user, env forwarding, and ssh-agent proxy.
-    let (remote_user, image_user, mut env_fwd, ssh_agent_proxy) =
-        resolve_user_and_env(client, ctx, project, features_build.as_ref()).await;
+    let (
+        remote_user,
+        image_user,
+        image_os,
+        image_arch,
+        image_variant,
+        mut env_fwd,
+        ssh_agent_proxy,
+    ) = resolve_user_and_env(client, ctx, project, features_build.as_ref()).await;
     info!("Resolved remote user: {remote_user} (image user: {image_user})");
 
     // 11-15. Build override context, UID remap, write override, and start.
@@ -566,6 +585,9 @@ async fn prepare_and_start(
         &mut env_fwd,
         &remote_user,
         &image_user,
+        image_os.as_deref(),
+        image_arch.as_deref(),
+        image_variant.as_deref(),
         agent_vol_name,
         agent_vol_target,
     )
@@ -916,14 +938,20 @@ async fn resolve_compose_image_info(
     features_build: Option<&crate::combined_dockerfile_build::ComposeFeaturesBuild>,
     docker_binaries: (Option<String>, Option<String>),
     progress: &ProgressSender,
-) -> (String, Option<cella_features::ImageMetadataUserInfo>) {
+) -> (
+    String,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<cella_features::ImageMetadataUserInfo>,
+) {
     // If features resolved an image, its metadata was already extracted.
     if let Some(fb) = features_build {
         let meta_user = fb
             .base_image_metadata
             .as_deref()
             .map(|m| cella_features::parse_image_metadata(m).1);
-        return (fb.image_user.clone(), meta_user);
+        return (fb.image_user.clone(), None, None, None, meta_user);
     }
 
     // Resolve compose config to find the service's image source.
@@ -933,7 +961,7 @@ async fn resolve_compose_image_info(
         Ok(r) => r,
         Err(e) => {
             warn!("Failed to resolve compose config for image metadata: {e}");
-            return ("root".to_string(), None);
+            return ("root".to_string(), None, None, None, None);
         }
     };
 
@@ -942,7 +970,7 @@ async fn resolve_compose_image_info(
         Ok(info) => info,
         Err(e) => {
             warn!("Failed to extract service build info: {e}");
-            return ("root".to_string(), None);
+            return ("root".to_string(), None, None, None, None);
         }
     };
 
@@ -971,11 +999,17 @@ async fn resolve_compose_image_info(
                 .metadata
                 .as_deref()
                 .map(|m| cella_features::parse_image_metadata(m).1);
-            (details.user, meta_user)
+            (
+                details.user,
+                details.os,
+                details.architecture,
+                details.variant,
+                meta_user,
+            )
         }
         Err(e) => {
             warn!("Failed to inspect image '{image_name}' for metadata: {e}");
-            ("root".to_string(), None)
+            ("root".to_string(), None, None, None, None)
         }
     }
 }
@@ -1029,6 +1063,7 @@ async fn build_uid_remap_image_compose(
     features_build: Option<&crate::combined_dockerfile_build::ComposeFeaturesBuild>,
     remote_user: &str,
     image_user: &str,
+    image_platform: Option<&str>,
 ) -> Result<Option<String>, Box<dyn std::error::Error + Send + Sync>> {
     let config_value = ctx
         .cfg
@@ -1055,6 +1090,7 @@ async fn build_uid_remap_image_compose(
             docker_path: ctx.cfg.build_tuning.docker_path.as_deref(),
             use_buildkit: ctx.cfg.build_tuning.use_buildkit,
         },
+        image_platform,
         ctx.progress,
     )
     .await
@@ -1110,6 +1146,9 @@ async fn build_override_and_start(
     env_fwd: &mut cella_env::EnvForwarding,
     remote_user: &str,
     image_user: &str,
+    image_os: Option<&str>,
+    image_arch: Option<&str>,
+    image_variant: Option<&str>,
     agent_vol_name: String,
     agent_vol_target: String,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -1170,9 +1209,16 @@ async fn build_override_and_start(
         request_gpu,
     };
 
-    let uid_image =
-        build_uid_remap_image_compose(ctx, project, features_build, remote_user, image_user)
-            .await?;
+    let platform = cella_backend::uid_image::image_platform(image_os, image_arch, image_variant);
+    let uid_image = build_uid_remap_image_compose(
+        ctx,
+        project,
+        features_build,
+        remote_user,
+        image_user,
+        platform.as_deref(),
+    )
+    .await?;
 
     compose_up_with_ssh_fallback(
         compose_cmd,

--- a/crates/cella-compose/src/orchestrate.rs
+++ b/crates/cella-compose/src/orchestrate.rs
@@ -437,23 +437,19 @@ async fn resolve_user_and_env(
 ) -> (
     String,
     String,
-    Option<String>,
-    Option<String>,
-    Option<String>,
     cella_env::EnvForwarding,
     Option<SshAgentProxyStatus>,
 ) {
     let cfg = ctx.cfg;
     let progress = ctx.progress;
-    let (image_user, image_os, image_arch, image_variant, image_meta_user) =
-        resolve_compose_image_info(
-            client,
-            project,
-            features_build,
-            cfg.docker_binaries(),
-            progress,
-        )
-        .await;
+    let (image_user, image_meta_user) = resolve_compose_image_info(
+        client,
+        project,
+        features_build,
+        cfg.docker_binaries(),
+        progress,
+    )
+    .await;
     let remote_user = resolve_remote_user(cfg.config, image_meta_user.as_ref(), &image_user);
     let managed_agent = client.capabilities().managed_agent;
     let skip_rules = cfg.network_rule_policy == cella_network::NetworkRulePolicy::Skip;
@@ -466,15 +462,7 @@ async fn resolve_user_and_env(
         client.host_gateway(),
     )
     .await;
-    (
-        remote_user,
-        image_user,
-        image_os,
-        image_arch,
-        image_variant,
-        env_fwd,
-        ssh_agent_proxy,
-    )
+    (remote_user, image_user, env_fwd, ssh_agent_proxy)
 }
 
 /// Prepare environment, write override YAML, and start compose services.
@@ -563,15 +551,8 @@ async fn prepare_and_start(
     .await?;
 
     // 10. Resolve remote user, env forwarding, and ssh-agent proxy.
-    let (
-        remote_user,
-        image_user,
-        image_os,
-        image_arch,
-        image_variant,
-        mut env_fwd,
-        ssh_agent_proxy,
-    ) = resolve_user_and_env(client, ctx, project, features_build.as_ref()).await;
+    let (remote_user, image_user, mut env_fwd, ssh_agent_proxy) =
+        resolve_user_and_env(client, ctx, project, features_build.as_ref()).await;
     info!("Resolved remote user: {remote_user} (image user: {image_user})");
 
     // 11-15. Build override context, UID remap, write override, and start.
@@ -585,9 +566,6 @@ async fn prepare_and_start(
         &mut env_fwd,
         &remote_user,
         &image_user,
-        image_os.as_deref(),
-        image_arch.as_deref(),
-        image_variant.as_deref(),
         agent_vol_name,
         agent_vol_target,
     )
@@ -938,20 +916,14 @@ async fn resolve_compose_image_info(
     features_build: Option<&crate::combined_dockerfile_build::ComposeFeaturesBuild>,
     docker_binaries: (Option<String>, Option<String>),
     progress: &ProgressSender,
-) -> (
-    String,
-    Option<String>,
-    Option<String>,
-    Option<String>,
-    Option<cella_features::ImageMetadataUserInfo>,
-) {
+) -> (String, Option<cella_features::ImageMetadataUserInfo>) {
     // If features resolved an image, its metadata was already extracted.
     if let Some(fb) = features_build {
         let meta_user = fb
             .base_image_metadata
             .as_deref()
             .map(|m| cella_features::parse_image_metadata(m).1);
-        return (fb.image_user.clone(), None, None, None, meta_user);
+        return (fb.image_user.clone(), meta_user);
     }
 
     // Resolve compose config to find the service's image source.
@@ -961,7 +933,7 @@ async fn resolve_compose_image_info(
         Ok(r) => r,
         Err(e) => {
             warn!("Failed to resolve compose config for image metadata: {e}");
-            return ("root".to_string(), None, None, None, None);
+            return ("root".to_string(), None);
         }
     };
 
@@ -970,7 +942,7 @@ async fn resolve_compose_image_info(
         Ok(info) => info,
         Err(e) => {
             warn!("Failed to extract service build info: {e}");
-            return ("root".to_string(), None, None, None, None);
+            return ("root".to_string(), None);
         }
     };
 
@@ -999,17 +971,11 @@ async fn resolve_compose_image_info(
                 .metadata
                 .as_deref()
                 .map(|m| cella_features::parse_image_metadata(m).1);
-            (
-                details.user,
-                details.os,
-                details.architecture,
-                details.variant,
-                meta_user,
-            )
+            (details.user, meta_user)
         }
         Err(e) => {
             warn!("Failed to inspect image '{image_name}' for metadata: {e}");
-            ("root".to_string(), None, None, None, None)
+            ("root".to_string(), None)
         }
     }
 }
@@ -1057,13 +1023,16 @@ async fn resolve_compose_gpu(ctx: &Ctx<'_>, config: &serde_json::Value) -> bool 
 /// Build a UID-remapped image for the compose service.
 ///
 /// Returns the UID-remapped image name, or `None` if remap was skipped.
+///
+/// The platform (`--platform`) is resolved internally by
+/// [`cella_backend::uid_image::build_uid_remap_image`] via image inspection,
+/// covering both image-only and features-build paths correctly.
 async fn build_uid_remap_image_compose(
     ctx: &Ctx<'_>,
     project: &ComposeProject,
     features_build: Option<&crate::combined_dockerfile_build::ComposeFeaturesBuild>,
     remote_user: &str,
     image_user: &str,
-    image_platform: Option<&str>,
 ) -> Result<Option<String>, Box<dyn std::error::Error + Send + Sync>> {
     let config_value = ctx
         .cfg
@@ -1077,6 +1046,10 @@ async fn build_uid_remap_image_compose(
         return Ok(None);
     }
 
+    // compose_image is the ACTUAL image that will be used as the remap base:
+    // either the features-build image override or the default {project}-{service}.
+    // build_uid_remap_image inspects THIS image to derive --platform, so the
+    // compose+features path (features_build is Some) gets the correct platform.
     let compose_image = features_build
         .and_then(|b| b.image_name_override.clone())
         .unwrap_or_else(|| format!("{}-{}", project.project_name, project.primary_service));
@@ -1090,7 +1063,6 @@ async fn build_uid_remap_image_compose(
             docker_path: ctx.cfg.build_tuning.docker_path.as_deref(),
             use_buildkit: ctx.cfg.build_tuning.use_buildkit,
         },
-        image_platform,
         ctx.progress,
     )
     .await
@@ -1146,9 +1118,6 @@ async fn build_override_and_start(
     env_fwd: &mut cella_env::EnvForwarding,
     remote_user: &str,
     image_user: &str,
-    image_os: Option<&str>,
-    image_arch: Option<&str>,
-    image_variant: Option<&str>,
     agent_vol_name: String,
     agent_vol_target: String,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -1209,16 +1178,9 @@ async fn build_override_and_start(
         request_gpu,
     };
 
-    let platform = cella_backend::uid_image::image_platform(image_os, image_arch, image_variant);
-    let uid_image = build_uid_remap_image_compose(
-        ctx,
-        project,
-        features_build,
-        remote_user,
-        image_user,
-        platform.as_deref(),
-    )
-    .await?;
+    let uid_image =
+        build_uid_remap_image_compose(ctx, project, features_build, remote_user, image_user)
+            .await?;
 
     compose_up_with_ssh_fallback(
         compose_cmd,

--- a/crates/cella-container/src/backend.rs
+++ b/crates/cella-container/src/backend.rs
@@ -591,6 +591,11 @@ impl ContainerBackend for AppleContainerBackend {
                 user,
                 env,
                 metadata,
+                // Apple Container CLI inspect doesn't expose OS/arch fields;
+                // platform is not needed for UID remap on this backend.
+                os: None,
+                architecture: None,
+                variant: None,
             })
         })
     }

--- a/crates/cella-docker/src/container.rs
+++ b/crates/cella-docker/src/container.rs
@@ -1476,6 +1476,9 @@ mod tests {
                 user: "vscode".to_string(),
                 env: vec!["PATH=/usr/local/bin".to_string()],
                 metadata: Some("{\"remoteUser\":\"vscode\"}".to_string()),
+                os: Some("linux".to_string()),
+                architecture: Some("amd64".to_string()),
+                variant: None,
             }));
 
         let details = mock.inspect_image_details("ubuntu:latest").await.unwrap();

--- a/crates/cella-docker/src/image.rs
+++ b/crates/cella-docker/src/image.rs
@@ -104,7 +104,11 @@ fn build_command_args(opts: &BuildOptions, use_buildx: bool) -> Vec<String> {
         args.push("--load".to_string());
     }
 
-    if let Some(platform) = &opts.platform {
+    // `--platform` requires BuildKit; the classic builder (use_buildkit=false) doesn't
+    // support it. Emit on both buildx and non-buildx paths when BuildKit is allowed.
+    if opts.use_buildkit
+        && let Some(platform) = &opts.platform
+    {
         args.extend(["--platform".to_string(), platform.clone()]);
     }
 
@@ -782,6 +786,20 @@ mod tests {
         assert!(
             !args.contains(&"--platform".to_string()),
             "platform:None must not emit --platform; args: {args:?}"
+        );
+    }
+
+    #[test]
+    fn build_args_platform_suppressed_on_classic_builder() {
+        // use_buildkit=false (classic builder) must never emit --platform,
+        // even when opts.platform is set. The classic builder doesn't support it.
+        let mut opts = basic_opts();
+        opts.use_buildkit = false;
+        opts.platform = Some("linux/amd64".to_string());
+        let args = build_command_args(&opts, false);
+        assert!(
+            !args.contains(&"--platform".to_string()),
+            "--platform must be suppressed on classic builder; args: {args:?}"
         );
     }
 

--- a/crates/cella-docker/src/image.rs
+++ b/crates/cella-docker/src/image.rs
@@ -104,6 +104,10 @@ fn build_command_args(opts: &BuildOptions, use_buildx: bool) -> Vec<String> {
         args.push("--load".to_string());
     }
 
+    if let Some(platform) = &opts.platform {
+        args.extend(["--platform".to_string(), platform.clone()]);
+    }
+
     args.extend(["-t".to_string(), opts.image_name.clone()]);
 
     args.extend([
@@ -342,6 +346,9 @@ impl DockerClient {
                     user,
                     env,
                     metadata,
+                    os: details.os.clone(),
+                    architecture: details.architecture.clone(),
+                    variant: details.variant.clone(),
                 })
             }
             Err(bollard::errors::Error::DockerResponseServerError {
@@ -394,6 +401,7 @@ mod tests {
             secrets: Vec::new(),
             use_buildkit: true,
             docker_path: None,
+            platform: None,
         }
     }
 
@@ -725,6 +733,22 @@ mod tests {
         assert_eq!(positions.len(), 2);
         assert_eq!(args[positions[0] + 1], "cli:1");
         assert_eq!(args[positions[1] + 1], "cfg:1");
+    }
+
+    #[test]
+    fn build_args_with_platform() {
+        let mut opts = basic_opts();
+        opts.platform = Some("linux/amd64".to_string());
+        let args = build_command_args(&opts, false);
+        assert!(args.contains(&"--platform".to_string()));
+        assert!(args.contains(&"linux/amd64".to_string()));
+    }
+
+    #[test]
+    fn build_args_no_platform_omits_flag() {
+        let opts = basic_opts();
+        let args = build_command_args(&opts, false);
+        assert!(!args.contains(&"--platform".to_string()));
     }
 
     #[test]

--- a/crates/cella-docker/src/image.rs
+++ b/crates/cella-docker/src/image.rs
@@ -752,6 +752,40 @@ mod tests {
     }
 
     #[test]
+    fn build_args_platform_with_buildkit_correct_order() {
+        // buildx path: ["buildx", "build", "--progress=plain", "--load",
+        //               "--platform", "linux/amd64", "-t", …]
+        // --platform must appear before -t and after --load.
+        let mut opts = basic_opts();
+        opts.platform = Some("linux/amd64".to_string());
+        let args = build_command_args(&opts, true);
+        assert!(args.contains(&"--platform".to_string()));
+        assert!(args.contains(&"linux/amd64".to_string()));
+        let platform_idx = args.iter().position(|a| a == "--platform").unwrap();
+        let tag_idx = args.iter().position(|a| a == "-t").unwrap();
+        let load_idx = args.iter().position(|a| a == "--load").unwrap();
+        assert!(
+            load_idx < platform_idx,
+            "--platform should come after --load; args: {args:?}"
+        );
+        assert!(
+            platform_idx < tag_idx,
+            "--platform should come before -t; args: {args:?}"
+        );
+    }
+
+    #[test]
+    fn build_args_no_platform_none_omits_flag_buildkit() {
+        // platform: None on the buildx path must not emit --platform at all.
+        let opts = basic_opts();
+        let args = build_command_args(&opts, true);
+        assert!(
+            !args.contains(&"--platform".to_string()),
+            "platform:None must not emit --platform; args: {args:?}"
+        );
+    }
+
+    #[test]
     fn is_cache_to_inline_matches() {
         assert!(is_cache_to_inline("type=inline"));
         assert!(is_cache_to_inline("type = inline"));

--- a/crates/cella-orchestrator/src/image.rs
+++ b/crates/cella-orchestrator/src/image.rs
@@ -72,6 +72,7 @@ pub async fn build_features_layer(
         secrets: vec![],
         use_buildkit: ctx.build_tuning.use_buildkit,
         docker_path: ctx.build_tuning.docker_path.map(str::to_string),
+        platform: None,
     };
 
     info!(
@@ -516,6 +517,7 @@ pub fn parse_build_options(
         secrets: vec![],
         use_buildkit: build_tuning.use_buildkit,
         docker_path: build_tuning.docker_path.map(str::to_string),
+        platform: None,
     }
 }
 

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -1859,7 +1859,7 @@ impl EnsureUpContext<'_> {
         &self,
         config: &serde_json::Value,
         img_name: &str,
-        base: &ImageDetails,
+        image_user: &str,
         remote_user: &str,
         create_opts: &mut cella_backend::CreateContainerOptions,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -1871,22 +1871,16 @@ impl EnsureUpContext<'_> {
             self.config.update_remote_user_uid_default,
         );
 
-        let image_platform = cella_backend::uid_image::image_platform(
-            base.os.as_deref(),
-            base.architecture.as_deref(),
-            base.variant.as_deref(),
-        );
         if update_uid
             && let Some(uid_img) = crate::uid_image::build_uid_remap_image(
                 self.client,
                 img_name,
-                &base.user,
+                image_user,
                 remote_user,
                 cella_backend::uid_image::BuildToolchain {
                     docker_path: self.config.build_tuning.docker_path,
                     use_buildkit: self.config.build_tuning.use_buildkit,
                 },
-                image_platform.as_deref(),
                 &self.progress,
             )
             .await?
@@ -1957,7 +1951,7 @@ impl EnsureUpContext<'_> {
         self.maybe_remap_uid(
             config,
             &img_name,
-            &base_image_details,
+            &base_image_details.user,
             &remote_user,
             &mut create_opts,
         )

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -1931,6 +1931,9 @@ impl EnsureUpContext<'_> {
             None
         };
 
+        // Clone only what's needed after `resolve_image_config` consumes `base_image_details`.
+        let image_user = base_image_details.user.clone();
+
         let agent_arch = self.detect_arch().await;
         let ImageConfig {
             image_env,
@@ -1939,7 +1942,7 @@ impl EnsureUpContext<'_> {
             mut create_opts,
         } = self.resolve_image_config(
             &img_name,
-            base_image_details.clone(),
+            base_image_details,
             resolved_features.as_ref(),
             &agent_arch,
         )?;
@@ -1951,7 +1954,7 @@ impl EnsureUpContext<'_> {
         self.maybe_remap_uid(
             config,
             &img_name,
-            &base_image_details.user,
+            &image_user,
             &remote_user,
             &mut create_opts,
         )

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -1859,7 +1859,7 @@ impl EnsureUpContext<'_> {
         &self,
         config: &serde_json::Value,
         img_name: &str,
-        image_user: &str,
+        base: &ImageDetails,
         remote_user: &str,
         create_opts: &mut cella_backend::CreateContainerOptions,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -1871,16 +1871,22 @@ impl EnsureUpContext<'_> {
             self.config.update_remote_user_uid_default,
         );
 
+        let image_platform = cella_backend::uid_image::image_platform(
+            base.os.as_deref(),
+            base.architecture.as_deref(),
+            base.variant.as_deref(),
+        );
         if update_uid
             && let Some(uid_img) = crate::uid_image::build_uid_remap_image(
                 self.client,
                 img_name,
-                image_user,
+                &base.user,
                 remote_user,
                 cella_backend::uid_image::BuildToolchain {
                     docker_path: self.config.build_tuning.docker_path,
                     use_buildkit: self.config.build_tuning.use_buildkit,
                 },
+                image_platform.as_deref(),
                 &self.progress,
             )
             .await?
@@ -1925,7 +1931,6 @@ impl EnsureUpContext<'_> {
             })
             .await?;
 
-        let image_user = base_image_details.user.clone();
         let image_metadata = if resolved_features.is_none() {
             base_image_details.metadata.clone()
         } else {
@@ -1940,7 +1945,7 @@ impl EnsureUpContext<'_> {
             mut create_opts,
         } = self.resolve_image_config(
             &img_name,
-            base_image_details,
+            base_image_details.clone(),
             resolved_features.as_ref(),
             &agent_arch,
         )?;
@@ -1952,7 +1957,7 @@ impl EnsureUpContext<'_> {
         self.maybe_remap_uid(
             config,
             &img_name,
-            &image_user,
+            &base_image_details,
             &remote_user,
             &mut create_opts,
         )


### PR DESCRIPTION
On a multi-arch host (e.g. Apple Silicon running an `amd64` devcontainer image), the `updateRemoteUserUID` derived build used the host's native builder, producing a **wrong-architecture** UID-remap layer — the container then fails to start. The official CLI passes `--platform <Os>/<Architecture>/<Variant>` to that build, derived from the base image's inspected details.

cella now does the same. The platform is computed **inside** `build_uid_remap_image` itself — it already receives the exact base image and the backend client, so it inspects that image and derives the platform there. This is the key design point: it fixes both the single-container and the Docker Compose paths definitively, including **compose + features** (where the remap base is the features-built image), without threading os/arch/variant through every call site.

- `ImageDetails` gains `os`/`architecture`/`variant`, populated from bollard's `ImageInspect`.
- `BuildOptions.platform`; `build_command_args` emits `--platform <p>` when set (buildx and classic paths), and omits it when `None`.
- `image_platform()` mirrors the official `[Os, Architecture, Variant].filter(Boolean).join('/')` (returns `None` when OS is empty/absent; drops empty arch/variant — no trailing slash).
- Only the UID-remap build sets a platform; the main Dockerfile/features builds are unchanged. On inspect failure / Apple Container backend / unavailable fields, `platform` is `None` and behavior is byte-identical to before.

Adversarial review caught that an earlier threading-based version dropped the platform on the compose+features path; the centralized-inspect design fixes that and removes the threading.

A separate PR (#166) skips the remap entirely on non-Linux hosts; the two compose cleanly (the non-Linux guard returns before this inspect).

Tests cover the `image_platform` matrix (incl. empty-arch / OS-only / missing OS) and `build_command_args` with/without a platform on the buildx path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)