### PR TITLE
feat(build): add --image-name

### DIFF
--- a/crates/cella-backend/src/traits.rs
+++ b/crates/cella-backend/src/traits.rs
@@ -181,6 +181,19 @@ pub trait ContainerBackend: Send + Sync {
 
     fn image_exists<'a>(&'a self, image: &'a str) -> BoxFuture<'a, Result<bool, BackendError>>;
 
+    /// Add an additional name (`target`) to an existing image (`source`).
+    ///
+    /// The image referenced by `source` must already exist locally. After this
+    /// succeeds the same image is reachable under both names. Used by
+    /// `cella build --image-name` to stamp the built/resolved image with each
+    /// requested name (the official `devcontainer build --image-name`
+    /// build-then-tag behavior).
+    fn tag_image<'a>(
+        &'a self,
+        source: &'a str,
+        target: &'a str,
+    ) -> BoxFuture<'a, Result<(), BackendError>>;
+
     fn inspect_image_details<'a>(
         &'a self,
         image: &'a str,

--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -45,6 +45,12 @@ pub struct BuildArgs {
     #[arg(long = "secret")]
     secrets: Vec<String>,
 
+    /// Name(s) to tag the built/resolved image with (repeatable). When set,
+    /// these are the names reported in the build result (matching the official
+    /// `devcontainer build --image-name`).
+    #[arg(long = "image-name")]
+    image_name: Vec<String>,
+
     /// Output format.
     #[arg(long, value_enum, default_value = "text")]
     output: OutputFormat,
@@ -233,7 +239,11 @@ impl BuildArgs {
         let result =
             result.map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })?;
 
-        print_result(&self.output, &result.image_name, true);
+        for name in &self.image_name {
+            client.tag_image(&result.image_name, name).await?;
+        }
+
+        print_result(&self.output, &self.reported_names(&result.image_name), true);
         Ok(())
     }
 
@@ -276,6 +286,10 @@ impl BuildArgs {
         let (img_name, _resolved_features, _image_details) = result?;
         let _ = renderer.await;
 
+        for name in &self.image_name {
+            client.tag_image(&img_name, name).await?;
+        }
+
         if let Some(container) = client.find_container(&resolved.workspace_root).await?
             && let Some(old_hash) = &container.config_hash
             && *old_hash != resolved.config_hash
@@ -285,8 +299,21 @@ impl BuildArgs {
             );
         }
 
-        print_result(&self.output, &img_name, false);
+        print_result(&self.output, &self.reported_names(&img_name), false);
         Ok(())
+    }
+
+    /// The image name(s) to report in the build result.
+    ///
+    /// When `--image-name` is set, the reported names are exactly those values
+    /// (the official CLI sets `imageNameResult = imageNames`, *replacing* the
+    /// built name). Otherwise the single built/resolved name is reported.
+    fn reported_names(&self, built: &str) -> Vec<String> {
+        if self.image_name.is_empty() {
+            vec![built.to_string()]
+        } else {
+            self.image_name.clone()
+        }
     }
 }
 
@@ -307,26 +334,32 @@ struct BuildResult {
 /// Build the compact JSON result line for `cella build`.
 ///
 /// Compact, single-line output (like the official CLI's `JSON.stringify`) so
-/// consumers that read one JSON object per line keep working.
-fn build_json_result(image_name: &str) -> String {
+/// consumers that read one JSON object per line keep working. `image_names`
+/// lists every reported name: the built name, or all `--image-name` values when
+/// that flag is set.
+fn build_json_result(image_names: &[String]) -> String {
     serde_json::to_string(&BuildResult {
         outcome: "success",
-        image_name: vec![image_name.to_owned()],
+        image_name: image_names.to_vec(),
     })
     .unwrap_or_default()
 }
 
 /// Print the build result in the requested output format.
-fn print_result(output: &OutputFormat, image_name: &str, compose: bool) {
+///
+/// `image_names` holds every reported name (the built name, or all
+/// `--image-name` values when set). The text mode lists them comma-separated.
+fn print_result(output: &OutputFormat, image_names: &[String], compose: bool) {
     match output {
         OutputFormat::Auto | OutputFormat::Text => {
+            let joined = image_names.join(", ");
             if compose {
-                eprintln!("Compose services built. Primary image: {image_name}");
+                eprintln!("Compose services built. Primary image: {joined}");
             } else {
-                eprintln!("Image built: {image_name}");
+                eprintln!("Image built: {joined}");
             }
         }
-        OutputFormat::Json => println!("{}", build_json_result(image_name)),
+        OutputFormat::Json => println!("{}", build_json_result(image_names)),
     }
 }
 
@@ -594,8 +627,49 @@ mod tests {
         // `outcome` is "success" (not "built"), `imageName` is an array, no extra
         // keys, no pretty indentation.
         assert_eq!(
-            build_json_result("ghcr.io/acme/devcontainer:latest"),
+            build_json_result(&["ghcr.io/acme/devcontainer:latest".to_string()]),
             r#"{"outcome":"success","imageName":["ghcr.io/acme/devcontainer:latest"]}"#
+        );
+    }
+
+    #[test]
+    fn build_json_result_lists_all_image_names() {
+        // With multiple `--image-name`, every name appears in the imageName array
+        // in order (official `imageNameResult = imageNames`).
+        assert_eq!(
+            build_json_result(&["one:1".to_string(), "two:2".to_string()]),
+            r#"{"outcome":"success","imageName":["one:1","two:2"]}"#
+        );
+    }
+
+    #[test]
+    fn image_name_is_repeatable() {
+        let args = parse_build(&["--image-name", "a:1", "--image-name", "b:2"]);
+        assert_eq!(args.image_name, vec!["a:1".to_string(), "b:2".to_string()]);
+    }
+
+    #[test]
+    fn image_name_defaults_to_empty() {
+        assert!(parse_build(&[]).image_name.is_empty());
+    }
+
+    #[test]
+    fn reported_names_uses_built_when_no_image_name() {
+        // No --image-name → report the single built/resolved name.
+        let args = parse_build(&[]);
+        assert_eq!(
+            args.reported_names("built:latest"),
+            vec!["built:latest".to_string()]
+        );
+    }
+
+    #[test]
+    fn reported_names_replaces_with_image_names() {
+        // --image-name replaces the built name with exactly the given values.
+        let args = parse_build(&["--image-name", "x:1", "--image-name", "y:2"]);
+        assert_eq!(
+            args.reported_names("built:latest"),
+            vec!["x:1".to_string(), "y:2".to_string()]
         );
     }
 }

--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -239,8 +239,16 @@ impl BuildArgs {
         let result =
             result.map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })?;
 
-        for name in &self.image_name {
-            client.tag_image(&result.image_name, name).await?;
+        if !self.image_name.is_empty() {
+            // `docker compose build` neither builds nor pulls an image-only
+            // service, so the resolved image may be remote-only; `tag_image`
+            // needs it present locally. Pull it if missing before tagging.
+            if !client.image_exists(&result.image_name).await? {
+                client.pull_image(&result.image_name).await?;
+            }
+            for name in &self.image_name {
+                client.tag_image(&result.image_name, name).await?;
+            }
         }
 
         print_result(&self.output, &self.reported_names(&result.image_name), true);
@@ -353,10 +361,11 @@ fn print_result(output: &OutputFormat, image_names: &[String], compose: bool) {
     match output {
         OutputFormat::Auto | OutputFormat::Text => {
             let joined = image_names.join(", ");
-            if compose {
-                eprintln!("Compose services built. Primary image: {joined}");
-            } else {
-                eprintln!("Image built: {joined}");
+            match (compose, image_names.len() > 1) {
+                (true, false) => eprintln!("Compose services built. Primary image: {joined}"),
+                (true, true) => eprintln!("Compose services built. Tagged images: {joined}"),
+                (false, false) => eprintln!("Image built: {joined}"),
+                (false, true) => eprintln!("Image built and tagged: {joined}"),
             }
         }
         OutputFormat::Json => println!("{}", build_json_result(image_names)),

--- a/crates/cella-cli/src/commands/features/test.rs
+++ b/crates/cella-cli/src/commands/features/test.rs
@@ -1456,6 +1456,14 @@ mod tests {
             panic!("unexpected image_exists call");
         }
 
+        fn tag_image<'a>(
+            &'a self,
+            _: &'a str,
+            _: &'a str,
+        ) -> BoxFuture<'a, Result<(), BackendError>> {
+            panic!("unexpected tag_image call");
+        }
+
         fn inspect_image_details<'a>(
             &'a self,
             _: &'a str,

--- a/crates/cella-container/src/backend.rs
+++ b/crates/cella-container/src/backend.rs
@@ -579,6 +579,14 @@ impl ContainerBackend for AppleContainerBackend {
         Box::pin(async move { self.cli.image_exists(image).await })
     }
 
+    fn tag_image<'a>(
+        &'a self,
+        source: &'a str,
+        target: &'a str,
+    ) -> BoxFuture<'a, Result<(), BackendError>> {
+        Box::pin(async move { self.cli.image_tag(source, target).await })
+    }
+
     fn inspect_image_details<'a>(
         &'a self,
         image: &'a str,

--- a/crates/cella-container/src/sdk/mod.rs
+++ b/crates/cella-container/src/sdk/mod.rs
@@ -262,6 +262,22 @@ impl ContainerCli {
         Ok(output.exit_code == 0)
     }
 
+    /// Add an additional name (`target`) to an existing image (`source`).
+    ///
+    /// Wraps `container image tag <source> <target>`. The Apple `container` CLI
+    /// parses the target reference itself, so it is passed through verbatim
+    /// (registry host, port, and tag included).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the CLI exits non-zero or cannot be spawned.
+    pub async fn image_tag(&self, source: &str, target: &str) -> Result<(), BackendError> {
+        debug!(source, target, "tagging image");
+        run_cli_checked(&self.binary_path, &["image", "tag", source, target])
+            .await
+            .map(drop)
+    }
+
     /// Inspect an image and return raw JSON output (an array of image
     /// resources).
     ///

--- a/crates/cella-docker/src/client.rs
+++ b/crates/cella-docker/src/client.rs
@@ -267,6 +267,10 @@ pub mod mock {
         ImageExists {
             image: String,
         },
+        TagImage {
+            source: String,
+            target: String,
+        },
         InspectImageDetails {
             image: String,
         },
@@ -300,6 +304,7 @@ pub mod mock {
         pub pull_image_responses: Mutex<VecDeque<Result<(), BackendError>>>,
         pub build_image_responses: Mutex<VecDeque<Result<String, BackendError>>>,
         pub image_exists_responses: Mutex<VecDeque<Result<bool, BackendError>>>,
+        pub tag_image_responses: Mutex<VecDeque<Result<(), BackendError>>>,
         pub inspect_image_details_responses: Mutex<VecDeque<Result<ImageDetails, BackendError>>>,
         pub upload_files_responses: Mutex<VecDeque<Result<(), BackendError>>>,
     }
@@ -579,6 +584,24 @@ pub mod mock {
                 .unwrap()
                 .pop_front()
                 .expect("MockDockerClient: no image_exists response configured");
+            Box::pin(async move { result })
+        }
+
+        fn tag_image<'a>(
+            &'a self,
+            source: &'a str,
+            target: &'a str,
+        ) -> BoxFuture<'a, Result<(), BackendError>> {
+            self.record(MockCall::TagImage {
+                source: source.to_string(),
+                target: target.to_string(),
+            });
+            let result = self
+                .tag_image_responses
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("MockDockerClient: no tag_image response configured");
             Box::pin(async move { result })
         }
 

--- a/crates/cella-docker/src/docker_api_impl.rs
+++ b/crates/cella-docker/src/docker_api_impl.rs
@@ -265,6 +265,18 @@ impl ContainerBackend for DockerClient {
         })
     }
 
+    fn tag_image<'a>(
+        &'a self,
+        source: &'a str,
+        target: &'a str,
+    ) -> BoxFuture<'a, Result<(), BackendError>> {
+        Box::pin(async move {
+            DockerClient::tag_image(self, source, target)
+                .await
+                .map_err(BackendError::from)
+        })
+    }
+
     fn inspect_image_details<'a>(
         &'a self,
         image: &'a str,

--- a/crates/cella-docker/src/image.rs
+++ b/crates/cella-docker/src/image.rs
@@ -3,7 +3,7 @@
 use std::fmt::Write as _;
 use std::process::Stdio;
 
-use bollard::query_parameters::CreateImageOptions;
+use bollard::query_parameters::{CreateImageOptions, TagImageOptions};
 use futures_util::StreamExt;
 use tracing::{debug, info};
 
@@ -23,6 +23,33 @@ pub(crate) fn normalize_user(raw: &str) -> String {
     } else {
         user.to_string()
     }
+}
+
+/// Split an image reference into its repository and optional tag.
+///
+/// The tag is the part after the LAST `:` that comes *after* the last `/`. A
+/// `:` that appears before a `/` is a registry-host port (e.g.
+/// `host:5000/img`), not a tag, so it is left in the repository. Returns
+/// `(repo, None)` when no tag is present so the caller can let Docker default
+/// it (`latest`) rather than synthesizing one.
+///
+/// Examples:
+/// - `img` → (`img`, None)
+/// - `img:tag` → (`img`, Some(`tag`))
+/// - `repo/img:tag` → (`repo/img`, Some(`tag`))
+/// - `host:5000/img:tag` → (`host:5000/img`, Some(`tag`))
+/// - `host:5000/img` → (`host:5000/img`, None)
+fn split_image_repo_tag(reference: &str) -> (&str, Option<&str>) {
+    let last_slash = reference.rfind('/');
+    // Only consider a `:` that comes after the last `/` (or anywhere when there
+    // is no `/`) as the tag separator; an earlier `:` is a registry port.
+    let search_from = last_slash.map_or(0, |i| i + 1);
+    reference[search_from..]
+        .rfind(':')
+        .map_or((reference, None), |rel| {
+            let colon = search_from + rel;
+            (&reference[..colon], Some(&reference[colon + 1..]))
+        })
 }
 
 /// Resolve the docker binary path (defaults to `docker` on `PATH`).
@@ -333,6 +360,31 @@ impl DockerClient {
             }) => Ok(false),
             Err(e) => Err(CellaDockerError::DockerApi(e)),
         }
+    }
+
+    /// Add an additional name (`target`) to an existing image (`source`).
+    ///
+    /// `source` is the image to tag (it must already exist locally); `target`
+    /// is the new reference, which may carry a registry host (with a port) and
+    /// an optional tag — e.g. `ghcr.io:443/org/img:1`. The target's repository
+    /// and tag are split apart so a registry port is never mistaken for a tag.
+    /// When the target has no tag, Docker defaults it (`latest`).
+    ///
+    /// # Errors
+    ///
+    /// Returns `CellaDockerError::DockerApi` if the tag operation fails (e.g.
+    /// the source image does not exist).
+    pub async fn tag_image(&self, source: &str, target: &str) -> Result<(), CellaDockerError> {
+        let (repo, tag) = split_image_repo_tag(target);
+        let options = TagImageOptions {
+            repo: Some(repo.to_string()),
+            tag: tag.map(ToString::to_string),
+        };
+        debug!("Tagging image {source} as {target}");
+        self.inner()
+            .tag_image(source, Some(options))
+            .await
+            .map_err(CellaDockerError::DockerApi)
     }
 
     /// Inspect an image and return its user, env, and metadata in one API call.
@@ -827,6 +879,55 @@ mod tests {
         assert!(is_cache_to_inline("dest=x,type=inline,mode=max"));
         assert!(!is_cache_to_inline("type=registry,ref=r"));
         assert!(!is_cache_to_inline(""));
+    }
+
+    // -----------------------------------------------------------------------
+    // split_image_repo_tag (target reference parsing for `tag_image`)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn split_repo_tag_bare_name_has_no_tag() {
+        assert_eq!(split_image_repo_tag("img"), ("img", None));
+    }
+
+    #[test]
+    fn split_repo_tag_name_with_tag() {
+        assert_eq!(split_image_repo_tag("img:tag"), ("img", Some("tag")));
+    }
+
+    #[test]
+    fn split_repo_tag_repo_path_with_tag() {
+        assert_eq!(
+            split_image_repo_tag("repo/img:tag"),
+            ("repo/img", Some("tag"))
+        );
+    }
+
+    #[test]
+    fn split_repo_tag_registry_port_and_tag() {
+        // The `:` before the `/` is a registry port, not the tag.
+        assert_eq!(
+            split_image_repo_tag("host:5000/img:tag"),
+            ("host:5000/img", Some("tag"))
+        );
+    }
+
+    #[test]
+    fn split_repo_tag_registry_port_without_tag() {
+        // Only a registry port, no tag — the port must stay in the repo and the
+        // tag must be None (Docker defaults it to `latest`).
+        assert_eq!(
+            split_image_repo_tag("host:5000/img"),
+            ("host:5000/img", None)
+        );
+    }
+
+    #[test]
+    fn split_repo_tag_multi_segment_repo_with_tag() {
+        assert_eq!(
+            split_image_repo_tag("ghcr.io:443/org/img:1"),
+            ("ghcr.io:443/org/img", Some("1"))
+        );
     }
 
     #[test]

--- a/crates/cella-docker/src/integration_tests/mod.rs
+++ b/crates/cella-docker/src/integration_tests/mod.rs
@@ -6,3 +6,4 @@
 mod claude_seed_tests;
 mod network_tests;
 mod spec_identity_tests;
+mod tag_image_tests;

--- a/crates/cella-docker/src/integration_tests/tag_image_tests.rs
+++ b/crates/cella-docker/src/integration_tests/tag_image_tests.rs
@@ -1,0 +1,62 @@
+//! Integration test: `tag_image` adds a new name to an existing image.
+//!
+//! This is the backend primitive behind `cella build --image-name` (the
+//! official build-then-tag flow): after `tag_image(source, target)` the image
+//! is reachable under `target`. The test pulls a small image, tags it, and
+//! asserts the new tag exists via `image_exists`.
+
+use bollard::query_parameters::RemoveImageOptions;
+
+use crate::client::DockerClient;
+
+const SOURCE_IMAGE: &str = "busybox:latest";
+
+/// `tag_image` makes the source image reachable under a new name. Uses an
+/// explicit tag so the no-tag → `latest` defaulting does not affect the
+/// `image_exists` lookup. Cleans up the created tag afterward.
+#[cella_testing::runtime_test(docker)]
+async fn tag_image_adds_reachable_name() {
+    let Ok(client) = DockerClient::connect() else {
+        return;
+    };
+
+    if client.pull_image(SOURCE_IMAGE).await.is_err() {
+        return;
+    }
+
+    let target = format!("cella-it-tag-image-{}:tagtest", std::process::id());
+
+    // The new name must not exist before tagging.
+    let before = client
+        .image_exists(&target)
+        .await
+        .expect("image_exists before tag");
+    assert!(!before, "target tag {target} must not exist before tagging");
+
+    client
+        .tag_image(SOURCE_IMAGE, &target)
+        .await
+        .expect("tag_image");
+
+    let after = client
+        .image_exists(&target)
+        .await
+        .expect("image_exists after tag");
+
+    // Best-effort cleanup of the tag we created (don't fail the test on it).
+    // `force` drops just this tag; the shared busybox image id is untouched
+    // because `busybox:latest` still references it.
+    let cleanup_opts = RemoveImageOptions {
+        force: true,
+        ..Default::default()
+    };
+    let _ = client
+        .inner()
+        .remove_image(&target, Some(cleanup_opts), None)
+        .await;
+
+    assert!(
+        after,
+        "image must be reachable under the new tag {target} after tag_image"
+    );
+}

--- a/crates/cella-orchestrator/src/prune.rs
+++ b/crates/cella-orchestrator/src/prune.rs
@@ -437,6 +437,7 @@ mod tests {
         panic_method!(pull_image, image: &'a str => Result<(), BackendError>);
         panic_method!(build_image, opts: &'a cella_backend::BuildOptions => Result<String, BackendError>);
         panic_method!(image_exists, image: &'a str => Result<bool, BackendError>);
+        panic_method!(tag_image, source: &'a str, target: &'a str => Result<(), BackendError>);
         panic_method!(inspect_image_details, image: &'a str => Result<cella_backend::ImageDetails, BackendError>);
         fn upload_files<'a>(
             &'a self,

--- a/crates/cella-orchestrator/src/shell_detect.rs
+++ b/crates/cella-orchestrator/src/shell_detect.rs
@@ -535,6 +535,7 @@ mod tests {
         panic_method!(pull_image, image: &'a str => Result<(), BackendError>);
         panic_method!(build_image, opts: &'a cella_backend::BuildOptions => Result<String, BackendError>);
         panic_method!(image_exists, image: &'a str => Result<bool, BackendError>);
+        panic_method!(tag_image, source: &'a str, target: &'a str => Result<(), BackendError>);
         panic_method!(inspect_image_details, image: &'a str => Result<cella_backend::ImageDetails, BackendError>);
         fn upload_files<'a>(
             &'a self,

--- a/crates/cella-tool-install/src/lib.rs
+++ b/crates/cella-tool-install/src/lib.rs
@@ -2164,6 +2164,14 @@ mod tests {
             unimplemented!()
         }
 
+        fn tag_image<'a>(
+            &'a self,
+            _: &'a str,
+            _: &'a str,
+        ) -> BoxFuture<'a, Result<(), BackendError>> {
+            unimplemented!()
+        }
+
         fn inspect_image_details<'a>(
             &'a self,
             _: &'a str,


### PR DESCRIPTION
## What

Adds `cella build --image-name <name>` (repeatable) — tags the built/resolved image with each name and reports those names, matching the official `devcontainer build --image-name`.

## How

Follows official's **build-then-tag** flow: build/resolve the image as today, then `docker tag` it with each `--image-name`. Works on both the single-container path (tags the `ensure_image` result) and the Docker Compose path (tags the real primary-service image — newly available since the `(compose)` sentinel was dropped).

- New `ContainerBackend::tag_image(source, target)`:
  - **Docker** (bollard `tag_image`): a `split_image_repo_tag` helper splits the target into repo + optional tag, treating a `:` only as a tag separator when it follows the last `/` so a registry port (`host:5000/img`) is never mistaken for a tag. Six unit tests cover the cases.
  - **Apple Container**: `container image tag <source> <target>` (verified subcommand + source-first order; matches cella-container's existing singular `image` CLI group).
  - All mock backends implement it.
- Reporting: when `--image-name` is set, the result's `imageName` array lists exactly those names (official `imageNameResult = imageNames`); otherwise the built name as before. The JSON shape (`{"outcome":"success","imageName":[...]}`) is unchanged.

## Scope

`--label`, `--push`, and `--output` (buildx) remain separate follow-up PRs. This PR does **not** touch the `--output text|json` format-selector mechanism — only which names are reported.

## Tests

Unit: flag parsing (repeatable), the docker repo/tag split (incl. registry-port cases), and multi-name reporting/JSON shape. A `#[runtime_test(docker)]` (runs in CI, skips locally) tags a pulled image and asserts the new name is reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
