### PR TITLE
feat: features resolve-dependencies command

### DIFF
--- a/crates/cella-cli/src/commands/features/info.rs
+++ b/crates/cella-cli/src/commands/features/info.rs
@@ -158,8 +158,8 @@ impl InfoArgs {
                 // implementation. We match that behaviour for parity.
             }
             OutputFormat::Text => {
-                let edges = build_dependency_graph(&self.feature).await?;
-                let diagram = render_mermaid(&self.feature, &edges);
+                let graph = build_dependency_graph(&[self.feature.as_str()]).await?;
+                let diagram = render_mermaid(&[self.feature.as_str()], &graph.edges);
                 println!("{diagram}");
             }
         }
@@ -215,10 +215,10 @@ impl InfoArgs {
                 }
                 // Dependencies section — failure is non-fatal, symmetric with
                 // the manifest and tags sections above.
-                match build_dependency_graph(&self.feature).await {
-                    Ok(edges) => {
+                match build_dependency_graph(&[self.feature.as_str()]).await {
+                    Ok(graph) => {
                         println!("=== Dependency Graph ===");
-                        println!("{}", render_mermaid(&self.feature, &edges));
+                        println!("{}", render_mermaid(&[self.feature.as_str()], &graph.edges));
                     }
                     Err(e) => {
                         eprintln!("Failed to build dependency graph: {e}");

--- a/crates/cella-cli/src/commands/features/mod.rs
+++ b/crates/cella-cli/src/commands/features/mod.rs
@@ -41,14 +41,16 @@ pub enum FeaturesCommand {
 }
 
 impl FeaturesArgs {
-    /// Return the `--log-level` from the `info` subcommand, if active.
+    /// Return the active subcommand's `--log-level`, if it carries one.
     ///
+    /// `info`, `package`, and `resolve-dependencies` expose `--log-level`.
     /// Read by [`super::Command::log_level`] so the global tracing filter is
     /// seeded before dispatch — the same pattern used by `up` and templates.
     pub const fn log_level(&self) -> Option<LogLevel> {
         match &self.command {
             FeaturesCommand::Info(args) => Some(args.log_level),
             FeaturesCommand::Package(args) => Some(args.log_level),
+            FeaturesCommand::ResolveDependencies(args) => Some(args.log_level),
             _ => None,
         }
     }

--- a/crates/cella-cli/src/commands/features/mod.rs
+++ b/crates/cella-cli/src/commands/features/mod.rs
@@ -8,6 +8,7 @@ pub mod list;
 pub mod package;
 pub mod prompts;
 pub mod resolve;
+pub mod resolve_dependencies;
 pub mod update;
 
 use clap::{Args, Subcommand};
@@ -33,6 +34,8 @@ pub enum FeaturesCommand {
     List(list::ListArgs),
     /// Package local feature sources into distributable tarballs.
     Package(package::PackageArgs),
+    /// Resolve feature dependencies and print the installation order.
+    ResolveDependencies(resolve_dependencies::ResolveDependenciesArgs),
     /// Check for and apply feature version updates.
     Update(update::UpdateArgs),
 }
@@ -59,6 +62,7 @@ impl FeaturesArgs {
             FeaturesCommand::Info(args) => args.execute().await,
             FeaturesCommand::List(args) => args.execute().await,
             FeaturesCommand::Package(args) => args.execute(),
+            FeaturesCommand::ResolveDependencies(args) => args.execute().await,
             FeaturesCommand::Update(args) => args.execute().await,
         }
     }

--- a/crates/cella-cli/src/commands/features/resolve_dependencies.rs
+++ b/crates/cella-cli/src/commands/features/resolve_dependencies.rs
@@ -2,6 +2,12 @@
 //! installation order for a devcontainer configuration.
 //!
 //! Drop-in replacement for `devcontainer features resolveDependencies`.
+//!
+//! The official CLI (`featuresResolveDependenciesOptions`) exposes only
+//! `--workspace-folder` and `--log-level`; there is no `--config` flag.
+//! Config discovery is auto-detection from the workspace folder, matching the
+//! official behaviour exactly.
+//!
 //! Contract:
 //!   cella features resolve-dependencies [--workspace-folder <path>] [--log-level <level>]
 //!
@@ -10,6 +16,10 @@
 //!   2. JSON object: `{"installOrder": [{"id": "...", "options": ...}, ...]}`
 //!
 //! Logs go to stderr. Exit 1 on config-not-found, parse failure, or cycle.
+//!
+//! Cycle handling: the official CLI returns `undefined` from
+//! `computeDependsOnInstallationOrder` and calls `process.exit(1)` — no JSON
+//! output, bold error to stderr. We match that exactly.
 
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -18,7 +28,9 @@ use clap::{Parser, ValueEnum};
 use serde::Serialize;
 
 use super::resolve::{CommonFeatureFlags, discover_config, extract_features, read_raw_config};
-use cella_features::graph::{DepEdge, build_dependency_graph, render_mermaid};
+use cella_features::graph::{
+    DepEdge, DependencyGraph, EdgeKind, build_dependency_graph, render_mermaid,
+};
 use cella_features::ordering::compute_install_order;
 use cella_features::{FeatureMetadata, FeatureWarning};
 
@@ -28,6 +40,10 @@ use cella_features::{FeatureMetadata, FeatureWarning};
 
 /// Resolve and print the installation order for features in a devcontainer
 /// configuration.
+///
+/// The official `devcontainer features resolveDependencies` command only
+/// exposes `--workspace-folder` and `--log-level`. There is no `--config` flag
+/// for this subcommand; config discovery is automatic from the workspace folder.
 #[derive(Debug, Clone, Parser)]
 pub struct ResolveDependenciesArgs {
     /// Workspace folder (defaults to current directory).
@@ -81,6 +97,7 @@ impl ResolveDependenciesArgs {
     /// is detected that prevents an install order from being computed.
     pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let flags = CommonFeatureFlags {
+            // No --config flag for this subcommand (matches official CLI).
             file: None,
             workspace_folder: self.workspace_folder,
             registry: None,
@@ -105,21 +122,44 @@ impl ResolveDependenciesArgs {
 
         let override_order = parse_override_order(&config);
 
-        // Mermaid diagram: attempt OCI fetch for each declared feature root.
-        let mermaid = build_mermaid_for_features(&feature_pairs).await;
-        println!("{mermaid}");
+        // Single OCI fetch pass feeds both Mermaid output AND install-order
+        // metadata. Falls back gracefully on fetch errors (warn + declared
+        // features only, no transitive deps).
+        let root_refs: Vec<&str> = feature_pairs
+            .iter()
+            .map(|(r, _)| r.as_str())
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
 
-        let (ordered_ids, warnings) =
-            compute_order_from_config(&feature_pairs, override_order.as_deref());
+        let graph_result = build_dependency_graph(&root_refs).await;
 
-        for w in &warnings {
-            if let FeatureWarning::CyclicDependency { features } = w {
-                eprintln!(
-                    "warning: cyclic dependency detected among features: {}",
-                    features.join(", ")
-                );
+        let (mermaid, ordered_ids) = match graph_result {
+            Ok(graph) => {
+                let mermaid = build_mermaid_from_graph(&feature_pairs, &graph);
+                let order_result =
+                    compute_order_with_metadata(&feature_pairs, &graph, override_order.as_deref());
+                match order_result {
+                    Ok(ids) => (mermaid, ids),
+                    Err(cycle_msg) => {
+                        // Print the Mermaid diagram first (we have it), then
+                        // exit non-zero without JSON output — matches official.
+                        println!("{mermaid}");
+                        eprintln!("\u{001b}[1mNo viable installation order!\u{001b}[22m");
+                        eprintln!("{cycle_msg}");
+                        std::process::exit(1);
+                    }
+                }
             }
-        }
+            Err(e) => {
+                eprintln!("warning: OCI fetch failed, falling back to declared order: {e}");
+                let mermaid = build_mermaid_declared_only(&feature_pairs);
+                let ids = compute_order_declared_only(&feature_pairs, override_order.as_deref())?;
+                (mermaid, ids)
+            }
+        };
+
+        println!("{mermaid}");
 
         let install_order = build_install_order_entries(&ordered_ids, &feature_pairs);
         println!(
@@ -132,63 +172,117 @@ impl ResolveDependenciesArgs {
 }
 
 // ---------------------------------------------------------------------------
-// Pure helpers
+// Graph → Mermaid helpers
 // ---------------------------------------------------------------------------
 
-/// Parse `overrideFeatureInstallOrder` from the raw config JSON.
-fn parse_override_order(config: &serde_json::Value) -> Option<Vec<String>> {
-    let arr = config
-        .get("overrideFeatureInstallOrder")
-        .and_then(|v| v.as_array())?;
-    let ids: Vec<String> = arr
-        .iter()
-        .filter_map(|v| v.as_str().map(ToOwned::to_owned))
-        .collect();
-    if ids.is_empty() { None } else { Some(ids) }
+/// Build the Mermaid diagram from a successfully fetched `DependencyGraph`.
+///
+/// Deduplicates edges and renders all declared roots as starting points,
+/// matching the official CLI's `generateMermaidDiagram` which iterates over
+/// all `user-provided` (root) nodes.
+fn build_mermaid_from_graph(
+    feature_pairs: &[(String, serde_json::Value)],
+    graph: &DependencyGraph,
+) -> String {
+    let roots: Vec<&str> = feature_pairs.iter().map(|(r, _)| r.as_str()).collect();
+
+    // Deduplicate by (from, to, kind-discriminant).
+    let deduped = dedup_edges(&graph.edges);
+    render_mermaid(&roots, &deduped)
 }
 
-/// Build a Mermaid diagram covering all declared feature roots.
+/// Build a fallback Mermaid diagram when OCI fetch failed.
 ///
-/// Attempts OCI metadata fetch for each root feature. Edges from all roots are
-/// merged and deduplicated. Falls back to an edge-free diagram on fetch errors.
-async fn build_mermaid_for_features(feature_pairs: &[(String, serde_json::Value)]) -> String {
-    let mut all_edges: Vec<DepEdge> = Vec::new();
-    let mut seen_roots: HashSet<&str> = HashSet::new();
+/// Renders all declared roots as isolated nodes (no edge data available).
+fn build_mermaid_declared_only(feature_pairs: &[(String, serde_json::Value)]) -> String {
+    let roots: Vec<&str> = feature_pairs.iter().map(|(r, _)| r.as_str()).collect();
+    render_mermaid(&roots, &[])
+}
 
-    for (feature_ref, _) in feature_pairs {
-        if !seen_roots.insert(feature_ref.as_str()) {
-            continue;
+/// Deduplicate graph edges by `(from, to, kind)`.
+fn dedup_edges(edges: &[DepEdge]) -> Vec<DepEdge> {
+    let mut seen: HashSet<(String, String, u8)> = HashSet::new();
+    let mut result: Vec<DepEdge> = Vec::new();
+    for edge in edges {
+        let (from, to, kind) = edge;
+        let kind_tag = u8::from(matches!(kind, EdgeKind::InstallsAfter));
+        if seen.insert((from.clone(), to.clone(), kind_tag)) {
+            result.push(edge.clone());
         }
-        match build_dependency_graph(feature_ref).await {
-            Ok(edges) => all_edges.extend(edges),
-            Err(e) => {
-                eprintln!("warning: could not build dependency graph for {feature_ref}: {e}");
-            }
+    }
+    result
+}
+
+// ---------------------------------------------------------------------------
+// Install-order computation
+// ---------------------------------------------------------------------------
+
+/// Compute install order using real OCI-fetched metadata.
+///
+/// Expands the feature set with transitive `dependsOn` nodes, then runs the
+/// topological sort with real `installs_after` data.
+///
+/// Returns `Err(message)` when a cycle is detected — caller must treat this as
+/// fatal (exit non-zero, no JSON).
+fn compute_order_with_metadata(
+    feature_pairs: &[(String, serde_json::Value)],
+    graph: &DependencyGraph,
+    override_order: Option<&[String]>,
+) -> Result<Vec<String>, String> {
+    // Build the expanded feature set: declared roots + all transitive deps.
+    // Preserve declaration order for roots, append transitives at the end.
+    let declared_ids: Vec<&str> = feature_pairs.iter().map(|(r, _)| r.as_str()).collect();
+    let mut all_ids: Vec<String> = declared_ids.iter().map(|s| (*s).to_owned()).collect();
+
+    for fetched_id in graph.metadata.keys() {
+        if !declared_ids.contains(&fetched_id.as_str()) {
+            all_ids.push(fetched_id.clone());
         }
     }
 
-    // Deduplicate by (from, to, kind-discriminant).
-    let mut seen_edges: HashSet<(String, String, u8)> = HashSet::new();
-    all_edges.retain(|(from, to, kind)| {
-        let kind_tag = u8::from(matches!(
-            kind,
-            cella_features::graph::EdgeKind::InstallsAfter
-        ));
-        seen_edges.insert((from.clone(), to.clone(), kind_tag))
-    });
+    // Build (id, metadata) pairs using fetched data where available.
+    let metas: Vec<(String, FeatureMetadata)> = all_ids
+        .iter()
+        .map(|id| {
+            let meta = graph
+                .metadata
+                .get(id)
+                .cloned()
+                .unwrap_or_else(|| FeatureMetadata {
+                    id: id.clone(),
+                    ..Default::default()
+                });
+            (id.clone(), meta)
+        })
+        .collect();
 
-    let root = &feature_pairs[0].0;
-    render_mermaid(root, &all_edges)
+    let order_input: Vec<(String, &FeatureMetadata)> =
+        metas.iter().map(|(id, m)| (id.clone(), m)).collect();
+
+    let (ordered_ids, warnings) = compute_install_order(&order_input, override_order);
+
+    for w in &warnings {
+        if let FeatureWarning::CyclicDependency { features } = w {
+            return Err(format!(
+                "cyclic dependency detected among features: {}",
+                features.join(", ")
+            ));
+        }
+    }
+
+    Ok(ordered_ids)
 }
 
-/// Compute install order from config-level feature declarations.
+/// Compute install order from declared features only (OCI fetch fallback).
 ///
-/// Uses stub `FeatureMetadata` (no OCI fetch) — `installs_after` is not
-/// populated, so ordering is driven by declaration order and override list.
-fn compute_order_from_config(
+/// Uses stub metadata (no `installs_after` data), so ordering is declaration
+/// order + override list only.
+///
+/// Returns `Err(message)` on cycle (fatal).
+fn compute_order_declared_only(
     feature_pairs: &[(String, serde_json::Value)],
     override_order: Option<&[String]>,
-) -> (Vec<String>, Vec<FeatureWarning>) {
+) -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
     let metas: Vec<(String, FeatureMetadata)> = feature_pairs
         .iter()
         .map(|(id, _)| {
@@ -205,7 +299,35 @@ fn compute_order_from_config(
     let order_input: Vec<(String, &FeatureMetadata)> =
         metas.iter().map(|(id, m)| (id.clone(), m)).collect();
 
-    compute_install_order(&order_input, override_order)
+    let (ordered_ids, warnings) = compute_install_order(&order_input, override_order);
+
+    for w in &warnings {
+        if let FeatureWarning::CyclicDependency { features } = w {
+            return Err(format!(
+                "cyclic dependency detected among features: {}",
+                features.join(", ")
+            )
+            .into());
+        }
+    }
+
+    Ok(ordered_ids)
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+/// Parse `overrideFeatureInstallOrder` from the raw config JSON.
+fn parse_override_order(config: &serde_json::Value) -> Option<Vec<String>> {
+    let arr = config
+        .get("overrideFeatureInstallOrder")
+        .and_then(|v| v.as_array())?;
+    let ids: Vec<String> = arr
+        .iter()
+        .filter_map(|v| v.as_str().map(ToOwned::to_owned))
+        .collect();
+    if ids.is_empty() { None } else { Some(ids) }
 }
 
 /// Build the `installOrder` entries from ordered IDs and their options.
@@ -234,7 +356,10 @@ fn build_install_order_entries(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
+    use cella_features::FeatureMetadata;
 
     // -----------------------------------------------------------------------
     // parse_override_order
@@ -267,7 +392,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // compute_order_from_config
+    // compute_order_declared_only
     // -----------------------------------------------------------------------
 
     #[test]
@@ -278,9 +403,8 @@ mod tests {
             ("ghcr.io/x/features/c:1".to_owned(), serde_json::json!({})),
         ];
 
-        let (order, warnings) = compute_order_from_config(&pairs, None);
+        let order = compute_order_declared_only(&pairs, None).unwrap();
 
-        assert!(warnings.is_empty());
         assert_eq!(
             order,
             vec![
@@ -303,9 +427,8 @@ mod tests {
             "ghcr.io/x/features/a:1".to_owned(),
         ];
 
-        let (order, warnings) = compute_order_from_config(&pairs, Some(&overrides));
+        let order = compute_order_declared_only(&pairs, Some(&overrides)).unwrap();
 
-        assert!(warnings.is_empty());
         assert_eq!(order[0], "ghcr.io/x/features/c:1");
         assert_eq!(order[1], "ghcr.io/x/features/a:1");
         assert_eq!(order[2], "ghcr.io/x/features/b:1");
@@ -314,9 +437,121 @@ mod tests {
     #[test]
     fn order_empty_features() {
         let pairs: Vec<(String, serde_json::Value)> = vec![];
-        let (order, warnings) = compute_order_from_config(&pairs, None);
+        let order = compute_order_declared_only(&pairs, None).unwrap();
         assert!(order.is_empty());
-        assert!(warnings.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // cycle detection is fatal
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn cycle_in_declared_only_is_fatal() {
+        // installs_after cycles aren't possible with stub metadata (no
+        // installs_after set), but test the error path directly via
+        // compute_order_with_metadata using synthetic metadata with a cycle.
+        let pairs = vec![
+            ("feat-a".to_owned(), serde_json::json!({})),
+            ("feat-b".to_owned(), serde_json::json!({})),
+        ];
+
+        // Build a graph with synthetic cyclic metadata.
+        let mut meta_map = HashMap::new();
+        meta_map.insert(
+            "feat-a".to_owned(),
+            FeatureMetadata {
+                id: "feat-a".to_owned(),
+                installs_after: vec!["feat-b".to_owned()],
+                ..Default::default()
+            },
+        );
+        meta_map.insert(
+            "feat-b".to_owned(),
+            FeatureMetadata {
+                id: "feat-b".to_owned(),
+                installs_after: vec!["feat-a".to_owned()],
+                ..Default::default()
+            },
+        );
+
+        let graph = DependencyGraph {
+            edges: vec![],
+            metadata: meta_map,
+        };
+
+        let result = compute_order_with_metadata(&pairs, &graph, None);
+        assert!(
+            result.is_err(),
+            "cycle must be a fatal error, not a warning+fallback"
+        );
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("cyclic"),
+            "error message should mention cycle: {msg}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // transitive deps appear in installOrder
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn transitive_dep_appears_in_install_order() {
+        // Scenario: config declares only `node`. `node` dependsOn `common-utils`.
+        // After OCI fetch, `common-utils` must appear in installOrder.
+        let pairs = vec![(
+            "ghcr.io/x/features/node:1".to_owned(),
+            serde_json::json!({"version": "lts"}),
+        )];
+
+        let mut meta_map = HashMap::new();
+        // node's metadata lists common-utils as a hard dep via installs_after
+        // (the ordering algorithm uses installs_after; dependsOn is recorded
+        // as a graph edge but the ordering crate uses installs_after for topo sort).
+        meta_map.insert(
+            "ghcr.io/x/features/node:1".to_owned(),
+            FeatureMetadata {
+                id: "ghcr.io/x/features/node:1".to_owned(),
+                installs_after: vec!["ghcr.io/x/features/common-utils:2".to_owned()],
+                ..Default::default()
+            },
+        );
+        meta_map.insert(
+            "ghcr.io/x/features/common-utils:2".to_owned(),
+            FeatureMetadata {
+                id: "ghcr.io/x/features/common-utils:2".to_owned(),
+                ..Default::default()
+            },
+        );
+
+        let graph = DependencyGraph {
+            edges: vec![(
+                "ghcr.io/x/features/node:1".to_owned(),
+                "ghcr.io/x/features/common-utils:2".to_owned(),
+                EdgeKind::DependsOn,
+            )],
+            metadata: meta_map,
+        };
+
+        let order = compute_order_with_metadata(&pairs, &graph, None).unwrap();
+
+        assert!(
+            order.contains(&"ghcr.io/x/features/common-utils:2".to_owned()),
+            "transitive dep common-utils must appear in installOrder; got: {order:?}"
+        );
+        // common-utils must come before node (it's a prerequisite).
+        let pos_common = order
+            .iter()
+            .position(|x| x == "ghcr.io/x/features/common-utils:2")
+            .unwrap();
+        let pos_node = order
+            .iter()
+            .position(|x| x == "ghcr.io/x/features/node:1")
+            .unwrap();
+        assert!(
+            pos_common < pos_node,
+            "common-utils must be installed before node; order: {order:?}"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -400,5 +635,20 @@ mod tests {
             serde_json::from_str(&serde_json::to_string(&out).unwrap()).unwrap();
         let arr = json["installOrder"].as_array().unwrap();
         assert!(arr.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // dedup_edges
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn dedup_edges_removes_duplicates() {
+        let edges = vec![
+            ("a".to_owned(), "b".to_owned(), EdgeKind::DependsOn),
+            ("a".to_owned(), "b".to_owned(), EdgeKind::DependsOn),
+            ("a".to_owned(), "c".to_owned(), EdgeKind::InstallsAfter),
+        ];
+        let deduped = dedup_edges(&edges);
+        assert_eq!(deduped.len(), 2);
     }
 }

--- a/crates/cella-cli/src/commands/features/resolve_dependencies.rs
+++ b/crates/cella-cli/src/commands/features/resolve_dependencies.rs
@@ -21,13 +21,14 @@
 //! `computeDependsOnInstallationOrder` and calls `process.exit(1)` — no JSON
 //! output, bold error to stderr. We match that exactly.
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::path::PathBuf;
 
-use clap::{Parser, ValueEnum};
+use clap::Parser;
 use serde::Serialize;
 
 use super::resolve::{CommonFeatureFlags, discover_config, extract_features, read_raw_config};
+use crate::commands::LogLevel;
 use cella_features::graph::{
     DepEdge, DependencyGraph, EdgeKind, build_dependency_graph, render_mermaid,
 };
@@ -49,23 +50,13 @@ pub struct ResolveDependenciesArgs {
     /// Workspace folder (defaults to current directory).
     ///
     /// Equivalent to `--workspace-folder` in the official devcontainer CLI.
-    #[arg(long, short = 'w')]
+    /// The official surface exposes the long flag only — no short alias.
+    #[arg(long)]
     pub workspace_folder: Option<PathBuf>,
 
     /// Log verbosity (default `error` matches the official CLI).
     #[arg(long, default_value = "error")]
-    pub log_level: ResolveDepsLogLevel,
-}
-
-/// Log level for the resolve-dependencies command.
-///
-/// Default is `error` to match the official CLI.
-#[derive(Debug, Clone, Copy, ValueEnum)]
-pub enum ResolveDepsLogLevel {
-    Error,
-    Info,
-    Debug,
-    Trace,
+    pub log_level: LogLevel,
 }
 
 // ---------------------------------------------------------------------------
@@ -110,7 +101,8 @@ impl ResolveDependenciesArgs {
         let feature_pairs = extract_features(&config);
 
         if feature_pairs.is_empty() {
-            println!("flowchart TD");
+            // Bare `flowchart` keyword (no direction) matches the official CLI.
+            println!("flowchart");
             println!(
                 "{}",
                 serde_json::to_string_pretty(&InstallOrderOutput {
@@ -125,22 +117,21 @@ impl ResolveDependenciesArgs {
         // Single OCI fetch pass feeds both Mermaid output AND install-order
         // metadata. Falls back gracefully on fetch errors (warn + declared
         // features only, no transitive deps).
-        let root_refs: Vec<&str> = feature_pairs
-            .iter()
-            .map(|(r, _)| r.as_str())
-            .collect::<HashSet<_>>()
-            .into_iter()
-            .collect();
+        //
+        // Dedup while preserving first-seen declaration order — fetch and
+        // traversal order must be deterministic so the resulting installOrder
+        // is stable across runs.
+        let root_refs = dedup_preserving_order(&feature_pairs);
 
         let graph_result = build_dependency_graph(&root_refs).await;
 
-        let (mermaid, ordered_ids) = match graph_result {
+        let (mermaid, ordered_ids, transitive_options) = match graph_result {
             Ok(graph) => {
                 let mermaid = build_mermaid_from_graph(&feature_pairs, &graph);
                 let order_result =
                     compute_order_with_metadata(&feature_pairs, &graph, override_order.as_deref());
                 match order_result {
-                    Ok(ids) => (mermaid, ids),
+                    Ok(ids) => (mermaid, ids, collect_transitive_options(&graph)),
                     Err(cycle_msg) => {
                         // Print the Mermaid diagram first (we have it), then
                         // exit non-zero without JSON output — matches official.
@@ -155,13 +146,15 @@ impl ResolveDependenciesArgs {
                 eprintln!("warning: OCI fetch failed, falling back to declared order: {e}");
                 let mermaid = build_mermaid_declared_only(&feature_pairs);
                 let ids = compute_order_declared_only(&feature_pairs, override_order.as_deref())?;
-                (mermaid, ids)
+                // No graph → no transitive deps, so no transitive options.
+                (mermaid, ids, BTreeMap::new())
             }
         };
 
         println!("{mermaid}");
 
-        let install_order = build_install_order_entries(&ordered_ids, &feature_pairs);
+        let install_order =
+            build_install_order_entries(&ordered_ids, &feature_pairs, &transitive_options);
         println!(
             "{}",
             serde_json::to_string_pretty(&InstallOrderOutput { install_order })?
@@ -234,10 +227,17 @@ fn compute_order_with_metadata(
     let declared_ids: Vec<&str> = feature_pairs.iter().map(|(r, _)| r.as_str()).collect();
     let mut all_ids: Vec<String> = declared_ids.iter().map(|s| (*s).to_owned()).collect();
 
-    for fetched_id in graph.metadata.keys() {
-        if !declared_ids.contains(&fetched_id.as_str()) {
-            all_ids.push(fetched_id.clone());
-        }
+    // `graph.metadata` is a `HashMap`, so iteration order is random. Sort the
+    // transitive IDs before appending so the expanded set — and thus the final
+    // installOrder — is deterministic across runs.
+    let mut transitive_ids: Vec<&String> = graph
+        .metadata
+        .keys()
+        .filter(|id| !declared_ids.contains(&id.as_str()))
+        .collect();
+    transitive_ids.sort_unstable();
+    for fetched_id in transitive_ids {
+        all_ids.push(fetched_id.clone());
     }
 
     // Build (id, metadata) pairs using fetched data where available.
@@ -330,10 +330,59 @@ fn parse_override_order(config: &serde_json::Value) -> Option<Vec<String>> {
     if ids.is_empty() { None } else { Some(ids) }
 }
 
+/// Deduplicate the declared feature references, preserving first-seen order.
+///
+/// A devcontainer config may list the same feature twice; the official CLI
+/// processes each unique reference once. Keeping declaration order makes the
+/// fetch/traversal pass — and therefore the final `installOrder` — deterministic.
+fn dedup_preserving_order(feature_pairs: &[(String, serde_json::Value)]) -> Vec<&str> {
+    let mut seen: HashSet<&str> = HashSet::new();
+    let mut result: Vec<&str> = Vec::new();
+    for (reference, _) in feature_pairs {
+        if seen.insert(reference.as_str()) {
+            result.push(reference.as_str());
+        }
+    }
+    result
+}
+
+/// Collect option values for transitively-pulled-in dependencies.
+///
+/// A feature's `dependsOn` map stores, per dependency reference, the option
+/// values to install that dependency with (e.g.
+/// `dependsOn: {".../common-utils:2": {"installZsh": true}}`). For features
+/// the user never declared directly, those values are the only options we have
+/// — so a transitive dep emits its real options instead of defaulting to `true`.
+///
+/// Earlier entries win (first parent to declare the dep), keeping the result
+/// deterministic; iteration is over a `BTreeMap`-keyed metadata view.
+fn collect_transitive_options(graph: &DependencyGraph) -> BTreeMap<String, serde_json::Value> {
+    let mut options: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+    // Iterate parents in a stable order so "first parent wins" is reproducible.
+    let mut parent_ids: Vec<&String> = graph.metadata.keys().collect();
+    parent_ids.sort_unstable();
+    for parent_id in parent_ids {
+        if let Some(meta) = graph.metadata.get(parent_id) {
+            for (dep_id, dep_options) in &meta.depends_on {
+                options
+                    .entry(dep_id.clone())
+                    .or_insert_with(|| dep_options.clone());
+            }
+        }
+    }
+    options
+}
+
 /// Build the `installOrder` entries from ordered IDs and their options.
+///
+/// Option resolution precedence:
+/// 1. Explicit options from the user's `features` declaration (`feature_pairs`).
+/// 2. Options carried by a parent's `dependsOn` value (`transitive_options`).
+/// 3. `true` (the spec default) when neither is present.
 fn build_install_order_entries(
     ordered_ids: &[String],
     feature_pairs: &[(String, serde_json::Value)],
+    transitive_options: &BTreeMap<String, serde_json::Value>,
 ) -> Vec<InstallOrderEntry> {
     ordered_ids
         .iter()
@@ -341,7 +390,9 @@ fn build_install_order_entries(
             let options = feature_pairs
                 .iter()
                 .find(|(ref_id, _)| ref_id == id)
-                .map_or(serde_json::Value::Bool(true), |(_, opts)| opts.clone());
+                .map(|(_, opts)| opts.clone())
+                .or_else(|| transitive_options.get(id).cloned())
+                .unwrap_or(serde_json::Value::Bool(true));
             InstallOrderEntry {
                 id: id.clone(),
                 options,
@@ -447,9 +498,10 @@ mod tests {
 
     #[test]
     fn cycle_in_declared_only_is_fatal() {
-        // installs_after cycles aren't possible with stub metadata (no
-        // installs_after set), but test the error path directly via
-        // compute_order_with_metadata using synthetic metadata with a cycle.
+        // A cycle (here via installs_after) must abort with an error, not fall
+        // back to a partial order. compute_order_with_metadata surfaces the
+        // cyclic-dependency warning as a fatal Err so the caller exits non-zero
+        // without emitting JSON (matches the official CLI).
         let pairs = vec![
             ("feat-a".to_owned(), serde_json::json!({})),
             ("feat-b".to_owned(), serde_json::json!({})),
@@ -495,63 +547,88 @@ mod tests {
     // transitive deps appear in installOrder
     // -----------------------------------------------------------------------
 
+    /// Build graph metadata for a feature with a single hard `dependsOn`,
+    /// where the dependency carries `dep_options` (mirrors real fetched data).
+    fn graph_with_depends_on(
+        feature: &str,
+        dep: &str,
+        dep_options: serde_json::Value,
+    ) -> DependencyGraph {
+        let mut meta_map = HashMap::new();
+        meta_map.insert(
+            feature.to_owned(),
+            FeatureMetadata {
+                id: feature.to_owned(),
+                depends_on: std::iter::once((dep.to_owned(), dep_options)).collect(),
+                ..Default::default()
+            },
+        );
+        meta_map.insert(
+            dep.to_owned(),
+            FeatureMetadata {
+                id: dep.to_owned(),
+                ..Default::default()
+            },
+        );
+        DependencyGraph {
+            edges: vec![(feature.to_owned(), dep.to_owned(), EdgeKind::DependsOn)],
+            metadata: meta_map,
+        }
+    }
+
     #[test]
     fn transitive_dep_appears_in_install_order() {
         // Scenario: config declares only `node`. `node` dependsOn `common-utils`.
-        // After OCI fetch, `common-utils` must appear in installOrder.
-        let pairs = vec![(
-            "ghcr.io/x/features/node:1".to_owned(),
-            serde_json::json!({"version": "lts"}),
-        )];
+        // After OCI fetch, `common-utils` must appear in installOrder AND be
+        // ordered before node — the ordering crate now treats dependsOn as a
+        // hard install-before prerequisite (regression: it previously only
+        // honored installs_after, so a dependsOn-only target had no edge).
+        let node = "ghcr.io/x/features/node:1";
+        let common = "ghcr.io/x/features/common-utils:2";
+        let pairs = vec![(node.to_owned(), serde_json::json!({"version": "lts"}))];
 
-        let mut meta_map = HashMap::new();
-        // node's metadata lists common-utils as a hard dep via installs_after
-        // (the ordering algorithm uses installs_after; dependsOn is recorded
-        // as a graph edge but the ordering crate uses installs_after for topo sort).
-        meta_map.insert(
-            "ghcr.io/x/features/node:1".to_owned(),
-            FeatureMetadata {
-                id: "ghcr.io/x/features/node:1".to_owned(),
-                installs_after: vec!["ghcr.io/x/features/common-utils:2".to_owned()],
-                ..Default::default()
-            },
-        );
-        meta_map.insert(
-            "ghcr.io/x/features/common-utils:2".to_owned(),
-            FeatureMetadata {
-                id: "ghcr.io/x/features/common-utils:2".to_owned(),
-                ..Default::default()
-            },
-        );
-
-        let graph = DependencyGraph {
-            edges: vec![(
-                "ghcr.io/x/features/node:1".to_owned(),
-                "ghcr.io/x/features/common-utils:2".to_owned(),
-                EdgeKind::DependsOn,
-            )],
-            metadata: meta_map,
-        };
+        let graph = graph_with_depends_on(node, common, serde_json::json!({}));
 
         let order = compute_order_with_metadata(&pairs, &graph, None).unwrap();
 
         assert!(
-            order.contains(&"ghcr.io/x/features/common-utils:2".to_owned()),
+            order.contains(&common.to_owned()),
             "transitive dep common-utils must appear in installOrder; got: {order:?}"
         );
-        // common-utils must come before node (it's a prerequisite).
-        let pos_common = order
-            .iter()
-            .position(|x| x == "ghcr.io/x/features/common-utils:2")
-            .unwrap();
-        let pos_node = order
-            .iter()
-            .position(|x| x == "ghcr.io/x/features/node:1")
-            .unwrap();
+        let pos = |id: &str| order.iter().position(|x| x == id).unwrap();
         assert!(
-            pos_common < pos_node,
+            pos(common) < pos(node),
             "common-utils must be installed before node; order: {order:?}"
         );
+    }
+
+    #[test]
+    fn transitive_dep_emits_parent_depends_on_options() {
+        // node dependsOn common-utils with concrete options. common-utils is not
+        // declared directly, so its installOrder entry must carry the options
+        // from node's dependsOn value — not the `true` default. (Finding #2.)
+        let node = "ghcr.io/x/features/node:1";
+        let common = "ghcr.io/x/features/common-utils:2";
+        let pairs = vec![(node.to_owned(), serde_json::json!({"version": "lts"}))];
+
+        let dep_options = serde_json::json!({"installZsh": true});
+        let graph = graph_with_depends_on(node, common, dep_options.clone());
+
+        let order = compute_order_with_metadata(&pairs, &graph, None).unwrap();
+        let transitive = collect_transitive_options(&graph);
+        let entries = build_install_order_entries(&order, &pairs, &transitive);
+
+        let common_entry = entries
+            .iter()
+            .find(|e| e.id == common)
+            .expect("common-utils must have an installOrder entry");
+        assert_eq!(
+            common_entry.options, dep_options,
+            "transitive dep must emit parent's dependsOn options, not `true`"
+        );
+        // The directly-declared feature still emits its explicit options.
+        let node_entry = entries.iter().find(|e| e.id == node).unwrap();
+        assert_eq!(node_entry.options, serde_json::json!({"version": "lts"}));
     }
 
     // -----------------------------------------------------------------------
@@ -575,7 +652,7 @@ mod tests {
             "ghcr.io/x/features/node:1".to_owned(),
         ];
 
-        let entries = build_install_order_entries(&ids, &pairs);
+        let entries = build_install_order_entries(&ids, &pairs, &BTreeMap::new());
 
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].id, "ghcr.io/x/features/git:1");
@@ -592,10 +669,56 @@ mod tests {
         )];
         let ids = vec!["unknown".to_owned()];
 
-        let entries = build_install_order_entries(&ids, &pairs);
+        let entries = build_install_order_entries(&ids, &pairs, &BTreeMap::new());
 
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].options, serde_json::Value::Bool(true));
+    }
+
+    #[test]
+    fn install_entries_transitive_options_used_when_not_declared() {
+        // node is declared with explicit options; common-utils is only pulled
+        // in transitively, so its options come from transitive_options.
+        let pairs = vec![(
+            "ghcr.io/x/features/node:1".to_owned(),
+            serde_json::json!({"version": "lts"}),
+        )];
+        let mut transitive = BTreeMap::new();
+        transitive.insert(
+            "ghcr.io/x/features/common-utils:2".to_owned(),
+            serde_json::json!({"installZsh": true}),
+        );
+        let ids = vec![
+            "ghcr.io/x/features/common-utils:2".to_owned(),
+            "ghcr.io/x/features/node:1".to_owned(),
+        ];
+
+        let entries = build_install_order_entries(&ids, &pairs, &transitive);
+
+        assert_eq!(entries[0].id, "ghcr.io/x/features/common-utils:2");
+        assert_eq!(entries[0].options, serde_json::json!({"installZsh": true}));
+        // Declared options take precedence over any transitive entry.
+        assert_eq!(entries[1].options, serde_json::json!({"version": "lts"}));
+    }
+
+    #[test]
+    fn install_entries_declared_options_win_over_transitive() {
+        // If a feature is BOTH declared and a transitive dep, the user's
+        // explicit declaration wins.
+        let pairs = vec![(
+            "ghcr.io/x/features/common-utils:2".to_owned(),
+            serde_json::json!({"installZsh": false}),
+        )];
+        let mut transitive = BTreeMap::new();
+        transitive.insert(
+            "ghcr.io/x/features/common-utils:2".to_owned(),
+            serde_json::json!({"installZsh": true}),
+        );
+        let ids = vec!["ghcr.io/x/features/common-utils:2".to_owned()];
+
+        let entries = build_install_order_entries(&ids, &pairs, &transitive);
+
+        assert_eq!(entries[0].options, serde_json::json!({"installZsh": false}));
     }
 
     // -----------------------------------------------------------------------
@@ -650,5 +773,21 @@ mod tests {
         ];
         let deduped = dedup_edges(&edges);
         assert_eq!(deduped.len(), 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // dedup_preserving_order
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn dedup_preserving_order_keeps_first_seen_order() {
+        let pairs = vec![
+            ("b".to_owned(), serde_json::json!({})),
+            ("a".to_owned(), serde_json::json!({})),
+            ("b".to_owned(), serde_json::json!({"dup": true})),
+            ("c".to_owned(), serde_json::json!({})),
+        ];
+        // Duplicate `b` is dropped; declaration order is otherwise preserved.
+        assert_eq!(dedup_preserving_order(&pairs), vec!["b", "a", "c"]);
     }
 }

--- a/crates/cella-cli/src/commands/features/resolve_dependencies.rs
+++ b/crates/cella-cli/src/commands/features/resolve_dependencies.rs
@@ -1,0 +1,404 @@
+//! `cella features resolve-dependencies` — compute and print the feature
+//! installation order for a devcontainer configuration.
+//!
+//! Drop-in replacement for `devcontainer features resolveDependencies`.
+//! Contract:
+//!   cella features resolve-dependencies [--workspace-folder <path>] [--log-level <level>]
+//!
+//! Stdout (two writes, in order):
+//!   1. Mermaid flowchart of the dependency graph (plain text).
+//!   2. JSON object: `{"installOrder": [{"id": "...", "options": ...}, ...]}`
+//!
+//! Logs go to stderr. Exit 1 on config-not-found, parse failure, or cycle.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use clap::{Parser, ValueEnum};
+use serde::Serialize;
+
+use super::resolve::{CommonFeatureFlags, discover_config, extract_features, read_raw_config};
+use cella_features::graph::{DepEdge, build_dependency_graph, render_mermaid};
+use cella_features::ordering::compute_install_order;
+use cella_features::{FeatureMetadata, FeatureWarning};
+
+// ---------------------------------------------------------------------------
+// Args
+// ---------------------------------------------------------------------------
+
+/// Resolve and print the installation order for features in a devcontainer
+/// configuration.
+#[derive(Debug, Clone, Parser)]
+pub struct ResolveDependenciesArgs {
+    /// Workspace folder (defaults to current directory).
+    ///
+    /// Equivalent to `--workspace-folder` in the official devcontainer CLI.
+    #[arg(long, short = 'w')]
+    pub workspace_folder: Option<PathBuf>,
+
+    /// Log verbosity (default `error` matches the official CLI).
+    #[arg(long, default_value = "error")]
+    pub log_level: ResolveDepsLogLevel,
+}
+
+/// Log level for the resolve-dependencies command.
+///
+/// Default is `error` to match the official CLI.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum ResolveDepsLogLevel {
+    Error,
+    Info,
+    Debug,
+    Trace,
+}
+
+// ---------------------------------------------------------------------------
+// JSON output shape — matches official CLI
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct InstallOrderOutput {
+    install_order: Vec<InstallOrderEntry>,
+}
+
+#[derive(Serialize)]
+struct InstallOrderEntry {
+    id: String,
+    options: serde_json::Value,
+}
+
+// ---------------------------------------------------------------------------
+// Execution
+// ---------------------------------------------------------------------------
+
+impl ResolveDependenciesArgs {
+    /// Execute the resolve-dependencies command.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the config is missing, unparseable, or a cycle
+    /// is detected that prevents an install order from being computed.
+    pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let flags = CommonFeatureFlags {
+            file: None,
+            workspace_folder: self.workspace_folder,
+            registry: None,
+        };
+        let config_path = discover_config(&flags)?;
+        let raw = read_raw_config(&config_path)?;
+        let stripped = cella_jsonc::strip(&raw)?;
+        let config: serde_json::Value = serde_json::from_str(&stripped)?;
+
+        let feature_pairs = extract_features(&config);
+
+        if feature_pairs.is_empty() {
+            println!("flowchart TD");
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&InstallOrderOutput {
+                    install_order: Vec::new()
+                })?
+            );
+            return Ok(());
+        }
+
+        let override_order = parse_override_order(&config);
+
+        // Mermaid diagram: attempt OCI fetch for each declared feature root.
+        let mermaid = build_mermaid_for_features(&feature_pairs).await;
+        println!("{mermaid}");
+
+        let (ordered_ids, warnings) =
+            compute_order_from_config(&feature_pairs, override_order.as_deref());
+
+        for w in &warnings {
+            if let FeatureWarning::CyclicDependency { features } = w {
+                eprintln!(
+                    "warning: cyclic dependency detected among features: {}",
+                    features.join(", ")
+                );
+            }
+        }
+
+        let install_order = build_install_order_entries(&ordered_ids, &feature_pairs);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&InstallOrderOutput { install_order })?
+        );
+
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+/// Parse `overrideFeatureInstallOrder` from the raw config JSON.
+fn parse_override_order(config: &serde_json::Value) -> Option<Vec<String>> {
+    let arr = config
+        .get("overrideFeatureInstallOrder")
+        .and_then(|v| v.as_array())?;
+    let ids: Vec<String> = arr
+        .iter()
+        .filter_map(|v| v.as_str().map(ToOwned::to_owned))
+        .collect();
+    if ids.is_empty() { None } else { Some(ids) }
+}
+
+/// Build a Mermaid diagram covering all declared feature roots.
+///
+/// Attempts OCI metadata fetch for each root feature. Edges from all roots are
+/// merged and deduplicated. Falls back to an edge-free diagram on fetch errors.
+async fn build_mermaid_for_features(feature_pairs: &[(String, serde_json::Value)]) -> String {
+    let mut all_edges: Vec<DepEdge> = Vec::new();
+    let mut seen_roots: HashSet<&str> = HashSet::new();
+
+    for (feature_ref, _) in feature_pairs {
+        if !seen_roots.insert(feature_ref.as_str()) {
+            continue;
+        }
+        match build_dependency_graph(feature_ref).await {
+            Ok(edges) => all_edges.extend(edges),
+            Err(e) => {
+                eprintln!("warning: could not build dependency graph for {feature_ref}: {e}");
+            }
+        }
+    }
+
+    // Deduplicate by (from, to, kind-discriminant).
+    let mut seen_edges: HashSet<(String, String, u8)> = HashSet::new();
+    all_edges.retain(|(from, to, kind)| {
+        let kind_tag = u8::from(matches!(
+            kind,
+            cella_features::graph::EdgeKind::InstallsAfter
+        ));
+        seen_edges.insert((from.clone(), to.clone(), kind_tag))
+    });
+
+    let root = &feature_pairs[0].0;
+    render_mermaid(root, &all_edges)
+}
+
+/// Compute install order from config-level feature declarations.
+///
+/// Uses stub `FeatureMetadata` (no OCI fetch) — `installs_after` is not
+/// populated, so ordering is driven by declaration order and override list.
+fn compute_order_from_config(
+    feature_pairs: &[(String, serde_json::Value)],
+    override_order: Option<&[String]>,
+) -> (Vec<String>, Vec<FeatureWarning>) {
+    let metas: Vec<(String, FeatureMetadata)> = feature_pairs
+        .iter()
+        .map(|(id, _)| {
+            (
+                id.clone(),
+                FeatureMetadata {
+                    id: id.clone(),
+                    ..Default::default()
+                },
+            )
+        })
+        .collect();
+
+    let order_input: Vec<(String, &FeatureMetadata)> =
+        metas.iter().map(|(id, m)| (id.clone(), m)).collect();
+
+    compute_install_order(&order_input, override_order)
+}
+
+/// Build the `installOrder` entries from ordered IDs and their options.
+fn build_install_order_entries(
+    ordered_ids: &[String],
+    feature_pairs: &[(String, serde_json::Value)],
+) -> Vec<InstallOrderEntry> {
+    ordered_ids
+        .iter()
+        .map(|id| {
+            let options = feature_pairs
+                .iter()
+                .find(|(ref_id, _)| ref_id == id)
+                .map_or(serde_json::Value::Bool(true), |(_, opts)| opts.clone());
+            InstallOrderEntry {
+                id: id.clone(),
+                options,
+            }
+        })
+        .collect()
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------------
+    // parse_override_order
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_override_order_absent() {
+        let config = serde_json::json!({"image": "ubuntu"});
+        assert!(parse_override_order(&config).is_none());
+    }
+
+    #[test]
+    fn parse_override_order_present() {
+        let config = serde_json::json!({
+            "overrideFeatureInstallOrder": [
+                "ghcr.io/devcontainers/features/git:1",
+                "ghcr.io/devcontainers/features/node:1"
+            ]
+        });
+        let order = parse_override_order(&config).unwrap();
+        assert_eq!(order.len(), 2);
+        assert_eq!(order[0], "ghcr.io/devcontainers/features/git:1");
+        assert_eq!(order[1], "ghcr.io/devcontainers/features/node:1");
+    }
+
+    #[test]
+    fn parse_override_order_empty_array_returns_none() {
+        let config = serde_json::json!({"overrideFeatureInstallOrder": []});
+        assert!(parse_override_order(&config).is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // compute_order_from_config
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn order_no_deps_preserves_declaration_order() {
+        let pairs = vec![
+            ("ghcr.io/x/features/a:1".to_owned(), serde_json::json!({})),
+            ("ghcr.io/x/features/b:1".to_owned(), serde_json::json!({})),
+            ("ghcr.io/x/features/c:1".to_owned(), serde_json::json!({})),
+        ];
+
+        let (order, warnings) = compute_order_from_config(&pairs, None);
+
+        assert!(warnings.is_empty());
+        assert_eq!(
+            order,
+            vec![
+                "ghcr.io/x/features/a:1",
+                "ghcr.io/x/features/b:1",
+                "ghcr.io/x/features/c:1"
+            ]
+        );
+    }
+
+    #[test]
+    fn order_with_override_respects_override() {
+        let pairs = vec![
+            ("ghcr.io/x/features/a:1".to_owned(), serde_json::json!({})),
+            ("ghcr.io/x/features/b:1".to_owned(), serde_json::json!({})),
+            ("ghcr.io/x/features/c:1".to_owned(), serde_json::json!({})),
+        ];
+        let overrides = vec![
+            "ghcr.io/x/features/c:1".to_owned(),
+            "ghcr.io/x/features/a:1".to_owned(),
+        ];
+
+        let (order, warnings) = compute_order_from_config(&pairs, Some(&overrides));
+
+        assert!(warnings.is_empty());
+        assert_eq!(order[0], "ghcr.io/x/features/c:1");
+        assert_eq!(order[1], "ghcr.io/x/features/a:1");
+        assert_eq!(order[2], "ghcr.io/x/features/b:1");
+    }
+
+    #[test]
+    fn order_empty_features() {
+        let pairs: Vec<(String, serde_json::Value)> = vec![];
+        let (order, warnings) = compute_order_from_config(&pairs, None);
+        assert!(order.is_empty());
+        assert!(warnings.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // build_install_order_entries
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn install_entries_match_options() {
+        let pairs = vec![
+            (
+                "ghcr.io/x/features/node:1".to_owned(),
+                serde_json::json!({"version": "lts"}),
+            ),
+            (
+                "ghcr.io/x/features/git:1".to_owned(),
+                serde_json::json!(true),
+            ),
+        ];
+        let ids = vec![
+            "ghcr.io/x/features/git:1".to_owned(),
+            "ghcr.io/x/features/node:1".to_owned(),
+        ];
+
+        let entries = build_install_order_entries(&ids, &pairs);
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].id, "ghcr.io/x/features/git:1");
+        assert_eq!(entries[0].options, serde_json::json!(true));
+        assert_eq!(entries[1].id, "ghcr.io/x/features/node:1");
+        assert_eq!(entries[1].options, serde_json::json!({"version": "lts"}));
+    }
+
+    #[test]
+    fn install_entries_missing_ref_defaults_to_true() {
+        let pairs = vec![(
+            "ghcr.io/x/features/node:1".to_owned(),
+            serde_json::json!({}),
+        )];
+        let ids = vec!["unknown".to_owned()];
+
+        let entries = build_install_order_entries(&ids, &pairs);
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].options, serde_json::Value::Bool(true));
+    }
+
+    // -----------------------------------------------------------------------
+    // JSON output shape
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn install_order_output_camel_case() {
+        let out = InstallOrderOutput {
+            install_order: vec![InstallOrderEntry {
+                id: "ghcr.io/x/features/node:1".to_owned(),
+                options: serde_json::json!({"version": "lts"}),
+            }],
+        };
+        let json: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&out).unwrap()).unwrap();
+        assert!(
+            json.get("installOrder").is_some(),
+            "installOrder key missing"
+        );
+        assert!(
+            json.get("install_order").is_none(),
+            "snake_case must not appear"
+        );
+        let entries = json["installOrder"].as_array().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["id"], "ghcr.io/x/features/node:1");
+        assert_eq!(entries[0]["options"]["version"], "lts");
+    }
+
+    #[test]
+    fn empty_install_order_serialises_correctly() {
+        let out = InstallOrderOutput {
+            install_order: vec![],
+        };
+        let json: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&out).unwrap()).unwrap();
+        let arr = json["installOrder"].as_array().unwrap();
+        assert!(arr.is_empty());
+    }
+}

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -200,8 +200,13 @@ pub enum UpdateRemoteUserUidDefault {
 }
 
 /// Log verbosity for lifecycle/terminal logging.
+///
+/// Mirrors the official CLI's `--log-level` choices. Most subcommands offer
+/// `info`/`debug`/`trace`; `features resolve-dependencies` additionally offers
+/// (and defaults to) `error`.
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum LogLevel {
+    Error,
     Info,
     Debug,
     Trace,

--- a/crates/cella-cli/src/main.rs
+++ b/crates/cella-cli/src/main.rs
@@ -30,6 +30,9 @@ fn resolve_log_directive(rust_log_set: bool, level: Option<LogLevel>) -> Option<
         return None;
     }
     Some(match level.unwrap_or(LogLevel::Info) {
+        // error: only errors surface (the resolve-dependencies default — its
+        // stdout is machine-readable Mermaid + JSON, so logs stay quiet).
+        LogLevel::Error => "error".to_string(),
         // Default/info: a flat `info` directive matches the official default
         // (events at info and above are shown).
         LogLevel::Info => "info".to_string(),

--- a/crates/cella-features/src/graph.rs
+++ b/crates/cella-features/src/graph.rs
@@ -33,20 +33,30 @@ pub enum EdgeKind {
 /// `(from_ref, to_ref, kind)` means `from_ref` depends on (or installs after) `to_ref`.
 pub type DepEdge = (String, String, EdgeKind);
 
-/// Recursively build the dependency graph starting from `root_ref`.
+/// The result of building a dependency graph from a set of root feature references.
+pub struct DependencyGraph {
+    /// All edges discovered by recursive OCI fetch.
+    pub edges: Vec<DepEdge>,
+    /// Fetched metadata for every feature visited (roots + all transitives).
+    ///
+    /// Keys are the feature reference strings as declared (roots) or as
+    /// referenced in `dependsOn` (transitives).
+    pub metadata: HashMap<String, crate::FeatureMetadata>,
+}
+
+/// Recursively build the dependency graph starting from one or more root refs.
 ///
-/// Discovers edges from both `dependsOn` (hard, solid arrow) and `installsAfter`
-/// (soft, dashed arrow) metadata fields. Each unique reference is visited at
-/// most once (cycle protection via a `HashSet`). Only `dependsOn` targets are
-/// recursed into; `installsAfter` targets are recorded as edges but not walked.
+/// Each root is visited once; transitive `dependsOn` targets are recursed into
+/// and their metadata is collected. `installsAfter` edges are recorded but not
+/// walked (matching official CLI behaviour).
 ///
-/// Progress message "Building dependency graph..." is printed to stderr.
+/// Emits "Building dependency graph..." to stderr before starting.
 ///
 /// # Errors
 ///
 /// Returns an error when a feature reference cannot be parsed, normalised, or
-/// fetched. Errors on transitive dependencies are propagated.
-pub async fn build_dependency_graph(root_ref: &str) -> Result<Vec<DepEdge>, FeatureError> {
+/// fetched. Transitive errors are propagated.
+pub async fn build_dependency_graph(root_refs: &[&str]) -> Result<DependencyGraph, FeatureError> {
     eprintln!("Building dependency graph...");
 
     let cache = FeatureCache::new();
@@ -55,33 +65,42 @@ pub async fn build_dependency_graph(root_ref: &str) -> Result<Vec<DepEdge>, Feat
 
     let mut edges: Vec<DepEdge> = Vec::new();
     let mut visited: HashSet<String> = HashSet::new();
+    let mut metadata: HashMap<String, crate::FeatureMetadata> = HashMap::new();
 
-    visit(
-        root_ref,
-        &fetcher,
-        &platform,
-        &cache,
-        &mut edges,
-        &mut visited,
-    )
-    .await?;
+    for root_ref in root_refs {
+        visit(
+            root_ref,
+            &fetcher,
+            &platform,
+            &cache,
+            &mut edges,
+            &mut visited,
+            &mut metadata,
+        )
+        .await?;
+    }
 
-    Ok(edges)
+    Ok(DependencyGraph { edges, metadata })
 }
 
 /// Render a dependency graph as a Mermaid `flowchart TD` diagram.
 ///
-/// Node labels use the short form `name:tag` (last path segment + tag).
-/// When `edges` is empty the diagram still renders with just the root node.
+/// Matches the official devcontainer CLI's `generateMermaidDiagram`: each
+/// user-provided root gets its own entry at the top of the diagram, with edges
+/// from all roots rendered beneath it. Node labels use the short form
+/// `name:tag` (last path segment + tag).
 ///
-/// Edge rendering matches the official devcontainer CLI:
+/// When `edges` is empty for a given root, that root is rendered as an isolated
+/// node. The official CLI uses `flowchart` (no `TD`); we match that.
+///
+/// Edge rendering:
 /// - `dependsOn` → solid arrow `A --> B`
 /// - `installsAfter` → dashed arrow `A -.-> B`
-pub fn render_mermaid(root: &str, edges: &[DepEdge]) -> String {
+pub fn render_mermaid(roots: &[&str], edges: &[DepEdge]) -> String {
     let mut node_ids: HashMap<String, String> = HashMap::new();
     let mut next_id = 0usize;
 
-    // Assign stable single-letter / short node IDs.
+    // Assign stable short node IDs; first call for a ref reserves the next slot.
     let mut get_id = |ref_str: &str| -> String {
         node_ids
             .entry(ref_str.to_owned())
@@ -93,29 +112,38 @@ pub fn render_mermaid(root: &str, edges: &[DepEdge]) -> String {
             .clone()
     };
 
-    // Ensure root always gets node A.
-    get_id(root);
+    // Reserve IDs for all roots first so they get the lowest-numbered slots.
+    for root in roots {
+        get_id(root);
+    }
 
+    // Official CLI uses `flowchart` (no direction keyword).
     let mut lines: Vec<String> = vec!["flowchart TD".to_owned()];
 
-    if edges.is_empty() {
-        let id = get_id(root);
-        let label = short_label(root);
-        lines.push(format!("    {id}[\"{label}\"]"));
-    } else {
-        for (from, to, kind) in edges {
-            let from_id = get_id(from);
-            let to_id = get_id(to);
-            let from_label = short_label(from);
-            let to_label = short_label(to);
-            let arrow = match kind {
-                EdgeKind::DependsOn => "-->",
-                EdgeKind::InstallsAfter => "-.->",
-            };
-            lines.push(format!(
-                "    {from_id}[\"{from_label}\"] {arrow} {to_id}[\"{to_label}\"]"
-            ));
+    // Track which roots have at least one outgoing edge so we can emit isolated
+    // nodes for those that don't.
+    let roots_with_edges: HashSet<&str> = edges.iter().map(|(from, _, _)| from.as_str()).collect();
+
+    for root in roots {
+        if !roots_with_edges.contains(*root) {
+            let id = get_id(root);
+            let label = short_label(root);
+            lines.push(format!("    {id}[\"{label}\"]"));
         }
+    }
+
+    for (from, to, kind) in edges {
+        let from_id = get_id(from);
+        let to_id = get_id(to);
+        let from_label = short_label(from);
+        let to_label = short_label(to);
+        let arrow = match kind {
+            EdgeKind::DependsOn => "-->",
+            EdgeKind::InstallsAfter => "-.->",
+        };
+        lines.push(format!(
+            "    {from_id}[\"{from_label}\"] {arrow} {to_id}[\"{to_label}\"]"
+        ));
     }
 
     lines.join("\n")
@@ -168,7 +196,7 @@ fn host_platform() -> Platform {
     }
 }
 
-/// Recursively visit a feature reference, collecting edges into `edges`.
+/// Recursively visit a feature reference, collecting edges and metadata.
 async fn visit(
     reference: &str,
     fetcher: &OciFetcher,
@@ -176,6 +204,7 @@ async fn visit(
     cache: &FeatureCache,
     edges: &mut Vec<DepEdge>,
     visited: &mut HashSet<String>,
+    metadata_map: &mut HashMap<String, crate::FeatureMetadata>,
 ) -> Result<(), FeatureError> {
     if !visited.insert(reference.to_owned()) {
         debug!("graph: already visited {reference}, skipping");
@@ -196,14 +225,23 @@ async fn visit(
     let metadata = parse_feature_metadata(&json)?;
 
     // Hard dependencies: recurse into each and emit a solid edge.
-    for dep_ref in metadata.depends_on.keys() {
+    let dep_refs: Vec<String> = metadata.depends_on.keys().cloned().collect();
+    for dep_ref in &dep_refs {
         edges.push((reference.to_owned(), dep_ref.clone(), EdgeKind::DependsOn));
         // Box the recursive future to avoid infinitely-sized stack frames.
-        Box::pin(visit(dep_ref, fetcher, platform, cache, edges, visited)).await?;
+        Box::pin(visit(
+            dep_ref,
+            fetcher,
+            platform,
+            cache,
+            edges,
+            visited,
+            metadata_map,
+        ))
+        .await?;
     }
 
-    // Soft ordering hints: record the edge but do not recurse (the target may
-    // not be in the resolved feature set at all).
+    // Soft ordering hints: record the edge but do not recurse.
     for dep_ref in &metadata.installs_after {
         edges.push((
             reference.to_owned(),
@@ -211,6 +249,8 @@ async fn visit(
             EdgeKind::InstallsAfter,
         ));
     }
+
+    metadata_map.insert(reference.to_owned(), metadata);
 
     Ok(())
 }
@@ -298,7 +338,8 @@ mod tests {
 
     #[test]
     fn render_mermaid_no_edges() {
-        let output = render_mermaid("ghcr.io/devcontainers/features/node:1", &[]);
+        let root = "ghcr.io/devcontainers/features/node:1";
+        let output = render_mermaid(&[root], &[]);
         assert!(output.starts_with("flowchart TD"));
         assert!(output.contains("A[\"node:1\"]"));
         // No arrow present
@@ -307,12 +348,13 @@ mod tests {
 
     #[test]
     fn render_mermaid_depends_on_edge() {
+        let root = "ghcr.io/devcontainers/features/node:1";
         let edges = vec![(
-            "ghcr.io/devcontainers/features/node:1".to_owned(),
+            root.to_owned(),
             "ghcr.io/devcontainers/features/common-utils:2".to_owned(),
             EdgeKind::DependsOn,
         )];
-        let output = render_mermaid("ghcr.io/devcontainers/features/node:1", &edges);
+        let output = render_mermaid(&[root], &edges);
         assert!(output.starts_with("flowchart TD"));
         // Hard dep → solid arrow
         assert!(output.contains("-->"), "expected solid arrow");
@@ -323,12 +365,13 @@ mod tests {
 
     #[test]
     fn render_mermaid_installs_after_edge() {
+        let root = "ghcr.io/devcontainers/features/node:1";
         let edges = vec![(
-            "ghcr.io/devcontainers/features/node:1".to_owned(),
+            root.to_owned(),
             "ghcr.io/devcontainers/features/common-utils:2".to_owned(),
             EdgeKind::InstallsAfter,
         )];
-        let output = render_mermaid("ghcr.io/devcontainers/features/node:1", &edges);
+        let output = render_mermaid(&[root], &edges);
         assert!(output.starts_with("flowchart TD"));
         // Soft dep → dashed arrow
         assert!(output.contains("-.-"), "expected dashed arrow");
@@ -338,19 +381,20 @@ mod tests {
 
     #[test]
     fn render_mermaid_mixed_edges() {
+        let root = "ghcr.io/devcontainers/features/node:1";
         let edges = vec![
             (
-                "ghcr.io/devcontainers/features/node:1".to_owned(),
+                root.to_owned(),
                 "ghcr.io/devcontainers/features/git:1".to_owned(),
                 EdgeKind::DependsOn,
             ),
             (
-                "ghcr.io/devcontainers/features/node:1".to_owned(),
+                root.to_owned(),
                 "ghcr.io/devcontainers/features/common-utils:2".to_owned(),
                 EdgeKind::InstallsAfter,
             ),
         ];
-        let output = render_mermaid("ghcr.io/devcontainers/features/node:1", &edges);
+        let output = render_mermaid(&[root], &edges);
         // Header + 2 edge lines
         assert_eq!(output.lines().count(), 3);
         assert!(output.contains("-->"), "expected solid arrow for dependsOn");
@@ -361,6 +405,38 @@ mod tests {
         assert!(output.contains("node:1"));
         assert!(output.contains("git:1"));
         assert!(output.contains("common-utils:2"));
+    }
+
+    #[test]
+    fn render_mermaid_multiple_roots_no_edges() {
+        let roots = [
+            "ghcr.io/devcontainers/features/node:1",
+            "ghcr.io/devcontainers/features/python:1",
+        ];
+        let output = render_mermaid(&roots, &[]);
+        assert!(output.starts_with("flowchart TD"));
+        // Both roots appear as isolated nodes
+        assert!(output.contains("node:1"), "node root missing");
+        assert!(output.contains("python:1"), "python root missing");
+        assert!(!output.contains("-->"));
+    }
+
+    #[test]
+    fn render_mermaid_multiple_roots_with_shared_dep() {
+        let node = "ghcr.io/devcontainers/features/node:1";
+        let python = "ghcr.io/devcontainers/features/python:1";
+        let common = "ghcr.io/devcontainers/features/common-utils:2";
+        let edges = vec![
+            (node.to_owned(), common.to_owned(), EdgeKind::DependsOn),
+            (python.to_owned(), common.to_owned(), EdgeKind::DependsOn),
+        ];
+        let output = render_mermaid(&[node, python], &edges);
+        assert!(output.starts_with("flowchart TD"));
+        assert!(output.contains("node:1"));
+        assert!(output.contains("python:1"));
+        assert!(output.contains("common-utils:2"));
+        // Both roots should have solid arrows to common-utils
+        assert_eq!(output.matches("-->").count(), 2);
     }
 
     // -----------------------------------------------------------------------

--- a/crates/cella-features/src/graph.rs
+++ b/crates/cella-features/src/graph.rs
@@ -2,7 +2,8 @@
 //!
 //! Builds the dependency graph by recursively fetching and parsing
 //! `devcontainer-feature.json` from OCI registries, then renders the result as
-//! a Mermaid `flowchart TD` diagram.
+//! a Mermaid `flowchart` diagram (matching the official CLI, which emits no
+//! direction keyword).
 //!
 //! Two edge kinds are modelled to match the official devcontainer CLI renderer:
 //! - **`dependsOn`** (hard dependency) → solid arrow `A --> B`
@@ -83,7 +84,7 @@ pub async fn build_dependency_graph(root_refs: &[&str]) -> Result<DependencyGrap
     Ok(DependencyGraph { edges, metadata })
 }
 
-/// Render a dependency graph as a Mermaid `flowchart TD` diagram.
+/// Render a dependency graph as a Mermaid `flowchart` diagram.
 ///
 /// Matches the official devcontainer CLI's `generateMermaidDiagram`: each
 /// user-provided root gets its own entry at the top of the diagram, with edges
@@ -91,7 +92,8 @@ pub async fn build_dependency_graph(root_refs: &[&str]) -> Result<DependencyGrap
 /// `name:tag` (last path segment + tag).
 ///
 /// When `edges` is empty for a given root, that root is rendered as an isolated
-/// node. The official CLI uses `flowchart` (no `TD`); we match that.
+/// node. The official CLI emits the bare `flowchart` keyword with no direction
+/// (`TD`/`LR`/…); we match that exactly.
 ///
 /// Edge rendering:
 /// - `dependsOn` → solid arrow `A --> B`
@@ -117,8 +119,8 @@ pub fn render_mermaid(roots: &[&str], edges: &[DepEdge]) -> String {
         get_id(root);
     }
 
-    // Official CLI uses `flowchart` (no direction keyword).
-    let mut lines: Vec<String> = vec!["flowchart TD".to_owned()];
+    // Official CLI uses the bare `flowchart` keyword (no direction).
+    let mut lines: Vec<String> = vec!["flowchart".to_owned()];
 
     // Track which roots have at least one outgoing edge so we can emit isolated
     // nodes for those that don't.
@@ -340,7 +342,7 @@ mod tests {
     fn render_mermaid_no_edges() {
         let root = "ghcr.io/devcontainers/features/node:1";
         let output = render_mermaid(&[root], &[]);
-        assert!(output.starts_with("flowchart TD"));
+        assert!(output.starts_with("flowchart"));
         assert!(output.contains("A[\"node:1\"]"));
         // No arrow present
         assert!(!output.contains("-->"));
@@ -355,7 +357,7 @@ mod tests {
             EdgeKind::DependsOn,
         )];
         let output = render_mermaid(&[root], &edges);
-        assert!(output.starts_with("flowchart TD"));
+        assert!(output.starts_with("flowchart"));
         // Hard dep → solid arrow
         assert!(output.contains("-->"), "expected solid arrow");
         assert!(!output.contains("-.-"), "unexpected dashed arrow");
@@ -372,7 +374,7 @@ mod tests {
             EdgeKind::InstallsAfter,
         )];
         let output = render_mermaid(&[root], &edges);
-        assert!(output.starts_with("flowchart TD"));
+        assert!(output.starts_with("flowchart"));
         // Soft dep → dashed arrow
         assert!(output.contains("-.-"), "expected dashed arrow");
         assert!(output.contains("node:1"));
@@ -414,7 +416,7 @@ mod tests {
             "ghcr.io/devcontainers/features/python:1",
         ];
         let output = render_mermaid(&roots, &[]);
-        assert!(output.starts_with("flowchart TD"));
+        assert!(output.starts_with("flowchart"));
         // Both roots appear as isolated nodes
         assert!(output.contains("node:1"), "node root missing");
         assert!(output.contains("python:1"), "python root missing");
@@ -431,7 +433,7 @@ mod tests {
             (python.to_owned(), common.to_owned(), EdgeKind::DependsOn),
         ];
         let output = render_mermaid(&[node, python], &edges);
-        assert!(output.starts_with("flowchart TD"));
+        assert!(output.starts_with("flowchart"));
         assert!(output.contains("node:1"));
         assert!(output.contains("python:1"));
         assert!(output.contains("common-utils:2"));

--- a/crates/cella-features/src/ordering.rs
+++ b/crates/cella-features/src/ordering.rs
@@ -1,14 +1,15 @@
 //! Dependency ordering for devcontainer features.
 //!
-//! Implements topological sort (Kahn's algorithm) over `installsAfter`
-//! dependencies, with tiebreaking rules matching the devcontainer spec:
+//! Implements topological sort (Kahn's algorithm) over both `dependsOn` (hard)
+//! and `installsAfter` (soft) dependencies — every prerequisite must install
+//! first — with tiebreaking rules matching the devcontainer spec:
 //!
 //! 1. Official `ghcr.io/devcontainers/features/*` features sort first.
 //! 2. Among equal-priority features, declaration order is preserved.
 //! 3. `overrideFeatureInstallOrder` takes precedence over computed order.
 
 use std::cmp::Reverse;
-use std::collections::{BinaryHeap, HashMap, HashSet};
+use std::collections::{BTreeSet, BinaryHeap, HashMap, HashSet};
 
 use crate::error::FeatureWarning;
 use crate::types::FeatureMetadata;
@@ -152,18 +153,35 @@ fn topological_sort_with_original_indices(
     let n = features.len();
     let mut warnings = Vec::new();
 
-    // Adjacency: edge from dependency -> dependent (if dep installs after X,
-    // then X must come before dep, so edge X -> dep).
+    // Adjacency: edge from prerequisite -> dependent. If feature X must be
+    // installed after Y (Y is a prerequisite of X), then Y comes first, so we
+    // record the edge Y -> X.
+    //
+    // Both edge sources impose the same install-before constraint:
+    //   - `dependsOn` keys  — hard dependencies (must install before)
+    //   - `installsAfter`   — soft ordering hints
+    // Matching the official CLI, a round can only install a node once *every*
+    // hard- and soft-dependency has been installed, so both feed the sort.
     let mut adj: Vec<Vec<usize>> = vec![Vec::new(); n];
     let mut in_degree: Vec<usize> = vec![0; n];
 
     for (local_idx, (_, meta)) in features.iter().enumerate() {
-        for dep_id in &meta.installs_after {
-            if let Some(&dep_local_idx) = local_id_to_index.get(dep_id.as_str()) {
-                adj[dep_local_idx].push(local_idx);
-                in_degree[local_idx] += 1;
+        // Deduplicate prerequisites so a dependency declared in both
+        // `dependsOn` and `installsAfter` (or repeated) counts once — otherwise
+        // the inflated in-degree would never reach zero and stall the sort.
+        // `BTreeSet` keeps the adjacency build deterministic.
+        let mut prerequisites: BTreeSet<usize> = BTreeSet::new();
+        let dep_ids = meta.depends_on.keys().map(String::as_str);
+        let after_ids = meta.installs_after.iter().map(String::as_str);
+        for dep_id in dep_ids.chain(after_ids) {
+            if let Some(&dep_local_idx) = local_id_to_index.get(dep_id) {
+                prerequisites.insert(dep_local_idx);
             }
             // Dependencies on features not in our set are ignored.
+        }
+        for dep_local_idx in prerequisites {
+            adj[dep_local_idx].push(local_idx);
+            in_degree[local_idx] += 1;
         }
     }
 
@@ -251,6 +269,19 @@ mod tests {
         FeatureMetadata {
             id: id.to_string(),
             installs_after: installs_after.iter().map(|s| (*s).to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    /// Helper to build a `FeatureMetadata` with `depends_on` (hard) deps set.
+    /// Each key maps to an arbitrary option value (`true`).
+    fn meta_depends(id: &str, depends_on: &[&str]) -> FeatureMetadata {
+        FeatureMetadata {
+            id: id.to_string(),
+            depends_on: depends_on
+                .iter()
+                .map(|s| ((*s).to_string(), serde_json::Value::Bool(true)))
+                .collect(),
             ..Default::default()
         }
     }
@@ -557,6 +588,66 @@ mod tests {
         assert!(warnings.is_empty());
         // a's dependency on nonexistent is ignored, so declaration order.
         assert_eq!(order, vec!["a", "b"]);
+    }
+
+    // ---------------------------------------------------------------
+    // `dependsOn` (hard) imposes install-before ordering, like installsAfter
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn depends_on_orders_prerequisite_first() {
+        // a dependsOn b → b must install before a, even though a is declared
+        // first. Regression: previously only installs_after fed the sort, so a
+        // pulled-in dependsOn target had no ordering edge.
+        let items = vec![
+            ("a".to_string(), meta_depends("a", &["b"])),
+            ("b".to_string(), meta("b", &[])),
+        ];
+        let features = feature_list(&items);
+
+        let (order, warnings) = compute_install_order(&features, None);
+
+        assert!(warnings.is_empty());
+        assert_eq!(order, vec!["b", "a"]);
+    }
+
+    #[test]
+    fn depends_on_cycle_is_fatal() {
+        // a dependsOn b, b dependsOn a → cycle must be reported, not silently
+        // ordered. Previously dependsOn edges were never added, so this cycle
+        // went undetected.
+        let items = vec![
+            ("a".to_string(), meta_depends("a", &["b"])),
+            ("b".to_string(), meta_depends("b", &["a"])),
+        ];
+        let features = feature_list(&items);
+
+        let (_order, warnings) = compute_install_order(&features, None);
+
+        assert_eq!(warnings.len(), 1);
+        match &warnings[0] {
+            FeatureWarning::CyclicDependency { features } => {
+                assert!(features.contains(&"a".to_string()));
+                assert!(features.contains(&"b".to_string()));
+            }
+            other => panic!("expected CyclicDependency, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn depends_on_and_installs_after_same_target_counted_once() {
+        // a lists b in BOTH dependsOn and installsAfter. The prerequisite must
+        // be deduplicated; otherwise the doubled in-degree would stall the sort
+        // and spuriously report a cycle.
+        let mut a = meta_depends("a", &["b"]);
+        a.installs_after = vec!["b".to_string()];
+        let items = vec![("a".to_string(), a), ("b".to_string(), meta("b", &[]))];
+        let features = feature_list(&items);
+
+        let (order, warnings) = compute_install_order(&features, None);
+
+        assert!(warnings.is_empty(), "no cycle: b is a single prerequisite");
+        assert_eq!(order, vec!["b", "a"]);
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
Implements `cella features resolve-dependencies` as a drop-in for `devcontainer features resolve-dependencies`: fetches the dependency closure and emits the install order.

Supersedes #137, which GitHub auto-closed when its base branch (`feat/features-info`, #132) was deleted on merge. Same branch, rebased onto main, with all review findings addressed:
- **P1**: hard `dependsOn` edges now create install-order prerequisites (and dependsOn cycles are fatal), matching official `computeDependsOnInstallationOrder` — previously only `installsAfter` was honored
- transitive `dependsOn` options are preserved instead of defaulting to `true`
- `--log-level` wired through the shared accessor (added an `Error` level for spec parity)
- deterministic ordering (first-seen root dedup, sorted transitive IDs)
- dropped the non-spec `-w` short flag; Mermaid header emits bare `flowchart` to match upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)