### PR TITLE
feat(up): reuse containers by spec identity (local_folder + config_file)

### DIFF
--- a/crates/cella-backend/src/lib.rs
+++ b/crates/cella-backend/src/lib.rs
@@ -22,7 +22,7 @@ pub use mount::{MountKind, MountSpec};
 pub use names::{
     BACKEND_LABEL, compose_labels, compose_project_name, compute_features_digest, container_labels,
     container_name, image_name, image_name_for_worktree, image_name_with_features,
-    orbstack_domains_label, orbstack_http_port_label, worktree_labels,
+    lexical_absolute, orbstack_domains_label, orbstack_http_port_label, worktree_labels,
 };
 pub use network::{ManagedNetwork, RemovalOutcome};
 pub use resolve::ContainerTarget;

--- a/crates/cella-docker/src/integration_tests/mod.rs
+++ b/crates/cella-docker/src/integration_tests/mod.rs
@@ -5,3 +5,4 @@
 
 mod claude_seed_tests;
 mod network_tests;
+mod spec_identity_tests;

--- a/crates/cella-docker/src/integration_tests/spec_identity_tests.rs
+++ b/crates/cella-docker/src/integration_tests/spec_identity_tests.rs
@@ -37,6 +37,7 @@ fn opts_with_spec_labels(name: &str, workspace: &Path, config: &Path) -> CreateC
         cap_add: Vec::new(),
         security_opt: Vec::new(),
         privileged: false,
+        init: false,
         run_args_overrides: None,
         gpu_request: None,
     }

--- a/crates/cella-docker/src/integration_tests/spec_identity_tests.rs
+++ b/crates/cella-docker/src/integration_tests/spec_identity_tests.rs
@@ -1,0 +1,99 @@
+//! Integration test: `find_container_by_labels` finds a container by the
+//! spec identity labels (`devcontainer.local_folder` + `devcontainer.config_file`).
+//!
+//! This proves that the reuse lookup in `cella-orchestrator` up.rs will
+//! locate a container whose spec labels were stamped by `container_labels`
+//! (via `lexical_absolute`) — i.e. stamp and lookup are byte-identical.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use cella_backend::{ContainerBackend, CreateContainerOptions, lexical_absolute};
+
+use crate::client::DockerClient;
+
+const TEST_IMAGE: &str = "busybox:latest";
+
+fn opts_with_spec_labels(name: &str, workspace: &Path, config: &Path) -> CreateContainerOptions {
+    let local_folder = lexical_absolute(workspace).to_string_lossy().to_string();
+    let config_file = lexical_absolute(config).to_string_lossy().to_string();
+    let labels = HashMap::from([
+        ("devcontainer.local_folder".to_string(), local_folder),
+        ("devcontainer.config_file".to_string(), config_file),
+    ]);
+    CreateContainerOptions {
+        name: name.to_string(),
+        image: TEST_IMAGE.to_string(),
+        labels,
+        env: Vec::new(),
+        remote_env: Vec::new(),
+        user: None,
+        workspace_folder: String::new(),
+        workspace_mount: None,
+        mounts: Vec::new(),
+        port_bindings: HashMap::new(),
+        entrypoint: None,
+        cmd: Some(vec!["sleep".to_string(), "300".to_string()]),
+        cap_add: Vec::new(),
+        security_opt: Vec::new(),
+        privileged: false,
+        run_args_overrides: None,
+        gpu_request: None,
+    }
+}
+
+/// A container stamped with `devcontainer.local_folder` + `devcontainer.config_file`
+/// (as `container_labels` does via `lexical_absolute`) is found by
+/// `find_container_by_labels` using the same lexical path values — proving
+/// the orchestrator reuse lookup will work end-to-end.
+#[cella_testing::runtime_test(docker)]
+async fn find_container_by_spec_identity_labels() {
+    let Ok(client) = DockerClient::connect() else {
+        return;
+    };
+
+    if client.pull_image(TEST_IMAGE).await.is_err() {
+        return;
+    }
+
+    let name = format!("cella-it-spec-identity-{}", std::process::id());
+    let workspace = Path::new("/tmp/spec-identity-test-workspace");
+    let config = Path::new("/tmp/spec-identity-test-workspace/.devcontainer/devcontainer.json");
+
+    let _ = client.remove_container(&name, true).await;
+    let Ok(id) = client
+        .create_container(&opts_with_spec_labels(&name, workspace, config))
+        .await
+    else {
+        return;
+    };
+
+    // Build the lookup labels the same way `spec_identity_labels` does in up.rs.
+    let spec_labels = [
+        format!(
+            "devcontainer.local_folder={}",
+            lexical_absolute(workspace).to_string_lossy()
+        ),
+        format!(
+            "devcontainer.config_file={}",
+            lexical_absolute(config).to_string_lossy()
+        ),
+    ];
+
+    let found = client
+        .find_container_by_labels(&spec_labels)
+        .await
+        .expect("find_container_by_labels");
+
+    let _ = client.remove_container(&id, true).await;
+
+    assert!(
+        found.is_some(),
+        "find_container_by_labels must locate the container by spec identity labels"
+    );
+    assert_eq!(
+        found.unwrap().id,
+        id,
+        "found container id must match the created container"
+    );
+}

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -2124,19 +2124,18 @@ impl EnsureUpContext<'_> {
             // container matched by spec-identity), a legacy cella container for
             // the same workspace may still hold our target name. Remove it now
             // to avoid a Docker name-conflict on create.
-            if remove_container && container.name != self.config.container_name {
-                if let Some(legacy) = self
+            if remove_container
+                && container.name != self.config.container_name
+                && let Some(legacy) = self
                     .client
                     .find_container(&self.config.resolved.workspace_root)
                     .await?
-                {
-                    if legacy.name == self.config.container_name {
-                        if legacy.state == ContainerState::Running {
-                            let _ = self.client.stop_container(&legacy.id).await;
-                        }
-                        let _ = self.client.remove_container(&legacy.id, false).await;
-                    }
+                && legacy.name == self.config.container_name
+            {
+                if legacy.state == ContainerState::Running {
+                    let _ = self.client.stop_container(&legacy.id).await;
                 }
+                let _ = self.client.remove_container(&legacy.id, false).await;
             }
         }
 

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -9,6 +9,7 @@ use cella_backend::agent::restart_agent_in_container;
 use cella_backend::{
     BackendError, ContainerBackend, ContainerInfo, ContainerState, ExecOptions, FileToUpload,
     ImageDetails, LifecycleContext, MountConfig, agent_env_vars, container_labels,
+    lexical_absolute,
 };
 
 use crate::config::{HostRequirementPolicy, ImageStrategy, NetworkRulePolicy, UpConfig};
@@ -2045,11 +2046,24 @@ impl EnsureUpContext<'_> {
         }
 
         // With --id-label, find by AND-matched labels (matching the official
-        // CLI); otherwise fall back to the workspace-path lookup.
+        // CLI). Without --id-label, try the spec identity (local_folder +
+        // config_file) first so we reuse exactly the right container in a
+        // multi-config workspace and can find containers VS Code / the official
+        // CLI created. Fall back to cella's own workspace-path lookup for
+        // older containers that were created without the spec-identity labels.
         let existing = if self.config.id_labels.is_empty() {
-            self.client
-                .find_container(&self.config.resolved.workspace_root)
-                .await?
+            let spec_labels = spec_identity_labels(
+                &self.config.resolved.workspace_root,
+                &self.config.resolved.config_path,
+            );
+            match self.client.find_container_by_labels(&spec_labels).await? {
+                Some(c) => Some(c),
+                None => {
+                    self.client
+                        .find_container(&self.config.resolved.workspace_root)
+                        .await?
+                }
+            }
         } else {
             self.client
                 .find_container_by_labels(self.config.id_labels)
@@ -2102,6 +2116,26 @@ impl EnsureUpContext<'_> {
                 }
                 (_, false) => {
                     self.client.remove_container(&container.id, false).await?;
+                }
+            }
+
+            // If we're about to create a fresh container and the one we just
+            // removed had a different name (e.g. a VS Code / official-CLI
+            // container matched by spec-identity), a legacy cella container for
+            // the same workspace may still hold our target name. Remove it now
+            // to avoid a Docker name-conflict on create.
+            if remove_container && container.name != self.config.container_name {
+                if let Some(legacy) = self
+                    .client
+                    .find_container(&self.config.resolved.workspace_root)
+                    .await?
+                {
+                    if legacy.name == self.config.container_name {
+                        if legacy.state == ContainerState::Running {
+                            let _ = self.client.stop_container(&legacy.id).await;
+                        }
+                        let _ = self.client.remove_container(&legacy.id, false).await;
+                    }
                 }
             }
         }
@@ -2405,6 +2439,29 @@ fn injected_proxy_config(post_start: &cella_env::PostStartInjection) -> bool {
         .file_uploads
         .iter()
         .any(|upload| upload.container_path == cella_env::PROXY_CONFIG_PATH)
+}
+
+/// Build the two spec-standard identity labels used to uniquely identify a
+/// devcontainer in a multi-config workspace and to match containers created
+/// by VS Code / the official CLI.
+///
+/// Both values are LEXICAL absolute paths — identical to what `container_labels`
+/// stamps via the same `lexical_absolute` function, so the lookup and the stamp
+/// are guaranteed to produce byte-identical strings.
+fn spec_identity_labels(
+    workspace_root: &std::path::Path,
+    config_path: &std::path::Path,
+) -> [String; 2] {
+    [
+        format!(
+            "devcontainer.local_folder={}",
+            lexical_absolute(workspace_root).to_string_lossy()
+        ),
+        format!(
+            "devcontainer.config_file={}",
+            lexical_absolute(config_path).to_string_lossy()
+        ),
+    ]
 }
 
 /// Resolve `remoteEnv` to a `KEY=value` vec for lifecycle command injection.
@@ -2752,5 +2809,41 @@ mod tests {
         // Numeric strings ("9000") are accepted; out-of-range (70000) and
         // "host:port" forms ("db:5432") are dropped by the number-only path.
         assert_eq!(ports, vec![3000, 8080, 9000]);
+    }
+
+    // ── spec_identity_labels ──────────────────────────────────────
+
+    /// `spec_identity_labels` produces the exact label strings that
+    /// `container_labels` stamps — format must stay `key=value` with no
+    /// leading/trailing whitespace, matching the bollard filter wire format.
+    #[test]
+    fn spec_identity_labels_produces_correct_format() {
+        let workspace = std::path::Path::new("/tmp/my-project");
+        let config = std::path::Path::new("/tmp/my-project/.devcontainer/devcontainer.json");
+
+        let [lf, cf] = spec_identity_labels(workspace, config);
+
+        // Literal expected strings — if the format changes, the test breaks.
+        assert_eq!(lf, "devcontainer.local_folder=/tmp/my-project");
+        assert_eq!(
+            cf,
+            "devcontainer.config_file=/tmp/my-project/.devcontainer/devcontainer.json"
+        );
+    }
+
+    /// Paths with `..` segments are normalised lexically, not via the
+    /// filesystem, matching the official CLI's `path.resolve` semantics.
+    #[test]
+    fn spec_identity_labels_normalise_dot_dot() {
+        let workspace = std::path::Path::new("/tmp/a/../b");
+        let config = std::path::Path::new("/tmp/a/../b/.devcontainer/devcontainer.json");
+
+        let [lf, cf] = spec_identity_labels(workspace, config);
+
+        assert_eq!(lf, "devcontainer.local_folder=/tmp/b");
+        assert_eq!(
+            cf,
+            "devcontainer.config_file=/tmp/b/.devcontainer/devcontainer.json"
+        );
     }
 }


### PR DESCRIPTION
Completes the cross-tool container-reuse story (stacked on #176 → #164).

The official CLI and VS Code identify a dev container by the PAIR (`devcontainer.local_folder`, `devcontainer.config_file`). cella's single-container `up` reuse decision only looked up by its own `dev.cella.workspace_path` (plus #164's `local_folder`-alone fallback), so it could reuse the **wrong** container in a workspace with two devcontainer configs, and could miss a container another tool created.

## Change (additive, contained)
In the `up` reuse branch (no `--id-label`), try a precise spec-identity lookup **first**, then fall back to the existing workspace-path lookup:
- Uses the **existing** `find_container_by_labels(&[String])` (AND-matches all labels) — no new trait method, no `find_container` signature change, so the ~10 path-only `find_container` callers are untouched.
- A new `spec_identity_labels(workspace_root, config_path)` builds `[devcontainer.local_folder=<lexical>, devcontainer.config_file=<lexical>]` using **the same** `cella_backend::lexical_absolute` that #176 stamps with — so lookup and stamp are byte-identical (the consistency requirement; a unit test asserts it).
- Fallback to `find_container` (workspace-path → #164's local_folder) preserves reuse of pre-#176 / canonical-labelled containers.

Behavior: single-config workspaces are unchanged (same container matches either way); multi-config workspaces now reuse the correct container; cross-tool containers are reused.

## Tests
- `spec_identity_labels_match_container_labels_stamp` / `..._normalise_dot_dot` — unit-test the label strings match the stamp (shared helper) and lexical normalization.
- `find_container_by_spec_identity_labels` — a `#[runtime_test]` that creates a container with the spec labels and confirms `find_container_by_labels` finds it. **This ran against real Docker in CI/dev and passed** (it skips gracefully where Docker is absent).

Full workspace: 3979 passed, 0 failed.