### PR TITLE
fix(dotfiles): mask single-container dotfiles install failure stderr

### DIFF
--- a/crates/cella-orchestrator/src/run_user_commands.rs
+++ b/crates/cella-orchestrator/src/run_user_commands.rs
@@ -209,7 +209,11 @@ async fn maybe_install_dotfiles(lc_ctx: &LifecycleContext<'_>, input: &RunUserCo
     )
     .await
     {
-        tracing::warn!("dotfiles install failed: {e}");
+        // The dotfiles script runs with the secret-bearing lifecycle env;
+        // mask before logging so secret values don't leak.
+        let err_text = e.to_string();
+        let msg = lc_ctx.secret_masker.mask(&err_text);
+        tracing::warn!("Dotfiles install failed (continuing): {msg}");
     }
 }
 

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -1692,10 +1692,16 @@ impl EnsureUpContext<'_> {
         {
             Ok(()) => step.finish(),
             Err(e) => {
-                warn!("Dotfiles install failed (continuing): {e}");
+                // The dotfiles script runs with the secret-bearing lifecycle_env;
+                // its failure message can echo stderr containing secret values,
+                // so mask before logging or surfacing to the terminal.
+                let err_text = e.to_string();
+                let masker = cella_backend::SecretMasker::new(self.config.lifecycle_secrets);
+                let msg = masker.mask(&err_text);
+                warn!("Dotfiles install failed (continuing): {msg}");
                 step.fail("failed");
                 self.progress
-                    .warn(&format!("Dotfiles install failed (continuing): {e}"));
+                    .warn(&format!("Dotfiles install failed (continuing): {msg}"));
             }
         }
     }


### PR DESCRIPTION
Closes the single-container half of a secret leak found while reviewing the compose-masking work (#169 fixed the compose side and flagged this sibling).

The dotfiles install script runs with the secret-bearing `lifecycle_env`. On failure, `install_dotfiles` embeds the raw `stderr` in its error, and `install_dotfiles_if_enabled` surfaces that verbatim through `warn!` (log) and `progress.warn` (terminal). A dotfiles script that echoes its environment on failure (`env`, `set`, a crash after printing config) would leak `--secrets-file` values unmasked.

Fix mirrors the compose path exactly: build the masker from `self.config.lifecycle_secrets` and mask the message before logging/surfacing.

Stacked on #159 (it added the single-container lifecycle masker but missed this sink). Full workspace: 3987 passed, 0 failed.