### PR TITLE
fix(daemon): drop racy port-reclaim assertion in ssh-proxy rebridge test

### DIFF
--- a/crates/cella-daemon/src/management.rs
+++ b/crates/cella-daemon/src/management.rs
@@ -1095,7 +1095,13 @@ mod tests {
                 refcount,
                 action,
                 upstream_reachable,
-                port_changed,
+                // `port_changed` is best-effort, not asserted: reclaiming the
+                // exact preferred port on rebind is racy under parallel tests
+                // (a concurrent ephemeral bind can grab the just-freed port),
+                // and the implementation deliberately falls back to a random
+                // port when reclaim fails. The invariant that matters is that
+                // the rebridged port accepts connections, checked below.
+                ..
             } => {
                 assert_eq!(action, SshProxyRefreshAction::Rebridged);
                 assert_eq!(refcount, 1);
@@ -1103,10 +1109,6 @@ mod tests {
                     upstream_reachable,
                     Some(true),
                     "live upstream must probe reachable over RPC"
-                );
-                assert!(
-                    !port_changed,
-                    "loopback rebind should reclaim the same port"
                 );
                 let _client = tokio::net::TcpStream::connect(("127.0.0.1", bridge_port))
                     .await


### PR DESCRIPTION
The `ssh_agent_proxy_refresh_rebridges_stale_upstream_over_rpc` test asserts `!port_changed` — i.e. that rebridging always reclaims the same loopback port. That's not deterministic: under `cargo test`'s parallel execution a concurrent ephemeral bind can grab the just-freed port, and `bind_preferred_or_random` deliberately falls back to a random port when reclaim fails (the impl comment even says so). So the assertion flakes in CI.

Dropped the `port_changed` assertion; the meaningful invariant — the rebridged port accepts connections — is still checked right below.

Surfaced while merging the PR queue: this flake was failing Integration Test on unrelated PRs.