### PR TITLE
fix(labels): stamp spec local_folder/config_file with lexical paths

### DIFF
--- a/crates/cella-backend/src/names.rs
+++ b/crates/cella-backend/src/names.rs
@@ -410,6 +410,21 @@ mod tests {
     }
 
     #[test]
+    fn lexical_absolute_normalizes_without_touching_fs() {
+        // `.` and `..` are collapsed textually — no filesystem access, no
+        // symlink resolution.  `..` never ascends past the root.
+        assert_eq!(
+            lexical_absolute(Path::new("/tmp/a/../b/./c")),
+            PathBuf::from("/tmp/b/c")
+        );
+        assert_eq!(lexical_absolute(Path::new("/../..")), PathBuf::from("/"));
+        assert_eq!(
+            lexical_absolute(Path::new("/already/clean")),
+            PathBuf::from("/already/clean")
+        );
+    }
+
+    #[test]
     fn labels_contain_docker_runtime() {
         let labels = container_labels(
             &PathBuf::from("/tmp/test"),

--- a/crates/cella-cli/src/commands/down.rs
+++ b/crates/cella-cli/src/commands/down.rs
@@ -242,7 +242,7 @@ async fn stop_compose_project(
 /// to the caller, because the container is already gone and the
 /// enclosing `cella down --rm` has succeeded.
 ///
-/// The `dev.cella.workspace_path` label is set from the canonicalized
+/// The `dev.cella.workspace_path` label is set from the lexical absolute
 /// workspace path at container creation, matching the input
 /// `ensure_repo_network` hashes — so the derived network name lines up.
 async fn cleanup_workspace_network(

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -30,6 +30,7 @@ mod upgrade;
 
 use std::io::IsTerminal;
 
+use cella_backend::names::lexical_absolute;
 use clap::{Args, Subcommand, ValueEnum};
 use tracing::warn;
 
@@ -457,6 +458,13 @@ pub fn warn_if_missing_backend_label(container: &cella_backend::ContainerInfo) {
 
 /// Resolve the workspace folder from an optional argument or the current directory.
 ///
+/// Returns a lexical absolute path (no symlink resolution) so that downstream
+/// consumers — `container_labels`, `devcontainer_id`, and VS Code / the
+/// official CLI — all work from the same un-resolved path form. Using
+/// `canonicalize` here would silently resolve symlinks (e.g. macOS
+/// `/tmp` → `/private/tmp`), causing mismatches with any tool that looks up
+/// a container by the label value it originally stamped.
+///
 /// # Errors
 ///
 /// Returns error if the current directory cannot be determined.
@@ -464,9 +472,9 @@ pub fn resolve_workspace_folder(
     opt: Option<&std::path::Path>,
 ) -> Result<std::path::PathBuf, Box<dyn std::error::Error + Send + Sync>> {
     if let Some(wf) = opt {
-        Ok(wf.canonicalize().unwrap_or_else(|_| wf.to_path_buf()))
+        Ok(lexical_absolute(wf))
     } else {
-        Ok(std::env::current_dir()?)
+        Ok(lexical_absolute(&std::env::current_dir()?))
     }
 }
 
@@ -906,8 +914,8 @@ mod tests {
     fn resolve_workspace_folder_with_existing_path() {
         let tmp = std::env::temp_dir();
         let result = resolve_workspace_folder(Some(&tmp)).unwrap();
-        // canonicalize should succeed for an existing directory
-        assert_eq!(result, tmp.canonicalize().unwrap());
+        // lexical_absolute: no symlink resolution, dot/dotdot collapsed textually.
+        assert_eq!(result, lexical_absolute(&tmp));
     }
 
     #[test]
@@ -915,8 +923,19 @@ mod tests {
         let fake = PathBuf::from("/nonexistent/path/to/workspace");
         let result =
             resolve_workspace_folder(Some(Path::new("/nonexistent/path/to/workspace"))).unwrap();
-        // canonicalize fails, so it returns the path as-is
+        // Path doesn't need to exist — lexical_absolute works without hitting the FS.
         assert_eq!(result, fake);
+    }
+
+    #[test]
+    fn resolve_workspace_folder_does_not_follow_symlinks() {
+        // lexical_absolute preserves the caller-supplied path form, so a symlink
+        // path is stamped as-is rather than resolved to its target. This matters
+        // for container-label / devcontainerId consistency with VS Code and the
+        // official CLI, both of which use the symlink path for lookups.
+        let fake_symlink = PathBuf::from("/fake/link/workspace");
+        let result = resolve_workspace_folder(Some(&fake_symlink)).unwrap();
+        assert_eq!(result, fake_symlink);
     }
 
     // ── is_binary_newer_than ────────────────────────────────────────


### PR DESCRIPTION
A bounded, safe step toward cross-tool container reuse (the core drop-in promise).

The official CLI and VS Code stamp `devcontainer.local_folder` and `devcontainer.config_file` with **lexical** absolute paths (Node `path.resolve` — resolves `.`/`..` textually, does NOT follow symlinks). cella stamped them with `canonicalize()` (symlink-resolved). On a symlinked workspace the two disagree, so when you `cella up` a workspace and then open it in VS Code / the official CLI, that tool computes the lexical path, doesn't find a matching `devcontainer.local_folder` label, and **creates a duplicate container** instead of reusing cella's.

Fix: stamp the spec labels with a lexical absolute path. The `dev.cella.*` labels stay canonical — they back cella's *own* primary container lookup, so this change doesn't touch cella's own reuse path (lowest risk). For non-symlinked workspaces (the common case) lexical == canonical, so there's no behavior change there.

`lexical_absolute` is a small duplicate of the helper #152 uses for `${devcontainerId}` (cella-backend is tier-3 and can't import cella-config's), so cella's path model stays consistent across labels and devcontainerId.

## Tests
- `lexical_absolute_normalizes_without_touching_fs` — `..`/`.` resolved textually, never ascends past root, no FS access.
- Updated `labels_contain_spec_standard_keys` to assert the spec labels equal the lexical path.
- Full workspace: 3976 passed, 0 failed.

Complements #164 (which made `find_container`'s fallback look up by the lexical `local_folder`); together they close the symlinked-workspace cross-tool reuse gap in both directions.