### PR TITLE
feat(build): --output buildx spec + always-JSON result

### DIFF
--- a/crates/cella-backend/src/types.rs
+++ b/crates/cella-backend/src/types.rs
@@ -155,7 +155,7 @@ pub struct InteractiveExecOptions {
 // ---------------------------------------------------------------------------
 
 /// Image inspection results.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ImageDetails {
     /// Normalized USER (user portion only, defaults to `"root"`).
     pub user: String,

--- a/crates/cella-backend/src/types.rs
+++ b/crates/cella-backend/src/types.rs
@@ -203,6 +203,14 @@ pub struct BuildOptions {
     /// When set, emits `--platform <value>` on the docker build command.
     /// Derived from the base image's inspected OS/architecture/variant.
     pub platform: Option<String>,
+    /// buildx output spec (`--output`, e.g. `type=local,dest=…`,
+    /// `type=tar,dest=…`). buildx-only: when set it emits `--output <spec>` and
+    /// *replaces* the default `--load` (which is itself shorthand for
+    /// `--output=docker`). Set only on the final image build — exactly one build
+    /// site carries it, so an export spec never starves a follow-up `FROM` of a
+    /// loaded base. The backend errors if it is set without `BuildKit`/buildx,
+    /// since dropping it would silently exit 0 with nothing written to `dest=`.
+    pub output: Option<String>,
 }
 
 impl Default for BuildOptions {
@@ -220,6 +228,7 @@ impl Default for BuildOptions {
             use_buildkit: true,
             docker_path: None,
             platform: None,
+            output: None,
         }
     }
 }

--- a/crates/cella-backend/src/uid_image.rs
+++ b/crates/cella-backend/src/uid_image.rs
@@ -180,6 +180,9 @@ pub async fn build_uid_remap_image(
         use_buildkit: toolchain.use_buildkit,
         docker_path: toolchain.docker_path.map(str::to_string),
         platform,
+        // The UID-remap build is a post-build transform on an already-built
+        // image, never the `--output` export target — keep the default --load.
+        output: None,
     };
 
     info!("Building UID remap image: {uid_image} (UID {host_uid}:{host_gid})");

--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use clap::Args;
 use tracing::{info, warn};
 
-use super::{BuildKitMode, ComposePullPolicy, ImagePullPolicy, LogFormat, LogLevel, OutputFormat};
+use super::{BuildKitMode, ComposePullPolicy, ImagePullPolicy, LogFormat, LogLevel};
 
 use cella_backend::{BuildSecret, container_name};
 use cella_config::devcontainer::resolve;
@@ -50,10 +50,6 @@ pub struct BuildArgs {
     /// `devcontainer build --image-name`).
     #[arg(long = "image-name")]
     image_name: Vec<String>,
-
-    /// Output format.
-    #[arg(long, value_enum, default_value = "text")]
-    output: OutputFormat,
 
     /// Docker Compose profile(s) to activate (repeatable).
     #[arg(long = "profile")]
@@ -110,10 +106,6 @@ pub struct BuildArgs {
 }
 
 impl BuildArgs {
-    pub const fn is_text_output(&self) -> bool {
-        matches!(self.output, OutputFormat::Auto | OutputFormat::Text)
-    }
-
     /// The `--log-level` value, seeded into the global tracing filter by main.rs
     /// before dispatch (mirrors `up`).
     pub const fn log_level(&self) -> Option<LogLevel> {
@@ -251,7 +243,7 @@ impl BuildArgs {
             }
         }
 
-        print_result(&self.output, &self.reported_names(&result.image_name), true);
+        print_result(&self.reported_names(&result.image_name), true);
         Ok(())
     }
 
@@ -307,7 +299,7 @@ impl BuildArgs {
             );
         }
 
-        print_result(&self.output, &self.reported_names(&img_name), false);
+        print_result(&self.reported_names(&img_name), false);
         Ok(())
     }
 
@@ -325,7 +317,7 @@ impl BuildArgs {
     }
 }
 
-/// JSON result emitted by `cella build --output json`.
+/// JSON result emitted by `cella build` on stdout.
 ///
 /// Mirrors the official `devcontainer build` contract — devcontainers/cli
 /// `devContainersSpecCLI.ts` emits `JSON.stringify({ outcome: 'success',
@@ -353,22 +345,25 @@ fn build_json_result(image_names: &[String]) -> String {
     .unwrap_or_default()
 }
 
-/// Print the build result in the requested output format.
+/// Print the build result.
+///
+/// Always emits the machine-readable JSON result line to **stdout** (matching
+/// the official `devcontainer build`, which unconditionally writes
+/// `JSON.stringify(result)`), plus a friendly human summary to **stderr**. The
+/// human line is a cella extra; keeping it on stderr means it never pollutes the
+/// stdout JSON that scripts parse, so there is no `--output text|json` selector.
 ///
 /// `image_names` holds every reported name (the built name, or all
-/// `--image-name` values when set). The text mode lists them comma-separated.
-fn print_result(output: &OutputFormat, image_names: &[String], compose: bool) {
-    match output {
-        OutputFormat::Auto | OutputFormat::Text => {
-            let joined = image_names.join(", ");
-            match (compose, image_names.len() > 1) {
-                (true, false) => eprintln!("Compose services built. Primary image: {joined}"),
-                (true, true) => eprintln!("Compose services built. Tagged images: {joined}"),
-                (false, false) => eprintln!("Image built: {joined}"),
-                (false, true) => eprintln!("Image built and tagged: {joined}"),
-            }
-        }
-        OutputFormat::Json => println!("{}", build_json_result(image_names)),
+/// `--image-name` values when set). The human summary lists them comma-separated.
+fn print_result(image_names: &[String], compose: bool) {
+    println!("{}", build_json_result(image_names));
+
+    let joined = image_names.join(", ");
+    match (compose, image_names.len() > 1) {
+        (true, false) => eprintln!("Compose services built. Primary image: {joined}"),
+        (true, true) => eprintln!("Compose services built. Tagged images: {joined}"),
+        (false, false) => eprintln!("Image built: {joined}"),
+        (false, true) => eprintln!("Image built and tagged: {joined}"),
     }
 }
 
@@ -649,6 +644,31 @@ mod tests {
             build_json_result(&["one:1".to_string(), "two:2".to_string()]),
             r#"{"outcome":"success","imageName":["one:1","two:2"]}"#
         );
+    }
+
+    #[test]
+    fn build_always_emits_json_result_no_format_flag() {
+        // `cella build` has no `--output text|json` format selector — it always
+        // emits the JSON result to stdout (matching the official `devcontainer
+        // build`, which unconditionally writes `JSON.stringify(result)`). Verify
+        // the result line is well-formed regardless of which other flags were
+        // parsed, so nothing can gate it off.
+        for extra in [
+            vec![],
+            vec!["--no-cache"],
+            vec!["--log-format", "json"],
+            vec!["--image-name", "x:1"],
+        ] {
+            let args = parse_build(&extra);
+            let line = build_json_result(&args.reported_names("built:latest"));
+            let parsed: serde_json::Value =
+                serde_json::from_str(&line).expect("result line is valid JSON");
+            assert_eq!(parsed["outcome"], "success", "for flags {extra:?}");
+            assert!(
+                parsed["imageName"].is_array(),
+                "imageName must be an array for flags {extra:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -78,6 +78,14 @@ pub struct BuildArgs {
     #[arg(long = "cache-to")]
     cache_to: Option<String>,
 
+    /// buildx output spec, passed through to `docker buildx build --output`
+    /// (e.g. `type=local,dest=./out`, `type=tar,dest=image.tar`). Overrides the
+    /// default behavior of loading the built image into the local docker store.
+    /// buildx-only (errors without `BuildKit`/buildx); single-container path
+    /// only (not supported on the Docker Compose path).
+    #[arg(long = "output")]
+    output: Option<String>,
+
     /// Control whether `BuildKit` is used when building images.
     #[arg(long, value_enum, default_value = "auto")]
     buildkit: BuildKitMode,
@@ -173,15 +181,19 @@ impl BuildArgs {
 
     /// Reject or warn on build flags that don't apply to the Docker Compose path.
     ///
-    /// Matches the official CLI, which errors on `--platform`/`--push` and
-    /// `--cache-to` for compose. `--cache-from`/`--buildkit` only affect the
-    /// single-container buildx path; the official CLI accepts them without error,
-    /// so cella warns rather than failing (never silently ignores).
+    /// Matches the official CLI, which errors on `--platform`/`--push`,
+    /// `--output`, and `--cache-to` for compose. `--cache-from`/`--buildkit`
+    /// only affect the single-container buildx path; the official CLI accepts
+    /// them without error, so cella warns rather than failing (never silently
+    /// ignores).
     fn reject_unsupported_compose_flags(
         &self,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         if self.platform.is_some() {
             return Err("--platform or --push not supported.".into());
+        }
+        if self.output.is_some() {
+            return Err("--output not supported.".into());
         }
         if self.cache_to.is_some() {
             return Err("--cache-to not supported.".into());
@@ -272,6 +284,10 @@ impl BuildArgs {
                 cache_to: self.cache_to.as_deref(),
                 platform: self.platform.as_deref(),
             },
+            // buildx `--output` export spec. The orchestrator routes it to the
+            // single final build (base when there are no features, features
+            // layer otherwise) so an export never starves a `FROM` of a base.
+            output: self.output.as_deref(),
             // `--omit-config-remote-env-from-metadata` is wired on `up` only;
             // `cella build` keeps the full metadata label.
             omit_remote_env_from_metadata: false,
@@ -286,8 +302,25 @@ impl BuildArgs {
         let (img_name, _resolved_features, _image_details) = result?;
         let _ = renderer.await;
 
-        for name in &self.image_name {
-            client.tag_image(&img_name, name).await?;
+        // A `--output` export (e.g. type=local/tar) does NOT load the built
+        // image into the docker store, so it can't be tagged afterward. The
+        // official CLI feeds `-t` straight into the single buildx invocation,
+        // where buildx ignores tags for non-loading outputs — so `--image-name`
+        // is effectively a no-op alongside `--output`. Mirror that: skip the tag
+        // step (which would otherwise fail with "no such image") and warn rather
+        // than silently dropping it. The reported names still follow official,
+        // which sets `imageNameResult = imageNames` regardless of `--output`.
+        if self.output.is_some() {
+            if !self.image_name.is_empty() {
+                warn!(
+                    "--image-name tags are not applied alongside --output: the export does not \
+                     load an image into the docker store to tag"
+                );
+            }
+        } else {
+            for name in &self.image_name {
+                client.tag_image(&img_name, name).await?;
+            }
         }
 
         if let Some(container) = client.find_container(&resolved.workspace_root).await?
@@ -530,6 +563,49 @@ mod tests {
                 .is_ok()
         );
         assert!(parse_build(&[]).reject_unsupported_compose_flags().is_ok());
+    }
+
+    #[test]
+    fn output_buildx_spec_parses_and_is_captured() {
+        // `--output` is a free-form buildx spec passed through to the build.
+        let args = parse_build(&["--output", "type=local,dest=./out"]);
+        assert_eq!(args.output.as_deref(), Some("type=local,dest=./out"));
+    }
+
+    #[test]
+    fn output_defaults_to_none() {
+        assert!(parse_build(&[]).output.is_none());
+    }
+
+    #[test]
+    fn compose_rejects_output() {
+        // Official `doBuild` rejects `--output` for the compose path with the
+        // exact message "--output not supported." cella mirrors it.
+        let err = parse_build(&["--output", "type=local,dest=./out"])
+            .reject_unsupported_compose_flags()
+            .expect_err("compose must reject --output");
+        assert_eq!(err.to_string(), "--output not supported.");
+    }
+
+    #[test]
+    fn output_with_image_name_still_reports_image_names() {
+        // `--output` and `--image-name` can be set together. The tag step is
+        // skipped at runtime (a non-loading export can't be tagged), but the
+        // reported names still follow official, which sets
+        // `imageNameResult = imageNames` regardless of `--output`.
+        let args = parse_build(&[
+            "--output",
+            "type=local,dest=./out",
+            "--image-name",
+            "x:1",
+            "--image-name",
+            "y:2",
+        ]);
+        assert_eq!(args.output.as_deref(), Some("type=local,dest=./out"));
+        assert_eq!(
+            args.reported_names("built:latest"),
+            vec!["x:1".to_string(), "y:2".to_string()]
+        );
     }
 
     #[test]

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -370,13 +370,15 @@ impl Command {
         match self {
             Self::Up(args) => args.is_text_output(),
             Self::Code(args) => args.is_text_output(),
-            Self::Build(args) => args.is_text_output(),
             Self::Down(args) => args.is_text_output(),
             // These emit a JSON envelope on stdout; spinners would fight it.
             Self::ReadConfiguration(_)
             | Self::RunUserCommands(_)
             | Self::SetUp(_)
             | Self::Templates(_) => false,
+            // `build` falls through to `true`: it always writes its JSON result
+            // to stdout and the human summary to stderr, so spinners (stderr-only)
+            // never corrupt the stdout JSON and follow the normal TTY rules.
             _ => true,
         }
     }

--- a/crates/cella-docker/src/image.rs
+++ b/crates/cella-docker/src/image.rs
@@ -124,11 +124,18 @@ fn build_command_args(opts: &BuildOptions, use_buildx: bool) -> Vec<String> {
     }
     args.push("build".to_string());
 
-    // `--progress=plain` and `--load` are buildx-only. The classic builder
-    // rejects `--progress`, and official emits neither on the legacy path.
+    // `--progress=plain`, `--load`, and `--output` are buildx-only. The classic
+    // builder rejects `--progress`, and official emits none of these on the
+    // legacy path. A `--output <spec>` *replaces* `--load` (which is itself
+    // shorthand for `--output=docker`); the two are mutually exclusive, so the
+    // export spec wins when set (mirrors the official singleContainer.ts).
     if use_buildx {
         args.push("--progress=plain".to_string());
-        args.push("--load".to_string());
+        if let Some(output) = &opts.output {
+            args.extend(["--output".to_string(), output.clone()]);
+        } else {
+            args.push("--load".to_string());
+        }
     }
 
     // `--platform` is a BuildKit/buildx flag; the classic `docker build`
@@ -289,6 +296,19 @@ impl DockerClient {
                 "--platform is ignored without BuildKit/buildx (classic docker build); \
                  building for the host architecture"
             );
+        }
+
+        // `--output` is buildx-only too, but unlike --cache-to/--platform it
+        // cannot be silently dropped: doing so would exit 0 having written
+        // nothing to the user's `dest=`, a silent success with the wrong result.
+        // Error clearly instead (the classic builder has no equivalent, and we
+        // can't "force" a buildx that isn't installed).
+        if !use_buildx && opts.output.is_some() {
+            return Err(CellaDockerError::BuildFailed {
+                message: "--output requires BuildKit/buildx, which is not available \
+                          (enable BuildKit or install docker buildx)"
+                    .to_string(),
+            });
         }
 
         let args = build_command_args(opts, use_buildx);
@@ -469,6 +489,7 @@ mod tests {
             use_buildkit: true,
             docker_path: None,
             platform: None,
+            output: None,
         }
     }
 
@@ -613,6 +634,49 @@ mod tests {
         let opts = basic_opts();
         let args = build_command_args(&opts, false);
         assert!(!args.contains(&"--load".to_string()));
+    }
+
+    #[test]
+    fn build_args_output_replaces_load_on_buildx() {
+        // `--output <spec>` and `--load` are mutually exclusive (--load is
+        // shorthand for --output=docker). When output is set on the buildx path,
+        // `--output <spec>` is emitted and `--load` is suppressed.
+        let mut opts = basic_opts();
+        opts.output = Some("type=local,dest=/tmp/out".to_string());
+        let args = build_command_args(&opts, true);
+        assert!(
+            !args.contains(&"--load".to_string()),
+            "--load must be suppressed when --output is set; args: {args:?}"
+        );
+        let idx = args
+            .iter()
+            .position(|a| a == "--output")
+            .expect("--output emitted on buildx path");
+        assert_eq!(args[idx + 1], "type=local,dest=/tmp/out");
+    }
+
+    #[test]
+    fn build_args_output_not_emitted_on_classic_builder() {
+        // `--output` is buildx-only; the classic builder must never receive it
+        // (build_image errors before reaching here on that path, but the arg
+        // builder must not emit it regardless).
+        let mut opts = basic_opts();
+        opts.output = Some("type=local,dest=/tmp/out".to_string());
+        let args = build_command_args(&opts, false);
+        assert!(
+            !args.contains(&"--output".to_string()),
+            "classic builder must not receive --output; args: {args:?}"
+        );
+    }
+
+    #[test]
+    fn build_args_no_output_keeps_load_on_buildx() {
+        // Without --output, the buildx path keeps the default --load so the
+        // built image lands in the local docker store.
+        let opts = basic_opts();
+        let args = build_command_args(&opts, true);
+        assert!(args.contains(&"--load".to_string()));
+        assert!(!args.contains(&"--output".to_string()));
     }
 
     #[test]

--- a/crates/cella-docker/src/integration_tests/mod.rs
+++ b/crates/cella-docker/src/integration_tests/mod.rs
@@ -5,5 +5,6 @@
 
 mod claude_seed_tests;
 mod network_tests;
+mod output_export_tests;
 mod spec_identity_tests;
 mod tag_image_tests;

--- a/crates/cella-docker/src/integration_tests/output_export_tests.rs
+++ b/crates/cella-docker/src/integration_tests/output_export_tests.rs
@@ -52,15 +52,13 @@ async fn output_type_local_exports_to_dest() {
 
     let context = scratch_dir("ctx");
     let dest = scratch_dir("dest");
-    if std::fs::create_dir_all(&context).is_err() || std::fs::create_dir_all(&dest).is_err() {
-        return;
-    }
+    // Setup failures are real bugs (not an unavailable runtime) — fail loudly.
+    std::fs::create_dir_all(&context).expect("create build context dir");
+    std::fs::create_dir_all(&dest).expect("create output dest dir");
 
     // Trivial, registry-free build: scratch base + a single sentinel file.
     let dockerfile = "FROM busybox:latest\nRUN echo cella > /cella-export-sentinel\n";
-    if std::fs::write(context.join("Dockerfile"), dockerfile).is_err() {
-        return;
-    }
+    std::fs::write(context.join("Dockerfile"), dockerfile).expect("write test Dockerfile");
     // Pre-pull the base so the build itself needs no registry round-trip beyond
     // the (cached) base; if the pull fails (offline), skip rather than fail.
     if client.pull_image("busybox:latest").await.is_err() {

--- a/crates/cella-docker/src/integration_tests/output_export_tests.rs
+++ b/crates/cella-docker/src/integration_tests/output_export_tests.rs
@@ -1,0 +1,102 @@
+//! Integration test: `build_image` with a buildx `--output type=local,dest=…`
+//! export writes the built filesystem to the destination directory.
+//!
+//! This is the backend primitive behind `cella build --output <spec>`: when an
+//! output spec is set, `build_image` runs `docker buildx build --output <spec>`
+//! (replacing the default `--load`), so the result is exported to the local
+//! filesystem rather than loaded into the docker image store. No registry is
+//! needed. The test builds a trivial Dockerfile that writes a sentinel file and
+//! asserts that file lands under `dest=`.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use cella_backend::BuildOptions;
+
+use crate::client::DockerClient;
+
+/// Whether `docker buildx` is available. `--output` is buildx-only, so the test
+/// skips (rather than fails) when buildx is absent — `build_image` would
+/// correctly return an error in that case, which is its own unit-tested path.
+fn has_buildx() -> bool {
+    std::process::Command::new("docker")
+        .args(["buildx", "version"])
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+/// A unique scratch directory under the system temp dir, removed first so a
+/// stale run can't mask a failure. Mirrors the `/tmp`-path style of the other
+/// integration tests (no `tempfile` dev-dependency in this crate).
+fn scratch_dir(suffix: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "cella-it-output-export-{}-{suffix}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    dir
+}
+
+/// `build_image` with `--output type=local,dest=<dir>` exports the built image's
+/// filesystem to `<dir>`. The Dockerfile creates `/cella-export-sentinel`, so
+/// after the build that file must exist under the destination directory.
+#[cella_testing::runtime_test(docker)]
+async fn output_type_local_exports_to_dest() {
+    let Ok(client) = DockerClient::connect() else {
+        return;
+    };
+    // `--output` needs buildx; skip cleanly when it isn't installed.
+    if !has_buildx() {
+        return;
+    }
+
+    let context = scratch_dir("ctx");
+    let dest = scratch_dir("dest");
+    if std::fs::create_dir_all(&context).is_err() || std::fs::create_dir_all(&dest).is_err() {
+        return;
+    }
+
+    // Trivial, registry-free build: scratch base + a single sentinel file.
+    let dockerfile = "FROM busybox:latest\nRUN echo cella > /cella-export-sentinel\n";
+    if std::fs::write(context.join("Dockerfile"), dockerfile).is_err() {
+        return;
+    }
+    // Pre-pull the base so the build itself needs no registry round-trip beyond
+    // the (cached) base; if the pull fails (offline), skip rather than fail.
+    if client.pull_image("busybox:latest").await.is_err() {
+        return;
+    }
+
+    let opts = BuildOptions {
+        image_name: format!("cella-it-output-export-{}:test", std::process::id()),
+        context_path: context.clone(),
+        dockerfile: "Dockerfile".to_string(),
+        args: HashMap::new(),
+        target: None,
+        cache_from: Vec::new(),
+        cache_to: None,
+        options: Vec::new(),
+        secrets: Vec::new(),
+        use_buildkit: true,
+        docker_path: None,
+        platform: None,
+        output: Some(format!("type=local,dest={}", dest.display())),
+    };
+
+    let result = client.build_image(&opts, |_| {}).await;
+
+    // Sentinel exported to the destination → the `--output` export landed.
+    let sentinel = dest.join("cella-export-sentinel");
+    let exported = sentinel.exists();
+
+    // Best-effort cleanup of both scratch dirs.
+    let _ = std::fs::remove_dir_all(&context);
+    let _ = std::fs::remove_dir_all(&dest);
+
+    result.expect("build_image with --output type=local should succeed");
+    assert!(
+        exported,
+        "expected exported sentinel at {} after --output type=local export",
+        sentinel.display()
+    );
+}

--- a/crates/cella-orchestrator/src/image.rs
+++ b/crates/cella-orchestrator/src/image.rs
@@ -30,6 +30,11 @@ pub struct FeaturesLayerContext<'a> {
     /// features layer never inherits CLI cache I/O — its FROM image is a
     /// cella-internal base no external registry cache would match.
     pub build_tuning: crate::config::BuildTuning<'a>,
+    /// buildx output spec (`--output`) for the FINAL image. When features are
+    /// layered, the features image *is* the final image, so the export spec
+    /// belongs here — never on the base build, which must stay loadable for the
+    /// features `FROM`.
+    pub output: Option<&'a str>,
     pub progress: &'a ProgressSender,
 }
 
@@ -73,6 +78,9 @@ pub async fn build_features_layer(
         use_buildkit: ctx.build_tuning.use_buildkit,
         docker_path: ctx.build_tuning.docker_path.map(str::to_string),
         platform: ctx.build_tuning.platform.map(str::to_string),
+        // Features layer is the final image when features are present, so the
+        // buildx `--output` export spec is applied here.
+        output: ctx.output.map(str::to_string),
     };
 
     info!(
@@ -110,12 +118,31 @@ pub struct EnsureImageInput<'a> {
     /// Build/backend tuning. Toolchain inputs (`docker_path`, `use_buildkit`)
     /// apply to every build site; cache I/O applies to the base build only.
     pub build_tuning: crate::config::BuildTuning<'a>,
+    /// buildx output spec (`--output <spec>`, e.g. `type=local,dest=…`). Applied
+    /// to exactly ONE build — the final image: the base build when there are no
+    /// features, or the features layer when there are. It is never applied to a
+    /// base build that a features layer will `FROM`, since an export spec does
+    /// not load an image into the docker store. `None` keeps the default
+    /// `--load` everywhere (the `up` path, which must run the container).
+    pub output: Option<&'a str>,
     /// `--omit-config-remote-env-from-metadata`: strip `remoteEnv` from the
     /// generated `devcontainer.metadata` label baked into the built image.
     pub omit_remote_env_from_metadata: bool,
     /// Lockfile policy for feature resolution.
     pub lockfile_policy: cella_features::LockfilePolicy,
     pub progress: &'a ProgressSender,
+}
+
+/// The buildx output spec for the *base* image build.
+///
+/// `--output` belongs on exactly one build — the final image. When a features
+/// layer will be built on top (`will_build_features`), that layer is the final
+/// image and carries `--output`; the base build must NOT, because an export
+/// spec (e.g. `type=local`) does not load an image into the docker store, so a
+/// features `FROM <base>` would fail. Returns `None` in that case; otherwise
+/// the base build is the final image and gets the spec.
+const fn base_output(will_build_features: bool, output: Option<&str>) -> Option<&str> {
+    if will_build_features { None } else { output }
 }
 
 /// Ensure the dev container image exists (pull or build), including features layer.
@@ -161,6 +188,7 @@ pub async fn ensure_image(
         base_image_details: &base_image_details,
         no_cache: input.no_cache,
         build_tuning: input.build_tuning,
+        output: input.output,
         omit_remote_env_from_metadata: input.omit_remote_env_from_metadata,
         lockfile_policy: input.lockfile_policy,
         progress: input.progress,
@@ -240,6 +268,12 @@ async fn resolve_base_image(
             input.client.pull_image(image).await?;
             step.finish();
         }
+        // Image-only config: there is no build here. With features, the export
+        // spec rides the features layer (handled by the caller); with no
+        // features there is no build at all, so a `--output` has nothing to
+        // attach to and is a no-op. This matches the official CLI, whose
+        // `extendImage` is a passthrough for an image-only, zero-feature config
+        // and never runs a buildx `--output` build.
         Ok(image.to_string())
     } else if let Some(build) = effective_build_config(input.config) {
         let img_name = resolve_image_name(input.workspace_root, input.config_name, input.config);
@@ -252,6 +286,10 @@ async fn resolve_base_image(
             input.build_tuning,
         );
         build_opts.secrets = input.secrets.to_vec();
+        // `--output` lands on the base build only when it is the final image
+        // (no features layer to follow). With features, the export spec goes on
+        // the features layer instead so the base stays loadable for its `FROM`.
+        build_opts.output = base_output(will_build_features, input.output).map(str::to_string);
 
         if !will_build_features {
             let metadata_label = cella_features::generate_metadata_label(
@@ -301,6 +339,9 @@ struct FeaturesBuildInput<'a> {
     base_image_details: &'a ImageDetails,
     no_cache: bool,
     build_tuning: crate::config::BuildTuning<'a>,
+    /// buildx output spec for the features layer (the final image when features
+    /// are present). Threaded straight through from [`EnsureImageInput::output`].
+    output: Option<&'a str>,
     omit_remote_env_from_metadata: bool,
     lockfile_policy: cella_features::LockfilePolicy,
     progress: &'a ProgressSender,
@@ -371,6 +412,7 @@ async fn resolve_and_build_features(
         image_user: &input.base_image_details.user,
         no_cache: input.no_cache,
         build_tuning: input.build_tuning.toolchain(),
+        output: input.output,
         progress: input.progress,
     };
     let features_image = build_features_layer(&ctx).await?;
@@ -542,6 +584,10 @@ pub fn parse_build_options(
         use_buildkit: build_tuning.use_buildkit,
         docker_path: build_tuning.docker_path.map(str::to_string),
         platform: build_tuning.platform.map(str::to_string),
+        // `--output` is not part of BuildTuning (it must reach only the final
+        // build, not every site): the caller sets it via `base_output` when this
+        // base build is the final image.
+        output: None,
     }
 }
 
@@ -1039,5 +1085,33 @@ mod tests {
         assert!(parse_platform_str("/amd64").is_none());
         assert!(parse_platform_str("linux/").is_none());
         assert!(parse_platform_str("").is_none());
+    }
+
+    // ── base_output: --output placement (final-build only) ───────────
+    //
+    // `ensure_image` is Docker-coupled, so the load-bearing placement rule
+    // (the base build gets `--output` *only* when it is the final image) is
+    // pinned here on the pure helper instead. A regression that applied the
+    // export spec to a base build that a features layer will `FROM` would break
+    // every featured devcontainer — these arms guard exactly that.
+
+    #[test]
+    fn base_output_suppressed_when_features_will_build() {
+        // With a features layer to follow, the base build must NOT carry the
+        // export spec — it has to stay loadable for the features `FROM`. The
+        // spec moves to the features layer (the final image) instead.
+        assert_eq!(base_output(true, Some("type=local,dest=/tmp/out")), None);
+        assert_eq!(base_output(true, None), None);
+    }
+
+    #[test]
+    fn base_output_applied_when_base_is_final() {
+        // No features: the base build IS the final image, so it carries the
+        // export spec verbatim (and stays `None` when none was requested).
+        assert_eq!(
+            base_output(false, Some("type=local,dest=/tmp/out")),
+            Some("type=local,dest=/tmp/out")
+        );
+        assert_eq!(base_output(false, None), None);
     }
 }

--- a/crates/cella-orchestrator/src/image.rs
+++ b/crates/cella-orchestrator/src/image.rs
@@ -145,6 +145,18 @@ const fn base_output(will_build_features: bool, output: Option<&str>) -> Option<
     if will_build_features { None } else { output }
 }
 
+/// Whether to skip inspecting the base image after the build.
+///
+/// A non-loading `--output` export with no features builds the image but does
+/// NOT load it into the local store, so a follow-up `inspect_image_details`
+/// would fail right after a successful export. In that one case the inspect is
+/// skipped (the no-features build path discards these details, and `up` never
+/// exports). With features, the base build still `--load`s (the export rides the
+/// features layer), so the base remains inspectable.
+const fn skip_base_inspect(has_features: bool, output: Option<&str>) -> bool {
+    !has_features && output.is_some()
+}
+
 /// Ensure the dev container image exists (pull or build), including features layer.
 ///
 /// When `no_cache` is true, `--no-cache` and `--pull` are passed to the base
@@ -171,6 +183,14 @@ pub async fn ensure_image(
         .is_some_and(|obj| !obj.is_empty());
 
     let base_image_tag = resolve_base_image(input, has_features).await?;
+
+    // A non-loading `--output` export (no features) builds the image but does
+    // NOT load it into the local store, so inspecting it would fail right after a
+    // successful export. `cella build` discards these details on the no-features
+    // path and `up` never exports, so return empty details instead of failing.
+    if skip_base_inspect(has_features, input.output) {
+        return Ok((base_image_tag, None, ImageDetails::default()));
+    }
 
     let base_image_details = input.client.inspect_image_details(&base_image_tag).await?;
 
@@ -1113,5 +1133,26 @@ mod tests {
             Some("type=local,dest=/tmp/out")
         );
         assert_eq!(base_output(false, None), None);
+    }
+
+    // ── skip_base_inspect: don't inspect a non-loaded export ─────────
+    //
+    // `ensure_image` inspects the base image after building. A non-loading
+    // `--output` export (no features) leaves nothing in the local store to
+    // inspect, so the inspect MUST be skipped — otherwise the command fails
+    // right after a successful export. A regression that re-enabled the inspect
+    // there would break every `cella build --output type=local/tar` on a
+    // Dockerfile config; this pins exactly that case.
+
+    #[test]
+    fn skip_base_inspect_only_for_no_features_export() {
+        // No features + a `--output` export → skip the inspect (image not loaded).
+        assert!(skip_base_inspect(false, Some("type=local,dest=/tmp/out")));
+        // No export → inspect normally (the build loaded the image).
+        assert!(!skip_base_inspect(false, None));
+        // With features the base build still loads (export rides the features
+        // layer), so the base stays inspectable regardless of `--output`.
+        assert!(!skip_base_inspect(true, Some("type=local,dest=/tmp/out")));
+        assert!(!skip_base_inspect(true, None));
     }
 }

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -1939,6 +1939,9 @@ impl EnsureUpContext<'_> {
                 pull_policy: self.config.pull_policy,
                 secrets: &self.config.build_secrets,
                 build_tuning: self.config.build_tuning,
+                // `up` has no `--output` (it must load the image to run the
+                // container); the buildx export spec is a `build`-only flag.
+                output: None,
                 omit_remote_env_from_metadata: self.config.metadata_options.omit_remote_env,
                 lockfile_policy: self.config.lockfile_policy,
                 progress: &self.progress,


### PR DESCRIPTION
Resolves the `cella build --output` collision and adds the official buildx `--output`. Two commits:

## 1. Always emit the JSON result to stdout (drop the `--output text|json` selector)

cella's `--output text|json` was a **non-official** result-format selector. The official `devcontainer build` (`doBuild`) unconditionally writes `JSON.stringify(result)` to stdout — there is no format flag. So `cella build` now **always** prints the JSON result to **stdout** and the friendly "Image built…" summary to **stderr** (a cella extra; on stderr it never pollutes the stdout JSON). `Command::is_text_output()` for `build` falls through to `true` — spinners are stderr-only and follow the normal TTY/`--log-format` rules without touching the stdout JSON. (Breaking change to cella's old `--output text|json`, allowed by the project's no-backward-compat policy.)

## 2. Add `--output <buildx-spec>`

Now that `--output` is free, it becomes the buildx output spec (`type=local,dest=…`, `type=tar,dest=…`), matching official.

- It **replaces** `--load` on the buildx path (the two are mutually exclusive — `--load` is `--output=docker`).
- buildx-only: `build_image` errors clearly when `--output` is set without BuildKit/buildx (rather than exiting 0 with an empty `dest=`).
- Applied to **exactly one build — the final image**: the base build when there are no features, the features layer when there are. It's threaded separately from the (`Copy`) `BuildTuning` and gated by a unit-tested `base_output` helper, so an export never starves a features `FROM` of a loadable base.
- Compose path rejects it with `--output not supported.` (matches official `doBuild`).
- `--image-name` + `--output`: the tag step is skipped (a non-loading export leaves no image to tag) with a warning; reported names still follow official.

## Scope

`--push` is deferred to its own PR (it needs a registry to validate). `--label` likewise.

## Tests

Unit: parsing, compose rejection, `--output` replaces `--load`/not-on-classic, the `base_output` final-build placement (both arms), always-JSON-result. A `#[runtime_test(docker)]` builds with `--output type=local,dest=<tmpdir>` and asserts the export lands on disk (no registry needed; runs in CI, skips locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
