### PR TITLE
fix(env): make userEnvProbe robust (Alpine + interactive-shell noise)

### DIFF
--- a/crates/cella-env/src/user_env_probe.rs
+++ b/crates/cella-env/src/user_env_probe.rs
@@ -87,7 +87,12 @@ pub const PROBE_METHODS: &[ProbeMethod] = &[
 /// from the output. Returns `None` when `probe_type` is `None`.
 ///
 /// PowerShell (`pwsh` / `pwsh-preview`) uses `-Login -Command` or `-Command`
-/// instead of POSIX flags, matching the official devcontainer CLI behaviour.
+/// instead of POSIX flags. Because PowerShell's `echo` is an alias for
+/// `Write-Output` (which always appends a newline, treating `-n` as literal
+/// data), the marker write uses `[Console]::Write(...)` instead. Similarly,
+/// `/proc/self/environ` is not reliable in PowerShell, so the PowerShell path
+/// uses `Get-ChildItem Env:` with `printenv`-style newline separation and
+/// ignores `method` for the env-dump command.
 pub fn probe_command(
     probe_type: UserEnvProbe,
     shell: &str,
@@ -97,12 +102,18 @@ pub fn probe_command(
     if probe_type == UserEnvProbe::None {
         return None;
     }
-    let wrapped = format!("echo -n {marker}; {}; echo -n {marker}", method.command);
     let name = std::path::Path::new(shell)
         .file_name()
         .and_then(|s| s.to_str())
         .unwrap_or("");
     if name == "pwsh" || name == "pwsh-preview" {
+        // PowerShell: use [Console]::Write for no-newline marker and
+        // Get-ChildItem Env: for newline-delimited KEY=VALUE output.
+        let wrapped = format!(
+            "[Console]::Write('{marker}'); \
+             Get-ChildItem Env: | ForEach-Object {{ \"$($_.Name)=$($_.Value)\" }}; \
+             [Console]::Write('{marker}')"
+        );
         let mut args = vec![shell.to_string()];
         if matches!(
             probe_type,
@@ -114,6 +125,7 @@ pub fn probe_command(
         args.push(wrapped);
         Some(args)
     } else {
+        let wrapped = format!("echo -n {marker}; {}; echo -n {marker}", method.command);
         let flags = probe_type.shell_flags()?;
         Some(vec![
             shell.to_string(),
@@ -239,7 +251,6 @@ mod tests {
     #[test]
     fn probe_command_pwsh_login_interactive_uses_login_flag() {
         let marker = "M";
-        let inner = format!("echo -n {marker}; cat /proc/self/environ; echo -n {marker}");
         let cmd = probe_command(
             UserEnvProbe::LoginInteractiveShell,
             "/usr/bin/pwsh",
@@ -247,17 +258,28 @@ mod tests {
             PROBE_METHODS[0],
         )
         .unwrap();
-        assert_eq!(
-            cmd,
-            vec!["/usr/bin/pwsh", "-Login", "-Command", &inner],
-            "pwsh LoginInteractiveShell must include -Login"
+        assert_eq!(cmd[0], "/usr/bin/pwsh");
+        assert_eq!(cmd[1], "-Login");
+        assert_eq!(cmd[2], "-Command");
+        // Must use [Console]::Write for no-newline marker (not echo -n)
+        assert!(
+            cmd[3].contains("[Console]::Write('M')"),
+            "pwsh marker must use [Console]::Write, not echo -n: {cmd:?}"
+        );
+        // Must use Get-ChildItem Env: instead of cat /proc/self/environ
+        assert!(
+            cmd[3].contains("Get-ChildItem Env:"),
+            "pwsh env dump must use Get-ChildItem Env:: {cmd:?}"
+        );
+        assert!(
+            !cmd[3].contains("echo -n"),
+            "pwsh must NOT use echo -n (emits -n as literal data): {cmd:?}"
         );
     }
 
     #[test]
     fn probe_command_pwsh_interactive_no_login_flag() {
         let marker = "M";
-        let inner = format!("echo -n {marker}; cat /proc/self/environ; echo -n {marker}");
         let cmd = probe_command(
             UserEnvProbe::InteractiveShell,
             "/usr/bin/pwsh",
@@ -265,10 +287,11 @@ mod tests {
             PROBE_METHODS[0],
         )
         .unwrap();
-        assert_eq!(
-            cmd,
-            vec!["/usr/bin/pwsh", "-Command", &inner],
-            "pwsh InteractiveShell must NOT include -Login"
+        assert_eq!(cmd[0], "/usr/bin/pwsh");
+        assert_eq!(cmd[1], "-Command");
+        assert!(
+            !cmd[2].contains("echo -n"),
+            "pwsh must NOT use echo -n: {cmd:?}"
         );
     }
 
@@ -283,6 +306,57 @@ mod tests {
         .unwrap();
         assert_eq!(cmd[1], "-Login");
         assert_eq!(cmd[2], "-Command");
+    }
+
+    /// Regression: PowerShell `echo -n` outputs `-n` literally (emits a
+    /// newline before the probed content), corrupting the first env var.
+    /// The fix is `[Console]::Write(marker)` which writes without a newline.
+    #[test]
+    fn probe_command_pwsh_marker_no_newline_regression() {
+        let marker = "UNIQUE-MARKER-123";
+        let cmd = probe_command(
+            UserEnvProbe::LoginInteractiveShell,
+            "/usr/bin/pwsh",
+            marker,
+            PROBE_METHODS[0],
+        )
+        .unwrap();
+        let inner = &cmd[cmd.len() - 1];
+        assert!(
+            inner.contains(&format!("[Console]::Write('{marker}')")),
+            "marker must be written with [Console]::Write to avoid leading newline: {inner}"
+        );
+        assert!(
+            !inner.contains("echo"),
+            "must not use echo for marker in pwsh — echo is Write-Output and adds a newline: {inner}"
+        );
+    }
+
+    /// Regression: PowerShell does not reliably pass NUL bytes through stdout,
+    /// so `cat /proc/self/environ` output is unreliable under pwsh. The probe
+    /// must use `Get-ChildItem Env:` (newline-delimited) instead, regardless
+    /// of which `ProbeMethod` is passed.
+    #[test]
+    fn probe_command_pwsh_uses_get_child_item_not_proc_environ() {
+        for method in PROBE_METHODS {
+            let cmd = probe_command(
+                UserEnvProbe::LoginInteractiveShell,
+                "/usr/bin/pwsh",
+                "M",
+                *method,
+            )
+            .unwrap();
+            let inner = &cmd[cmd.len() - 1];
+            assert!(
+                inner.contains("Get-ChildItem Env:"),
+                "pwsh probe must use Get-ChildItem Env: (method={}): {inner}",
+                method.command
+            );
+            assert!(
+                !inner.contains("/proc/self/environ"),
+                "pwsh probe must NOT use /proc/self/environ (NUL passthrough unreliable): {inner}"
+            );
+        }
     }
 
     #[test]

--- a/crates/cella-env/src/user_env_probe.rs
+++ b/crates/cella-env/src/user_env_probe.rs
@@ -1,7 +1,8 @@
 //! userEnvProbe spec implementation.
 //!
 //! Generates the command to probe the container user's environment
-//! and parses the null-delimited output.
+//! and parses the output, mirroring the official devcontainer CLI's
+//! marker-wrapped, multi-method approach.
 
 use std::collections::HashMap;
 use std::fmt;
@@ -58,26 +59,90 @@ impl FromStr for UserEnvProbe {
     }
 }
 
-/// Generate the shell command to probe the user's environment.
+/// A strategy for reading the probed environment, in priority order.
 ///
-/// Returns `None` if `probe_type` is `None`.
-pub fn probe_command(probe_type: UserEnvProbe, shell: &str) -> Option<Vec<String>> {
-    let flags = probe_type.shell_flags()?;
-    Some(vec![
-        shell.to_string(),
-        flags.to_string(),
-        "-c".to_string(),
-        "env -0".to_string(),
-    ])
+/// `cat /proc/self/environ` (the kernel's NUL-delimited environ file) is tried
+/// first because it needs no external tool; `printenv` (newline-delimited) is
+/// the fallback for shells/images without it. Mirrors the official CLI.
+#[derive(Clone, Copy, Debug)]
+pub struct ProbeMethod {
+    pub command: &'static str,
+    pub separator: char,
 }
 
-/// Parse null-delimited environment output into a map.
+pub const PROBE_METHODS: &[ProbeMethod] = &[
+    ProbeMethod {
+        command: "cat /proc/self/environ",
+        separator: '\0',
+    },
+    ProbeMethod {
+        command: "printenv",
+        separator: '\n',
+    },
+];
+
+/// Build the argv to probe the user's environment with `method`.
 ///
-/// Filters out `PWD` — the probed working directory is meaningless
-/// (it's the probe command's cwd) and can interfere with exec sessions.
-pub fn parse_probed_env(output: &str) -> HashMap<String, String> {
-    output
-        .split('\0')
+/// Wraps the inner command in `marker` so shell-startup noise can be stripped
+/// from the output. Returns `None` when `probe_type` is `None`.
+///
+/// PowerShell (`pwsh` / `pwsh-preview`) uses `-Login -Command` or `-Command`
+/// instead of POSIX flags, matching the official devcontainer CLI behaviour.
+pub fn probe_command(
+    probe_type: UserEnvProbe,
+    shell: &str,
+    marker: &str,
+    method: ProbeMethod,
+) -> Option<Vec<String>> {
+    if probe_type == UserEnvProbe::None {
+        return None;
+    }
+    let wrapped = format!("echo -n {marker}; {}; echo -n {marker}", method.command);
+    let name = std::path::Path::new(shell)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("");
+    if name == "pwsh" || name == "pwsh-preview" {
+        let mut args = vec![shell.to_string()];
+        if matches!(
+            probe_type,
+            UserEnvProbe::LoginShell | UserEnvProbe::LoginInteractiveShell
+        ) {
+            args.push("-Login".to_string());
+        }
+        args.push("-Command".to_string());
+        args.push(wrapped);
+        Some(args)
+    } else {
+        let flags = probe_type.shell_flags()?;
+        Some(vec![
+            shell.to_string(),
+            flags.to_string(),
+            "-c".to_string(),
+            wrapped,
+        ])
+    }
+}
+
+/// Parse probe output into a KEY=VALUE map.
+///
+/// Extracts the text between the first and last `marker` (stripping any
+/// shell-startup noise outside them), then splits on `separator`. Returns an
+/// empty map when the markers are absent so the caller can fall back to another
+/// probe method. Drops `PWD`.
+pub fn parse_probed_env(output: &str, marker: &str, separator: char) -> HashMap<String, String> {
+    let Some(start) = output.find(marker) else {
+        return HashMap::new();
+    };
+    let inner_start = start + marker.len();
+    let Some(end) = output.rfind(marker) else {
+        return HashMap::new();
+    };
+    if end < inner_start {
+        return HashMap::new();
+    }
+    output[inner_start..end]
+        .split(separator)
         .filter(|s| !s.is_empty())
         .filter_map(|entry| {
             let (key, value) = entry.split_once('=')?;
@@ -115,34 +180,202 @@ pub fn merge_env<S: std::hash::BuildHasher>(
 mod tests {
     use super::*;
 
+    // ── probe_command ────────────────────────────────────────────────────────
+
     #[test]
-    fn probe_command_none() {
-        assert!(probe_command(UserEnvProbe::None, "/bin/bash").is_none());
+    fn probe_command_none_returns_none() {
+        assert!(probe_command(UserEnvProbe::None, "/bin/bash", "M", PROBE_METHODS[0]).is_none());
     }
 
     #[test]
-    fn probe_command_login_shell() {
-        let cmd = probe_command(UserEnvProbe::LoginShell, "/bin/bash").unwrap();
-        assert_eq!(cmd, vec!["/bin/bash", "-l", "-c", "env -0"]);
+    fn probe_command_login_shell_wraps_with_marker() {
+        let marker = "abc-123";
+        let cmd = probe_command(
+            UserEnvProbe::LoginShell,
+            "/bin/bash",
+            marker,
+            PROBE_METHODS[0],
+        )
+        .unwrap();
+        assert_eq!(cmd[0], "/bin/bash");
+        assert_eq!(cmd[1], "-l");
+        assert_eq!(cmd[2], "-c");
+        assert!(
+            cmd[3].contains(&format!("echo -n {marker}")),
+            "inner command must be marker-wrapped: {cmd:?}"
+        );
+        assert!(
+            cmd[3].contains("cat /proc/self/environ"),
+            "inner command must use /proc/self/environ: {cmd:?}"
+        );
     }
 
     #[test]
     fn probe_command_interactive_shell() {
-        let cmd = probe_command(UserEnvProbe::InteractiveShell, "/bin/zsh").unwrap();
-        assert_eq!(cmd, vec!["/bin/zsh", "-i", "-c", "env -0"]);
+        let cmd = probe_command(
+            UserEnvProbe::InteractiveShell,
+            "/bin/zsh",
+            "M",
+            PROBE_METHODS[0],
+        )
+        .unwrap();
+        assert_eq!(cmd[0], "/bin/zsh");
+        assert_eq!(cmd[1], "-i");
+        assert_eq!(cmd[2], "-c");
     }
 
     #[test]
-    fn probe_command_default() {
-        let cmd = probe_command(UserEnvProbe::LoginInteractiveShell, "/bin/bash").unwrap();
-        assert_eq!(cmd, vec!["/bin/bash", "-li", "-c", "env -0"]);
+    fn probe_command_login_interactive_shell() {
+        let cmd = probe_command(
+            UserEnvProbe::LoginInteractiveShell,
+            "/bin/bash",
+            "M",
+            PROBE_METHODS[0],
+        )
+        .unwrap();
+        assert_eq!(cmd[1], "-li");
     }
+
+    #[test]
+    fn probe_command_pwsh_login_interactive_uses_login_flag() {
+        let marker = "M";
+        let inner = format!("echo -n {marker}; cat /proc/self/environ; echo -n {marker}");
+        let cmd = probe_command(
+            UserEnvProbe::LoginInteractiveShell,
+            "/usr/bin/pwsh",
+            marker,
+            PROBE_METHODS[0],
+        )
+        .unwrap();
+        assert_eq!(
+            cmd,
+            vec!["/usr/bin/pwsh", "-Login", "-Command", &inner],
+            "pwsh LoginInteractiveShell must include -Login"
+        );
+    }
+
+    #[test]
+    fn probe_command_pwsh_interactive_no_login_flag() {
+        let marker = "M";
+        let inner = format!("echo -n {marker}; cat /proc/self/environ; echo -n {marker}");
+        let cmd = probe_command(
+            UserEnvProbe::InteractiveShell,
+            "/usr/bin/pwsh",
+            marker,
+            PROBE_METHODS[0],
+        )
+        .unwrap();
+        assert_eq!(
+            cmd,
+            vec!["/usr/bin/pwsh", "-Command", &inner],
+            "pwsh InteractiveShell must NOT include -Login"
+        );
+    }
+
+    #[test]
+    fn probe_command_pwsh_preview_login() {
+        let cmd = probe_command(
+            UserEnvProbe::LoginShell,
+            "/usr/bin/pwsh-preview",
+            "M",
+            PROBE_METHODS[0],
+        )
+        .unwrap();
+        assert_eq!(cmd[1], "-Login");
+        assert_eq!(cmd[2], "-Command");
+    }
+
+    #[test]
+    fn probe_command_printenv_fallback_method() {
+        let marker = "abc-123";
+        let cmd = probe_command(
+            UserEnvProbe::LoginShell,
+            "/bin/bash",
+            marker,
+            PROBE_METHODS[1],
+        )
+        .unwrap();
+        assert!(
+            cmd[3].contains("printenv"),
+            "second method must use printenv: {cmd:?}"
+        );
+    }
+
+    // ── parse_probed_env ─────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_nul_delimited_clean() {
+        let marker = "abc-123";
+        let output =
+            format!("{marker}HOME=/home/user\0PATH=/usr/bin:/bin\0SHELL=/bin/bash\0{marker}");
+        let env = parse_probed_env(&output, marker, '\0');
+        assert_eq!(env.get("HOME"), Some(&"/home/user".to_string()));
+        assert_eq!(env.get("PATH"), Some(&"/usr/bin:/bin".to_string()));
+        assert_eq!(env.get("SHELL"), Some(&"/bin/bash".to_string()));
+        assert_eq!(env.len(), 3);
+    }
+
+    #[test]
+    fn parse_strips_leading_startup_noise() {
+        let marker = "abc-123";
+        let output = format!("Welcome to my shell!\n{marker}HOME=/home/u\0PATH=/bin\0{marker}");
+        let env = parse_probed_env(&output, marker, '\0');
+        assert_eq!(env.get("HOME"), Some(&"/home/u".to_string()));
+        assert_eq!(env.get("PATH"), Some(&"/bin".to_string()));
+        assert_eq!(env.len(), 2, "startup noise must not appear as env vars");
+    }
+
+    #[test]
+    fn parse_newline_delimited_printenv_form() {
+        let marker = "abc-123";
+        let output = format!("{marker}HOME=/home/user\nPATH=/usr/bin\nSHELL=/bin/bash\n{marker}");
+        let env = parse_probed_env(&output, marker, '\n');
+        assert_eq!(env.get("HOME"), Some(&"/home/user".to_string()));
+        assert_eq!(env.get("PATH"), Some(&"/usr/bin".to_string()));
+        assert_eq!(env.get("SHELL"), Some(&"/bin/bash".to_string()));
+        assert_eq!(env.len(), 3);
+    }
+
+    #[test]
+    fn parse_no_marker_returns_empty() {
+        let env = parse_probed_env("HOME=/home/user\0PATH=/usr/bin\0", "abc-123", '\0');
+        assert!(
+            env.is_empty(),
+            "absent marker must yield empty map (caller falls back)"
+        );
+    }
+
+    #[test]
+    fn parse_filters_pwd() {
+        let marker = "abc-123";
+        let output = format!("{marker}HOME=/home/user\0PWD=/tmp\0SHELL=/bin/bash\0{marker}");
+        let env = parse_probed_env(&output, marker, '\0');
+        assert!(!env.contains_key("PWD"), "PWD must be dropped");
+        assert_eq!(env.len(), 2);
+    }
+
+    #[test]
+    fn parse_empty_inner() {
+        let marker = "abc-123";
+        let output = format!("{marker}{marker}");
+        let env = parse_probed_env(&output, marker, '\0');
+        assert!(env.is_empty());
+    }
+
+    #[test]
+    fn parse_entry_without_equals_skipped() {
+        let marker = "M";
+        let output = format!("{marker}GOOD=value\0BADENTRY\0ALSO_GOOD=val2\0{marker}");
+        let env = parse_probed_env(&output, marker, '\0');
+        assert_eq!(env.len(), 2);
+        assert!(env.contains_key("GOOD"));
+        assert!(env.contains_key("ALSO_GOOD"));
+    }
+
+    // ── merge_env ────────────────────────────────────────────────────────────
 
     #[test]
     fn merge_env_later_entry_wins_config_over_cli() {
-        // The `up` lifecycle env is built as [CLI --remote-env..., config
-        // remoteEnv...] and fed here, so config must win on key collision
-        // (merge_env applies entries in order, last write wins).
         let probed = HashMap::from([("PATH".to_string(), "/usr/bin".to_string())]);
         let entries = vec![
             "FOO=cli".to_string(),
@@ -154,62 +387,6 @@ mod tests {
         assert!(!merged.contains(&"FOO=cli".to_string()));
         assert!(merged.contains(&"BAR=cli".to_string()));
         assert!(merged.contains(&"PATH=/usr/bin".to_string()));
-    }
-
-    #[test]
-    fn parse_env_output() {
-        let output = "HOME=/home/user\0PATH=/usr/bin:/bin\0SHELL=/bin/bash\0";
-        let env = parse_probed_env(output);
-        assert_eq!(env.get("HOME"), Some(&"/home/user".to_string()));
-        assert_eq!(env.get("PATH"), Some(&"/usr/bin:/bin".to_string()));
-        assert_eq!(env.get("SHELL"), Some(&"/bin/bash".to_string()));
-        assert_eq!(env.len(), 3);
-    }
-
-    #[test]
-    fn parse_empty_output() {
-        let env = parse_probed_env("");
-        assert!(env.is_empty());
-    }
-
-    #[test]
-    fn parse_entry_without_equals() {
-        let output = "GOOD=value\0BADENTRY\0ALSO_GOOD=val2\0";
-        let env = parse_probed_env(output);
-        assert_eq!(env.len(), 2);
-        assert!(env.contains_key("GOOD"));
-        assert!(env.contains_key("ALSO_GOOD"));
-    }
-
-    #[test]
-    fn parse_env_filters_pwd() {
-        let output = "HOME=/home/user\0PWD=/tmp\0SHELL=/bin/bash\0";
-        let env = parse_probed_env(output);
-        assert_eq!(env.len(), 2);
-        assert!(!env.contains_key("PWD"));
-        assert_eq!(env.get("HOME"), Some(&"/home/user".to_string()));
-    }
-
-    #[test]
-    fn from_str_roundtrip() {
-        for variant in [
-            UserEnvProbe::None,
-            UserEnvProbe::LoginShell,
-            UserEnvProbe::InteractiveShell,
-            UserEnvProbe::LoginInteractiveShell,
-        ] {
-            assert_eq!(UserEnvProbe::from_str(variant.as_str()).unwrap(), variant);
-        }
-    }
-
-    #[test]
-    fn from_str_invalid() {
-        assert!(UserEnvProbe::from_str("bogus").is_err());
-    }
-
-    #[test]
-    fn default_is_login_interactive() {
-        assert_eq!(UserEnvProbe::default(), UserEnvProbe::LoginInteractiveShell);
     }
 
     #[test]
@@ -234,5 +411,29 @@ mod tests {
             Some(&"/custom/bin:/usr/bin".to_string())
         );
         assert_eq!(merged_map.get("HOME"), Some(&"/home/user".to_string()));
+    }
+
+    // ── UserEnvProbe enum ────────────────────────────────────────────────────
+
+    #[test]
+    fn from_str_roundtrip() {
+        for variant in [
+            UserEnvProbe::None,
+            UserEnvProbe::LoginShell,
+            UserEnvProbe::InteractiveShell,
+            UserEnvProbe::LoginInteractiveShell,
+        ] {
+            assert_eq!(UserEnvProbe::from_str(variant.as_str()).unwrap(), variant);
+        }
+    }
+
+    #[test]
+    fn from_str_invalid() {
+        assert!(UserEnvProbe::from_str("bogus").is_err());
+    }
+
+    #[test]
+    fn default_is_login_interactive() {
+        assert_eq!(UserEnvProbe::default(), UserEnvProbe::LoginInteractiveShell);
     }
 }

--- a/crates/cella-orchestrator/src/env_cache.rs
+++ b/crates/cella-orchestrator/src/env_cache.rs
@@ -70,13 +70,12 @@ pub async fn probe_and_cache_user_env(
     Some(env)
 }
 
-/// Try one probe method and return the parsed env, or `None` to signal the
+/// Try one probe method and return the parsed env, or an error to signal the
 /// caller should fall back to the next method.
 ///
-/// Returns `None` on timeout (caller must not retry — a hang is a hang), on
-/// exec error, on non-zero exit, or when the parsed map is empty.
-/// A timeout is signalled by setting the bool to `true`; all other failures
-/// leave it `false`.
+/// Returns `Ok(env)` on success. Returns `Err(true)` on timeout (caller must
+/// not retry — a hang is a hang). Returns `Err(false)` on exec error,
+/// non-zero exit, or when the parsed map is empty.
 async fn try_probe_method(
     client: &dyn ContainerBackend,
     container_id: &str,

--- a/crates/cella-orchestrator/src/env_cache.rs
+++ b/crates/cella-orchestrator/src/env_cache.rs
@@ -5,7 +5,9 @@ use tracing::{debug, warn};
 
 use cella_backend::{ContainerBackend, ExecOptions, FileToUpload};
 use cella_env::platform::DockerRuntime;
-use cella_env::user_env_probe::UserEnvProbe;
+use cella_env::user_env_probe::{
+    PROBE_METHODS, ProbeMethod, UserEnvProbe, parse_probed_env, probe_command,
+};
 
 /// Compute the per-user, per-probe-type cache path for the probed environment.
 ///
@@ -68,10 +70,82 @@ pub async fn probe_and_cache_user_env(
     Some(env)
 }
 
+/// Try one probe method and return the parsed env, or `None` to signal the
+/// caller should fall back to the next method.
+///
+/// Returns `None` on timeout (caller must not retry — a hang is a hang), on
+/// exec error, on non-zero exit, or when the parsed map is empty.
+/// A timeout is signalled by setting the bool to `true`; all other failures
+/// leave it `false`.
+async fn try_probe_method(
+    client: &dyn ContainerBackend,
+    container_id: &str,
+    user: &str,
+    probe_type: UserEnvProbe,
+    shell: &str,
+    marker: &str,
+    method: ProbeMethod,
+) -> Result<HashMap<String, String>, bool> {
+    let Some(cmd) = probe_command(probe_type, shell, marker, method) else {
+        // Only happens for UserEnvProbe::None — already guarded in run_env_probe.
+        return Err(false);
+    };
+
+    debug!(
+        "Running userEnvProbe ({probe_type}) with {shell} via `{}`: {cmd:?}",
+        method.command
+    );
+
+    let exec_opts = ExecOptions {
+        cmd,
+        user: Some(user.to_string()),
+        env: None,
+        working_dir: None,
+    };
+    let exec_future = client.exec_command(container_id, &exec_opts);
+
+    let result = match tokio::time::timeout(Duration::from_secs(10), exec_future).await {
+        Ok(Ok(r)) => r,
+        Ok(Err(_)) => return Err(false),
+        Err(_) => {
+            warn!(
+                "userEnvProbe timed out after 10s \
+                 — avoid waiting for user input in shell startup scripts"
+            );
+            return Err(true); // timed out — abort all further methods
+        }
+    };
+
+    if result.exit_code != 0 {
+        debug!(
+            "userEnvProbe method `{}` failed (exit {}): {}",
+            method.command,
+            result.exit_code,
+            result.stderr.trim()
+        );
+        return Err(false);
+    }
+
+    let env = parse_probed_env(&result.stdout, marker, method.separator);
+    if env.is_empty() {
+        debug!(
+            "userEnvProbe method `{}` yielded empty env — trying fallback",
+            method.command
+        );
+        return Err(false);
+    }
+
+    Ok(env)
+}
+
 /// Execute the environment probe command and parse the output.
 ///
-/// Applies a 10-second timeout to prevent indefinite hangs from shell
-/// startup scripts that wait for user input.
+/// Tries each method in [`PROBE_METHODS`] in order, returning the first
+/// non-empty result. A UUID marker is embedded in the shell command so that
+/// shell-startup noise printed to stdout is stripped before parsing.
+///
+/// Applies a 10-second timeout per method. A timeout aborts all further
+/// attempts — a hanging shell startup script won't be retried.
 async fn run_env_probe(
     client: &dyn ContainerBackend,
     container_id: &str,
@@ -79,39 +153,31 @@ async fn run_env_probe(
     probe_type: UserEnvProbe,
     shell: &str,
 ) -> Option<HashMap<String, String>> {
-    let probe_cmd = cella_env::user_env_probe::probe_command(probe_type, shell)?;
-
-    debug!("Running userEnvProbe ({probe_type}) with {shell}: {probe_cmd:?}");
-
-    let exec_opts = ExecOptions {
-        cmd: probe_cmd,
-        user: Some(user.to_string()),
-        env: None,
-        working_dir: None,
-    };
-    let exec_future = client.exec_command(container_id, &exec_opts);
-
-    let result = if let Ok(r) = tokio::time::timeout(Duration::from_secs(10), exec_future).await {
-        r.ok()?
-    } else {
-        warn!(
-            "userEnvProbe timed out after 10s \
-             — avoid waiting for user input in shell startup scripts"
-        );
-        return None;
-    };
-
-    if result.exit_code != 0 {
-        debug!(
-            "userEnvProbe failed (exit {}): {}",
-            result.exit_code,
-            result.stderr.trim()
-        );
+    if probe_type == UserEnvProbe::None {
         return None;
     }
 
-    let env = cella_env::user_env_probe::parse_probed_env(&result.stdout);
-    if env.is_empty() { None } else { Some(env) }
+    let marker = uuid::Uuid::new_v4().to_string();
+
+    for method in PROBE_METHODS {
+        match try_probe_method(
+            client,
+            container_id,
+            user,
+            probe_type,
+            shell,
+            &marker,
+            *method,
+        )
+        .await
+        {
+            Ok(env) => return Some(env),
+            Err(true) => return None, // timed out — don't retry a hanging shell
+            Err(false) => {}          // other failure — fall back to next method
+        }
+    }
+
+    None
 }
 
 /// Write the probed environment to a cache file inside the container.


### PR DESCRIPTION
cella's `userEnvProbe` ran `<shell> <flags> -c "env -0"` with no output marker and no fallback. Two real bugs:

1. **Breaks on Alpine/busybox.** `env -0` is a GNU coreutils extension; busybox `env` doesn't have it. The probe exits non-zero, cella returns `None`, and the container starts with *no* user environment injected.
2. **Interactive shells corrupt the first var.** With `-i`, a `.bashrc`/`.zshrc` that prints to stdout (banners, `echo`) gets prepended to the probe output. Splitting on the delimiter merged that noise into the first env var's key, silently dropping it (commonly `HOME`).

This matches the official CLI's technique (`devcontainers/cli` `injectHeadless.ts`):
- Probe via `cat /proc/self/environ` (the kernel's NUL-delimited environ file — no external tool), falling back to `printenv` (newline-delimited) only if that yields nothing.
- Wrap the inner command in a per-run UUID marker (`echo -n MARK; …; echo -n MARK`) and extract the text between the first and last marker, so shell-startup noise outside the markers is stripped.
- Handle PowerShell (`pwsh`/`pwsh-preview`) with `-Login -Command` / `-Command` instead of POSIX `-lic` flags.
- Drop `PWD` (unchanged).

## Implementation
- `cella-env/user_env_probe.rs`: new `ProbeMethod` + `PROBE_METHODS` (priority-ordered, extensible); `probe_command` now takes the marker + method and wraps the command (+ pwsh branch); `parse_probed_env` extracts between markers then splits on the method's separator. 20 unit tests (marker wrapping, pwsh login/non-login, printenv form, startup-noise stripping, absent-marker → empty, PWD drop, malformed entries).
- `cella-orchestrator/env_cache.rs`: `run_env_probe` generates a UUID marker once and tries each method in order (extracted `try_probe_method` to stay under the 100-LOC clippy limit), returning the first non-empty result; a 10s timeout aborts all methods (a hang is a hang), other failures fall through to the next.

## Tests
Full workspace: 3982 passed, 0 failed. (One unrelated cella-cli read-configuration test is a known intermittent parallel race — passes isolated and on repeat; this branch doesn't touch that code.)