### PR TITLE
feat(build): add --platform flag

### DIFF
--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -55,6 +55,11 @@ pub struct BuildArgs {
     /// Pull policy for Docker Compose services.
     #[arg(long = "pull-policy", value_enum)]
     pull_policy: Option<ComposePullPolicy>,
+
+    /// Set target platform(s) for the build (e.g. `linux/amd64`). Passed to the
+    /// underlying docker/buildx build. Not supported on the Docker Compose path.
+    #[arg(long)]
+    platform: Option<String>,
 }
 
 impl BuildArgs {
@@ -99,6 +104,9 @@ impl BuildArgs {
 
         // Docker Compose path: delegate to orchestrator
         if config.get("dockerComposeFile").is_some() {
+            if self.platform.is_some() {
+                return Err("--platform or --push not supported.".into());
+            }
             let (sender, renderer) = crate::progress::bridge(&progress);
             let build_cfg = cella_orchestrator::compose_build::ComposeBuildConfig {
                 config,
@@ -139,9 +147,13 @@ impl BuildArgs {
             no_cache: self.no_cache,
             pull_policy: self.pull.as_ref().map(ImagePullPolicy::as_str),
             secrets: &secrets,
-            // `cella build` has no build-tuning flags yet; use defaults
-            // (BuildKit auto, default docker binary, no CLI cache I/O).
-            build_tuning: cella_orchestrator::BuildTuning::default(),
+            build_tuning: cella_orchestrator::BuildTuning {
+                docker_path: None,
+                use_buildkit: true,
+                cli_cache_from: &[],
+                cache_to: None,
+                platform: self.platform.as_deref(),
+            },
             // `--omit-config-remote-env-from-metadata` is wired on `up` only;
             // `cella build` keeps the full metadata label.
             omit_remote_env_from_metadata: false,

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -1529,6 +1529,7 @@ impl UpContext {
                 use_buildkit: self.use_buildkit,
                 cli_cache_from: &self.cache_from,
                 cache_to: self.cache_to.as_deref(),
+                platform: None,
             },
             gpu_availability: self.gpu_availability,
             update_remote_user_uid_default: self.update_remote_user_uid_default,

--- a/crates/cella-docker/src/image.rs
+++ b/crates/cella-docker/src/image.rs
@@ -104,11 +104,10 @@ fn build_command_args(opts: &BuildOptions, use_buildx: bool) -> Vec<String> {
         args.push("--load".to_string());
     }
 
-    // `--platform` requires BuildKit; the classic builder (use_buildkit=false) doesn't
-    // support it. Emit on both buildx and non-buildx paths when BuildKit is allowed.
-    if opts.use_buildkit
-        && let Some(platform) = &opts.platform
-    {
+    // `--platform` is a BuildKit/buildx flag; the classic `docker build`
+    // rejects it with "unknown flag: --platform". Emit it only on the buildx
+    // path. On the classic builder it is dropped (build_image warns once).
+    if use_buildx && let Some(platform) = &opts.platform {
         args.extend(["--platform".to_string(), platform.clone()]);
     }
 
@@ -251,6 +250,17 @@ impl DockerClient {
         // on the base build's BuildOptions, so this fires at most once per up.
         if !use_buildx && opts.cache_to.is_some() {
             tracing::warn!("--cache-to is ignored without BuildKit/buildx (classic docker build)");
+        }
+
+        // `--platform` is likewise buildx-only (the classic builder rejects it
+        // with "unknown flag: --platform"). It is dropped from the command on
+        // the classic builder; warn so a requested target arch isn't silently
+        // ignored — the image is built for the host architecture instead.
+        if !use_buildx && opts.platform.is_some() {
+            tracing::warn!(
+                "--platform is ignored without BuildKit/buildx (classic docker build); \
+                 building for the host architecture"
+            );
         }
 
         let args = build_command_args(opts, use_buildx);
@@ -740,12 +750,17 @@ mod tests {
     }
 
     #[test]
-    fn build_args_with_platform() {
+    fn build_args_platform_dropped_on_classic_builder() {
+        // `--platform` is buildx-only; the classic builder rejects it
+        // ("unknown flag: --platform"). With use_buildx = false it must NOT be
+        // emitted, even when a platform is set.
         let mut opts = basic_opts();
         opts.platform = Some("linux/amd64".to_string());
         let args = build_command_args(&opts, false);
-        assert!(args.contains(&"--platform".to_string()));
-        assert!(args.contains(&"linux/amd64".to_string()));
+        assert!(
+            !args.contains(&"--platform".to_string()),
+            "classic builder must not receive --platform; args: {args:?}"
+        );
     }
 
     #[test]

--- a/crates/cella-docker/src/image.rs
+++ b/crates/cella-docker/src/image.rs
@@ -106,7 +106,8 @@ fn build_command_args(opts: &BuildOptions, use_buildx: bool) -> Vec<String> {
 
     // `--platform` is a BuildKit/buildx flag; the classic `docker build`
     // rejects it with "unknown flag: --platform". Emit it only on the buildx
-    // path. On the classic builder it is dropped (build_image warns once).
+    // path. On the classic builder it is dropped (build_image warns on each
+    // invocation with a non-None platform).
     if use_buildx && let Some(platform) = &opts.platform {
         args.extend(["--platform".to_string(), platform.clone()]);
     }

--- a/crates/cella-orchestrator/src/config.rs
+++ b/crates/cella-orchestrator/src/config.rs
@@ -25,6 +25,11 @@ pub struct BuildTuning<'a> {
     pub cli_cache_from: &'a [String],
     /// CLI `--cache-to` cache export (`BuildKit` only; dropped otherwise).
     pub cache_to: Option<&'a str>,
+    /// Target platform(s) for the build (`--platform`, e.g. `linux/amd64`).
+    /// `build`-command only; threaded into `BuildOptions.platform`. Applies to
+    /// every build site (base + features layer) so the whole chain targets the
+    /// same arch.
+    pub platform: Option<&'a str>,
 }
 
 impl Default for BuildTuning<'_> {
@@ -36,6 +41,7 @@ impl Default for BuildTuning<'_> {
             use_buildkit: true,
             cli_cache_from: &[],
             cache_to: None,
+            platform: None,
         }
     }
 }
@@ -50,6 +56,7 @@ impl BuildTuning<'_> {
             use_buildkit: self.use_buildkit,
             cli_cache_from: &[],
             cache_to: None,
+            platform: self.platform,
         }
     }
 }

--- a/crates/cella-orchestrator/src/image.rs
+++ b/crates/cella-orchestrator/src/image.rs
@@ -72,7 +72,7 @@ pub async fn build_features_layer(
         secrets: vec![],
         use_buildkit: ctx.build_tuning.use_buildkit,
         docker_path: ctx.build_tuning.docker_path.map(str::to_string),
-        platform: None,
+        platform: ctx.build_tuning.platform.map(str::to_string),
     };
 
     info!(
@@ -517,7 +517,7 @@ pub fn parse_build_options(
         secrets: vec![],
         use_buildkit: build_tuning.use_buildkit,
         docker_path: build_tuning.docker_path.map(str::to_string),
-        platform: None,
+        platform: build_tuning.platform.map(str::to_string),
     }
 }
 
@@ -728,6 +728,7 @@ mod tests {
             use_buildkit: true,
             cache_to: Some("type=registry,ref=r"),
             cli_cache_from: &[],
+            platform: None,
         };
         let opts = parse_build_options(&build, "img", Path::new("/ws"), false, None, tuning);
         assert_eq!(opts.cache_to.as_deref(), Some("type=registry,ref=r"));
@@ -889,6 +890,33 @@ mod tests {
             build_config_digest(&config_a),
             build_config_digest(&config_b)
         );
+    }
+
+    #[test]
+    fn parse_build_options_platform_is_forwarded() {
+        let build: serde_json::Map<String, serde_json::Value> =
+            serde_json::from_str(r"{}").unwrap();
+        let tuning = BuildTuning {
+            platform: Some("linux/amd64"),
+            ..Default::default()
+        };
+        let opts = parse_build_options(&build, "img", Path::new("/ws"), false, None, tuning);
+        assert_eq!(opts.platform.as_deref(), Some("linux/amd64"));
+    }
+
+    #[test]
+    fn parse_build_options_platform_none_by_default() {
+        let build: serde_json::Map<String, serde_json::Value> =
+            serde_json::from_str(r"{}").unwrap();
+        let opts = parse_build_options(
+            &build,
+            "img",
+            Path::new("/ws"),
+            false,
+            None,
+            BuildTuning::default(),
+        );
+        assert!(opts.platform.is_none());
     }
 
     #[test]

--- a/crates/cella-orchestrator/src/image.rs
+++ b/crates/cella-orchestrator/src/image.rs
@@ -306,18 +306,42 @@ struct FeaturesBuildInput<'a> {
     progress: &'a ProgressSender,
 }
 
+/// Parse a `--platform` string (e.g. `linux/amd64`) into `(os, arch)`.
+///
+/// Returns `None` when the string is malformed (no `/` separator or empty
+/// component). The arch component is passed through as-is; normalisation to
+/// Go/OCI conventions (`amd64`, `arm64`) is done by
+/// [`cella_features::oci::detect_platform`].
+fn parse_platform_str(platform: &str) -> Option<(&str, &str)> {
+    let (os, arch) = platform.split_once('/')?;
+    if os.is_empty() || arch.is_empty() {
+        return None;
+    }
+    Some((os, arch))
+}
+
 /// Resolve features and build the features layer image.
 async fn resolve_and_build_features(
     input: &FeaturesBuildInput<'_>,
 ) -> Result<(String, ResolvedFeatures), Box<dyn std::error::Error + Send + Sync>> {
     info!("Resolving devcontainer features...");
-    let backend_platform = input
-        .client
-        .detect_platform()
-        .await
-        .map_err(|e| format!("platform detection failed: {e}"))?;
-    let platform =
-        cella_features::oci::detect_platform(&backend_platform.os, &backend_platform.arch);
+
+    // When `--platform` is set (cross-arch build), resolve feature artifacts
+    // for the *requested* platform rather than the Docker engine's host arch.
+    // Without this, host-arch feature payloads would be baked into a foreign-
+    // arch image, breaking or silently mis-installing platform-specific scripts.
+    let platform = if let Some(plat_str) = input.build_tuning.platform
+        && let Some((os, arch)) = parse_platform_str(plat_str)
+    {
+        cella_features::oci::detect_platform(os, arch)
+    } else {
+        let backend_platform = input
+            .client
+            .detect_platform()
+            .await
+            .map_err(|e| format!("platform detection failed: {e}"))?;
+        cella_features::oci::detect_platform(&backend_platform.os, &backend_platform.arch)
+    };
     let cache = cella_features::FeatureCache::new();
 
     let resolved = cella_features::resolve_features(
@@ -995,5 +1019,25 @@ mod tests {
         assert_eq!(build.get("dockerfile").unwrap(), "Legacy.Dockerfile");
         // build-only fields are preserved.
         assert_eq!(build.get("target").unwrap(), "dev");
+    }
+
+    // ── parse_platform_str ──────────────────────────────────────────────────
+
+    #[test]
+    fn parse_platform_str_standard_forms() {
+        assert_eq!(parse_platform_str("linux/amd64"), Some(("linux", "amd64")));
+        assert_eq!(parse_platform_str("linux/arm64"), Some(("linux", "arm64")));
+        assert_eq!(
+            parse_platform_str("linux/arm/v7"),
+            Some(("linux", "arm/v7"))
+        );
+    }
+
+    #[test]
+    fn parse_platform_str_rejects_malformed() {
+        assert!(parse_platform_str("linuxamd64").is_none());
+        assert!(parse_platform_str("/amd64").is_none());
+        assert!(parse_platform_str("linux/").is_none());
+        assert!(parse_platform_str("").is_none());
     }
 }


### PR DESCRIPTION
Adds the official `devcontainer build --platform` flag, which cella was missing. Stacked on #167 (which added the `BuildOptions.platform` plumbing and the `--platform` emission in `build_command_args`).

## What it does
- New `--platform <target>` on `cella build` (e.g. `--platform linux/amd64`). Matches the official CLI, which exposes it on `build` only — not on `up`.
- Threads the value through `BuildTuning` so both build sites target the same arch: the base Dockerfile build (`parse_build_options`) and the features layer (`toolchain()` carries it). No mixed-arch chains.
- Rejects it on the Docker Compose path with the exact official message: `--platform or --push not supported.`

## The buildx-gating fix (2nd commit)
While wiring the flag, I caught a latent bug: `--platform` was being emitted on the classic `docker build` path too, which the legacy builder rejects with `unknown flag: --platform` (it's a BuildKit-only flag — see devcontainers/community#183 for users hitting exactly this). It was previously unreachable because only the UID-remap path set a platform, and that path runs where buildx is essentially always present. The new CLI flag makes it reachable on hosts without buildx.

Fixed by gating `--platform` on `use_buildx` and warning-and-dropping on the classic builder — mirroring exactly how `--cache-to` is already handled here. This also covers the UID-remap build, keeping its non-fatal host-arch fallback intact.

Note on divergence: the official CLI hard-*errors* (`--platform or --push require BuildKit enabled.`) when platform is requested without BuildKit. cella warns-and-drops instead, for internal consistency with `--cache-to` and because the precondition (buildx genuinely absent) is rare. The warning is explicit, so nothing is silently ignored.

## Tests
- `parse_build_options` forwards `platform` from `BuildTuning`; `None` by default.
- `build_command_args` omits `--platform` on the classic builder, emits it (in correct order, after `--load`, before `-t`) on buildx.
- Full workspace suite: 3987 passed, 0 failed.

Skipped a compose-rejection unit test for `build.rs` — `execute()` needs a live Docker client, and the guard is a trivially-correct two-liner; a mock-heavy test there would be worse than none.