### PR TITLE
feat(runargs): apply --cap-add/--cap-drop/--volume/--read-only/--group-add

### DIFF
--- a/crates/cella-backend/src/types.rs
+++ b/crates/cella-backend/src/types.rs
@@ -581,6 +581,15 @@ pub struct RunArgsOverrides {
     pub cgroup_parent: Option<String>,
     pub cgroupns_mode: Option<String>,
 
+    // Capabilities, supplementary groups, bind mounts, and read-only rootfs.
+    // `cap_add` unions with the `capAdd` devcontainer property; the rest have
+    // no dedicated devcontainer.json field and arrive only via `runArgs`.
+    pub cap_add: Vec<String>,
+    pub cap_drop: Vec<String>,
+    pub group_add: Vec<String>,
+    pub binds: Vec<String>,
+    pub read_only: Option<bool>,
+
     // Devices
     pub devices: Vec<DeviceSpec>,
     pub device_cgroup_rules: Vec<String>,

--- a/crates/cella-config/src/config_map/run_args.rs
+++ b/crates/cella-config/src/config_map/run_args.rs
@@ -70,9 +70,14 @@ pub fn parse_run_args(args: &[String]) -> RunArgsOverrides {
                 parse_other_arg(flag, &mut i, inline_val, &next_val, &mut result);
             }
 
+            "--cap-add" | "--cap-drop" | "--group-add" | "--volume" | "-v" => {
+                parse_capability_arg(flag, &mut i, inline_val, &next_val, &mut result);
+            }
+
             // -- Boolean flags (no value) --
             "--init" => result.init = Some(true),
             "--privileged" => result.privileged = Some(true),
+            "--read-only" => result.read_only = Some(true),
 
             _ => {
                 result.unrecognized.push(arg.clone());
@@ -369,6 +374,39 @@ fn parse_other_arg(
     }
 }
 
+/// Parse capability, supplementary-group, and bind-mount flags.
+fn parse_capability_arg(
+    flag: &str,
+    i: &mut usize,
+    inline_val: Option<&str>,
+    next_val: &NextValFn<'_>,
+    result: &mut RunArgsOverrides,
+) {
+    match flag {
+        "--cap-add" => {
+            if let Some(v) = next_val(i, inline_val) {
+                result.cap_add.push(v);
+            }
+        }
+        "--cap-drop" => {
+            if let Some(v) = next_val(i, inline_val) {
+                result.cap_drop.push(v);
+            }
+        }
+        "--group-add" => {
+            if let Some(v) = next_val(i, inline_val) {
+                result.group_add.push(v);
+            }
+        }
+        "--volume" | "-v" => {
+            if let Some(v) = next_val(i, inline_val) {
+                result.binds.push(v);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// Parse a byte size string (e.g., "512m", "2g", "1024") into bytes.
 pub fn parse_byte_size(s: &str) -> Option<i64> {
     let s = s.trim().to_lowercase();
@@ -651,6 +689,51 @@ mod tests {
         ]));
         assert_eq!(r.log_driver.as_deref(), Some("json-file"));
         assert_eq!(r.log_opt.get("max-size").unwrap(), "10m");
+    }
+
+    // -- Capabilities / groups / volumes / read-only --
+
+    #[test]
+    fn parse_cap_add_and_drop() {
+        let r = parse_run_args(&args(&["--cap-add=SYS_PTRACE", "--cap-drop", "MKNOD"]));
+        assert_eq!(r.cap_add, vec!["SYS_PTRACE"]);
+        assert_eq!(r.cap_drop, vec!["MKNOD"]);
+    }
+
+    #[test]
+    fn parse_volume_short_and_long() {
+        let r = parse_run_args(&args(&["-v", "/h:/c", "--volume=/data:/data:ro"]));
+        assert_eq!(r.binds, vec!["/h:/c", "/data:/data:ro"]);
+    }
+
+    #[test]
+    fn parse_group_add() {
+        let r = parse_run_args(&args(&["--group-add", "docker"]));
+        assert_eq!(r.group_add, vec!["docker"]);
+    }
+
+    #[test]
+    fn parse_read_only() {
+        let r = parse_run_args(&args(&["--read-only"]));
+        assert_eq!(r.read_only, Some(true));
+    }
+
+    /// The canonical debugger block: `--cap-add` + `--security-opt` together.
+    /// Neither must land in `unrecognized` (the bug this parser arm fixes).
+    #[test]
+    fn cap_add_with_security_opt_not_unrecognized() {
+        let r = parse_run_args(&args(&[
+            "--cap-add=SYS_PTRACE",
+            "--security-opt",
+            "seccomp=unconfined",
+        ]));
+        assert!(
+            r.unrecognized.is_empty(),
+            "unrecognized: {:?}",
+            r.unrecognized
+        );
+        assert_eq!(r.cap_add, vec!["SYS_PTRACE"]);
+        assert_eq!(r.security_opt, vec!["seccomp=unconfined"]);
     }
 
     // -- Unrecognized --

--- a/crates/cella-container/src/backend.rs
+++ b/crates/cella-container/src/backend.rs
@@ -1148,13 +1148,24 @@ fn push_override_args(args: &mut Vec<String>, overrides: &RunArgsOverrides) {
         args.push("--runtime".to_string());
         args.push(runtime.clone());
     }
+
+    // Capabilities and bind mounts: Apple Container accepts `--cap-add`
+    // (since 0.12.0) and `--volume`, so forward runArgs that use them.
+    for cap in &overrides.cap_add {
+        args.push("--cap-add".to_string());
+        args.push(cap.clone());
+    }
+    for bind in &overrides.binds {
+        args.push("--volume".to_string());
+        args.push(bind.clone());
+    }
 }
 
 /// Collect runArgs override flags that Apple Container has no equivalent for.
 fn collect_unsupported_overrides(overrides: &RunArgsOverrides) -> Vec<&'static str> {
     let mut ignored = Vec::new();
 
-    let flags: [(bool, &'static str); 22] = [
+    let flags: [(bool, &'static str); 25] = [
         (overrides.network_mode.is_some(), "--network"),
         (overrides.hostname.is_some(), "--hostname"),
         (!overrides.extra_hosts.is_empty(), "--add-host"),
@@ -1183,6 +1194,12 @@ fn collect_unsupported_overrides(overrides: &RunArgsOverrides) -> Vec<&'static s
             "--log-driver/--log-opt",
         ),
         (overrides.restart_policy.is_some(), "--restart"),
+        // Apple Container accepts --cap-add (0.12.0+) and --volume (forwarded in
+        // push_override_args), but these three have no verified equivalent — warn
+        // rather than emit an unknown flag that would fail `container create`.
+        (!overrides.cap_drop.is_empty(), "--cap-drop"),
+        (!overrides.group_add.is_empty(), "--group-add"),
+        (overrides.read_only == Some(true), "--read-only"),
     ];
 
     for (present, flag) in flags {
@@ -1888,6 +1905,37 @@ mod tests {
             !args.contains(&"--init".to_string()),
             "--init must not appear here; it is OR-d and emitted in build_create_args"
         );
+    }
+
+    #[test]
+    fn push_override_args_emits_cap_add_and_volume() {
+        let overrides = RunArgsOverrides {
+            cap_add: vec!["SYS_PTRACE".to_string()],
+            binds: vec!["/h:/c:ro".to_string()],
+            ..RunArgsOverrides::default()
+        };
+        let mut args = Vec::new();
+        push_override_args(&mut args, &overrides);
+        let pairs: Vec<(&str, &str)> = args
+            .windows(2)
+            .map(|w| (w[0].as_str(), w[1].as_str()))
+            .collect();
+        assert!(pairs.contains(&("--cap-add", "SYS_PTRACE")));
+        assert!(pairs.contains(&("--volume", "/h:/c:ro")));
+    }
+
+    #[test]
+    fn collect_unsupported_includes_cap_drop_group_add_read_only() {
+        let overrides = RunArgsOverrides {
+            cap_drop: vec!["MKNOD".to_string()],
+            group_add: vec!["docker".to_string()],
+            read_only: Some(true),
+            ..RunArgsOverrides::default()
+        };
+        let ignored = collect_unsupported_overrides(&overrides);
+        assert!(ignored.contains(&"--cap-drop"));
+        assert!(ignored.contains(&"--group-add"));
+        assert!(ignored.contains(&"--read-only"));
     }
 
     #[test]

--- a/crates/cella-docker/src/config_map/mod.rs
+++ b/crates/cella-docker/src/config_map/mod.rs
@@ -121,7 +121,7 @@ fn apply_overrides(opts: &CreateContainerOptions, host_config: &mut HostConfig) 
     let mut security_opt = opts.security_opt.clone();
     let mut privileged = opts.privileged;
     let mut init = opts.init;
-    let cap_add = opts.cap_add.clone();
+    let mut cap_add = opts.cap_add.clone();
     let mut labels = opts.labels.clone();
     let mut hostname = None;
 
@@ -129,6 +129,7 @@ fn apply_overrides(opts: &CreateContainerOptions, host_config: &mut HostConfig) 
         apply_run_args_to_host_config(host_config, ra);
         extra_hosts.extend(ra.extra_hosts.clone());
         security_opt.extend(ra.security_opt.clone());
+        cap_add.extend(ra.cap_add.clone());
         if let Some(p) = ra.privileged {
             privileged = p || privileged;
         }
@@ -148,6 +149,13 @@ fn apply_overrides(opts: &CreateContainerOptions, host_config: &mut HostConfig) 
                 .push(gpu_request_to_device_request(gpu));
         }
     }
+
+    // `opts.cap_add` already arrives sorted+deduped from `merge_security_config`
+    // (via `map_merged_string_list`), which feeds both the single-container and
+    // compose paths. Re-apply after unioning runArgs `--cap-add` so the combined
+    // set keeps identical semantics; capability order is irrelevant to Docker.
+    cap_add.sort();
+    cap_add.dedup();
 
     let has_run_args_gpu = opts
         .run_args_overrides
@@ -262,6 +270,18 @@ fn apply_security_overrides(hc: &mut HostConfig, ra: &RunArgsOverrides) {
             _ => bollard::models::HostConfigCgroupnsModeEnum::PRIVATE,
         });
     }
+    // Unlike `cap_add` (unioned with the `capAdd` property in `apply_overrides`),
+    // these come only from runArgs — a single source — so they apply as-is, the
+    // same way other single-source runArgs lists (dns, devices) are passed through.
+    if !ra.cap_drop.is_empty() {
+        hc.cap_drop = Some(ra.cap_drop.clone());
+    }
+    if !ra.group_add.is_empty() {
+        hc.group_add = Some(ra.group_add.clone());
+    }
+    if ra.read_only == Some(true) {
+        hc.readonly_rootfs = Some(true);
+    }
 }
 
 /// Apply device-related overrides to `HostConfig`.
@@ -302,6 +322,11 @@ fn apply_misc_overrides(hc: &mut HostConfig, ra: &RunArgsOverrides) {
     }
     if !ra.tmpfs.is_empty() {
         hc.tmpfs = Some(ra.tmpfs.clone());
+    }
+    // `binds` has a single writer here (configured mounts use `HostConfig.mounts`),
+    // so a plain assignment is safe; revisit if another binds source is added.
+    if !ra.binds.is_empty() {
+        hc.binds = Some(ra.binds.clone());
     }
     if let Some(ref v) = ra.pid_mode {
         hc.pid_mode = Some(v.clone());
@@ -804,6 +829,61 @@ mod tests {
         let hc = config.host_config.unwrap();
         assert!(hc.cap_add.is_none());
         assert!(hc.security_opt.is_none());
+    }
+
+    #[test]
+    fn run_args_cap_add_unions_with_property() {
+        // `capAdd` property + runArgs `--cap-add` must both survive (union),
+        // sorted and deduped — the discriminating both-sources case.
+        let mut opts = minimal_opts();
+        opts.cap_add = vec!["SYS_PTRACE".to_string()];
+        opts.run_args_overrides = Some(RunArgsOverrides {
+            cap_add: vec!["NET_ADMIN".to_string()],
+            ..Default::default()
+        });
+        let hc = to_bollard_config(&opts).host_config.unwrap();
+        assert_eq!(
+            hc.cap_add,
+            Some(vec!["NET_ADMIN".to_string(), "SYS_PTRACE".to_string()])
+        );
+    }
+
+    #[test]
+    fn run_args_cap_add_dedups_across_sources() {
+        let mut opts = minimal_opts();
+        opts.cap_add = vec!["SYS_PTRACE".to_string()];
+        opts.run_args_overrides = Some(RunArgsOverrides {
+            cap_add: vec!["SYS_PTRACE".to_string()],
+            ..Default::default()
+        });
+        let hc = to_bollard_config(&opts).host_config.unwrap();
+        assert_eq!(hc.cap_add, Some(vec!["SYS_PTRACE".to_string()]));
+    }
+
+    #[test]
+    fn run_args_cap_drop_group_add_read_only() {
+        let mut opts = minimal_opts();
+        opts.run_args_overrides = Some(RunArgsOverrides {
+            cap_drop: vec!["MKNOD".to_string()],
+            group_add: vec!["docker".to_string()],
+            read_only: Some(true),
+            ..Default::default()
+        });
+        let hc = to_bollard_config(&opts).host_config.unwrap();
+        assert_eq!(hc.cap_drop, Some(vec!["MKNOD".to_string()]));
+        assert_eq!(hc.group_add, Some(vec!["docker".to_string()]));
+        assert_eq!(hc.readonly_rootfs, Some(true));
+    }
+
+    #[test]
+    fn run_args_binds_applied() {
+        let mut opts = minimal_opts();
+        opts.run_args_overrides = Some(RunArgsOverrides {
+            binds: vec!["/host:/container:ro".to_string()],
+            ..Default::default()
+        });
+        let hc = to_bollard_config(&opts).host_config.unwrap();
+        assert_eq!(hc.binds, Some(vec!["/host:/container:ro".to_string()]));
     }
 
     #[test]


### PR DESCRIPTION
## What

These `runArgs` flags were being parsed into an `unrecognized` bucket and dropped with a warning, so they silently had no effect on the container. The most visible casualty is the classic debugger setup:

```jsonc
"runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"]
```

`--security-opt` already worked, so the container came up "fine" — but `--cap-add=SYS_PTRACE` was dropped, and the debugger failed anyway with only a buried warning. This wires the dropped HostConfig-level flags through to the actual container config: `--cap-add`, `--cap-drop`, `--group-add`, `-v`/`--volume`, and `--read-only`.

## Why it's needed

The official devcontainer CLI shells out to `docker run` and passes `runArgs` through verbatim, so it supports every flag for free. cella talks to the Docker API directly (bollard), so each flag has to be parsed and mapped — and anything unmapped just vanishes. `runArgs` was already ~90% covered (networking, resources, security-opt, devices, ulimits, sysctls, tmpfs, labels, logging, restart, init, privileged); this closes the remaining HostConfig cluster.

## How

- **Parser** (`cella-config`): new `--cap-add`/`--cap-drop`/`--group-add`/`-v`/`--volume` arm and a `--read-only` boolean.
- **Docker backend** (`cella-docker`, bollard): `--cap-add` unions with the `capAdd` devcontainer property then sort+dedups — matching `merge_security_config`/`map_merged_string_list`, which already feeds both the single-container and compose paths, so order/dedup stay identical everywhere. The other four come only from `runArgs` (single source) and apply straight to `HostConfig` (`cap_drop`, `group_add`, `binds`, `readonly_rootfs`).
- **Apple Container backend** (`cella-container`): forwards `--cap-add` (supported since 0.12.0) and `--volume` as native CLI args; `--cap-drop`/`--group-add`/`--read-only` join the unsupported-warning list rather than being emitted blindly (an unknown flag would fail `container create`) or dropped silently.

## Deferred (follow-ups, not regressions)

The container-body flags (`-e`/`--env`, `-p`/`--publish`/`--expose`, `-u`/`--user`, `-w`/`--workdir`) each carry a semantic decision (env precedence, the remoteUser UID path, the existing WorkingDir behavior) and get their own PRs. `--mount` and `--volumes-from` are the same HostConfig family but niche. `--name`/`--entrypoint` are left as open questions (cella tracks containers by labels, and `--entrypoint` overlaps with agent-entrypoint work).

## Tests

Unit tests for parsing (inline and spaced forms, the debugger block staying out of `unrecognized`), the bollard mapping (cap_add union + cross-source dedup, cap_drop/group_add/read_only, binds), and the Apple backend (emits cap-add/volume, warns the other three). Full workspace `cargo clippy`/`cargo test` green; no Docker required for any of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)