### PR TITLE
feat(build): apply --additional-features

### DIFF
--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -31,6 +31,12 @@ pub struct BuildArgs {
     #[arg(long)]
     config: Option<PathBuf>,
 
+    /// Additional features to apply, as a JSON object matching the
+    /// devcontainer.json `features` section. Merged into the resolved config
+    /// before the build (applies to both compose and single-container).
+    #[arg(long = "additional-features")]
+    additional_features: Option<String>,
+
     #[command(flatten)]
     backend: crate::backend::BackendArgs,
 
@@ -120,10 +126,18 @@ impl BuildArgs {
         let cwd = super::resolve_workspace_folder(self.workspace_folder.as_deref())?;
 
         info!("Resolving devcontainer config...");
-        let resolved = resolve::config(&cwd, self.config.as_deref())?;
+        let mut resolved = resolve::config(&cwd, self.config.as_deref())?;
 
         for w in &resolved.warnings {
             warn!("{}", w.message);
+        }
+
+        // Merge CLI --additional-features into the resolved config BEFORE the
+        // compose/single-container split, so both paths build the added features
+        // (the official CLI applies --additional-features to both).
+        if let Some(ref additional) = self.additional_features {
+            super::features::resolve::merge_additional_features(&mut resolved.config, additional)
+                .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })?;
         }
 
         let config = &resolved.config;
@@ -479,6 +493,22 @@ mod tests {
                 .is_ok()
         );
         assert!(parse_build(&[]).reject_unsupported_compose_flags().is_ok());
+    }
+
+    #[test]
+    fn additional_features_parses_and_merges_into_config() {
+        let args = parse_build(&[
+            "--additional-features",
+            r#"{"ghcr.io/x/y:1":{"version":"1"}}"#,
+        ]);
+        let json = args
+            .additional_features
+            .as_deref()
+            .expect("--additional-features captured");
+        let mut config = serde_json::json!({ "image": "ubuntu" });
+        super::super::features::resolve::merge_additional_features(&mut config, json)
+            .expect("merge succeeds");
+        assert_eq!(config["features"]["ghcr.io/x/y:1"]["version"], "1");
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds `--additional-features` to `cella build` — a JSON object (same shape as the devcontainer.json `features` section) whose entries are layered onto the resolved config before building, matching the official `devcontainer build --additional-features`.

## How

The flag is merged into the resolved config **before** the compose-vs-single-container split, so both build paths pick up the added features (the official CLI applies it to both). It reuses the exact `merge_additional_features` helper `cella up` already uses, so the merge semantics (added under `features`, existing keys preserved) are identical across commands. Because the merge happens before the build, the added features also flow into the image-name digest and the `devcontainer.metadata` label, same as `up`.

## Scope

This is one flag of the build image-naming group. `--image-name` and `--label` are **deliberately deferred** to a follow-up: on the pure `image:`-pull path (no Dockerfile, no features) cella pulls the image as-is with no build step to attach a name/label to, so those two flags need a backend image-mutation primitive (a tag for `--image-name`; a rebuild/relabel for `--label`) to be correct across all config shapes — handled properly in their own PR rather than half-implemented here. `--push` / `--output` (buildx) remain a separate PR too.

## Tests

Flag parsing plus a merge assertion (an added feature lands under `config.features`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
