### PR TITLE
feat: templates metadata command

### DIFF
--- a/crates/cella-cli/src/commands/templates.rs
+++ b/crates/cella-cli/src/commands/templates.rs
@@ -179,14 +179,17 @@ impl TemplatesApplyArgs {
 impl TemplatesMetadataArgs {
     pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         match metadata::fetch_manifest_metadata(&self.template_id).await {
-            Ok(Some(raw)) => {
-                // Re-parse and re-serialize so the output is valid JSON (not
-                // the annotation's raw escaped string).
-                let parsed: Value = serde_json::from_str(&raw)
-                    .map_err(|e| format!("metadata annotation is not valid JSON: {e}"))?;
-                println!("{}", serde_json::to_string(&parsed).expect("serializable"));
-                Ok(())
-            }
+            Ok(Some(raw)) => match render_metadata_annotation(&raw) {
+                Ok(json) => {
+                    println!("{json}");
+                    Ok(())
+                }
+                Err(e) => {
+                    eprintln!("warning: metadata annotation is not valid JSON: {e}");
+                    println!("{{}}");
+                    std::process::exit(1);
+                }
+            },
             Ok(None) => {
                 eprintln!(
                     "Template resolved to '{}' but does not contain metadata on its manifest.",
@@ -205,6 +208,19 @@ impl TemplatesMetadataArgs {
             }
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Rendering helpers
+// ---------------------------------------------------------------------------
+
+/// Re-parse and re-serialize the raw metadata annotation string so the output
+/// is compact valid JSON rather than the annotation's escaped string value.
+///
+/// Returns `Err` when the annotation is not valid JSON.
+fn render_metadata_annotation(raw: &str) -> Result<String, serde_json::Error> {
+    let parsed: Value = serde_json::from_str(raw)?;
+    Ok(serde_json::to_string(&parsed).expect("re-serializing a Value is infallible"))
 }
 
 // ---------------------------------------------------------------------------
@@ -502,5 +518,36 @@ mod tests {
             template_id: "ghcr.io/devcontainers/templates/alpine".to_owned(),
         };
         assert_eq!(args.template_id, "ghcr.io/devcontainers/templates/alpine");
+    }
+
+    // -----------------------------------------------------------------------
+    // render_metadata_annotation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn render_valid_annotation_produces_compact_json() {
+        let raw = r#"{"id":"alpine","version":"1.0.0"}"#;
+        let result = render_metadata_annotation(raw).unwrap();
+        // Re-serialization should produce valid compact JSON.
+        let v: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(v["id"], Value::String("alpine".to_owned()));
+        assert_eq!(v["version"], Value::String("1.0.0".to_owned()));
+    }
+
+    #[test]
+    fn render_invalid_annotation_returns_err() {
+        let result = render_metadata_annotation("{not valid json}");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn render_annotation_with_whitespace_produces_compact_output() {
+        // Annotation may have extra whitespace or pretty-printing; output must be compact.
+        let raw = "{\n  \"id\": \"alpine\"\n}";
+        let result = render_metadata_annotation(raw).unwrap();
+        assert!(
+            !result.contains('\n'),
+            "output should be compact (no newlines)"
+        );
     }
 }

--- a/crates/cella-cli/src/commands/templates.rs
+++ b/crates/cella-cli/src/commands/templates.rs
@@ -41,7 +41,15 @@ pub enum TemplatesCommand {
 #[derive(Args)]
 pub struct TemplatesMetadataArgs {
     /// Template OCI reference (e.g. ghcr.io/devcontainers/templates/alpine).
-    pub template_id: String,
+    ///
+    /// Optional: the official CLI treats a missing/unresolvable ref as a
+    /// not-found result — it prints `{}` to stdout, warns, and exits 1 —
+    /// rather than erroring out with a clap usage message.
+    pub template_id: Option<String>,
+
+    /// Log verbosity level.
+    #[arg(long = "log-level", value_enum, default_value = "info")]
+    pub log_level: LogLevel,
 }
 
 /// Arguments for `cella templates apply`.
@@ -80,16 +88,19 @@ pub struct TemplatesApplyArgs {
 }
 
 impl TemplatesArgs {
-    /// Return the `--log-level` from the `apply` subcommand, if active.
+    /// Return the `--log-level` from whichever subcommand carries one (`apply`
+    /// or `metadata`), if active.
     ///
     /// Called by [`super::Command::log_level`] so the global tracing filter is
     /// seeded before dispatch — the same pattern used by `up` and
     /// `run-user-commands`.
     pub const fn apply_log_level(&self) -> Option<LogLevel> {
-        if let TemplatesCommand::Apply(args) = &self.command {
-            Some(args.log_level)
-        } else {
-            None
+        match &self.command {
+            TemplatesCommand::Apply(args) => Some(args.log_level),
+            TemplatesCommand::Metadata(args) => Some(args.log_level),
+            TemplatesCommand::New { .. }
+            | TemplatesCommand::List
+            | TemplatesCommand::Edit { .. } => None,
         }
     }
 
@@ -178,7 +189,15 @@ impl TemplatesApplyArgs {
 
 impl TemplatesMetadataArgs {
     pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        match metadata::fetch_manifest_metadata(&self.template_id).await {
+        // Official behavior: a missing or unresolvable ref is treated as a
+        // not-found result — print `{}` to stdout, warn on stderr, exit 1.
+        let Some(template_id) = self.template_id else {
+            eprintln!("error: no template identifier provided");
+            println!("{{}}");
+            std::process::exit(1);
+        };
+
+        match metadata::fetch_manifest_metadata(&template_id).await {
             Ok(Some(raw)) => match render_metadata_annotation(&raw) {
                 Ok(json) => {
                     println!("{json}");
@@ -192,8 +211,7 @@ impl TemplatesMetadataArgs {
             },
             Ok(None) => {
                 eprintln!(
-                    "Template resolved to '{}' but does not contain metadata on its manifest.",
-                    self.template_id
+                    "Template resolved to '{template_id}' but does not contain metadata on its manifest."
                 );
                 eprintln!(
                     "Ask the Template owner to republish this Template to populate the manifest."
@@ -512,12 +530,80 @@ mod tests {
     // TemplatesMetadataArgs
     // -----------------------------------------------------------------------
 
+    /// Wrapper so we can drive clap parsing of the metadata subcommand in unit
+    /// tests without reaching into the binary's top-level `Cli`.
+    #[derive(clap::Parser)]
+    struct MetadataHarness {
+        #[command(subcommand)]
+        command: TemplatesCommand,
+    }
+
+    fn parse_metadata(argv: &[&str]) -> Result<TemplatesMetadataArgs, clap::Error> {
+        let mut full = vec!["templates", "metadata"];
+        full.extend_from_slice(argv);
+        let parsed = <MetadataHarness as clap::Parser>::try_parse_from(full)?;
+        match parsed.command {
+            TemplatesCommand::Metadata(args) => Ok(args),
+            _ => unreachable!("parsed the metadata subcommand"),
+        }
+    }
+
     #[test]
     fn metadata_args_captures_template_id() {
-        let args = TemplatesMetadataArgs {
-            template_id: "ghcr.io/devcontainers/templates/alpine".to_owned(),
+        let args = parse_metadata(&["ghcr.io/devcontainers/templates/alpine"]).unwrap();
+        assert_eq!(
+            args.template_id.as_deref(),
+            Some("ghcr.io/devcontainers/templates/alpine")
+        );
+    }
+
+    #[test]
+    fn metadata_template_id_is_optional() {
+        // Regression: a missing template id must NOT make clap exit with a usage
+        // error. It parses to `None`, and the command then prints `{}`/exits 1
+        // at runtime (matching the official "unresolvable ref" contract).
+        let args = parse_metadata(&[]).unwrap();
+        assert!(args.template_id.is_none());
+    }
+
+    #[test]
+    fn metadata_accepts_log_level_flag() {
+        // Regression: the metadata subcommand must accept `--log-level`,
+        // matching the official CLI's registered flag surface.
+        for level in ["info", "debug", "trace"] {
+            let args = parse_metadata(&[
+                "ghcr.io/devcontainers/templates/alpine",
+                "--log-level",
+                level,
+            ])
+            .unwrap_or_else(|e| panic!("--log-level {level} should parse: {e}"));
+            assert!(args.template_id.is_some());
+        }
+    }
+
+    #[test]
+    fn metadata_log_level_defaults_to_info() {
+        let args = parse_metadata(&["ghcr.io/devcontainers/templates/alpine"]).unwrap();
+        assert!(matches!(args.log_level, LogLevel::Info));
+    }
+
+    #[test]
+    fn metadata_log_level_wired_through_apply_log_level() {
+        let parsed = <MetadataHarness as clap::Parser>::try_parse_from([
+            "templates",
+            "metadata",
+            "ghcr.io/devcontainers/templates/alpine",
+            "--log-level",
+            "debug",
+        ])
+        .unwrap();
+        let templates_args = TemplatesArgs {
+            command: parsed.command,
         };
-        assert_eq!(args.template_id, "ghcr.io/devcontainers/templates/alpine");
+        assert!(matches!(
+            templates_args.apply_log_level(),
+            Some(LogLevel::Debug)
+        ));
     }
 
     // -----------------------------------------------------------------------

--- a/crates/cella-cli/src/commands/templates.rs
+++ b/crates/cella-cli/src/commands/templates.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use clap::{Args, Subcommand};
 use serde_json::Value;
 
-use cella_templates::{SelectedFeature, TemplateError, apply, fetcher, options};
+use cella_templates::{SelectedFeature, TemplateError, apply, fetcher, metadata, options};
 
 use super::LogLevel;
 
@@ -19,6 +19,8 @@ pub struct TemplatesArgs {
 pub enum TemplatesCommand {
     /// Apply a template to a workspace folder.
     Apply(TemplatesApplyArgs),
+    /// Fetch a published template's metadata from its OCI manifest.
+    Metadata(TemplatesMetadataArgs),
     /// Create a new template.
     New {
         /// Name for the template.
@@ -31,6 +33,15 @@ pub enum TemplatesCommand {
         /// Name of the template to edit.
         name: String,
     },
+}
+
+/// Arguments for `cella templates metadata`.
+///
+/// Flag surface matches `devcontainer templates metadata` exactly.
+#[derive(Args)]
+pub struct TemplatesMetadataArgs {
+    /// Template OCI reference (e.g. ghcr.io/devcontainers/templates/alpine).
+    pub template_id: String,
 }
 
 /// Arguments for `cella templates apply`.
@@ -85,6 +96,7 @@ impl TemplatesArgs {
     pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         match self.command {
             TemplatesCommand::Apply(args) => args.execute().await,
+            TemplatesCommand::Metadata(args) => args.execute().await,
             TemplatesCommand::New { .. }
             | TemplatesCommand::List
             | TemplatesCommand::Edit { .. } => {
@@ -161,6 +173,37 @@ impl TemplatesApplyArgs {
         println!("{}", serde_json::to_string(&output).expect("serializable"));
 
         Ok(())
+    }
+}
+
+impl TemplatesMetadataArgs {
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        match metadata::fetch_manifest_metadata(&self.template_id).await {
+            Ok(Some(raw)) => {
+                // Re-parse and re-serialize so the output is valid JSON (not
+                // the annotation's raw escaped string).
+                let parsed: Value = serde_json::from_str(&raw)
+                    .map_err(|e| format!("metadata annotation is not valid JSON: {e}"))?;
+                println!("{}", serde_json::to_string(&parsed).expect("serializable"));
+                Ok(())
+            }
+            Ok(None) => {
+                eprintln!(
+                    "Template resolved to '{}' but does not contain metadata on its manifest.",
+                    self.template_id
+                );
+                eprintln!(
+                    "Ask the Template owner to republish this Template to populate the manifest."
+                );
+                println!("{{}}");
+                std::process::exit(1);
+            }
+            Err(e) => {
+                eprintln!("error: {e}");
+                println!("{{}}");
+                std::process::exit(1);
+            }
+        }
     }
 }
 
@@ -447,5 +490,17 @@ mod tests {
         };
         let result = args.execute().await;
         assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // TemplatesMetadataArgs
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn metadata_args_captures_template_id() {
+        let args = TemplatesMetadataArgs {
+            template_id: "ghcr.io/devcontainers/templates/alpine".to_owned(),
+        };
+        assert_eq!(args.template_id, "ghcr.io/devcontainers/templates/alpine");
     }
 }

--- a/crates/cella-cli/src/main.rs
+++ b/crates/cella-cli/src/main.rs
@@ -1000,6 +1000,29 @@ mod tests {
     }
 
     #[test]
+    fn templates_metadata_log_level_wired() {
+        use super::commands::LogLevel;
+        let cli = parse(&[
+            "cella",
+            "templates",
+            "metadata",
+            "ghcr.io/devcontainers/templates/rust",
+            "--log-level",
+            "trace",
+        ])
+        .unwrap();
+        assert!(matches!(cli.command.log_level(), Some(LogLevel::Trace)));
+    }
+
+    #[test]
+    fn templates_metadata_template_id_optional() {
+        // Regression: a missing template id must parse (clap must not exit 2);
+        // the runtime path then prints `{}`/exits 1 per the official contract.
+        let cli = parse(&["cella", "templates", "metadata"]).unwrap();
+        assert!(cli.command.log_level().is_some());
+    }
+
+    #[test]
     fn templates_apply_default_log_level_is_info() {
         use super::commands::LogLevel;
         let cli = parse(&[

--- a/crates/cella-templates/src/fetcher.rs
+++ b/crates/cella-templates/src/fetcher.rs
@@ -5,14 +5,14 @@
 
 use std::path::PathBuf;
 
-use oci_distribution::Reference;
-use oci_distribution::client::{ClientConfig, ClientProtocol};
 use sha2::{Digest, Sha256};
 use tracing::debug;
 
 use crate::TemplateMetadata;
 use crate::cache::TemplateCache;
 use crate::error::TemplateError;
+use crate::oci_ref::build_oci_client;
+use crate::oci_ref::parse_template_ref;
 
 /// Fetch a template artifact from an OCI registry and return the local
 /// path where it was extracted.
@@ -36,13 +36,7 @@ pub async fn fetch_template(
         return Ok(cached);
     }
 
-    let config = ClientConfig {
-        protocol: ClientProtocol::Https,
-        ..ClientConfig::default()
-    };
-    let client = oci_distribution::Client::new(config);
-    let oci_ref = Reference::with_tag(registry.clone(), repository.clone(), tag.clone());
-    let auth = cella_oci::build_registry_auth(&registry);
+    let (client, oci_ref, auth) = build_oci_client(&registry, &repository, &tag);
 
     debug!("fetching template {registry}/{repository}:{tag}");
 
@@ -131,24 +125,6 @@ pub fn read_template_metadata(
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Parse a template reference into `(registry, repository, tag)`.
-fn parse_template_ref(template_ref: &str) -> Result<(String, String, String), TemplateError> {
-    let (base, tag) = match template_ref.rsplit_once(':') {
-        Some((b, t)) if !t.contains('/') && !t.is_empty() => (b, t.to_owned()),
-        _ => (template_ref, "latest".to_owned()),
-    };
-
-    let (registry, repository) =
-        base.split_once('/')
-            .ok_or_else(|| TemplateError::RegistryError {
-                registry: template_ref.to_owned(),
-                message: "invalid template reference: expected registry/repository[:tag]"
-                    .to_owned(),
-            })?;
-
-    Ok((registry.to_owned(), repository.to_owned(), tag))
-}
-
 fn find_extractable_layer<'a>(
     manifest: &'a oci_distribution::manifest::OciImageManifest,
     template_ref: &str,
@@ -178,28 +154,6 @@ fn find_extractable_layer<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn parse_full_ref() {
-        let (reg, repo, tag) =
-            parse_template_ref("ghcr.io/devcontainers/templates/rust:5.0.0").unwrap();
-        assert_eq!(reg, "ghcr.io");
-        assert_eq!(repo, "devcontainers/templates/rust");
-        assert_eq!(tag, "5.0.0");
-    }
-
-    #[test]
-    fn parse_ref_no_tag() {
-        let (reg, repo, tag) = parse_template_ref("ghcr.io/devcontainers/templates/rust").unwrap();
-        assert_eq!(reg, "ghcr.io");
-        assert_eq!(repo, "devcontainers/templates/rust");
-        assert_eq!(tag, "latest");
-    }
-
-    #[test]
-    fn parse_ref_invalid() {
-        assert!(parse_template_ref("noslash").is_err());
-    }
 
     #[test]
     fn extractable_layer_detection() {

--- a/crates/cella-templates/src/fetcher.rs
+++ b/crates/cella-templates/src/fetcher.rs
@@ -28,24 +28,27 @@ pub async fn fetch_template(
     template_ref: &str,
     cache: &TemplateCache,
 ) -> Result<PathBuf, TemplateError> {
-    let (registry, repository, tag) = parse_template_ref(template_ref)?;
+    let parsed = parse_template_ref(template_ref)?;
+    let registry = parsed.registry.clone();
+    let repository = parsed.repository.clone();
+    let version = parsed.version.as_str().to_owned();
 
     // Check cache first
-    if let Some(cached) = cache.get_template(&registry, &repository, &tag) {
+    if let Some(cached) = cache.get_template(&registry, &repository, &version) {
         debug!("template cache hit for {template_ref}");
         return Ok(cached);
     }
 
-    let (client, oci_ref, auth) = build_oci_client(&registry, &repository, &tag);
+    let (client, oci_ref, auth) = build_oci_client(&parsed);
 
-    debug!("fetching template {registry}/{repository}:{tag}");
+    debug!("fetching template {registry}/{repository}@{version}");
 
     let (manifest, digest) = client
         .pull_image_manifest(&oci_ref, &auth)
         .await
         .map_err(|e| TemplateError::RegistryError {
             registry: registry.clone(),
-            message: format!("failed to pull manifest for {repository}:{tag}: {e}"),
+            message: format!("failed to pull manifest for {repository}:{version}: {e}"),
         })?;
 
     // Check cache by digest

--- a/crates/cella-templates/src/lib.rs
+++ b/crates/cella-templates/src/lib.rs
@@ -14,6 +14,8 @@ pub mod collection;
 pub mod error;
 pub mod fetcher;
 pub mod index;
+pub mod metadata;
+mod oci_ref;
 pub mod options;
 pub mod tags;
 pub mod types;

--- a/crates/cella-templates/src/metadata.rs
+++ b/crates/cella-templates/src/metadata.rs
@@ -4,14 +4,11 @@
 //! `dev.containers.metadata` annotation, which contains the template's JSON
 //! metadata as a string-escaped JSON value.
 
-use oci_distribution::Reference;
-use oci_distribution::client::{ClientConfig, ClientProtocol};
 use oci_distribution::manifest::OciManifest;
 use tracing::debug;
 
-use cella_oci::build_registry_auth;
-
 use crate::error::TemplateError;
+use crate::oci_ref::{build_oci_client, parse_template_ref};
 
 /// Annotation key used by the devcontainer CLI to embed template metadata.
 const METADATA_ANNOTATION: &str = "dev.containers.metadata";
@@ -33,13 +30,7 @@ const METADATA_ANNOTATION: &str = "dev.containers.metadata";
 pub async fn fetch_manifest_metadata(template_ref: &str) -> Result<Option<String>, TemplateError> {
     let (registry, repository, tag) = parse_template_ref(template_ref)?;
 
-    let config = ClientConfig {
-        protocol: ClientProtocol::Https,
-        ..ClientConfig::default()
-    };
-    let client = oci_distribution::Client::new(config);
-    let oci_ref = Reference::with_tag(registry.clone(), repository.clone(), tag.clone());
-    let auth = build_registry_auth(&registry);
+    let (client, oci_ref, auth) = build_oci_client(&registry, &repository, &tag);
 
     debug!("fetching manifest for template {registry}/{repository}:{tag}");
 
@@ -85,30 +76,6 @@ fn extract_metadata_annotation(manifest: &OciManifest) -> Option<String> {
                 .cloned()
         }
     }
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/// Parse a template reference into `(registry, repository, tag)`.
-///
-/// Defaults to `latest` when no tag is present.
-fn parse_template_ref(template_ref: &str) -> Result<(String, String, String), TemplateError> {
-    let (base, tag) = match template_ref.rsplit_once(':') {
-        Some((b, t)) if !t.contains('/') && !t.is_empty() => (b, t.to_owned()),
-        _ => (template_ref, "latest".to_owned()),
-    };
-
-    let (registry, repository) =
-        base.split_once('/')
-            .ok_or_else(|| TemplateError::RegistryError {
-                registry: template_ref.to_owned(),
-                message: "invalid template reference: expected registry/repository[:tag]"
-                    .to_owned(),
-            })?;
-
-    Ok((registry.to_owned(), repository.to_owned(), tag))
 }
 
 // ===========================================================================
@@ -223,32 +190,5 @@ mod tests {
     fn image_index_no_annotation_returns_none() {
         let manifest = image_index(None, None);
         assert!(extract_metadata_annotation(&manifest).is_none());
-    }
-
-    // -----------------------------------------------------------------------
-    // parse_template_ref
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn parse_ref_with_tag() {
-        let (reg, repo, tag) =
-            parse_template_ref("ghcr.io/devcontainers/templates/alpine:1.2.3").unwrap();
-        assert_eq!(reg, "ghcr.io");
-        assert_eq!(repo, "devcontainers/templates/alpine");
-        assert_eq!(tag, "1.2.3");
-    }
-
-    #[test]
-    fn parse_ref_without_tag_defaults_to_latest() {
-        let (reg, repo, tag) =
-            parse_template_ref("ghcr.io/devcontainers/templates/alpine").unwrap();
-        assert_eq!(reg, "ghcr.io");
-        assert_eq!(repo, "devcontainers/templates/alpine");
-        assert_eq!(tag, "latest");
-    }
-
-    #[test]
-    fn parse_ref_no_slash_returns_error() {
-        assert!(parse_template_ref("noslash").is_err());
     }
 }

--- a/crates/cella-templates/src/metadata.rs
+++ b/crates/cella-templates/src/metadata.rs
@@ -1,0 +1,254 @@
+//! OCI manifest metadata fetcher for devcontainer templates.
+//!
+//! Fetches the OCI image manifest for a template reference and extracts the
+//! `dev.containers.metadata` annotation, which contains the template's JSON
+//! metadata as a string-escaped JSON value.
+
+use oci_distribution::Reference;
+use oci_distribution::client::{ClientConfig, ClientProtocol};
+use oci_distribution::manifest::OciManifest;
+use tracing::debug;
+
+use cella_oci::build_registry_auth;
+
+use crate::error::TemplateError;
+
+/// Annotation key used by the devcontainer CLI to embed template metadata.
+const METADATA_ANNOTATION: &str = "dev.containers.metadata";
+
+/// Fetch the `dev.containers.metadata` annotation from the OCI manifest for
+/// the given template reference.
+///
+/// The template reference should be in the form `registry/repository[:tag]`
+/// (e.g. `ghcr.io/devcontainers/templates/alpine`).
+///
+/// Returns:
+/// - `Ok(Some(value))` — annotation found; the raw JSON string value.
+/// - `Ok(None)` — manifest was fetched successfully but the annotation is absent.
+/// - `Err(_)` — network or registry error.
+///
+/// # Errors
+///
+/// Returns [`TemplateError`] for registry communication failures or invalid refs.
+pub async fn fetch_manifest_metadata(template_ref: &str) -> Result<Option<String>, TemplateError> {
+    let (registry, repository, tag) = parse_template_ref(template_ref)?;
+
+    let config = ClientConfig {
+        protocol: ClientProtocol::Https,
+        ..ClientConfig::default()
+    };
+    let client = oci_distribution::Client::new(config);
+    let oci_ref = Reference::with_tag(registry.clone(), repository.clone(), tag.clone());
+    let auth = build_registry_auth(&registry);
+
+    debug!("fetching manifest for template {registry}/{repository}:{tag}");
+
+    let (manifest, _digest) =
+        client
+            .pull_manifest(&oci_ref, &auth)
+            .await
+            .map_err(|e| TemplateError::RegistryError {
+                registry: registry.clone(),
+                message: format!("failed to pull manifest for {repository}:{tag}: {e}"),
+            })?;
+
+    Ok(extract_metadata_annotation(&manifest))
+}
+
+/// Extract the `dev.containers.metadata` annotation from an OCI manifest.
+///
+/// For an [`OciManifest::Image`], reads `manifest.annotations`.
+/// For an [`OciManifest::ImageIndex`], reads `index.annotations` first; if
+/// absent, falls back to the first index entry's `annotations`.
+fn extract_metadata_annotation(manifest: &OciManifest) -> Option<String> {
+    match manifest {
+        OciManifest::Image(img) => img
+            .annotations
+            .as_ref()
+            .and_then(|a| a.get(METADATA_ANNOTATION))
+            .cloned(),
+        OciManifest::ImageIndex(idx) => {
+            // Check the index-level annotations first.
+            let from_index = idx
+                .annotations
+                .as_ref()
+                .and_then(|a| a.get(METADATA_ANNOTATION))
+                .cloned();
+            if from_index.is_some() {
+                return from_index;
+            }
+            // Fall back to the first manifest entry's annotations.
+            idx.manifests
+                .first()
+                .and_then(|entry| entry.annotations.as_ref())
+                .and_then(|a| a.get(METADATA_ANNOTATION))
+                .cloned()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Parse a template reference into `(registry, repository, tag)`.
+///
+/// Defaults to `latest` when no tag is present.
+fn parse_template_ref(template_ref: &str) -> Result<(String, String, String), TemplateError> {
+    let (base, tag) = match template_ref.rsplit_once(':') {
+        Some((b, t)) if !t.contains('/') && !t.is_empty() => (b, t.to_owned()),
+        _ => (template_ref, "latest".to_owned()),
+    };
+
+    let (registry, repository) =
+        base.split_once('/')
+            .ok_or_else(|| TemplateError::RegistryError {
+                registry: template_ref.to_owned(),
+                message: "invalid template reference: expected registry/repository[:tag]"
+                    .to_owned(),
+            })?;
+
+    Ok((registry.to_owned(), repository.to_owned(), tag))
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use oci_distribution::manifest::{OciImageManifest, OciManifest};
+
+    use super::*;
+
+    /// Build an image manifest JSON string with optional annotations and
+    /// deserialize it into [`OciManifest`].
+    fn image_manifest(annotation_value: Option<&str>) -> OciManifest {
+        let annotations_json = annotation_value.map_or_else(
+            || "{}".to_owned(),
+            |v| {
+                let escaped = v.replace('"', "\\\"");
+                format!(r#"{{"dev.containers.metadata": "{escaped}"}}"#)
+            },
+        );
+        let json = format!(
+            r#"{{
+                "schemaVersion": 2,
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "config": {{"mediaType": "application/vnd.devcontainers", "digest": "sha256:abc", "size": 0}},
+                "layers": [],
+                "annotations": {annotations_json}
+            }}"#
+        );
+        let m: OciImageManifest = serde_json::from_str(&json).unwrap();
+        OciManifest::Image(m)
+    }
+
+    /// Build an image index JSON string and deserialize it into [`OciManifest`].
+    fn image_index(index_annotation: Option<&str>, entry_annotation: Option<&str>) -> OciManifest {
+        let index_ann_json = index_annotation.map_or_else(
+            || "null".to_owned(),
+            |v| {
+                let escaped = v.replace('"', "\\\"");
+                format!(r#"{{"dev.containers.metadata": "{escaped}"}}"#)
+            },
+        );
+        let entry_ann_json = entry_annotation.map_or_else(
+            || "null".to_owned(),
+            |v| {
+                let escaped = v.replace('"', "\\\"");
+                format!(r#"{{"dev.containers.metadata": "{escaped}"}}"#)
+            },
+        );
+        let json = format!(
+            r#"{{
+                "schemaVersion": 2,
+                "manifests": [
+                    {{
+                        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                        "digest": "sha256:abc",
+                        "size": 0,
+                        "annotations": {entry_ann_json}
+                    }}
+                ],
+                "annotations": {index_ann_json}
+            }}"#
+        );
+        serde_json::from_str(&json).unwrap()
+    }
+
+    // -----------------------------------------------------------------------
+    // extract_metadata_annotation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn image_manifest_returns_annotation() {
+        let manifest = image_manifest(Some(r#"{"id":"alpine","version":"1.0.0"}"#));
+        let result = extract_metadata_annotation(&manifest);
+        assert_eq!(
+            result.as_deref(),
+            Some(r#"{"id":"alpine","version":"1.0.0"}"#)
+        );
+    }
+
+    #[test]
+    fn image_manifest_without_annotation_returns_none() {
+        let manifest = image_manifest(None);
+        assert!(extract_metadata_annotation(&manifest).is_none());
+    }
+
+    #[test]
+    fn image_index_reads_index_level_annotation() {
+        let manifest = image_index(
+            Some(r#"{"id":"from-index"}"#),
+            Some(r#"{"id":"from-entry"}"#),
+        );
+        // Index-level annotation takes precedence.
+        assert_eq!(
+            extract_metadata_annotation(&manifest).as_deref(),
+            Some(r#"{"id":"from-index"}"#)
+        );
+    }
+
+    #[test]
+    fn image_index_falls_back_to_first_entry_annotation() {
+        let manifest = image_index(None, Some(r#"{"id":"from-entry"}"#));
+        assert_eq!(
+            extract_metadata_annotation(&manifest).as_deref(),
+            Some(r#"{"id":"from-entry"}"#)
+        );
+    }
+
+    #[test]
+    fn image_index_no_annotation_returns_none() {
+        let manifest = image_index(None, None);
+        assert!(extract_metadata_annotation(&manifest).is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // parse_template_ref
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_ref_with_tag() {
+        let (reg, repo, tag) =
+            parse_template_ref("ghcr.io/devcontainers/templates/alpine:1.2.3").unwrap();
+        assert_eq!(reg, "ghcr.io");
+        assert_eq!(repo, "devcontainers/templates/alpine");
+        assert_eq!(tag, "1.2.3");
+    }
+
+    #[test]
+    fn parse_ref_without_tag_defaults_to_latest() {
+        let (reg, repo, tag) =
+            parse_template_ref("ghcr.io/devcontainers/templates/alpine").unwrap();
+        assert_eq!(reg, "ghcr.io");
+        assert_eq!(repo, "devcontainers/templates/alpine");
+        assert_eq!(tag, "latest");
+    }
+
+    #[test]
+    fn parse_ref_no_slash_returns_error() {
+        assert!(parse_template_ref("noslash").is_err());
+    }
+}

--- a/crates/cella-templates/src/metadata.rs
+++ b/crates/cella-templates/src/metadata.rs
@@ -16,8 +16,10 @@ const METADATA_ANNOTATION: &str = "dev.containers.metadata";
 /// Fetch the `dev.containers.metadata` annotation from the OCI manifest for
 /// the given template reference.
 ///
-/// The template reference should be in the form `registry/repository[:tag]`
-/// (e.g. `ghcr.io/devcontainers/templates/alpine`).
+/// The template reference may be in the form `registry/repository[:tag]`
+/// (e.g. `ghcr.io/devcontainers/templates/alpine`) or pinned by digest
+/// (e.g. `ghcr.io/devcontainers/templates/alpine@sha256:<hex>`). A digest-pinned
+/// ref fetches the exact manifest by digest rather than by tag.
 ///
 /// Returns:
 /// - `Ok(Some(value))` — annotation found; the raw JSON string value.
@@ -28,11 +30,14 @@ const METADATA_ANNOTATION: &str = "dev.containers.metadata";
 ///
 /// Returns [`TemplateError`] for registry communication failures or invalid refs.
 pub async fn fetch_manifest_metadata(template_ref: &str) -> Result<Option<String>, TemplateError> {
-    let (registry, repository, tag) = parse_template_ref(template_ref)?;
+    let parsed = parse_template_ref(template_ref)?;
+    let registry = parsed.registry.clone();
+    let repository = parsed.repository.clone();
+    let version = parsed.version.as_str().to_owned();
 
-    let (client, oci_ref, auth) = build_oci_client(&registry, &repository, &tag);
+    let (client, oci_ref, auth) = build_oci_client(&parsed);
 
-    debug!("fetching manifest for template {registry}/{repository}:{tag}");
+    debug!("fetching manifest for template {registry}/{repository}@{version}");
 
     let (manifest, _digest) =
         client
@@ -40,7 +45,7 @@ pub async fn fetch_manifest_metadata(template_ref: &str) -> Result<Option<String
             .await
             .map_err(|e| TemplateError::RegistryError {
                 registry: registry.clone(),
-                message: format!("failed to pull manifest for {repository}:{tag}: {e}"),
+                message: format!("failed to pull manifest for {repository}:{version}: {e}"),
             })?;
 
     Ok(extract_metadata_annotation(&manifest))

--- a/crates/cella-templates/src/oci_ref.rs
+++ b/crates/cella-templates/src/oci_ref.rs
@@ -1,0 +1,92 @@
+//! Shared OCI reference parsing and client construction for template fetchers.
+
+use oci_distribution::Reference;
+use oci_distribution::client::{ClientConfig, ClientProtocol};
+
+use cella_oci::build_registry_auth;
+
+use crate::error::TemplateError;
+
+/// Parse a template reference into `(registry, repository, tag)`.
+///
+/// Defaults to `latest` when no tag is present.
+pub fn parse_template_ref(template_ref: &str) -> Result<(String, String, String), TemplateError> {
+    let (base, tag) = match template_ref.rsplit_once(':') {
+        Some((b, t)) if !t.contains('/') && !t.is_empty() => (b, t.to_owned()),
+        _ => (template_ref, "latest".to_owned()),
+    };
+
+    let (registry, repository) =
+        base.split_once('/')
+            .ok_or_else(|| TemplateError::RegistryError {
+                registry: template_ref.to_owned(),
+                message: "invalid template reference: expected registry/repository[:tag]"
+                    .to_owned(),
+            })?;
+
+    Ok((registry.to_owned(), repository.to_owned(), tag))
+}
+
+/// Build an OCI [`oci_distribution::Client`] and [`oci_distribution::Reference`]
+/// for the given `(registry, repository, tag)` triple.
+///
+/// Returns `(client, reference, auth)` ready for manifest or blob pulls.
+pub fn build_oci_client(
+    registry: &str,
+    repository: &str,
+    tag: &str,
+) -> (
+    oci_distribution::Client,
+    Reference,
+    oci_distribution::secrets::RegistryAuth,
+) {
+    let config = ClientConfig {
+        protocol: ClientProtocol::Https,
+        ..ClientConfig::default()
+    };
+    let client = oci_distribution::Client::new(config);
+    let oci_ref = Reference::with_tag(registry.to_owned(), repository.to_owned(), tag.to_owned());
+    let auth = build_registry_auth(registry);
+    (client, oci_ref, auth)
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_full_ref() {
+        let (reg, repo, tag) =
+            parse_template_ref("ghcr.io/devcontainers/templates/rust:5.0.0").unwrap();
+        assert_eq!(reg, "ghcr.io");
+        assert_eq!(repo, "devcontainers/templates/rust");
+        assert_eq!(tag, "5.0.0");
+    }
+
+    #[test]
+    fn parse_ref_no_tag_defaults_to_latest() {
+        let (reg, repo, tag) = parse_template_ref("ghcr.io/devcontainers/templates/rust").unwrap();
+        assert_eq!(reg, "ghcr.io");
+        assert_eq!(repo, "devcontainers/templates/rust");
+        assert_eq!(tag, "latest");
+    }
+
+    #[test]
+    fn parse_ref_invalid_returns_error() {
+        assert!(parse_template_ref("noslash").is_err());
+    }
+
+    #[test]
+    fn parse_ref_tag_with_slash_treated_as_no_tag() {
+        // A "tag" containing a slash is not a tag — treat as tagless (latest).
+        let (reg, repo, tag) =
+            parse_template_ref("ghcr.io/devcontainers/templates/rust:repo/path").unwrap();
+        assert_eq!(reg, "ghcr.io");
+        assert_eq!(repo, "devcontainers/templates/rust:repo/path");
+        assert_eq!(tag, "latest");
+    }
+}

--- a/crates/cella-templates/src/oci_ref.rs
+++ b/crates/cella-templates/src/oci_ref.rs
@@ -7,34 +7,100 @@ use cella_oci::build_registry_auth;
 
 use crate::error::TemplateError;
 
-/// Parse a template reference into `(registry, repository, tag)`.
+/// The pinned version of a template reference: a mutable tag or an immutable
+/// content digest.
 ///
-/// Defaults to `latest` when no tag is present.
-pub fn parse_template_ref(template_ref: &str) -> Result<(String, String, String), TemplateError> {
-    let (base, tag) = match template_ref.rsplit_once(':') {
-        Some((b, t)) if !t.contains('/') && !t.is_empty() => (b, t.to_owned()),
-        _ => (template_ref, "latest".to_owned()),
+/// Mirrors the official CLI's `getRef`, which resolves a ref to either a tag
+/// or a `sha256:` digest and pulls the manifest by whichever is most specific.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RefVersion {
+    /// A mutable tag, e.g. `latest` or `5.0.0`.
+    Tag(String),
+    /// A content-addressable digest, e.g. `sha256:abc123…`.
+    Digest(String),
+}
+
+impl RefVersion {
+    /// The version string used both as a cache key and as the manifest
+    /// reference in the registry URL (tag value or full `sha256:…` digest).
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Tag(t) | Self::Digest(t) => t,
+        }
+    }
+}
+
+/// A parsed template reference: registry, repository, and pinned version.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TemplateRef {
+    /// Registry host, e.g. `ghcr.io`.
+    pub registry: String,
+    /// Repository path, e.g. `devcontainers/templates/rust`.
+    pub repository: String,
+    /// Pinned tag or digest.
+    pub version: RefVersion,
+}
+
+/// Parse a template reference into its registry, repository, and version.
+///
+/// Resolution order mirrors the official CLI's `getRef`:
+/// - A `@sha256:<hex>` suffix is parsed as a digest (everything before `@` is
+///   the resource).
+/// - Otherwise a trailing `:tag` (where the last `:` is after the last `/`, so
+///   it isn't a registry port) is parsed as a tag.
+/// - With neither, the version defaults to the `latest` tag.
+///
+/// # Errors
+///
+/// Returns [`TemplateError::RegistryError`] when the reference has no
+/// `registry/repository` separator, or when a digest is malformed (wrong
+/// `algorithm:hex` shape or an unsupported algorithm).
+pub fn parse_template_ref(template_ref: &str) -> Result<TemplateRef, TemplateError> {
+    let invalid = |message: &str| TemplateError::RegistryError {
+        registry: template_ref.to_owned(),
+        message: message.to_owned(),
     };
 
-    let (registry, repository) =
-        base.split_once('/')
-            .ok_or_else(|| TemplateError::RegistryError {
-                registry: template_ref.to_owned(),
-                message: "invalid template reference: expected registry/repository[:tag]"
-                    .to_owned(),
-            })?;
+    let (base, version) = if let Some((resource, digest)) = template_ref.rsplit_once('@') {
+        // Digest-pinned ref, e.g. ghcr.io/devcontainers/templates/rust@sha256:<hex>.
+        let (algorithm, hex) = digest
+            .split_once(':')
+            .ok_or_else(|| invalid("invalid digest: expected format 'sha256:<hex>'"))?;
+        if algorithm != "sha256" {
+            return Err(invalid("unsupported digest algorithm: expected 'sha256'"));
+        }
+        if hex.is_empty() {
+            return Err(invalid("invalid digest: empty hash"));
+        }
+        (resource, RefVersion::Digest(digest.to_owned()))
+    } else {
+        match template_ref.rsplit_once(':') {
+            // A real tag: the `:` is after the last `/`, so it isn't a port.
+            Some((b, t)) if !t.contains('/') && !t.is_empty() => (b, RefVersion::Tag(t.to_owned())),
+            _ => (template_ref, RefVersion::Tag("latest".to_owned())),
+        }
+    };
 
-    Ok((registry.to_owned(), repository.to_owned(), tag))
+    let (registry, repository) = base
+        .split_once('/')
+        .ok_or_else(|| invalid("invalid template reference: expected registry/repository[:tag]"))?;
+
+    Ok(TemplateRef {
+        registry: registry.to_owned(),
+        repository: repository.to_owned(),
+        version,
+    })
 }
 
 /// Build an OCI [`oci_distribution::Client`] and [`oci_distribution::Reference`]
-/// for the given `(registry, repository, tag)` triple.
+/// for the given parsed [`TemplateRef`].
+///
+/// The reference is constructed by digest when the version is pinned, otherwise
+/// by tag — so a digest-pinned ref pulls the exact manifest rather than a tag.
 ///
 /// Returns `(client, reference, auth)` ready for manifest or blob pulls.
 pub fn build_oci_client(
-    registry: &str,
-    repository: &str,
-    tag: &str,
+    parsed: &TemplateRef,
 ) -> (
     oci_distribution::Client,
     Reference,
@@ -45,8 +111,13 @@ pub fn build_oci_client(
         ..ClientConfig::default()
     };
     let client = oci_distribution::Client::new(config);
-    let oci_ref = Reference::with_tag(registry.to_owned(), repository.to_owned(), tag.to_owned());
-    let auth = build_registry_auth(registry);
+    let registry = parsed.registry.clone();
+    let repository = parsed.repository.clone();
+    let oci_ref = match &parsed.version {
+        RefVersion::Tag(tag) => Reference::with_tag(registry, repository, tag.clone()),
+        RefVersion::Digest(digest) => Reference::with_digest(registry, repository, digest.clone()),
+    };
+    let auth = build_registry_auth(&parsed.registry);
     (client, oci_ref, auth)
 }
 
@@ -60,19 +131,18 @@ mod tests {
 
     #[test]
     fn parse_full_ref() {
-        let (reg, repo, tag) =
-            parse_template_ref("ghcr.io/devcontainers/templates/rust:5.0.0").unwrap();
-        assert_eq!(reg, "ghcr.io");
-        assert_eq!(repo, "devcontainers/templates/rust");
-        assert_eq!(tag, "5.0.0");
+        let parsed = parse_template_ref("ghcr.io/devcontainers/templates/rust:5.0.0").unwrap();
+        assert_eq!(parsed.registry, "ghcr.io");
+        assert_eq!(parsed.repository, "devcontainers/templates/rust");
+        assert_eq!(parsed.version, RefVersion::Tag("5.0.0".to_owned()));
     }
 
     #[test]
     fn parse_ref_no_tag_defaults_to_latest() {
-        let (reg, repo, tag) = parse_template_ref("ghcr.io/devcontainers/templates/rust").unwrap();
-        assert_eq!(reg, "ghcr.io");
-        assert_eq!(repo, "devcontainers/templates/rust");
-        assert_eq!(tag, "latest");
+        let parsed = parse_template_ref("ghcr.io/devcontainers/templates/rust").unwrap();
+        assert_eq!(parsed.registry, "ghcr.io");
+        assert_eq!(parsed.repository, "devcontainers/templates/rust");
+        assert_eq!(parsed.version, RefVersion::Tag("latest".to_owned()));
     }
 
     #[test]
@@ -83,10 +153,61 @@ mod tests {
     #[test]
     fn parse_ref_tag_with_slash_treated_as_no_tag() {
         // A "tag" containing a slash is not a tag — treat as tagless (latest).
-        let (reg, repo, tag) =
-            parse_template_ref("ghcr.io/devcontainers/templates/rust:repo/path").unwrap();
-        assert_eq!(reg, "ghcr.io");
-        assert_eq!(repo, "devcontainers/templates/rust:repo/path");
-        assert_eq!(tag, "latest");
+        let parsed = parse_template_ref("ghcr.io/devcontainers/templates/rust:repo/path").unwrap();
+        assert_eq!(parsed.registry, "ghcr.io");
+        assert_eq!(parsed.repository, "devcontainers/templates/rust:repo/path");
+        assert_eq!(parsed.version, RefVersion::Tag("latest".to_owned()));
+    }
+
+    #[test]
+    fn parse_digest_ref() {
+        // Regression: a digest-pinned ref must not mis-parse `@sha256` into the
+        // repository with the hex treated as a tag. The whole `sha256:<hex>`
+        // becomes the version, and the manifest is later fetched by digest.
+        let hex = "a".repeat(64);
+        let input = format!("ghcr.io/devcontainers/templates/rust@sha256:{hex}");
+        let parsed = parse_template_ref(&input).unwrap();
+        assert_eq!(parsed.registry, "ghcr.io");
+        assert_eq!(parsed.repository, "devcontainers/templates/rust");
+        assert_eq!(parsed.version, RefVersion::Digest(format!("sha256:{hex}")));
+    }
+
+    #[test]
+    fn parse_digest_ref_builds_reference_by_digest() {
+        let hex = "b".repeat(64);
+        let input = format!("ghcr.io/devcontainers/templates/rust@sha256:{hex}");
+        let parsed = parse_template_ref(&input).unwrap();
+        let (_, oci_ref, _) = build_oci_client(&parsed);
+        assert_eq!(oci_ref.digest(), Some(format!("sha256:{hex}").as_str()));
+        assert_eq!(oci_ref.tag(), None);
+    }
+
+    #[test]
+    fn parse_tag_ref_builds_reference_by_tag() {
+        let parsed = parse_template_ref("ghcr.io/devcontainers/templates/rust:5.0.0").unwrap();
+        let (_, oci_ref, _) = build_oci_client(&parsed);
+        assert_eq!(oci_ref.tag(), Some("5.0.0"));
+        assert_eq!(oci_ref.digest(), None);
+    }
+
+    #[test]
+    fn parse_digest_ref_rejects_non_sha256() {
+        let input = "ghcr.io/devcontainers/templates/rust@sha512:abcdef";
+        assert!(parse_template_ref(input).is_err());
+    }
+
+    #[test]
+    fn parse_digest_ref_rejects_malformed_digest() {
+        let input = "ghcr.io/devcontainers/templates/rust@notadigest";
+        assert!(parse_template_ref(input).is_err());
+    }
+
+    #[test]
+    fn version_as_str_returns_tag_or_digest() {
+        assert_eq!(RefVersion::Tag("latest".to_owned()).as_str(), "latest");
+        assert_eq!(
+            RefVersion::Digest("sha256:abc".to_owned()).as_str(),
+            "sha256:abc"
+        );
     }
 }


### PR DESCRIPTION
Implements `cella templates metadata` as a drop-in for `devcontainer templates metadata`: fetches the OCI manifest annotation and prints the template metadata JSON.

Supersedes #136, which GitHub auto-closed when its base branch (`feat/templates-apply`, #130) was deleted on merge. Same branch, rebased onto main, with all review findings addressed:
- missing/unresolvable ref prints `{}` to stdout, warns on stderr, exits 1 (matches official) instead of a clap usage error
- digest-pinned refs (`...@sha256:<hex>`) are parsed and fetched by digest, matching upstream `getRef`
- `--log-level info|debug|trace` wired through `TemplatesArgs::apply_log_level`
- `parse_template_ref` / OCI client construction deduped into `oci_ref.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)