### PR TITLE
feat(build): add toolchain, logging, and lockfile flags (parity with up)

### DIFF
--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use clap::Args;
 use tracing::{info, warn};
 
-use super::{ComposePullPolicy, ImagePullPolicy, OutputFormat};
+use super::{BuildKitMode, ComposePullPolicy, ImagePullPolicy, LogFormat, LogLevel, OutputFormat};
 
 use cella_backend::{BuildSecret, container_name};
 use cella_config::devcontainer::resolve;
@@ -59,11 +59,52 @@ pub struct BuildArgs {
     /// underlying docker/buildx build. Not supported on the Docker Compose path.
     #[arg(long)]
     platform: Option<String>,
+
+    /// Additional image(s) to use as a layer cache during the build (repeatable).
+    /// Single-container path only (not supported on the Docker Compose path).
+    #[arg(long = "cache-from")]
+    cache_from: Vec<String>,
+
+    /// Cache export destination for the build (`BuildKit` `--cache-to`).
+    /// Single-container path only (not supported on the Docker Compose path).
+    #[arg(long = "cache-to")]
+    cache_to: Option<String>,
+
+    /// Control whether `BuildKit` is used when building images.
+    #[arg(long, value_enum, default_value = "auto")]
+    buildkit: BuildKitMode,
+
+    /// Path to the Docker CLI binary (used for image builds and compose).
+    #[arg(long = "docker-path")]
+    docker_path: Option<String>,
+
+    /// Path to the Docker Compose CLI binary.
+    #[arg(long = "docker-compose-path")]
+    docker_compose_path: Option<String>,
+
+    /// Log verbosity for build output.
+    #[arg(long = "log-level", value_enum)]
+    log_level: Option<LogLevel>,
+
+    /// Log output format.
+    #[arg(long = "log-format", value_enum, default_value = "text")]
+    log_format: LogFormat,
 }
 
 impl BuildArgs {
     pub const fn is_text_output(&self) -> bool {
         matches!(self.output, OutputFormat::Auto | OutputFormat::Text)
+    }
+
+    /// The `--log-level` value, seeded into the global tracing filter by main.rs
+    /// before dispatch (mirrors `up`).
+    pub const fn log_level(&self) -> Option<LogLevel> {
+        self.log_level
+    }
+
+    /// The `--log-format` value (defaults to `Text`).
+    pub const fn log_format(&self) -> LogFormat {
+        self.log_format
     }
 
     pub async fn execute(
@@ -115,6 +156,8 @@ impl BuildArgs {
                 env_files: self.env_file.clone(),
                 pull_policy: self.pull_policy.as_ref().map(|p| p.as_str().to_string()),
                 secrets: secrets.clone(),
+                docker_path: self.docker_path.clone(),
+                docker_compose_path: self.docker_compose_path.clone(),
                 // Match the single-container build path: update the lockfile when
                 // features are present (`cella build` has no --no-lockfile flag yet).
                 lockfile_policy: cella_features::LockfilePolicy::Update,
@@ -147,10 +190,10 @@ impl BuildArgs {
             pull_policy: self.pull.as_ref().map(ImagePullPolicy::as_str),
             secrets: &secrets,
             build_tuning: cella_orchestrator::BuildTuning {
-                docker_path: None,
-                use_buildkit: true,
-                cli_cache_from: &[],
-                cache_to: None,
+                docker_path: self.docker_path.as_deref(),
+                use_buildkit: super::buildkit_enabled(self.buildkit),
+                cli_cache_from: &self.cache_from,
+                cache_to: self.cache_to.as_deref(),
                 platform: self.platform.as_deref(),
             },
             // `--omit-config-remote-env-from-metadata` is wired on `up` only;
@@ -296,6 +339,79 @@ mod tests {
     fn parse_secret_unknown_keys_ignored() {
         let secret = parse_build_secret("id=mysecret,foo=bar").unwrap();
         assert_eq!(secret.id, "mysecret");
+    }
+
+    use clap::Parser;
+
+    /// Minimal CLI wrapper to parse `BuildArgs` in isolation.
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        args: BuildArgs,
+    }
+
+    fn parse_build(extra: &[&str]) -> BuildArgs {
+        let mut argv = vec!["build"];
+        argv.extend_from_slice(extra);
+        TestCli::try_parse_from(argv).unwrap().args
+    }
+
+    #[test]
+    fn buildkit_default_is_auto_enabled() {
+        // No --buildkit flag → auto → BuildKit enabled.
+        let args = parse_build(&[]);
+        assert!(super::super::buildkit_enabled(args.buildkit));
+    }
+
+    #[test]
+    fn buildkit_never_disables() {
+        // `--buildkit never` maps to use_buildkit == false in BuildTuning.
+        let args = parse_build(&["--buildkit", "never"]);
+        assert!(!super::super::buildkit_enabled(args.buildkit));
+    }
+
+    #[test]
+    fn buildkit_auto_enables() {
+        let args = parse_build(&["--buildkit", "auto"]);
+        assert!(super::super::buildkit_enabled(args.buildkit));
+    }
+
+    #[test]
+    fn cache_from_is_repeatable() {
+        let args = parse_build(&["--cache-from", "a:1", "--cache-from", "b:2"]);
+        assert_eq!(args.cache_from, vec!["a:1".to_string(), "b:2".to_string()]);
+    }
+
+    #[test]
+    fn cache_to_and_docker_paths_parse() {
+        let args = parse_build(&[
+            "--cache-to",
+            "type=inline",
+            "--docker-path",
+            "/usr/bin/docker",
+            "--docker-compose-path",
+            "/usr/bin/docker-compose",
+        ]);
+        assert_eq!(args.cache_to.as_deref(), Some("type=inline"));
+        assert_eq!(args.docker_path.as_deref(), Some("/usr/bin/docker"));
+        assert_eq!(
+            args.docker_compose_path.as_deref(),
+            Some("/usr/bin/docker-compose")
+        );
+    }
+
+    #[test]
+    fn log_level_and_format_accessors_return_parsed_values() {
+        let args = parse_build(&["--log-level", "debug", "--log-format", "json"]);
+        assert!(matches!(args.log_level(), Some(LogLevel::Debug)));
+        assert!(matches!(args.log_format(), LogFormat::Json));
+    }
+
+    #[test]
+    fn log_level_defaults_to_none_and_format_to_text() {
+        let args = parse_build(&[]);
+        assert!(args.log_level().is_none());
+        assert!(matches!(args.log_format(), LogFormat::Text));
     }
 
     #[test]

--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -89,6 +89,12 @@ pub struct BuildArgs {
     /// Log output format.
     #[arg(long = "log-format", value_enum, default_value = "text")]
     log_format: LogFormat,
+
+    #[command(flatten)]
+    lockfile: super::LockfileArgs,
+
+    #[command(flatten)]
+    deprecated_lockfile: super::DeprecatedLockfileArgs,
 }
 
 impl BuildArgs {
@@ -144,51 +150,76 @@ impl BuildArgs {
 
         // Docker Compose path: delegate to orchestrator
         if config.get("dockerComposeFile").is_some() {
-            if self.platform.is_some() {
-                return Err("--platform or --push not supported.".into());
-            }
-            let (sender, renderer) = crate::progress::bridge(&progress);
-            let build_cfg = cella_orchestrator::compose_build::ComposeBuildConfig {
-                config,
-                config_path: &resolved.config_path,
-                workspace_root: &resolved.workspace_root,
-                profiles: self.profile.clone(),
-                env_files: self.env_file.clone(),
-                pull_policy: self.pull_policy.as_ref().map(|p| p.as_str().to_string()),
-                secrets: secrets.clone(),
-                docker_path: self.docker_path.clone(),
-                docker_compose_path: self.docker_compose_path.clone(),
-                // Match the single-container build path: update the lockfile when
-                // features are present (`cella build` has no --no-lockfile flag yet).
-                lockfile_policy: cella_features::LockfilePolicy::Update,
-            };
-            let result = cella_orchestrator::compose_build::compose_build(
-                client.as_ref(),
-                &build_cfg,
-                &sender,
-            )
-            .await
-            .map_err(|e| e.to_string());
-            drop(sender);
-            let _ = renderer.await;
-            let result =
-                result.map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })?;
-
-            print_result(&self.output, &result.image_name, true);
-            return Ok(());
+            return self
+                .execute_compose(client.as_ref(), &resolved, &secrets, progress)
+                .await;
         }
 
-        // Non-compose path
+        self.execute_single_container(client.as_ref(), &resolved, &secrets, progress)
+            .await
+    }
+
+    /// Build the image on the Docker Compose path.
+    ///
+    /// `--cache-from`/`--cache-to`/`--platform` are single-container only and
+    /// are not supported here (matching `up`); `--platform` is rejected
+    /// explicitly for parity with the official error message.
+    async fn execute_compose(
+        &self,
+        client: &dyn cella_backend::ContainerBackend,
+        resolved: &resolve::ResolvedConfig,
+        secrets: &[BuildSecret],
+        progress: crate::progress::Progress,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        if self.platform.is_some() {
+            return Err("--platform or --push not supported.".into());
+        }
+        let (sender, renderer) = crate::progress::bridge(&progress);
+        let build_cfg = cella_orchestrator::compose_build::ComposeBuildConfig {
+            config: &resolved.config,
+            config_path: &resolved.config_path,
+            workspace_root: &resolved.workspace_root,
+            profiles: self.profile.clone(),
+            env_files: self.env_file.clone(),
+            pull_policy: self.pull_policy.as_ref().map(|p| p.as_str().to_string()),
+            secrets: secrets.to_vec(),
+            docker_path: self.docker_path.clone(),
+            docker_compose_path: self.docker_compose_path.clone(),
+            lockfile_policy: super::derive_lockfile_policy(
+                &self.lockfile,
+                &self.deprecated_lockfile,
+            ),
+        };
+        let result = cella_orchestrator::compose_build::compose_build(client, &build_cfg, &sender)
+            .await
+            .map_err(|e| e.to_string());
+        drop(sender);
+        let _ = renderer.await;
+        let result =
+            result.map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })?;
+
+        print_result(&self.output, &result.image_name, true);
+        Ok(())
+    }
+
+    /// Build the image on the single-container (image / Dockerfile) path.
+    async fn execute_single_container(
+        &self,
+        client: &dyn cella_backend::ContainerBackend,
+        resolved: &resolve::ResolvedConfig,
+        secrets: &[BuildSecret],
+        progress: crate::progress::Progress,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let (sender, renderer) = crate::progress::bridge(&progress);
         let input = EnsureImageInput {
-            client: client.as_ref(),
-            config,
+            client,
+            config: &resolved.config,
             workspace_root: &resolved.workspace_root,
-            config_name,
+            config_name: resolved.name(),
             config_path: &resolved.config_path,
             no_cache: self.no_cache,
             pull_policy: self.pull.as_ref().map(ImagePullPolicy::as_str),
-            secrets: &secrets,
+            secrets,
             build_tuning: cella_orchestrator::BuildTuning {
                 docker_path: self.docker_path.as_deref(),
                 use_buildkit: super::buildkit_enabled(self.buildkit),
@@ -199,8 +230,10 @@ impl BuildArgs {
             // `--omit-config-remote-env-from-metadata` is wired on `up` only;
             // `cella build` keeps the full metadata label.
             omit_remote_env_from_metadata: false,
-            // `cella build` updates the lockfile when features are present.
-            lockfile_policy: cella_features::LockfilePolicy::Update,
+            lockfile_policy: super::derive_lockfile_policy(
+                &self.lockfile,
+                &self.deprecated_lockfile,
+            ),
             progress: &sender,
         };
         let result = cella_orchestrator::image::ensure_image(&input).await;
@@ -412,6 +445,68 @@ mod tests {
         let args = parse_build(&[]);
         assert!(args.log_level().is_none());
         assert!(matches!(args.log_format(), LogFormat::Text));
+    }
+
+    // ── lockfile policy derivation ──────────────────────────────────
+
+    fn build_lockfile_policy(extra: &[&str]) -> cella_features::LockfilePolicy {
+        let args = parse_build(extra);
+        super::super::derive_lockfile_policy(&args.lockfile, &args.deprecated_lockfile)
+    }
+
+    #[test]
+    fn lockfile_default_is_update() {
+        assert_eq!(
+            build_lockfile_policy(&[]),
+            cella_features::LockfilePolicy::Update
+        );
+    }
+
+    #[test]
+    fn no_lockfile_maps_to_no_lockfile() {
+        assert_eq!(
+            build_lockfile_policy(&["--no-lockfile"]),
+            cella_features::LockfilePolicy::NoLockfile
+        );
+    }
+
+    #[test]
+    fn frozen_lockfile_maps_to_frozen() {
+        assert_eq!(
+            build_lockfile_policy(&["--frozen-lockfile"]),
+            cella_features::LockfilePolicy::Frozen
+        );
+    }
+
+    #[test]
+    fn experimental_frozen_lockfile_maps_to_frozen() {
+        // Hidden deprecated alias behaves like --frozen-lockfile (matches up).
+        assert_eq!(
+            build_lockfile_policy(&["--experimental-frozen-lockfile"]),
+            cella_features::LockfilePolicy::Frozen
+        );
+    }
+
+    #[test]
+    fn experimental_lockfile_is_noop_update() {
+        // Deprecated; lockfile is written by default, so policy stays Update.
+        assert_eq!(
+            build_lockfile_policy(&["--experimental-lockfile"]),
+            cella_features::LockfilePolicy::Update
+        );
+    }
+
+    #[test]
+    fn no_lockfile_conflicts_with_frozen() {
+        let result = TestCli::try_parse_from(["build", "--no-lockfile", "--frozen-lockfile"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn no_lockfile_conflicts_with_experimental_frozen() {
+        let result =
+            TestCli::try_parse_from(["build", "--no-lockfile", "--experimental-frozen-lockfile"]);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -159,11 +159,34 @@ impl BuildArgs {
             .await
     }
 
+    /// Reject or warn on build flags that don't apply to the Docker Compose path.
+    ///
+    /// Matches the official CLI, which errors on `--platform`/`--push` and
+    /// `--cache-to` for compose. `--cache-from`/`--buildkit` only affect the
+    /// single-container buildx path; the official CLI accepts them without error,
+    /// so cella warns rather than failing (never silently ignores).
+    fn reject_unsupported_compose_flags(
+        &self,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        if self.platform.is_some() {
+            return Err("--platform or --push not supported.".into());
+        }
+        if self.cache_to.is_some() {
+            return Err("--cache-to not supported.".into());
+        }
+        if !self.cache_from.is_empty() {
+            warn!("--cache-from is ignored on the Docker Compose build path");
+        }
+        if matches!(self.buildkit, BuildKitMode::Never) {
+            warn!("--buildkit is ignored on the Docker Compose build path");
+        }
+        Ok(())
+    }
+
     /// Build the image on the Docker Compose path.
     ///
-    /// `--cache-from`/`--cache-to`/`--platform` are single-container only and
-    /// are not supported here (matching `up`); `--platform` is rejected
-    /// explicitly for parity with the official error message.
+    /// Buildx-only flags are validated up front by
+    /// [`reject_unsupported_compose_flags`].
     async fn execute_compose(
         &self,
         client: &dyn cella_backend::ContainerBackend,
@@ -171,9 +194,7 @@ impl BuildArgs {
         secrets: &[BuildSecret],
         progress: crate::progress::Progress,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        if self.platform.is_some() {
-            return Err("--platform or --push not supported.".into());
-        }
+        self.reject_unsupported_compose_flags()?;
         let (sender, renderer) = crate::progress::bridge(&progress);
         let build_cfg = cella_orchestrator::compose_build::ComposeBuildConfig {
             config: &resolved.config,
@@ -245,10 +266,9 @@ impl BuildArgs {
             && let Some(old_hash) = &container.config_hash
             && *old_hash != resolved.config_hash
         {
-            eprintln!(
-                "\x1b[33mWARNING:\x1b[0m Config has changed since this container was created."
+            warn!(
+                "Config has changed since this container was created. Run `cella up --rebuild` to recreate with the updated config."
             );
-            eprintln!("  Run `cella up --rebuild` to recreate with the updated config.");
         }
 
         print_result(&self.output, &img_name, false);
@@ -431,6 +451,34 @@ mod tests {
             args.docker_compose_path.as_deref(),
             Some("/usr/bin/docker-compose")
         );
+    }
+
+    #[test]
+    fn compose_rejects_platform_and_cache_to_but_warns_on_others() {
+        // Official errors on --platform/--push and --cache-to for compose.
+        assert!(
+            parse_build(&["--platform", "linux/amd64"])
+                .reject_unsupported_compose_flags()
+                .is_err()
+        );
+        assert!(
+            parse_build(&["--cache-to", "type=inline"])
+                .reject_unsupported_compose_flags()
+                .is_err()
+        );
+        // --cache-from / --buildkit are accepted on compose (warn, not error),
+        // matching the official CLI which doesn't reject them.
+        assert!(
+            parse_build(&["--cache-from", "x"])
+                .reject_unsupported_compose_flags()
+                .is_ok()
+        );
+        assert!(
+            parse_build(&["--buildkit", "never"])
+                .reject_unsupported_compose_flags()
+                .is_ok()
+        );
+        assert!(parse_build(&[]).reject_unsupported_compose_flags().is_ok());
     }
 
     #[test]

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -110,21 +110,18 @@ pub struct DeprecatedLockfileArgs {
 
 /// Derive the feature lockfile policy from the CLI lockfile flags.
 ///
-/// Deprecated aliases emit a warning to stderr before delegating. Shared by
+/// Deprecated aliases emit a `tracing` deprecation warning before delegating, so
+/// the message respects `--log-format json` instead of corrupting it. Shared by
 /// `up` and `build` so both commands map the flags identically.
 pub fn derive_lockfile_policy(
     lf: &LockfileArgs,
     deprecated: &DeprecatedLockfileArgs,
 ) -> cella_features::LockfilePolicy {
     if deprecated.experimental_lockfile {
-        eprintln!(
-            "warning: --experimental-lockfile is deprecated; lockfile is now written by default"
-        );
+        warn!("--experimental-lockfile is deprecated; lockfile is now written by default");
     }
     if deprecated.experimental_frozen_lockfile {
-        eprintln!(
-            "warning: --experimental-frozen-lockfile is deprecated; use --frozen-lockfile instead"
-        );
+        warn!("--experimental-frozen-lockfile is deprecated; use --frozen-lockfile instead");
     }
     if lf.no_lockfile {
         cella_features::LockfilePolicy::NoLockfile

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -72,6 +72,69 @@ pub struct DotfilesArgs {
     pub(crate) target_path: String,
 }
 
+/// Stable feature-lockfile flags controlling lockfile read/write behavior.
+///
+/// Shared verbatim by `up` and `build` (the official CLI exposes the same flags
+/// on both). Split from [`DeprecatedLockfileArgs`] so neither struct exceeds
+/// `clippy::struct_excessive_bools` (max 3 bools); both are flattened together
+/// by each command and consumed by [`derive_lockfile_policy`].
+#[derive(Args)]
+pub struct LockfileArgs {
+    /// Disable lockfile generation and pinning.
+    #[arg(
+        long,
+        conflicts_with_all = ["frozen_lockfile", "experimental_lockfile", "experimental_frozen_lockfile"],
+    )]
+    pub(crate) no_lockfile: bool,
+
+    /// Require the lockfile to exist and match resolved digests; fail if missing or different.
+    #[arg(long)]
+    pub(crate) frozen_lockfile: bool,
+}
+
+/// Hidden, deprecated lockfile aliases kept for devcontainer-CLI parity.
+///
+/// Flattened alongside [`LockfileArgs`]; both feed [`derive_lockfile_policy`].
+/// `experimental_lockfile` is a no-op (lockfiles are written by default now);
+/// `experimental_frozen_lockfile` maps to `--frozen-lockfile`.
+#[derive(Args)]
+pub struct DeprecatedLockfileArgs {
+    /// Deprecated: lockfile is now written by default.
+    #[arg(long, hide = true)]
+    pub(crate) experimental_lockfile: bool,
+
+    /// Deprecated alias for --frozen-lockfile.
+    #[arg(long, hide = true)]
+    pub(crate) experimental_frozen_lockfile: bool,
+}
+
+/// Derive the feature lockfile policy from the CLI lockfile flags.
+///
+/// Deprecated aliases emit a warning to stderr before delegating. Shared by
+/// `up` and `build` so both commands map the flags identically.
+pub fn derive_lockfile_policy(
+    lf: &LockfileArgs,
+    deprecated: &DeprecatedLockfileArgs,
+) -> cella_features::LockfilePolicy {
+    if deprecated.experimental_lockfile {
+        eprintln!(
+            "warning: --experimental-lockfile is deprecated; lockfile is now written by default"
+        );
+    }
+    if deprecated.experimental_frozen_lockfile {
+        eprintln!(
+            "warning: --experimental-frozen-lockfile is deprecated; use --frozen-lockfile instead"
+        );
+    }
+    if lf.no_lockfile {
+        cella_features::LockfilePolicy::NoLockfile
+    } else if lf.frozen_lockfile || deprecated.experimental_frozen_lockfile {
+        cella_features::LockfilePolicy::Frozen
+    } else {
+        cella_features::LockfilePolicy::Update
+    }
+}
+
 /// Common flags for commands that support verbose output.
 #[derive(Args, Clone)]
 pub struct VerboseArgs {

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -230,6 +230,14 @@ pub enum BuildKitMode {
     Never,
 }
 
+/// Map the clap `--buildkit` enum to a resolved "may use `BuildKit`" boolean.
+///
+/// `auto` → `true` (the backend probes for buildx and uses it when present);
+/// `never` → `false` (forces the classic builder). Shared by `up` and `build`.
+pub const fn buildkit_enabled(mode: BuildKitMode) -> bool {
+    !matches!(mode, BuildKitMode::Never)
+}
+
 /// Top-level CLI commands.
 #[derive(Subcommand)]
 pub enum Command {
@@ -338,9 +346,9 @@ impl Command {
 
     /// The `--log-level` value, if the subcommand carries one.
     ///
-    /// `up` (and `code`, which embeds the `up` arg surface), `run-user-commands`,
-    /// `set-up`, `templates`, `features`, and `upgrade` expose `--log-level`;
-    /// every other variant returns
+    /// `up` (and `code`, which embeds the `up` arg surface), `build`,
+    /// `run-user-commands`, `set-up`, `templates`, `features`, and `upgrade`
+    /// expose `--log-level`; every other variant returns
     /// `None`. main.rs reads this once, before subcommand dispatch, to seed the
     /// global tracing filter — the level can't be applied inside `execute()`
     /// because the subscriber is already installed by then.
@@ -348,6 +356,7 @@ impl Command {
         match self {
             Self::Up(args) => args.compat.log_level,
             Self::Code(args) => args.up.compat.log_level,
+            Self::Build(args) => args.log_level(),
             Self::RunUserCommands(args) => args.compat.log_level,
             Self::SetUp(args) => args.compat.log_level,
             Self::Templates(args) => args.apply_log_level(),
@@ -359,7 +368,8 @@ impl Command {
 
     /// The `--log-format` value (defaults to `Text`).
     ///
-    /// Only `up`/`code` expose `--log-format`; every other variant returns
+    /// `up`/`code`, `build`, `run-user-commands`, and `set-up` expose
+    /// `--log-format`; every other variant returns
     /// `Text`. Read once in main.rs to select the tracing formatter and to
     /// force spinners off under `Json` (indicatif ANSI escapes would corrupt
     /// machine-readable JSON log lines on stderr).
@@ -367,6 +377,7 @@ impl Command {
         match self {
             Self::Up(args) => args.compat.log_format,
             Self::Code(args) => args.up.compat.log_format,
+            Self::Build(args) => args.log_format(),
             Self::RunUserCommands(args) => args.compat.log_format,
             Self::SetUp(args) => args.compat.log_format,
             _ => LogFormat::Text,

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -157,30 +157,10 @@ pub struct UpResultArgs {
     pub(crate) omit_config_remote_env_from_metadata: bool,
 }
 
-/// Feature-lockfile flags for controlling lockfile read/write behavior.
-#[derive(Args)]
-pub struct UpLockfileArgs {
-    /// Disable lockfile generation and pinning.
-    #[arg(
-        long,
-        conflicts_with_all = ["frozen_lockfile", "experimental_lockfile", "experimental_frozen_lockfile"],
-    )]
-    pub(crate) no_lockfile: bool,
-
-    /// Require the lockfile to exist and match resolved digests; fail if missing or different.
-    #[arg(long)]
-    pub(crate) frozen_lockfile: bool,
-
-    /// Deprecated: lockfile is now written by default.
-    #[arg(long, hide = true)]
-    pub(crate) experimental_lockfile: bool,
-}
-
 /// Compatibility/diagnostic flags accepted for devcontainer-CLI parity.
 ///
-/// The data-folder fields and `omit_syntax_directive`/`experimental_frozen_lockfile`
-/// are no-ops in cella (it manages its own data dirs and has no feature
-/// lockfiles); the rest are wired into behavior in later phases.
+/// The data-folder fields and `omit_syntax_directive` are no-ops in cella (it
+/// manages its own data dirs); the rest are wired into behavior in later phases.
 #[derive(Args)]
 pub struct UpCompatArgs {
     /// Container data folder for in-container user data (compatibility no-op).
@@ -237,10 +217,6 @@ pub struct UpCompatArgs {
     /// Number of rows to render subprocess output for.
     #[arg(long = "terminal-rows", requires = "terminal_columns")]
     pub(crate) terminal_rows: Option<u16>,
-
-    /// Deprecated alias for --frozen-lockfile.
-    #[arg(long, hide = true)]
-    pub(crate) experimental_frozen_lockfile: bool,
 
     // `--omit-syntax-directive` is a true no-op in cella. The official CLI has
     // two effects: (A) it parses the user's Dockerfile in JS and strips any
@@ -324,7 +300,10 @@ pub struct UpArgs {
     pub(crate) result: UpResultArgs,
 
     #[command(flatten)]
-    pub(crate) lockfile: UpLockfileArgs,
+    pub(crate) lockfile: crate::commands::LockfileArgs,
+
+    #[command(flatten)]
+    pub(crate) deprecated_lockfile: crate::commands::DeprecatedLockfileArgs,
 
     #[command(flatten)]
     pub(crate) dotfiles: crate::commands::DotfilesArgs,
@@ -369,32 +348,6 @@ impl UpArgs {
             omit_syntax_directive = c.omit_syntax_directive,
             "up: accepted devcontainer-CLI compatibility no-op flags"
         );
-    }
-}
-
-/// Derive the lockfile policy from the CLI lockfile flags.
-///
-/// Deprecated aliases emit a warning to stderr before delegating.
-fn derive_lockfile_policy(
-    lf: &UpLockfileArgs,
-    compat: &UpCompatArgs,
-) -> cella_features::LockfilePolicy {
-    if lf.experimental_lockfile {
-        eprintln!(
-            "warning: --experimental-lockfile is deprecated; lockfile is now written by default"
-        );
-    }
-    if compat.experimental_frozen_lockfile {
-        eprintln!(
-            "warning: --experimental-frozen-lockfile is deprecated; use --frozen-lockfile instead"
-        );
-    }
-    if lf.no_lockfile {
-        cella_features::LockfilePolicy::NoLockfile
-    } else if lf.frozen_lockfile || compat.experimental_frozen_lockfile {
-        cella_features::LockfilePolicy::Frozen
-    } else {
-        cella_features::LockfilePolicy::Update
     }
 }
 
@@ -913,7 +866,10 @@ impl UpContext {
             ),
             omit_remote_env_from_metadata: args.result.omit_config_remote_env_from_metadata,
             dotfiles: build_dotfiles_config(&args.dotfiles),
-            lockfile_policy: derive_lockfile_policy(&args.lockfile, &args.compat),
+            lockfile_policy: super::derive_lockfile_policy(
+                &args.lockfile,
+                &args.deprecated_lockfile,
+            ),
         })
     }
 

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -690,11 +690,6 @@ fn resolve_lifecycle_secrets(
         .map_or_else(|| Ok(Vec::new()), |path| parse_secrets_file(path))
 }
 
-/// Map the clap `--buildkit` enum to a resolved "may use `BuildKit`" boolean.
-const fn buildkit_enabled(mode: BuildKitMode) -> bool {
-    !matches!(mode, BuildKitMode::Never)
-}
-
 /// Map the clap `--gpu-availability` enum to the backend policy.
 const fn map_gpu_availability(g: GpuAvailability) -> cella_backend::GpuAvailability {
     match g {
@@ -911,7 +906,7 @@ impl UpContext {
             docker_compose_path: args.build.docker_compose_path.clone(),
             cache_from: args.build.cache_from.clone(),
             cache_to: args.build.cache_to.clone(),
-            use_buildkit: buildkit_enabled(args.build.buildkit),
+            use_buildkit: super::buildkit_enabled(args.build.buildkit),
             gpu_availability: map_gpu_availability(args.compat.gpu_availability),
             update_remote_user_uid_default: map_uid_default(
                 args.compat.update_remote_user_uid_default,

--- a/crates/cella-cli/src/main.rs
+++ b/crates/cella-cli/src/main.rs
@@ -1040,6 +1040,35 @@ mod tests {
     }
 
     #[test]
+    fn build_log_level_feeds_global_filter() {
+        use super::commands::LogLevel;
+        // build's --log-level must reach Command::log_level() so main.rs seeds
+        // the global tracing filter (real handling, not a no-op).
+        let cli = parse(&["cella", "build", "--log-level", "debug"]).unwrap();
+        assert!(matches!(cli.command.log_level(), Some(LogLevel::Debug)));
+    }
+
+    #[test]
+    fn build_without_log_level_is_none() {
+        let cli = parse(&["cella", "build"]).unwrap();
+        assert!(cli.command.log_level().is_none());
+    }
+
+    #[test]
+    fn build_log_format_json_accessor() {
+        use super::commands::LogFormat;
+        let cli = parse(&["cella", "build", "--log-format", "json"]).unwrap();
+        assert!(matches!(cli.command.log_format(), LogFormat::Json));
+    }
+
+    #[test]
+    fn build_default_log_format_is_text() {
+        use super::commands::LogFormat;
+        let cli = parse(&["cella", "build"]).unwrap();
+        assert!(matches!(cli.command.log_format(), LogFormat::Text));
+    }
+
+    #[test]
     fn up_log_format_json_accessor() {
         use super::commands::LogFormat;
         let cli = parse(&["cella", "up", "--log-format", "json"]).unwrap();

--- a/crates/cella-compose/src/build_features.rs
+++ b/crates/cella-compose/src/build_features.rs
@@ -35,6 +35,11 @@ pub struct ComposeBuildConfig<'a> {
     pub pull_policy: Option<String>,
     /// `BuildKit` secrets forwarded to compose builds.
     pub secrets: Vec<BuildSecret>,
+    /// `docker` CLI binary path (`--docker-path`). `None` = `docker`.
+    pub docker_path: Option<String>,
+    /// Standalone `docker-compose` (V1) binary (`--docker-compose-path`).
+    /// Stored and forwarded; cella is V2-only so it is currently unused.
+    pub docker_compose_path: Option<String>,
     /// Feature lockfile policy derived from `--no-lockfile` / `--frozen-lockfile`.
     pub lockfile_policy: cella_features::LockfilePolicy,
 }
@@ -122,7 +127,8 @@ pub async fn compose_build(
     }
 
     // Run docker compose build
-    let compose_cmd = crate::ComposeCommand::new(&project);
+    let compose_cmd = crate::ComposeCommand::new(&project)
+        .with_docker_binaries(cfg.docker_path.clone(), cfg.docker_compose_path.clone());
     compose_cmd.build(None, false).await.map_err(
         |e| -> Box<dyn std::error::Error + Send + Sync> {
             format!("docker compose build failed: {e}").into()


### PR DESCRIPTION
## What

Wires a batch of `devcontainer build` flags that cella's `build` was missing but that already exist (and are implemented) on `cella up`:

- **Toolchain:** `--buildkit <auto|never>`, `--cache-from` (repeatable), `--cache-to`, `--docker-path`, `--docker-compose-path`
- **Logging:** `--log-level <info|debug|trace>`, `--log-format <text|json>`
- **Lockfile:** `--no-lockfile`, `--frozen-lockfile`, and the hidden deprecated `--experimental-lockfile` / `--experimental-frozen-lockfile` aliases

## How

These map onto infrastructure `up` already has, so the change is mostly threading + de-duplication:

- `--buildkit`/`--cache-from`/`--cache-to`/`--docker-path` replace the previously **hardcoded** `BuildTuning` values on the single-container build path; `--docker-compose-path` threads into the compose build path.
- `--log-level`/`--log-format` are wired into the existing `Command::log_level()` / `Command::log_format()` accessors that `main.rs` reads once before dispatch to seed the global tracing filter and force spinners off under `--log-format json`. So build gets the **same real handling** as `up` — not a silent no-op.
- Lockfile flags replace the hardcoded `LockfilePolicy::Update` at both build sites (compose + single-container) with the shared `derive_lockfile_policy`.

To avoid duplicating logic/conflict-rules, `buildkit_enabled`, `derive_lockfile_policy`, and the lockfile arg structs were lifted out of `up`'s module into `crate::commands` and are now shared verbatim by both commands (split into `LockfileArgs` + `DeprecatedLockfileArgs` to stay under `clippy::struct_excessive_bools`). `up`'s behavior is unchanged — same flags, same conflicts, same policy derivation.

## Scope — deferred to follow-up PRs (intentional, not an oversight)

`cella build` is still missing some official flags; they're deliberately **not** in this PR because each is its own concern:

- **Image-naming** (`--image-name`, `--label`, `--additional-features`) — next PR.
- **Push / output** (`--push`, and `--output` as a buildx output spec) — last PR. This one also resolves a flag-name collision: cella's current `--output text|json` is a *result-format* selector, but official `--output` is the buildx output destination, and official `build` always emits the result JSON to stdout unconditionally (no format flag). That behavior change + the new `--output` move together.

## Tests

Flag parsing, `--buildkit` → `use_buildkit` mapping, lockfile-policy derivation for build (default/no-lockfile/frozen/experimental aliases), and the `Command::Build` log-level/log-format accessors feeding the global filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
