### PR TITLE
docs(names): document intentional compose project-name divergence

### DIFF
--- a/crates/cella-backend/src/names.rs
+++ b/crates/cella-backend/src/names.rs
@@ -198,9 +198,9 @@ pub fn container_labels(
 /// stacks — cella's core feature. The official scheme would collide them onto
 /// one project. The trade-off is that cella and the official CLI/VS Code do
 /// NOT reuse each other's *compose* containers (compose reuse is keyed on the
-/// project name, not on the `devcontainer.local_folder`/`config_file` labels
-/// that the single-container path matches on). This is a deliberate product
-/// decision: worktree isolation over cross-tool compose reuse.
+/// project name, not on the `devcontainer.local_folder`/`devcontainer.config_file`
+/// labels that the single-container path matches on). This is a deliberate
+/// product decision: worktree isolation over cross-tool compose reuse.
 pub fn compose_project_name(workspace_root: &Path, config_name: Option<&str>) -> String {
     let identifier = identifier_from(workspace_root, config_name);
     let hash = workspace_hash(workspace_root);

--- a/crates/cella-backend/src/names.rs
+++ b/crates/cella-backend/src/names.rs
@@ -190,6 +190,17 @@ pub fn container_labels(
 }
 
 /// Generate compose project name: `cella-<name|folder>-<hash8>`.
+///
+/// INTENTIONAL divergence from the official CLI, which names the project
+/// `<workspaceFolderBasename>_devcontainer` (docker-compose's convention). The
+/// `<hash8>` is derived from the workspace path, so two git worktrees of the
+/// same repo get distinct project names and therefore isolated compose
+/// stacks — cella's core feature. The official scheme would collide them onto
+/// one project. The trade-off is that cella and the official CLI/VS Code do
+/// NOT reuse each other's *compose* containers (compose reuse is keyed on the
+/// project name, not on the `devcontainer.local_folder`/`config_file` labels
+/// that the single-container path matches on). This is a deliberate product
+/// decision: worktree isolation over cross-tool compose reuse.
 pub fn compose_project_name(workspace_root: &Path, config_name: Option<&str>) -> String {
     let identifier = identifier_from(workspace_root, config_name);
     let hash = workspace_hash(workspace_root);


### PR DESCRIPTION
Documents — per a deliberate product decision — why cella's compose project name (`cella-<id>-<hash>`) intentionally diverges from the official CLI's (`<folderBasename>_devcontainer`).

The `<hash>` is workspace-path-derived, so two git worktrees of the same repo get distinct compose projects (isolated stacks) — cella's core feature. The official's folder-based name would collide them onto one project. The trade-off: cella and VS Code / the official CLI don't reuse each other's *compose* containers, because compose reuse is keyed on the project name, not the `devcontainer.local_folder`/`config_file` labels that the single-container path now matches on (#177).

No behavior change — just a doc comment so this isn't mistaken for a bug and "fixed" into a worktree collision later.