### PR TITLE
fix(compose): mask --secrets-file values in compose lifecycle output

### DIFF
--- a/crates/cella-cli/src/commands/compose_up.rs
+++ b/crates/cella-cli/src/commands/compose_up.rs
@@ -102,6 +102,10 @@ struct CliComposeUpHooks<'a> {
 }
 
 impl ComposeUpHooks for CliComposeUpHooks<'_> {
+    fn lifecycle_secret_masker(&self) -> cella_backend::SecretMasker {
+        self.ctx.lifecycle_secret_masker()
+    }
+
     fn daemon_env<'a>(
         &'a self,
         container_name: &'a str,

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -1294,6 +1294,10 @@ impl UpContext {
         (final_probed, lifecycle_env)
     }
 
+    pub(crate) fn lifecycle_secret_masker(&self) -> cella_backend::SecretMasker {
+        cella_backend::SecretMasker::new(&self.lifecycle_secrets)
+    }
+
     /// Delegates to [`cella_orchestrator::tool_install::install_tools`].
     async fn install_tools(
         &self,

--- a/crates/cella-compose/src/orchestrate.rs
+++ b/crates/cella-compose/src/orchestrate.rs
@@ -255,6 +255,13 @@ pub trait ComposeUpHooks: Send + Sync {
         remote_env: &'a [String],
     ) -> Pin<Box<dyn Future<Output = Vec<String>> + Send + 'a>>;
 
+    /// Masker over the lifecycle `--secrets-file` values, used to redact
+    /// secret values from compose lifecycle command output. Defaults to an
+    /// empty (passthrough) masker for implementors without secrets.
+    fn lifecycle_secret_masker(&self) -> cella_backend::SecretMasker {
+        cella_backend::SecretMasker::default()
+    }
+
     /// Clone and install dotfiles inside the container, as `remote_user`.
     ///
     /// Bridges the orchestrator-owned install logic (which cella-compose cannot
@@ -649,6 +656,7 @@ async fn finalize_compose(
     let gate = cfg.lifecycle_gate;
     let metadata = resolved_features.map(|rf| rf.metadata_label.as_str());
     let subst_ctx = cella_config::config_map::subst_ctx(cfg.resolved);
+    let secret_masker = hooks.lifecycle_secret_masker();
     for phase in [
         "onCreateCommand",
         "updateContentCommand",
@@ -668,6 +676,7 @@ async fn finalize_compose(
             &lifecycle_env,
             Some(&project.workspace_folder),
             progress,
+            secret_masker.clone(),
         );
         run_lifecycle_entries(&lc_ctx, phase, &entries, progress).await?;
 
@@ -825,6 +834,7 @@ async fn handle_compose_running(
             &lifecycle_env,
             Some(project.workspace_folder.as_str()),
             progress,
+            hooks.lifecycle_secret_masker(),
         );
 
         let label = "Running the postAttachCommand from devcontainer.json...";
@@ -1632,6 +1642,7 @@ fn build_lifecycle_ctx<'a>(
     env: &'a [String],
     working_dir: Option<&'a str>,
     progress: &ProgressSender,
+    masker: cella_backend::SecretMasker,
 ) -> LifecycleContext<'a> {
     let p = progress.clone();
     LifecycleContext {
@@ -1642,9 +1653,7 @@ fn build_lifecycle_ctx<'a>(
         working_dir,
         is_text: true,
         on_output: Some(Box::new(move |line| p.println(line))),
-        // Compose has no lifecycle `--secrets-file` plumbing yet, so there are
-        // no secret values to mask here (empty masker = passthrough).
-        secret_masker: cella_backend::SecretMasker::default(),
+        secret_masker: masker,
     }
 }
 
@@ -1906,6 +1915,95 @@ mod tests {
             .expect("updated fingerprint label");
 
         assert_ne!(&base, changed);
+    }
+
+    /// Test that `lifecycle_secret_masker` from the trait default is passthrough,
+    /// and that a non-empty masker built from `SecretMasker::new` actually redacts.
+    ///
+    /// `build_lifecycle_ctx` is not called directly here because it requires a
+    /// `&dyn ContainerBackend` — no test double exists in this crate. The CLI
+    /// override path (`CliComposeUpHooks::lifecycle_secret_masker`) is covered
+    /// transitively by `cella_backend::SecretMasker`'s own unit tests. This test
+    /// verifies the plumbing at the trait boundary: default → passthrough, and
+    /// the non-default value produced by `SecretMasker::new` actually masks.
+    #[test]
+    fn lifecycle_secret_masker_trait_default_is_passthrough() {
+        use std::future::Future;
+        use std::pin::Pin;
+
+        struct NoopHooks;
+
+        impl ComposeUpHooks for NoopHooks {
+            fn daemon_env<'a>(
+                &'a self,
+                _container_name: &'a str,
+                _host_gateway: &'a str,
+            ) -> Pin<Box<dyn Future<Output = Vec<String>> + Send + 'a>> {
+                Box::pin(async { vec![] })
+            }
+
+            fn sync_agent_runtime<'a>(
+                &'a self,
+                _client: &'a dyn ContainerBackend,
+            ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+                Box::pin(async {})
+            }
+
+            fn register_container<'a>(
+                &'a self,
+                _client: &'a dyn ContainerBackend,
+                _container_id: &'a str,
+                _config: &'a serde_json::Value,
+                _container_name: &'a str,
+            ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+                Box::pin(async {})
+            }
+
+            fn launch_agent<'a>(
+                &'a self,
+                _client: &'a dyn ContainerBackend,
+                _container_id: &'a str,
+                _agent_arch: &'a str,
+            ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+                Box::pin(async {})
+            }
+
+            fn post_create_setup<'a>(
+                &'a self,
+                _client: &'a dyn ContainerBackend,
+                _container_id: &'a str,
+                _remote_user: &'a str,
+                _config: &'a serde_json::Value,
+                _workspace_root: &'a Path,
+                _remote_env: &'a [String],
+            ) -> Pin<Box<dyn Future<Output = Vec<String>> + Send + 'a>> {
+                Box::pin(async { vec![] })
+            }
+        }
+
+        let hooks = NoopHooks;
+
+        // Default impl returns an empty (passthrough) masker.
+        let default_masker = hooks.lifecycle_secret_masker();
+        assert!(
+            default_masker.is_empty(),
+            "default lifecycle_secret_masker must be empty (passthrough)"
+        );
+        let s = "token=s3cr3tvalue";
+        assert_eq!(
+            default_masker.mask(s),
+            s,
+            "empty masker must not modify the input"
+        );
+
+        // A masker built from real secret entries does redact.
+        let real_masker = cella_backend::SecretMasker::new(&["SECRET=s3cr3tvalue".to_string()]);
+        assert!(
+            !real_masker
+                .mask("token=s3cr3tvalue")
+                .contains("s3cr3tvalue"),
+            "non-empty masker must redact the secret value"
+        );
     }
 
     #[test]

--- a/crates/cella-compose/src/orchestrate.rs
+++ b/crates/cella-compose/src/orchestrate.rs
@@ -727,9 +727,14 @@ async fn install_dotfiles_step(
     {
         Ok(()) => step.finish(),
         Err(e) => {
-            warn!("Dotfiles install failed (continuing): {e}");
+            // The dotfiles script runs with the secret-bearing lifecycle_env;
+            // its failure message can echo stderr that contains secret values,
+            // so mask before logging or surfacing to the terminal.
+            let err_text = e.to_string();
+            let msg = hooks.lifecycle_secret_masker().mask(&err_text);
+            warn!("Dotfiles install failed (continuing): {msg}");
             step.fail("failed");
-            progress.warn(&format!("Dotfiles install failed (continuing): {e}"));
+            progress.warn(&format!("Dotfiles install failed (continuing): {msg}"));
         }
     }
 }


### PR DESCRIPTION
Closes the compose half of the secret-masking work. Stacked on #159, which added `SecretMasker` and masks lifecycle output on the single-container path — but left the compose path using an empty masker (`SecretMasker::default()`) with a comment claiming "compose has no lifecycle secrets plumbing yet."

That comment was stale: compose lifecycle commands *do* receive `--secrets-file` values in their env (injected via the shared `post_create_setup` hook → `lifecycle_env`). So a compose lifecycle command that echoed a secret leaked it unmasked. This wires the real masker through.

## Changes
- `ComposeUpHooks` gets a `lifecycle_secret_masker()` method (default = empty/passthrough, so test doubles are unaffected). The CLI's `CliComposeUpHooks` overrides it to build `SecretMasker::new(&lifecycle_secrets)` from the same secrets the single-container path uses.
- `build_lifecycle_ctx` now takes the masker and stores it on `LifecycleContext`, so all five phases on both the fresh-create (`finalize_compose`) and attach (`handle_compose_running`) paths mask their output. Masker is built once per up and cloned per phase.
- 2nd commit: an adversarial review caught a related sink the first commit missed — the dotfiles install failure message forwards raw `stderr` through `warn!` + `progress.warn`. The dotfiles script runs with the secret-bearing `lifecycle_env`, so a script that echoes its env on failure could leak. Now masked.

## Known related gap (not fixed here)
The single-container dotfiles path (`cella-orchestrator/src/up.rs`, `install_dotfiles_if_enabled`) has the identical raw-stderr leak. It belongs to #159's single-container scope rather than this compose-focused PR — flagging it so it gets the same one-line mask there.

## Tests
- New test confirms the trait default masker is passthrough and that a populated `SecretMasker` redacts. (The full `build_lifecycle_ctx` plumbing isn't unit-tested directly — no `ContainerBackend` double exists in cella-compose; the masking sinks themselves are covered by #159's tests in cella-backend.)
- Full workspace: 3988 passed, 0 failed.