### PR TITLE
feat(compose): apply containerUser/init/privileged/capAdd/securityOpt

### DIFF
--- a/crates/cella-compose/src/build_features.rs
+++ b/crates/cella-compose/src/build_features.rs
@@ -114,6 +114,8 @@ pub async fn compose_build(
             extra_volumes: Vec::new(),
             // GPU reservation is emitted only in the final override.
             request_gpu: false,
+            // `cella build` only builds the image; runtime security props apply at `up`.
+            security: cella_config::config_map::MergedSecurityConfig::default(),
         };
         let yaml = crate::override_file::generate_override_yaml(&override_config);
         crate::override_file::write_override_file(&project.override_file, &yaml)?;

--- a/crates/cella-compose/src/integration_tests/phase_tests.rs
+++ b/crates/cella-compose/src/integration_tests/phase_tests.rs
@@ -39,6 +39,7 @@ fn override_file_exists_before_compose_uses_it() {
         build_secrets: Vec::new(),
         extra_volumes: Vec::new(),
         request_gpu: false,
+        security: cella_config::config_map::MergedSecurityConfig::default(),
     };
 
     let yaml = generate_override_yaml(&override_cfg);
@@ -190,6 +191,7 @@ fn additional_contexts_in_override_for_features() {
         build_secrets: Vec::new(),
         extra_volumes: Vec::new(),
         request_gpu: false,
+        security: cella_config::config_map::MergedSecurityConfig::default(),
     };
 
     let yaml = generate_override_yaml(&override_cfg);

--- a/crates/cella-compose/src/integration_tests/smoke_tests.rs
+++ b/crates/cella-compose/src/integration_tests/smoke_tests.rs
@@ -24,6 +24,7 @@ fn plain_override(service: &str) -> OverrideConfig {
         build_secrets: Vec::new(),
         extra_volumes: Vec::new(),
         request_gpu: false,
+        security: cella_config::config_map::MergedSecurityConfig::default(),
     }
 }
 

--- a/crates/cella-compose/src/orchestrate.rs
+++ b/crates/cella-compose/src/orchestrate.rs
@@ -446,10 +446,11 @@ async fn resolve_user_and_env(
     String,
     cella_env::EnvForwarding,
     Option<SshAgentProxyStatus>,
+    cella_config::config_map::MergedSecurityConfig,
 ) {
     let cfg = ctx.cfg;
     let progress = ctx.progress;
-    let (image_user, image_meta_user) = resolve_compose_image_info(
+    let (image_user, image_meta_user, base_image_security) = resolve_compose_image_info(
         client,
         project,
         features_build,
@@ -457,6 +458,16 @@ async fn resolve_user_and_env(
         progress,
     )
     .await;
+    // Runtime security props: prefer the resolved-features config; fall back to
+    // the base image's metadata when no features are configured (mirrors the
+    // single-container effective_feature_config fallback in up.rs).
+    let effective_feature_config = features_build
+        .map(|fb| fb.resolved_features.container_config.clone())
+        .or(base_image_security);
+    let security = cella_config::config_map::merge_security_config(
+        cfg.config,
+        effective_feature_config.as_ref(),
+    );
     let remote_user = resolve_remote_user(cfg.config, image_meta_user.as_ref(), &image_user);
     let managed_agent = client.capabilities().managed_agent;
     let skip_rules = cfg.network_rule_policy == cella_network::NetworkRulePolicy::Skip;
@@ -469,7 +480,7 @@ async fn resolve_user_and_env(
         client.host_gateway(),
     )
     .await;
-    (remote_user, image_user, env_fwd, ssh_agent_proxy)
+    (remote_user, image_user, env_fwd, ssh_agent_proxy, security)
 }
 
 /// Prepare environment, write override YAML, and start compose services.
@@ -544,6 +555,8 @@ async fn prepare_and_start(
         extra_volumes: Vec::new(),
         // GPU reservation is emitted only in the final override, not at build.
         request_gpu: false,
+        // Runtime security props are applied in the final override, not at build.
+        security: cella_config::config_map::MergedSecurityConfig::default(),
     };
     write_build_override(project, features_build.as_ref(), &build_ov)?;
 
@@ -558,7 +571,7 @@ async fn prepare_and_start(
     .await?;
 
     // 10. Resolve remote user, env forwarding, and ssh-agent proxy.
-    let (remote_user, image_user, mut env_fwd, ssh_agent_proxy) =
+    let (remote_user, image_user, mut env_fwd, ssh_agent_proxy, security) =
         resolve_user_and_env(client, ctx, project, features_build.as_ref()).await;
     info!("Resolved remote user: {remote_user} (image user: {image_user})");
 
@@ -575,6 +588,7 @@ async fn prepare_and_start(
         &image_user,
         agent_vol_name,
         agent_vol_target,
+        security,
     )
     .await?;
 
@@ -873,6 +887,9 @@ struct OverrideContext {
     /// Whether to emit the GPU reservation block (config requires a GPU AND
     /// `--gpu-availability` grants it). Net-new compose GPU support.
     request_gpu: bool,
+    /// Merged container security/runtime properties (containerUser, init,
+    /// privileged, capAdd, securityOpt) applied to the primary service.
+    security: cella_config::config_map::MergedSecurityConfig,
 }
 
 // ---------------------------------------------------------------------------
@@ -904,6 +921,8 @@ fn write_build_override(
         // The build-time override never needs the GPU reservation; it is
         // emitted only in the final override used for `compose up`.
         request_gpu: false,
+        // build_ov carries default (empty) security props at build time.
+        security: ov.security.clone(),
     };
     let override_yaml = crate::override_file::generate_override_yaml(&override_config);
     crate::override_file::write_override_file(&project.override_file, &override_yaml)?;
@@ -923,22 +942,29 @@ fn write_build_override(
 /// For image-only services, inspects the image directly (pulling if needed).
 /// For build-based services, inspects the compose-built image (`{project}-{service}`).
 ///
-/// Returns `(image_user, Option<ImageMetadataUserInfo>)`. Falls back to
-/// `("root", None)` when inspection fails.
+/// Returns `(image_user, Option<ImageMetadataUserInfo>, Option<FeatureContainerConfig>)`.
+/// The third element is the base image's `devcontainer.metadata` container config,
+/// used for runtime security props when no features are configured (mirrors the
+/// single-container base-image-metadata fallback in `up.rs`). Falls back to
+/// `("root", None, None)` when inspection fails.
 async fn resolve_compose_image_info(
     client: &dyn ContainerBackend,
     project: &ComposeProject,
     features_build: Option<&crate::combined_dockerfile_build::ComposeFeaturesBuild>,
     docker_binaries: (Option<String>, Option<String>),
     progress: &ProgressSender,
-) -> (String, Option<cella_features::ImageMetadataUserInfo>) {
+) -> (
+    String,
+    Option<cella_features::ImageMetadataUserInfo>,
+    Option<cella_features::FeatureContainerConfig>,
+) {
     // If features resolved an image, its metadata was already extracted.
     if let Some(fb) = features_build {
         let meta_user = fb
             .base_image_metadata
             .as_deref()
             .map(|m| cella_features::parse_image_metadata(m).1);
-        return (fb.image_user.clone(), meta_user);
+        return (fb.image_user.clone(), meta_user, None);
     }
 
     // Resolve compose config to find the service's image source.
@@ -948,7 +974,7 @@ async fn resolve_compose_image_info(
         Ok(r) => r,
         Err(e) => {
             warn!("Failed to resolve compose config for image metadata: {e}");
-            return ("root".to_string(), None);
+            return ("root".to_string(), None, None);
         }
     };
 
@@ -957,7 +983,7 @@ async fn resolve_compose_image_info(
         Ok(info) => info,
         Err(e) => {
             warn!("Failed to extract service build info: {e}");
-            return ("root".to_string(), None);
+            return ("root".to_string(), None, None);
         }
     };
 
@@ -981,16 +1007,17 @@ async fn resolve_compose_image_info(
     };
 
     match client.inspect_image_details(&image_name).await {
-        Ok(details) => {
-            let meta_user = details
-                .metadata
-                .as_deref()
-                .map(|m| cella_features::parse_image_metadata(m).1);
-            (details.user, meta_user)
-        }
+        Ok(details) => match details
+            .metadata
+            .as_deref()
+            .map(cella_features::parse_image_metadata)
+        {
+            Some((cfg, user)) => (details.user, Some(user), Some(cfg)),
+            None => (details.user, None, None),
+        },
         Err(e) => {
             warn!("Failed to inspect image '{image_name}' for metadata: {e}");
-            ("root".to_string(), None)
+            ("root".to_string(), None, None)
         }
     }
 }
@@ -1110,6 +1137,7 @@ fn write_final_override(
         build_secrets: Vec::new(),
         extra_volumes: ov.extra_volumes.clone(),
         request_gpu: ov.request_gpu,
+        security: ov.security.clone(),
     };
     let override_yaml = crate::override_file::generate_override_yaml(&override_config);
     crate::override_file::write_override_file(&project.override_file, &override_yaml)?;
@@ -1135,6 +1163,7 @@ async fn build_override_and_start(
     image_user: &str,
     agent_vol_name: String,
     agent_vol_target: String,
+    security: cella_config::config_map::MergedSecurityConfig,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let cfg = ctx.cfg;
     let progress = ctx.progress;
@@ -1191,6 +1220,7 @@ async fn build_override_and_start(
         labels,
         extra_volumes: mount_specs,
         request_gpu,
+        security,
     };
 
     let uid_image =

--- a/crates/cella-compose/src/override_file.rs
+++ b/crates/cella-compose/src/override_file.rs
@@ -9,6 +9,7 @@ use std::fmt::Write;
 use std::path::{Path, PathBuf};
 
 use cella_backend::{MountKind, MountSpec};
+use cella_config::config_map::MergedSecurityConfig;
 
 use crate::error::CellaComposeError;
 
@@ -64,6 +65,12 @@ pub struct OverrideConfig {
     /// `[gpu]` (matching the official compose GPU override). Decided by
     /// `hostRequirements.gpu` AND `--gpu-availability`.
     pub request_gpu: bool,
+    /// Merged container security/runtime properties (containerUser, init,
+    /// privileged, capAdd, securityOpt). Emitted as `user:`/`init:`/`privileged:`/
+    /// `cap_add:`/`security_opt:` on the primary service, matching the official
+    /// compose override. Shares the type with the single-container create path so
+    /// both apply identical values.
+    pub security: MergedSecurityConfig,
 }
 
 /// Generate the override compose YAML as a string.
@@ -115,6 +122,9 @@ pub fn generate_override_yaml(config: &OverrideConfig) -> String {
         yaml.push_str("    entrypoint: [\"/bin/sh\", \"-c\"]\n");
         yaml.push_str("    command: [\"while sleep 1000; do :; done\"]\n");
     }
+
+    // Container security/runtime properties (init, user, privileged, caps).
+    write_security_section(&mut yaml, &config.security);
 
     // Environment variables
     if !config.extra_env.is_empty() {
@@ -202,6 +212,37 @@ pub fn generate_override_yaml(config: &OverrideConfig) -> String {
     yaml
 }
 
+/// Emit the container security/runtime section (init, user, privileged, capAdd,
+/// securityOpt) onto the primary service, matching the official compose override
+/// (`dockerCompose.ts` emits the same keys on the service definition).
+fn write_security_section(yaml: &mut String, sec: &MergedSecurityConfig) {
+    // Values come from devcontainer.json / image metadata, so quote them
+    // (consistent with the labels/env/image emission above). A double-quoted
+    // scalar keeps a stray `:`/`#`/newline inside the value instead of breaking
+    // the override or injecting new YAML keys.
+    if sec.init {
+        yaml.push_str("    init: true\n");
+    }
+    if let Some(ref user) = sec.container_user {
+        let _ = writeln!(yaml, "    user: \"{user}\"");
+    }
+    if sec.privileged {
+        yaml.push_str("    privileged: true\n");
+    }
+    if !sec.cap_add.is_empty() {
+        yaml.push_str("    cap_add:\n");
+        for cap in &sec.cap_add {
+            let _ = writeln!(yaml, "      - \"{cap}\"");
+        }
+    }
+    if !sec.security_opt.is_empty() {
+        yaml.push_str("    security_opt:\n");
+        for opt in &sec.security_opt {
+            let _ = writeln!(yaml, "      - \"{opt}\"");
+        }
+    }
+}
+
 /// Write the override file to disk, creating parent directories as needed.
 ///
 /// # Errors
@@ -244,7 +285,34 @@ mod tests {
             build_secrets: Vec::new(),
             extra_volumes: Vec::new(),
             request_gpu: false,
+            security: MergedSecurityConfig::default(),
         }
+    }
+
+    #[test]
+    fn runtime_security_properties_emitted() {
+        let mut config = base_config();
+        config.security.container_user = Some("vscode".to_string());
+        config.security.init = true;
+        config.security.privileged = true;
+        config.security.cap_add = vec!["SYS_PTRACE".to_string(), "NET_ADMIN".to_string()];
+        config.security.security_opt = vec!["seccomp=unconfined".to_string()];
+        let yaml = generate_override_yaml(&config);
+        assert!(yaml.contains("    init: true\n"), "yaml:\n{yaml}");
+        assert!(yaml.contains("    user: \"vscode\"\n"), "yaml:\n{yaml}");
+        assert!(yaml.contains("    privileged: true\n"), "yaml:\n{yaml}");
+        assert!(yaml.contains("    cap_add:\n      - \"SYS_PTRACE\"\n      - \"NET_ADMIN\"\n"));
+        assert!(yaml.contains("    security_opt:\n      - \"seccomp=unconfined\"\n"));
+    }
+
+    #[test]
+    fn runtime_security_properties_omitted_when_default() {
+        let yaml = generate_override_yaml(&base_config());
+        assert!(!yaml.contains("init:"));
+        assert!(!yaml.contains("user:"));
+        assert!(!yaml.contains("privileged:"));
+        assert!(!yaml.contains("cap_add:"));
+        assert!(!yaml.contains("security_opt:"));
     }
 
     #[test]

--- a/crates/cella-config/src/config_map/mod.rs
+++ b/crates/cella-config/src/config_map/mod.rs
@@ -90,32 +90,8 @@ pub fn map_config<S: std::hash::BuildHasher>(
     let env = map_merged_env(config, image_env);
     let remote_env = map_remote_env(config);
     let port_bindings = map_port_bindings(config);
-    let cap_add = map_merged_string_list(config, "capAdd", feature_config.map(|fc| &fc.cap_add));
-    let security_opt = map_merged_string_list(
-        config,
-        "securityOpt",
-        feature_config.map(|fc| &fc.security_opt),
-    );
-
-    let container_user = config
-        .get("containerUser")
-        .and_then(|v| v.as_str())
-        .map(String::from);
-
+    let sec = merge_security_config(config, feature_config);
     let (entrypoint, cmd) = build_entrypoint_cmd(config, feature_config, agent_arch);
-
-    let privileged = config
-        .get("privileged")
-        .and_then(serde_json::Value::as_bool)
-        .unwrap_or(false)
-        || feature_config.is_some_and(|fc| fc.privileged);
-
-    let init = config
-        .get("init")
-        .and_then(serde_json::Value::as_bool)
-        .unwrap_or(false)
-        || feature_config.is_some_and(|fc| fc.init);
-
     let gpu_request = map_gpu_device_request(config);
     let run_args_overrides = parse_run_args_from_config(config);
 
@@ -125,19 +101,72 @@ pub fn map_config<S: std::hash::BuildHasher>(
         labels: labels.into_iter().collect(),
         env,
         remote_env,
-        user: container_user,
+        user: sec.container_user,
         workspace_folder,
         workspace_mount,
         mounts,
         port_bindings,
         entrypoint,
         cmd,
-        cap_add,
-        security_opt,
-        privileged,
-        init,
+        cap_add: sec.cap_add,
+        security_opt: sec.security_opt,
+        privileged: sec.privileged,
+        init: sec.init,
         run_args_overrides,
         gpu_request,
+    }
+}
+
+/// Container security/runtime properties merged from devcontainer.json and
+/// feature/image metadata.
+///
+/// `capAdd`/`securityOpt` are unioned (deduplicated), `privileged`/`init` are
+/// OR-ed, and `containerUser` comes from devcontainer.json. Shared by the
+/// single-container create path ([`map_config`]) and the compose override
+/// generator so both apply identical values — official applies these on both
+/// paths (`devContainersSpecCLI` single-container run args and the
+/// `dockerCompose` service override).
+#[derive(Debug, Clone, Default)]
+pub struct MergedSecurityConfig {
+    /// `containerUser` — the user the container process runs as (`--user`).
+    pub container_user: Option<String>,
+    /// `capAdd` — Linux capabilities to add (`--cap-add`).
+    pub cap_add: Vec<String>,
+    /// `securityOpt` — security options (`--security-opt`).
+    pub security_opt: Vec<String>,
+    /// `privileged` — run the container privileged (`--privileged`).
+    pub privileged: bool,
+    /// `init` — wrap the container entrypoint with an init process (`--init`).
+    pub init: bool,
+}
+
+/// Merge container security/runtime properties from devcontainer.json with the
+/// merged feature/image metadata. See [`MergedSecurityConfig`].
+pub fn merge_security_config(
+    config: &serde_json::Value,
+    feature_config: Option<&FeatureContainerConfig>,
+) -> MergedSecurityConfig {
+    MergedSecurityConfig {
+        container_user: config
+            .get("containerUser")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        cap_add: map_merged_string_list(config, "capAdd", feature_config.map(|fc| &fc.cap_add)),
+        security_opt: map_merged_string_list(
+            config,
+            "securityOpt",
+            feature_config.map(|fc| &fc.security_opt),
+        ),
+        privileged: config
+            .get("privileged")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false)
+            || feature_config.is_some_and(|fc| fc.privileged),
+        init: config
+            .get("init")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false)
+            || feature_config.is_some_and(|fc| fc.init),
     }
 }
 


### PR DESCRIPTION
The Docker Compose path never applied `containerUser`/`init`/`privileged`/`capAdd`/`securityOpt` to the primary service. A devcontainer.json (or feature) requiring privileged mode, added capabilities, an init process, or a specific container user silently got none of them on compose — while the single-container path applied them all. So e.g. a docker-in-docker or debugger feature needing `--privileged`/`SYS_PTRACE` was broken on the compose path.

## Change
- **cella-config**: extract `merge_security_config(config, feature_config)` from `map_config` (pure refactor) so both paths share one merge — capAdd/securityOpt union, privileged/init OR, containerUser from devcontainer.json.
- **cella-compose**: add `OverrideConfig.security` and emit `init:`/`user:`/`privileged:`/`cap_add:`/`security_opt:` on the primary service (via `write_security_section`), matching the official `dockerCompose.ts` override.
- Compute the merged values once in `resolve_user_and_env`, preferring the resolved-features config and falling back to the base image's `devcontainer.metadata` when no features are configured — mirroring single-container's `effective_feature_config`, so security props baked into a prebuilt image are honored too.

## Tests
- `runtime_security_properties_emitted` / `_omitted_when_default` lock the YAML emission; existing override snapshots unchanged (defaults emit nothing).
- cella-config 276, cella-compose 276, cella-docker 342, cella-orchestrator 188 — all pass. clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
