### PR TITLE
fix(env): merge container base PATH into probed user env

### DIFF
--- a/crates/cella-env/src/user_env_probe.rs
+++ b/crates/cella-env/src/user_env_probe.rs
@@ -166,6 +166,36 @@ pub fn parse_probed_env(output: &str, marker: &str, separator: char) -> HashMap<
         .collect()
 }
 
+/// Merge a probed shell `PATH` with the container's base `PATH`.
+///
+/// Preserves shell-PATH precedence while re-inserting any container entries the
+/// shell dropped (e.g. a startup script that reset `PATH`). Mirrors the official
+/// CLI `mergePaths`: container-only entries are spliced in at their relative
+/// position; non-root users skip `*/sbin` entries.
+#[must_use]
+pub fn merge_paths(shell_path: &str, container_path: &str, root_user: bool) -> String {
+    let mut result: Vec<&str> = shell_path.split(':').collect();
+    let mut insert_at = 0usize;
+    for entry in container_path.split(':') {
+        if let Some(i) = result.iter().position(|e| *e == entry) {
+            insert_at = i + 1;
+        } else if root_user || !is_sbin_path(entry) {
+            result.insert(insert_at, entry);
+            insert_at += 1;
+        }
+    }
+    result.join(":")
+}
+
+/// Whether a PATH entry contains an `sbin` path component.
+///
+/// Matches the official regex `/\/sbin(\/|$)/` — a path segment that equals
+/// exactly `sbin` (e.g. `/sbin`, `/usr/sbin`, `/usr/sbin/x`), but NOT
+/// `/usr/sbinfoo`.
+fn is_sbin_path(entry: &str) -> bool {
+    entry.split('/').any(|seg| seg == "sbin")
+}
+
 /// Merge probed environment with `remoteEnv` from config.
 ///
 /// `remote_env` values override `probed` values.
@@ -461,6 +491,83 @@ mod tests {
         assert!(!merged.contains(&"FOO=cli".to_string()));
         assert!(merged.contains(&"BAR=cli".to_string()));
         assert!(merged.contains(&"PATH=/usr/bin".to_string()));
+    }
+
+    // -- merge_paths tests --
+
+    #[test]
+    fn merge_paths_shell_superset_unchanged() {
+        // Shell PATH already contains all container entries — no-op.
+        let shell = "/opt/tool/bin:/usr/bin:/bin";
+        let container = "/usr/bin:/bin";
+        assert_eq!(merge_paths(shell, container, false), shell);
+    }
+
+    #[test]
+    fn merge_paths_shell_reset_non_root_skips_sbin() {
+        // Shell startup script reset PATH to something simpler.
+        // Container entries missing from shell are re-inserted, but
+        // /usr/sbin and /sbin are skipped for non-root.
+        let shell = "/opt/tool/bin:/usr/bin";
+        let container = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+        let result = merge_paths(shell, container, false);
+        // /usr/local/sbin, /usr/sbin, /sbin must be absent
+        assert!(!result.split(':').any(|e| e == "/usr/local/sbin"));
+        assert!(!result.split(':').any(|e| e == "/usr/sbin"));
+        assert!(!result.split(':').any(|e| e == "/sbin"));
+        // /usr/local/bin, /usr/bin, /bin must be present
+        assert!(result.split(':').any(|e| e == "/usr/local/bin"));
+        assert!(result.split(':').any(|e| e == "/usr/bin"));
+        assert!(result.split(':').any(|e| e == "/bin"));
+        // Shell-original entries must be present
+        assert!(result.split(':').any(|e| e == "/opt/tool/bin"));
+    }
+
+    #[test]
+    fn merge_paths_shell_reset_root_keeps_sbin() {
+        // Same scenario but root — /sbin paths are kept.
+        let shell = "/opt/tool/bin:/usr/bin";
+        let container = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+        let result = merge_paths(shell, container, true);
+        assert!(result.split(':').any(|e| e == "/usr/local/sbin"));
+        assert!(result.split(':').any(|e| e == "/usr/sbin"));
+        assert!(result.split(':').any(|e| e == "/sbin"));
+    }
+
+    #[test]
+    fn merge_paths_interleaving_preserves_relative_order() {
+        // shell="/a:/c", container="/a:/b:/c:/d", non-root (no sbin entries).
+        // Expected: /a:/b:/c:/d  — container-only entries land in their
+        // relative position (b after a, d after c).
+        let result = merge_paths("/a:/c", "/a:/b:/c:/d", false);
+        assert_eq!(result, "/a:/b:/c:/d");
+    }
+
+    // -- is_sbin_path tests --
+
+    #[test]
+    fn is_sbin_path_matches_sbin_root() {
+        assert!(is_sbin_path("/sbin"));
+    }
+
+    #[test]
+    fn is_sbin_path_matches_usr_sbin() {
+        assert!(is_sbin_path("/usr/sbin"));
+    }
+
+    #[test]
+    fn is_sbin_path_matches_usr_sbin_subdir() {
+        assert!(is_sbin_path("/usr/sbin/x"));
+    }
+
+    #[test]
+    fn is_sbin_path_ignores_sbinfoo() {
+        assert!(!is_sbin_path("/usr/sbinfoo"));
+    }
+
+    #[test]
+    fn is_sbin_path_ignores_usr_bin() {
+        assert!(!is_sbin_path("/usr/bin"));
     }
 
     #[test]

--- a/crates/cella-env/src/user_env_probe.rs
+++ b/crates/cella-env/src/user_env_probe.rs
@@ -172,11 +172,15 @@ pub fn parse_probed_env(output: &str, marker: &str, separator: char) -> HashMap<
 /// shell dropped (e.g. a startup script that reset `PATH`). Mirrors the official
 /// CLI `mergePaths`: container-only entries are spliced in at their relative
 /// position; non-root users skip `*/sbin` entries.
+///
+/// Empty segments (from leading/trailing/doubled `:`) are filtered out before
+/// merging to prevent accidentally inserting `.` (current-working-directory) into
+/// `PATH`, which would be a security issue.
 #[must_use]
 pub fn merge_paths(shell_path: &str, container_path: &str, root_user: bool) -> String {
-    let mut result: Vec<&str> = shell_path.split(':').collect();
+    let mut result: Vec<&str> = shell_path.split(':').filter(|s| !s.is_empty()).collect();
     let mut insert_at = 0usize;
-    for entry in container_path.split(':') {
+    for entry in container_path.split(':').filter(|s| !s.is_empty()) {
         if let Some(i) = result.iter().position(|e| *e == entry) {
             insert_at = i + 1;
         } else if root_user || !is_sbin_path(entry) {
@@ -187,13 +191,16 @@ pub fn merge_paths(shell_path: &str, container_path: &str, root_user: bool) -> S
     result.join(":")
 }
 
-/// Whether a PATH entry contains an `sbin` path component.
+/// Whether a PATH entry is an sbin path component.
 ///
-/// Matches the official regex `/\/sbin(\/|$)/` — a path segment that equals
-/// exactly `sbin` (e.g. `/sbin`, `/usr/sbin`, `/usr/sbin/x`), but NOT
-/// `/usr/sbinfoo`.
+/// Matches the official regex `/\/sbin(\/|$)/` — requires a literal `/sbin`
+/// boundary, so `/sbin`, `/usr/sbin`, and `/usr/sbin/x` match, but
+/// `/usr/sbinfoo` and a bare `sbin` (no leading slash) do not.
 fn is_sbin_path(entry: &str) -> bool {
-    entry.split('/').any(|seg| seg == "sbin")
+    entry
+        .split('/')
+        .skip(1) // skip the empty segment before the leading '/'
+        .any(|seg| seg == "sbin")
 }
 
 /// Merge probed environment with `remoteEnv` from config.
@@ -568,6 +575,33 @@ mod tests {
     #[test]
     fn is_sbin_path_ignores_usr_bin() {
         assert!(!is_sbin_path("/usr/bin"));
+    }
+
+    /// Regression: bare `"sbin"` (no leading slash) must NOT match the
+    /// `/\/sbin(\/|$)/` regex — it is not an absolute path and the regex
+    /// requires a `/` before `sbin`.
+    #[test]
+    fn is_sbin_path_bare_sbin_no_match() {
+        assert!(!is_sbin_path("sbin"));
+    }
+
+    /// Regression: empty PATH segments (from `PATH=:` or `PATH=/bin:`) must
+    /// never appear in the merged result, since an empty segment means `.`
+    /// (current working directory) which is a security hazard.
+    #[test]
+    fn merge_paths_filters_empty_segments() {
+        // container_path with a trailing ':' produces an empty segment
+        let result = merge_paths("/usr/bin:/bin", "/usr/bin:/bin:", false);
+        assert!(
+            !result.split(':').any(str::is_empty),
+            "merged PATH must not contain empty segments (implicit '.'): {result}"
+        );
+        // shell_path with a leading ':' also filtered
+        let result = merge_paths(":/usr/bin:/bin", "/usr/bin:/bin", false);
+        assert!(
+            !result.split(':').any(str::is_empty),
+            "merged PATH must not contain empty segments from shell path: {result}"
+        );
     }
 
     #[test]

--- a/crates/cella-orchestrator/src/env_cache.rs
+++ b/crates/cella-orchestrator/src/env_cache.rs
@@ -138,6 +138,17 @@ async fn try_probe_method(
     Ok(env)
 }
 
+/// Whether `user` identifies the root account.
+///
+/// Docker's `--user` flag accepts several formats: a plain name (`root`), a
+/// plain UID (`0`), or `uid:gid` / `name:group` pairs (`0:0`, `root:root`,
+/// `root:0`, `0:root`). Inspect the part before `:` (if any) and treat the
+/// user as root when it is `"root"` or `"0"`.
+fn is_root_user(user: &str) -> bool {
+    let uid_or_name = user.split(':').next().unwrap_or(user);
+    uid_or_name == "root" || uid_or_name == "0"
+}
+
 /// Merge the container's base `PATH` (from image config) into the probed env so
 /// PATH entries a shell startup script dropped are recovered. Non-fatal: any
 /// lookup failure leaves the probed PATH untouched. Mirrors the official CLI.
@@ -162,7 +173,7 @@ async fn merge_container_base_path(
     let Some(container_path) = image_env.iter().find_map(|e| e.strip_prefix("PATH=")) else {
         return;
     };
-    let root_user = user == "root" || user == "0";
+    let root_user = is_root_user(user);
     let merged = cella_env::user_env_probe::merge_paths(&shell_path, container_path, root_user);
     env.insert("PATH".to_string(), merged);
 }
@@ -326,5 +337,48 @@ mod tests {
     fn cache_path_interactive_shell() {
         let path = cache_path("devuser", UserEnvProbe::InteractiveShell);
         assert!(path.ends_with("/.cella/env-interactiveShell.json"));
+    }
+
+    // -- is_root_user tests --
+
+    /// Regression: Docker `--user` accepts `uid:gid` and `name:group` forms.
+    /// `is_root_user` must recognise all root-identifying formats so that sbin
+    /// entries are correctly retained in the merged PATH for root containers.
+    #[test]
+    fn is_root_user_plain_name() {
+        assert!(is_root_user("root"));
+    }
+
+    #[test]
+    fn is_root_user_plain_uid() {
+        assert!(is_root_user("0"));
+    }
+
+    #[test]
+    fn is_root_user_uid_gid() {
+        assert!(is_root_user("0:0"));
+    }
+
+    #[test]
+    fn is_root_user_name_group() {
+        assert!(is_root_user("root:root"));
+    }
+
+    #[test]
+    fn is_root_user_root_gid() {
+        assert!(is_root_user("root:0"));
+    }
+
+    #[test]
+    fn is_root_user_uid_group_name() {
+        assert!(is_root_user("0:root"));
+    }
+
+    #[test]
+    fn is_root_user_non_root() {
+        assert!(!is_root_user("vscode"));
+        assert!(!is_root_user("1000"));
+        assert!(!is_root_user("1000:1000"));
+        assert!(!is_root_user("user:group"));
     }
 }

--- a/crates/cella-orchestrator/src/env_cache.rs
+++ b/crates/cella-orchestrator/src/env_cache.rs
@@ -65,7 +65,8 @@ pub async fn probe_and_cache_user_env(
     probe_type: UserEnvProbe,
     shell: &str,
 ) -> Option<HashMap<String, String>> {
-    let env = run_env_probe(client, container_id, user, probe_type, shell).await?;
+    let mut env = run_env_probe(client, container_id, user, probe_type, shell).await?;
+    merge_container_base_path(client, container_id, user, &mut env).await;
     write_env_cache(client, container_id, user, probe_type, &env).await;
     Some(env)
 }
@@ -135,6 +136,35 @@ async fn try_probe_method(
     }
 
     Ok(env)
+}
+
+/// Merge the container's base `PATH` (from image config) into the probed env so
+/// PATH entries a shell startup script dropped are recovered. Non-fatal: any
+/// lookup failure leaves the probed PATH untouched. Mirrors the official CLI.
+async fn merge_container_base_path(
+    client: &dyn ContainerBackend,
+    container_id: &str,
+    user: &str,
+    env: &mut HashMap<String, String>,
+) {
+    let Some(shell_path) = env.get("PATH").cloned() else {
+        return;
+    };
+    let Ok(info) = client.inspect_container(container_id).await else {
+        return;
+    };
+    let Some(image) = info.image else {
+        return;
+    };
+    let Ok(image_env) = client.inspect_image_env(&image).await else {
+        return;
+    };
+    let Some(container_path) = image_env.iter().find_map(|e| e.strip_prefix("PATH=")) else {
+        return;
+    };
+    let root_user = user == "root" || user == "0";
+    let merged = cella_env::user_env_probe::merge_paths(&shell_path, container_path, root_user);
+    env.insert("PATH".to_string(), merged);
 }
 
 /// Execute the environment probe command and parse the output.


### PR DESCRIPTION
Follow-on to #171 (stacked on it). After the userEnvProbe captures the shell environment, the official CLI merges the probed shell `PATH` with the container's base `PATH` (`injectHeadless.ts` `mergePaths`) so that entries a shell startup script *dropped* (e.g. a `.bashrc` that does `export PATH=/opt/tool/bin:/usr/bin`, losing the container's base dirs) are recovered. cella cached the probed PATH as-is, losing them.

## What it does
- New pure `merge_paths(shell_path, container_path, root_user)` in cella-env — a line-for-line port of the official `mergePaths`: start from the shell PATH, splice in any container entries not already present (preserving relative order), and skip `*/sbin` entries for non-root users. 9 unit tests (no-op superset, shell-reset with sbin skip, root keeps sbin, interleaving order, `is_sbin_path` matching `/sbin`·`/usr/sbin`·`/usr/sbin/x` but not `/usr/sbinfoo`).
- Wired self-contained in `probe_and_cache_user_env`: after probing, look up the container's base PATH (`inspect_container` → image → `inspect_image_env`) and merge before caching. Fully non-fatal — any lookup miss leaves the probed PATH untouched (no regression). No call-site changes; exec/lifecycle pick up the merged PATH via the cache.

Note: the base PATH is sourced from the image config (`inspect_image_env`), the standard container base — a creation-time `containerEnv.PATH` override is the rare exception and is handled separately via remoteEnv layering.

## Tests
cella-env userEnvProbe suite: 29 passed (incl. the 9 new). Full workspace: 3991 passed, 0 failed.