### PR TITLE
feat(exec): add --config / --override-config

### DIFF
--- a/crates/cella-cli/src/commands/exec.rs
+++ b/crates/cella-cli/src/commands/exec.rs
@@ -34,13 +34,14 @@ pub struct ExecArgs {
     #[arg(long, value_parser = crate::commands::parse_id_label)]
     id_label: Vec<String>,
 
-    /// Path to devcontainer.json — targets the container stamped with this
-    /// config file (overrides workspace-folder discovery).
+    /// Path to devcontainer.json. The default is .devcontainer/devcontainer.json
+    /// or, if that does not exist, .devcontainer.json in the workspace folder.
     #[arg(long)]
     config: Option<PathBuf>,
 
-    /// Path to a devcontainer.json that replaces the discovered config —
-    /// targets the container stamped with this config file.
+    /// Path to a devcontainer.json whose contents override any devcontainer.json
+    /// in the workspace folder (required when there is none otherwise). The
+    /// container is selected by the discovered config path, not this file's path.
     #[arg(long = "override-config")]
     override_config: Option<PathBuf>,
 
@@ -191,8 +192,8 @@ impl ExecArgs {
 /// The spec identity labels `up` stamps for a `(workspace, config)` pair:
 /// `devcontainer.local_folder` and `devcontainer.config_file`, both lexical
 /// (non-symlink-resolving) absolute paths. Byte-identical to what
-/// `build_container_labels` / `build_compose_labels` write, so a container can
-/// be matched by them.
+/// `cella_backend::names::container_labels` (single-container) and
+/// `build_compose_labels` (compose) write, so a container can be matched by them.
 fn spec_identity_labels(workspace_root: &Path, config_path: &Path) -> [String; 2] {
     [
         format!(

--- a/crates/cella-cli/src/commands/exec.rs
+++ b/crates/cella-cli/src/commands/exec.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::Args;
 use tracing::warn;
@@ -34,6 +34,16 @@ pub struct ExecArgs {
     #[arg(long, value_parser = crate::commands::parse_id_label)]
     id_label: Vec<String>,
 
+    /// Path to devcontainer.json — targets the container stamped with this
+    /// config file (overrides workspace-folder discovery).
+    #[arg(long)]
+    config: Option<PathBuf>,
+
+    /// Path to a devcontainer.json that replaces the discovered config —
+    /// targets the container stamped with this config file.
+    #[arg(long = "override-config")]
+    override_config: Option<PathBuf>,
+
     /// Target a specific compose service (defaults to primary service).
     #[arg(long)]
     service: Option<String>,
@@ -68,6 +78,7 @@ pub struct ExecArgs {
 
 impl ExecArgs {
     pub async fn execute(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let select_by_config = self.config_selects_container();
         let client = self.backend.resolve_client().await?;
 
         let user_opt = self.user;
@@ -79,32 +90,57 @@ impl ExecArgs {
         let output = self.output;
         let default_user_env_probe = self.default_user_env_probe;
 
-        let target = ContainerTarget {
-            container_id: self.container_id,
-            container_name: self.container_name,
-            id_labels: self.id_label,
-            workspace_folder: self.workspace_folder,
-        };
+        let container = if select_by_config {
+            // Explicit config selection (no higher-precedence id target). Resolve
+            // the path exactly as `up` does (config_with_override: `--config` wins;
+            // with only `--override-config` the recorded path is the discovered
+            // devcontainer.json, since the override supplies content, not the path),
+            // then target the container by its spec identity labels
+            // [local_folder + config_file] — the same (workspace, config) pair `up`
+            // stamps and reuses by. Resolve the workspace folder with the same helper
+            // `up` uses so `devcontainer.local_folder` matches byte-for-byte. Mirrors
+            // the official `findContainerAndIdLabels` workspace tier; id targets
+            // (handled below) take precedence. Explicit target → no picker.
+            let ws = crate::commands::resolve_workspace_folder(self.workspace_folder.as_deref())?;
+            let resolved = cella_config::devcontainer::resolve::config_with_override(
+                &ws,
+                self.config.as_deref(),
+                self.override_config.as_deref(),
+            )?;
+            find_container_by_spec_identity(
+                client.as_ref(),
+                &resolved.workspace_root,
+                &resolved.config_path,
+            )
+            .await?
+        } else {
+            let target = ContainerTarget {
+                container_id: self.container_id,
+                container_name: self.container_name,
+                id_labels: self.id_label,
+                workspace_folder: self.workspace_folder,
+            };
 
-        let has_explicit = picker::has_explicit_target(&target);
-        let container = match target.resolve(client.as_ref(), true).await {
-            Ok(c) => c,
-            Err(_) if !has_explicit => {
-                let containers = client.as_ref().list_cella_containers(true).await?;
-                let cwd_container = client
-                    .as_ref()
-                    .find_container(&std::env::current_dir()?)
-                    .await
-                    .ok()
-                    .flatten();
-                picker::resolve_container_interactive(
-                    &containers,
-                    cwd_container.as_ref().map(|c| c.name.as_str()),
-                    "Select a container:",
-                    None,
-                )?
+            let has_explicit = picker::has_explicit_target(&target);
+            match target.resolve(client.as_ref(), true).await {
+                Ok(c) => c,
+                Err(_) if !has_explicit => {
+                    let containers = client.as_ref().list_cella_containers(true).await?;
+                    let cwd_container = client
+                        .as_ref()
+                        .find_container(&std::env::current_dir()?)
+                        .await
+                        .ok()
+                        .flatten();
+                    picker::resolve_container_interactive(
+                        &containers,
+                        cwd_container.as_ref().map(|c| c.name.as_str()),
+                        "Select a container:",
+                        None,
+                    )?
+                }
+                Err(e) => return Err(e.into()),
             }
-            Err(e) => return Err(e.into()),
         };
         let container =
             super::resolve_service_container(client.as_ref(), container, service.as_deref())
@@ -137,6 +173,69 @@ impl ExecArgs {
         )
         .await
     }
+
+    /// Whether `--config`/`--override-config` should drive container resolution.
+    ///
+    /// True only when a config path is given AND no higher-precedence explicit
+    /// target (`--container-id`/`--container-name`/`--id-label`) is set. Mirrors
+    /// the official `findContainerAndIdLabels` precedence, where the config file
+    /// only feeds the workspace-tier label search and id targets win.
+    const fn config_selects_container(&self) -> bool {
+        (self.config.is_some() || self.override_config.is_some())
+            && self.container_id.is_none()
+            && self.container_name.is_none()
+            && self.id_label.is_empty()
+    }
+}
+
+/// The spec identity labels `up` stamps for a `(workspace, config)` pair:
+/// `devcontainer.local_folder` and `devcontainer.config_file`, both lexical
+/// (non-symlink-resolving) absolute paths. Byte-identical to what
+/// `build_container_labels` / `build_compose_labels` write, so a container can
+/// be matched by them.
+fn spec_identity_labels(workspace_root: &Path, config_path: &Path) -> [String; 2] {
+    [
+        format!(
+            "devcontainer.local_folder={}",
+            cella_backend::lexical_absolute(workspace_root).to_string_lossy()
+        ),
+        format!(
+            "devcontainer.config_file={}",
+            cella_backend::lexical_absolute(config_path).to_string_lossy()
+        ),
+    ]
+}
+
+/// Resolve the running container stamped with the given `(workspace, config)`
+/// spec identity (`--config` / `--override-config`), matching both the
+/// `devcontainer.local_folder` and `devcontainer.config_file` labels `up`
+/// records — the same pair cella keys container reuse on. An explicit target,
+/// so there is no interactive fallback.
+async fn find_container_by_spec_identity(
+    client: &dyn cella_backend::ContainerBackend,
+    workspace_root: &Path,
+    config_path: &Path,
+) -> Result<cella_backend::ContainerInfo, Box<dyn std::error::Error + Send + Sync>> {
+    let labels = spec_identity_labels(workspace_root, config_path);
+    let info = client
+        .find_container_by_labels(&labels)
+        .await?
+        .ok_or_else(|| {
+            format!(
+                "no dev container found for config '{}' in workspace '{}' — run `cella up` for it first",
+                config_path.display(),
+                workspace_root.display()
+            )
+        })?;
+    if info.state != cella_backend::ContainerState::Running {
+        return Err(format!(
+            "container '{}' for config '{}' exists but is not running; run `cella up` to start it",
+            info.name,
+            config_path.display()
+        )
+        .into());
+    }
+    Ok(info)
 }
 
 async fn resolve_exec_context(
@@ -374,6 +473,161 @@ mod tests {
         let r =
             crate::Cli::try_parse_from(["cella", "exec", "--id-label", "novalue", "--", "true"]);
         assert!(r.is_err(), "--id-label without '=value' must be rejected");
+    }
+
+    #[test]
+    fn config_and_override_config_parse() {
+        use clap::Parser;
+        let cli = crate::Cli::try_parse_from([
+            "cella",
+            "exec",
+            "--config",
+            "/a/devcontainer.json",
+            "--override-config",
+            "/b/override.json",
+            "--",
+            "true",
+        ])
+        .expect("--config/--override-config must parse");
+        let crate::commands::Command::Exec(args) = &cli.command else {
+            panic!("expected exec subcommand");
+        };
+        assert_eq!(
+            args.config.as_deref(),
+            Some(Path::new("/a/devcontainer.json"))
+        );
+        assert_eq!(
+            args.override_config.as_deref(),
+            Some(Path::new("/b/override.json"))
+        );
+    }
+
+    #[test]
+    fn spec_identity_labels_use_lexical_absolute_paths() {
+        let labels = spec_identity_labels(
+            Path::new("/repo"),
+            Path::new("/repo/.devcontainer/devcontainer.json"),
+        );
+        assert_eq!(
+            labels,
+            [
+                "devcontainer.local_folder=/repo".to_string(),
+                "devcontainer.config_file=/repo/.devcontainer/devcontainer.json".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn spec_identity_labels_make_relative_absolute() {
+        let labels = spec_identity_labels(Path::new("ws"), Path::new("sub/devcontainer.json"));
+        for (label, key) in labels
+            .iter()
+            .zip(["devcontainer.local_folder=", "devcontainer.config_file="])
+        {
+            let val = label.strip_prefix(key).expect("label key prefix");
+            assert!(
+                Path::new(val).is_absolute(),
+                "expected absolute, got: {val}"
+            );
+        }
+    }
+
+    /// Parse an `exec` invocation and return its args for predicate inspection.
+    fn exec_args(argv: &[&str]) -> ExecArgs {
+        use clap::Parser;
+        let cli = crate::Cli::try_parse_from(argv).expect("exec args must parse");
+        let crate::commands::Command::Exec(args) = cli.command else {
+            panic!("expected exec subcommand");
+        };
+        args
+    }
+
+    #[test]
+    fn config_alone_selects_by_config() {
+        let args = exec_args(["cella", "exec", "--config", "/a/dc.json", "--", "true"].as_ref());
+        assert!(args.config_selects_container());
+    }
+
+    #[test]
+    fn override_config_alone_selects_by_config() {
+        let args = exec_args(
+            [
+                "cella",
+                "exec",
+                "--override-config",
+                "/a/o.json",
+                "--",
+                "true",
+            ]
+            .as_ref(),
+        );
+        assert!(args.config_selects_container());
+    }
+
+    #[test]
+    fn container_id_takes_precedence_over_config() {
+        let args = exec_args(
+            [
+                "cella",
+                "exec",
+                "--config",
+                "/a/dc.json",
+                "--container-id",
+                "abc",
+                "--",
+                "true",
+            ]
+            .as_ref(),
+        );
+        assert!(
+            !args.config_selects_container(),
+            "--container-id must win over --config (official precedence)"
+        );
+    }
+
+    #[test]
+    fn id_label_takes_precedence_over_config() {
+        let args = exec_args(
+            [
+                "cella",
+                "exec",
+                "--config",
+                "/a/dc.json",
+                "--id-label",
+                "k=v",
+                "--",
+                "true",
+            ]
+            .as_ref(),
+        );
+        assert!(
+            !args.config_selects_container(),
+            "--id-label must win over --config (official precedence)"
+        );
+    }
+
+    #[test]
+    fn container_name_takes_precedence_over_config() {
+        let args = exec_args(
+            [
+                "cella",
+                "exec",
+                "--config",
+                "/a/dc.json",
+                "--container-name",
+                "my-ctr",
+                "--",
+                "true",
+            ]
+            .as_ref(),
+        );
+        assert!(!args.config_selects_container());
+    }
+
+    #[test]
+    fn no_config_does_not_select_by_config() {
+        let args = exec_args(["cella", "exec", "--", "true"].as_ref());
+        assert!(!args.config_selects_container());
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds `--config` and `--override-config` to `cella exec`, so you can exec into a specific dev container when several share one workspace folder — e.g. one created with `up --config variantA.json` and another with `variantB.json`. Without these, `exec` could only fall back to a workspace-folder lookup that matches `devcontainer.local_folder` alone and can't tell the variants apart.

## How

The flags resolve the config path exactly the way `up` does, via `config_with_override`:
- `--config` wins as the recorded path.
- With only `--override-config`, the recorded path is the *discovered* `devcontainer.json` (the override supplies content, not the path).

It then targets the container by its spec identity labels — both `devcontainer.local_folder` **and** `devcontainer.config_file` together — which is the same `(workspace, config)` pair `up` stamps and keys container reuse on (#177). Reusing `resolve_workspace_folder` + `lexical_absolute` makes `local_folder` byte-identical to the stamped value, and the same `config_file` derivation already matches both the single-container (`build_container_labels`) and compose (`build_compose_labels`) stamp sites.

Precedence follows the official CLI's `findContainerAndIdLabels`: `--container-id`, `--container-name`, and `--id-label` win; the config flags only drive the workspace-tier label search. So `exec --container-id X --config Y` resolves by `X`, matching upstream. It's an explicit target, so there's no interactive picker fallback.

## Why both labels (not config_file alone)

`config_file` is usually a globally-unique absolute path, but cella's container identity is `(local_folder + config_file)`. If the *same* shared config is used from two different workspaces (`up --config /shared/dc.json` from `/ws1` and `/ws2`), two distinct containers exist both stamped `config_file=/shared/dc.json`; matching on `config_file` alone would return an arbitrary one. Matching both labels is the correct, identity-faithful lookup and equals official's `newLabels`.

## Known follow-up (intentional, not in this PR)

The *no-flag* exec path still resolves by `local_folder` alone (`find_container`), so without `--config` it can't disambiguate variants the way official's `findContainerAndIdLabels` does (it always threads the discovered config into a `[local_folder + config_file]` search, plus a legacy fallback chain). That's a broader change to the shared resolution used by `exec`/`shell`/`install` and is tracked separately. This PR deliberately leaves a two-path difference: `--config` searches both labels; no-flag searches one.

## Tests

Unit tests cover flag parsing, the spec-identity label pair (lexical absolute, relative→absolute), and the precedence predicate (`--config` alone selects; `--container-id`/`--container-name`/`--id-label` each override it; no config doesn't select).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
