### PR TITLE
feat(build): add --label (single-container build paths)

### DIFF
--- a/crates/cella-backend/src/types.rs
+++ b/crates/cella-backend/src/types.rs
@@ -211,6 +211,13 @@ pub struct BuildOptions {
     /// loaded base. The backend errors if it is set without `BuildKit`/buildx,
     /// since dropping it would silently exit 0 with nothing written to `dest=`.
     pub output: Option<String>,
+    /// Image labels to bake into the built image (`--label key=value`, the
+    /// `cella build --label` flag). Each entry is a `key=value` string emitted
+    /// as `--label <entry>`; the value may be empty (`key=`). Unlike `--output`,
+    /// `--label` works on both the classic and buildx builders, so it is emitted
+    /// unconditionally. Set only on the final image build (the one that produces
+    /// the image the user ends up with), mirroring `output`.
+    pub labels: Vec<String>,
 }
 
 impl Default for BuildOptions {
@@ -229,6 +236,7 @@ impl Default for BuildOptions {
             docker_path: None,
             platform: None,
             output: None,
+            labels: Vec::new(),
         }
     }
 }

--- a/crates/cella-backend/src/uid_image.rs
+++ b/crates/cella-backend/src/uid_image.rs
@@ -183,6 +183,9 @@ pub async fn build_uid_remap_image(
         // The UID-remap build is a post-build transform on an already-built
         // image, never the `--output` export target — keep the default --load.
         output: None,
+        // Never the user's label target either; user `--label`s are baked onto
+        // the final image (base or features layer) before this transform runs.
+        labels: Vec::new(),
     };
 
     info!("Building UID remap image: {uid_image} (UID {host_uid}:{host_gid})");

--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -86,6 +86,16 @@ pub struct BuildArgs {
     #[arg(long = "output")]
     output: Option<String>,
 
+    /// Add metadata to the built image as a `key=value` image label
+    /// (repeatable). Emitted as `docker build --label key=value`, so the label
+    /// is baked into the built image. The value may be empty (`key=`). Applies
+    /// on both the classic and buildx builders. Single-container build path only:
+    /// a bare `image:` config with no build/features cannot be labeled, and the
+    /// Docker Compose path does not yet support it (both error rather than
+    /// silently ignoring the flag).
+    #[arg(long = "label", value_parser = parse_build_label)]
+    label: Vec<String>,
+
     /// Control whether `BuildKit` is used when building images.
     #[arg(long, value_enum, default_value = "auto")]
     buildkit: BuildKitMode,
@@ -198,6 +208,13 @@ impl BuildArgs {
         if self.cache_to.is_some() {
             return Err("--cache-to not supported.".into());
         }
+        if !self.label.is_empty() {
+            // Official applies `--label` as compose `build.labels` image labels
+            // via a generated override; cella doesn't yet write those, so error
+            // rather than silently dropping the flag (or mislabeling the
+            // container/service). Tracked follow-up.
+            return Err("--label is not yet supported on Docker Compose builds.".into());
+        }
         if !self.cache_from.is_empty() {
             warn!("--cache-from is ignored on the Docker Compose build path");
         }
@@ -288,6 +305,10 @@ impl BuildArgs {
             // single final build (base when there are no features, features
             // layer otherwise) so an export never starves a `FROM` of a base.
             output: self.output.as_deref(),
+            // `--label` image labels. Routed to the same single final build as
+            // `--output`; the orchestrator errors on a bare image:-no-features
+            // config (no build to attach them to).
+            labels: &self.label,
             // `--omit-config-remote-env-from-metadata` is wired on `up` only;
             // `cella build` keeps the full metadata label.
             omit_remote_env_from_metadata: false,
@@ -421,6 +442,18 @@ pub fn parse_build_secret(s: &str) -> Result<BuildSecret, String> {
         src,
         env,
     })
+}
+
+/// Validate a `--label` value (`key=value`). The key must be non-empty; the
+/// value may be empty (`key=`), matching `docker build --label` (which accepts
+/// `k=`). Mirrors [`crate::commands::parse_remote_env`]'s shape (non-empty key,
+/// any value) rather than `parse_id_label` (which also requires a non-empty
+/// value). Rejected at parse time so a malformed label never reaches the build.
+pub fn parse_build_label(s: &str) -> Result<String, String> {
+    match s.split_once('=') {
+        Some((k, _)) if !k.is_empty() => Ok(s.to_string()),
+        _ => Err("label must match <key>=<value> (key required; value may be empty)".to_string()),
+    }
 }
 
 #[cfg(test)]
@@ -563,6 +596,65 @@ mod tests {
                 .is_ok()
         );
         assert!(parse_build(&[]).reject_unsupported_compose_flags().is_ok());
+    }
+
+    // ── --label parsing / threading ─────────────────────────────────
+
+    #[test]
+    fn label_is_repeatable() {
+        let args = parse_build(&["--label", "a=1", "--label", "b=2"]);
+        assert_eq!(args.label, vec!["a=1".to_string(), "b=2".to_string()]);
+    }
+
+    #[test]
+    fn label_defaults_to_empty() {
+        assert!(parse_build(&[]).label.is_empty());
+    }
+
+    #[test]
+    fn label_accepts_empty_value() {
+        // `docker build --label k=` is valid (label with an empty value), so the
+        // parser must accept it — unlike `--id-label`, which requires a value.
+        let args = parse_build(&["--label", "k="]);
+        assert_eq!(args.label, vec!["k=".to_string()]);
+    }
+
+    #[test]
+    fn label_rejects_missing_equals() {
+        // No `=` at all → rejected at parse time.
+        assert!(TestCli::try_parse_from(["build", "--label", "novalue"]).is_err());
+    }
+
+    #[test]
+    fn label_rejects_empty_key() {
+        // `=value` has an empty key → rejected at parse time.
+        assert!(TestCli::try_parse_from(["build", "--label", "=value"]).is_err());
+    }
+
+    #[test]
+    fn parse_build_label_directly() {
+        // Key required; value optional (may be empty).
+        assert_eq!(parse_build_label("a=1").unwrap(), "a=1");
+        assert_eq!(parse_build_label("a=").unwrap(), "a=");
+        // A value with an `=` keeps the whole string (only the first `=` splits).
+        assert_eq!(parse_build_label("a=b=c").unwrap(), "a=b=c");
+        assert!(parse_build_label("novalue").is_err());
+        assert!(parse_build_label("=value").is_err());
+        assert!(parse_build_label("").is_err());
+    }
+
+    #[test]
+    fn compose_rejects_label() {
+        // The compose path does not yet support `--label` (it would need a
+        // generated `build.labels` override). cella errors with the exact
+        // message rather than silently dropping the flag.
+        let err = parse_build(&["--label", "a=1"])
+            .reject_unsupported_compose_flags()
+            .expect_err("compose must reject --label");
+        assert_eq!(
+            err.to_string(),
+            "--label is not yet supported on Docker Compose builds."
+        );
     }
 
     #[test]

--- a/crates/cella-docker/src/image.rs
+++ b/crates/cella-docker/src/image.rs
@@ -186,6 +186,15 @@ fn build_command_args(opts: &BuildOptions, use_buildx: bool) -> Vec<String> {
         args.push(opt.clone());
     }
 
+    // `--label key=value` bakes an image label into the built image. Unlike
+    // `--output`/`--platform`/`--progress` (buildx-only), `docker build --label`
+    // works on both the classic and buildx builders, so it is emitted on every
+    // path. Two-arg form matches the official CLI (`['--label', label]`). The
+    // value may be empty (`key=`); the CLI validates a non-empty key up front.
+    for label in &opts.labels {
+        args.extend(["--label".to_string(), label.clone()]);
+    }
+
     for secret in &opts.secrets {
         let mut spec = format!("id={}", secret.id);
         if let Some(ref src) = secret.src {
@@ -490,6 +499,7 @@ mod tests {
             docker_path: None,
             platform: None,
             output: None,
+            labels: Vec::new(),
         }
     }
 
@@ -677,6 +687,66 @@ mod tests {
         let args = build_command_args(&opts, true);
         assert!(args.contains(&"--load".to_string()));
         assert!(!args.contains(&"--output".to_string()));
+    }
+
+    #[test]
+    fn build_args_emits_label_on_classic_builder() {
+        // `docker build --label` works on the classic builder (unlike --output),
+        // so each label is emitted as a two-arg `--label key=value`.
+        let mut opts = basic_opts();
+        opts.labels = vec!["cella.test=1".to_string()];
+        let args = build_command_args(&opts, false);
+        let idx = args
+            .iter()
+            .position(|a| a == "--label")
+            .expect("--label emitted on classic builder");
+        assert_eq!(args[idx + 1], "cella.test=1");
+        // Context path is still last (labels precede it).
+        assert_eq!(args.last().unwrap(), "/src/project");
+    }
+
+    #[test]
+    fn build_args_emits_label_on_buildx_builder() {
+        // `--label` is not buildx-gated: it must also appear on the buildx path.
+        let mut opts = basic_opts();
+        opts.labels = vec!["cella.test=1".to_string()];
+        let args = build_command_args(&opts, true);
+        let idx = args
+            .iter()
+            .position(|a| a == "--label")
+            .expect("--label emitted on buildx builder");
+        assert_eq!(args[idx + 1], "cella.test=1");
+    }
+
+    #[test]
+    fn build_args_emits_each_label() {
+        // Repeatable: every label becomes its own `--label key=value` pair.
+        let mut opts = basic_opts();
+        opts.labels = vec![
+            "a=1".to_string(),
+            "b=2".to_string(),
+            // Empty value is allowed (`key=`).
+            "c=".to_string(),
+        ];
+        let args = build_command_args(&opts, false);
+        let positions: Vec<usize> = args
+            .iter()
+            .enumerate()
+            .filter(|(_, a)| *a == "--label")
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(positions.len(), 3);
+        assert_eq!(args[positions[0] + 1], "a=1");
+        assert_eq!(args[positions[1] + 1], "b=2");
+        assert_eq!(args[positions[2] + 1], "c=");
+        assert_eq!(args.last().unwrap(), "/src/project");
+    }
+
+    #[test]
+    fn build_args_no_labels_omits_flag() {
+        let opts = basic_opts();
+        let args = build_command_args(&opts, false);
+        assert!(!args.contains(&"--label".to_string()));
     }
 
     #[test]

--- a/crates/cella-docker/src/integration_tests/label_build_tests.rs
+++ b/crates/cella-docker/src/integration_tests/label_build_tests.rs
@@ -1,0 +1,96 @@
+//! Integration test: `build_image` with `--label key=value` bakes that label
+//! into the built image.
+//!
+//! This is the backend primitive behind `cella build --label`: when labels are
+//! set, `build_image` runs `docker [buildx] build --label key=value`, so the
+//! label is baked into the resulting image. The test builds a trivial Dockerfile
+//! with `--label cella.test=1`, then inspects the built image and asserts the
+//! label is present. `--label` works on both the classic and buildx builders, so
+//! (unlike the `--output` export test) this needs no buildx and no registry.
+//!
+//! `inspect_image_details` only surfaces the `devcontainer.metadata` label, so
+//! this reads the raw label map via `client.inner().inspect_image`.
+
+use std::collections::HashMap;
+
+use bollard::query_parameters::RemoveImageOptions;
+
+use cella_backend::BuildOptions;
+
+use crate::client::DockerClient;
+
+/// A unique scratch directory under the system temp dir, removed first so a
+/// stale run can't mask a failure (mirrors `output_export_tests`).
+fn scratch_dir(suffix: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "cella-it-label-build-{}-{suffix}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    dir
+}
+
+/// `build_image` with `--label cella.test=1` bakes that label into the built
+/// image. After the build, inspecting the image must report the label — this is
+/// the validation that matters: the label actually lands on the image, not just
+/// that the arg was emitted.
+#[cella_testing::runtime_test(docker)]
+async fn label_is_baked_into_built_image() {
+    let Ok(client) = DockerClient::connect() else {
+        return;
+    };
+
+    let context = scratch_dir("ctx");
+    // Setup failures are real bugs (not an unavailable runtime) — fail loudly.
+    std::fs::create_dir_all(&context).expect("create build context dir");
+
+    // Trivial, registry-free build once the base is cached.
+    let dockerfile = "FROM busybox:latest\n";
+    std::fs::write(context.join("Dockerfile"), dockerfile).expect("write test Dockerfile");
+    // Pre-pull the base so the build needs no registry round-trip beyond the
+    // (cached) base; if the pull fails (offline), skip rather than fail.
+    if client.pull_image("busybox:latest").await.is_err() {
+        return;
+    }
+
+    let image_name = format!("cella-it-label-build-{}:test", std::process::id());
+    let opts = BuildOptions {
+        image_name: image_name.clone(),
+        context_path: context.clone(),
+        dockerfile: "Dockerfile".to_string(),
+        labels: vec!["cella.test=1".to_string()],
+        ..Default::default()
+    };
+
+    let build_result = client.build_image(&opts, |_| {}).await;
+
+    // Read the raw label map (inspect_image_details only exposes the metadata
+    // label, so go through bollard directly).
+    let label_value = match client.inner().inspect_image(&image_name).await {
+        Ok(details) => details
+            .config
+            .as_ref()
+            .and_then(|c| c.labels.as_ref())
+            .and_then(|labels: &HashMap<String, String>| labels.get("cella.test"))
+            .cloned(),
+        Err(_) => None,
+    };
+
+    // Best-effort cleanup of the scratch dir and the image we built.
+    let _ = std::fs::remove_dir_all(&context);
+    let cleanup_opts = RemoveImageOptions {
+        force: true,
+        ..Default::default()
+    };
+    let _ = client
+        .inner()
+        .remove_image(&image_name, Some(cleanup_opts), None)
+        .await;
+
+    build_result.expect("build_image with --label should succeed");
+    assert_eq!(
+        label_value.as_deref(),
+        Some("1"),
+        "expected label cella.test=1 on the built image {image_name}, got {label_value:?}"
+    );
+}

--- a/crates/cella-docker/src/integration_tests/mod.rs
+++ b/crates/cella-docker/src/integration_tests/mod.rs
@@ -4,6 +4,7 @@
 //! gracefully when Docker is unavailable.
 
 mod claude_seed_tests;
+mod label_build_tests;
 mod network_tests;
 mod output_export_tests;
 mod spec_identity_tests;

--- a/crates/cella-docker/src/integration_tests/output_export_tests.rs
+++ b/crates/cella-docker/src/integration_tests/output_export_tests.rs
@@ -79,6 +79,7 @@ async fn output_type_local_exports_to_dest() {
         docker_path: None,
         platform: None,
         output: Some(format!("type=local,dest={}", dest.display())),
+        labels: Vec::new(),
     };
 
     let result = client.build_image(&opts, |_| {}).await;

--- a/crates/cella-orchestrator/src/image.rs
+++ b/crates/cella-orchestrator/src/image.rs
@@ -35,6 +35,10 @@ pub struct FeaturesLayerContext<'a> {
     /// belongs here — never on the base build, which must stay loadable for the
     /// features `FROM`.
     pub output: Option<&'a str>,
+    /// Image labels (`--label key=value`) for the FINAL image. Same placement
+    /// rule as `output`: when features are layered the features image is the
+    /// final image, so the labels are baked here. Empty slice = no labels.
+    pub labels: &'a [String],
     pub progress: &'a ProgressSender,
 }
 
@@ -81,6 +85,9 @@ pub async fn build_features_layer(
         // Features layer is the final image when features are present, so the
         // buildx `--output` export spec is applied here.
         output: ctx.output.map(str::to_string),
+        // Likewise the final image, so user `--label`s are baked here (the base
+        // build stays unlabeled — it is an internal FROM, not the user's image).
+        labels: ctx.labels.to_vec(),
     };
 
     info!(
@@ -125,6 +132,18 @@ pub struct EnsureImageInput<'a> {
     /// not load an image into the docker store. `None` keeps the default
     /// `--load` everywhere (the `up` path, which must run the container).
     pub output: Option<&'a str>,
+    /// Image labels (`--label key=value`, the `cella build --label` flag) to
+    /// bake into the FINAL image. Same placement rule as [`Self::output`]:
+    /// applied to exactly one build — the base build when there are no features,
+    /// the features layer when there are — never to a base build a features layer
+    /// will `FROM`. Unlike `output`, labels work on both the classic and buildx
+    /// builders. An empty slice bakes nothing (the `up` path, which never labels).
+    ///
+    /// A non-empty slice on a bare `image:` config with no features has no build
+    /// to attach to (cella does not wrap a pulled image in a Dockerfile), so
+    /// [`ensure_image`] returns an error rather than silently dropping the
+    /// labels — detected via [`image_labels_have_no_target`].
+    pub labels: &'a [String],
     /// `--omit-config-remote-env-from-metadata`: strip `remoteEnv` from the
     /// generated `devcontainer.metadata` label baked into the built image.
     pub omit_remote_env_from_metadata: bool,
@@ -143,6 +162,35 @@ pub struct EnsureImageInput<'a> {
 /// the base build is the final image and gets the spec.
 const fn base_output(will_build_features: bool, output: Option<&str>) -> Option<&str> {
     if will_build_features { None } else { output }
+}
+
+/// The image labels (`--label`) for the *base* image build.
+///
+/// Same placement rule as [`base_output`]: labels belong on exactly one build —
+/// the final image. When a features layer follows (`will_build_features`), it is
+/// the final image and carries the labels; the base build gets none, since it is
+/// an internal `FROM` target, not the image the user keeps. Otherwise the base
+/// build is the final image and gets all the labels. Unlike `--output`, labels
+/// do not affect whether the image loads, so there is no skip-inspect companion.
+fn base_labels(will_build_features: bool, labels: &[String]) -> Vec<String> {
+    if will_build_features {
+        Vec::new()
+    } else {
+        labels.to_vec()
+    }
+}
+
+/// Whether `--label`s were requested but have no build to attach to.
+///
+/// `--label` bakes a label via a `docker build --label`, so it needs a build.
+/// A bare `image:` config with no features runs no build — cella uses the pulled
+/// image as-is and does not wrap it in a Dockerfile — so requested labels would
+/// be silently dropped. `ensure_image` calls this in the image branch (where
+/// `will_build_features` is false iff there are no features) and errors instead.
+/// With features, the labels ride the features layer, so this is false. This is
+/// consistent with cella not stamping `devcontainer.metadata` on pulled images.
+const fn image_labels_have_no_target(will_build_features: bool, has_labels: bool) -> bool {
+    has_labels && !will_build_features
 }
 
 /// Whether to skip inspecting the base image after the build.
@@ -209,6 +257,7 @@ pub async fn ensure_image(
         no_cache: input.no_cache,
         build_tuning: input.build_tuning,
         output: input.output,
+        labels: input.labels,
         omit_remote_env_from_metadata: input.omit_remote_env_from_metadata,
         lockfile_policy: input.lockfile_policy,
         progress: input.progress,
@@ -275,6 +324,18 @@ async fn resolve_base_image(
     let force_pull = input.pull_policy == Some("always");
     let never_pull = input.pull_policy == Some("never");
     if let Some(image) = input.config.get("image").and_then(|v| v.as_str()) {
+        // A bare `image:` config with no features runs no build, so `--label`
+        // has nothing to attach to (cella uses the pulled image as-is rather
+        // than wrapping it in a Dockerfile). Fail loudly *before* the pull
+        // instead of silently dropping the labels. With features the labels ride
+        // the features layer, so `will_build_features` gates this off.
+        if image_labels_have_no_target(will_build_features, !input.labels.is_empty()) {
+            return Err(
+                "--label requires a build (a Dockerfile, build:, or features); \
+                        a bare image: config is used as-is and cannot be labeled."
+                    .into(),
+            );
+        }
         let exists = input.client.image_exists(image).await?;
         if never_pull {
             if !exists {
@@ -310,6 +371,9 @@ async fn resolve_base_image(
         // (no features layer to follow). With features, the export spec goes on
         // the features layer instead so the base stays loadable for its `FROM`.
         build_opts.output = base_output(will_build_features, input.output).map(str::to_string);
+        // User `--label`s land on the base build only when it is the final image;
+        // with features they move to the features layer (the final image).
+        build_opts.labels = base_labels(will_build_features, input.labels);
 
         if !will_build_features {
             let metadata_label = cella_features::generate_metadata_label(
@@ -362,6 +426,9 @@ struct FeaturesBuildInput<'a> {
     /// buildx output spec for the features layer (the final image when features
     /// are present). Threaded straight through from [`EnsureImageInput::output`].
     output: Option<&'a str>,
+    /// Image labels for the features layer (the final image when features are
+    /// present). Threaded straight through from [`EnsureImageInput::labels`].
+    labels: &'a [String],
     omit_remote_env_from_metadata: bool,
     lockfile_policy: cella_features::LockfilePolicy,
     progress: &'a ProgressSender,
@@ -433,6 +500,7 @@ async fn resolve_and_build_features(
         no_cache: input.no_cache,
         build_tuning: input.build_tuning.toolchain(),
         output: input.output,
+        labels: input.labels,
         progress: input.progress,
     };
     let features_image = build_features_layer(&ctx).await?;
@@ -608,6 +676,9 @@ pub fn parse_build_options(
         // build, not every site): the caller sets it via `base_output` when this
         // base build is the final image.
         output: None,
+        // Same as `output`: the caller sets labels via `base_labels` only when
+        // this base build is the final image (no features layer to follow).
+        labels: Vec::new(),
     }
 }
 
@@ -1133,6 +1204,50 @@ mod tests {
             Some("type=local,dest=/tmp/out")
         );
         assert_eq!(base_output(false, None), None);
+    }
+
+    // ── base_labels: --label placement (final-build only) ────────────
+    //
+    // Same load-bearing rule as `base_output`: user `--label`s belong on the
+    // final image, so a base build that a features layer will `FROM` must stay
+    // unlabeled (the labels move to the features layer). Pinned on the pure
+    // helper since `resolve_base_image` is Docker-coupled.
+
+    #[test]
+    fn base_labels_suppressed_when_features_will_build() {
+        // Features to follow → the base build is an internal FROM, not the final
+        // image, so it gets no user labels (they ride the features layer).
+        assert!(base_labels(true, &["a=1".to_string(), "b=2".to_string()]).is_empty());
+        assert!(base_labels(true, &[]).is_empty());
+    }
+
+    #[test]
+    fn base_labels_applied_when_base_is_final() {
+        // No features: the base build IS the final image, so it carries every
+        // label verbatim (and stays empty when none were requested).
+        assert_eq!(
+            base_labels(false, &["a=1".to_string(), "b=2".to_string()]),
+            vec!["a=1".to_string(), "b=2".to_string()]
+        );
+        assert!(base_labels(false, &[]).is_empty());
+    }
+
+    // ── image_labels_have_no_target: bare image: + --label error ─────
+    //
+    // `--label` needs a build. A bare `image:` config with no features runs no
+    // build (cella uses the pulled image as-is), so requested labels would be
+    // silently dropped — `ensure_image` errors instead. With features the labels
+    // ride the features layer, so there IS a target. This pins exactly that gate.
+
+    #[test]
+    fn image_labels_have_no_target_only_when_no_build_and_labels() {
+        // Bare image: (no features) + labels requested → no target, must error.
+        assert!(image_labels_have_no_target(false, true));
+        // No labels requested → nothing to drop, no error regardless of build.
+        assert!(!image_labels_have_no_target(false, false));
+        // Features will build → the features layer is the label target; OK.
+        assert!(!image_labels_have_no_target(true, true));
+        assert!(!image_labels_have_no_target(true, false));
     }
 
     // ── skip_base_inspect: don't inspect a non-loaded export ─────────

--- a/crates/cella-orchestrator/src/image.rs
+++ b/crates/cella-orchestrator/src/image.rs
@@ -135,8 +135,8 @@ pub struct EnsureImageInput<'a> {
     /// Image labels (`--label key=value`, the `cella build --label` flag) to
     /// bake into the FINAL image. Same placement rule as [`Self::output`]:
     /// applied to exactly one build — the base build when there are no features,
-    /// the features layer when there are — never to a base build a features layer
-    /// will `FROM`. Unlike `output`, labels work on both the classic and buildx
+    /// the features layer when there are — never to a base build that a features
+    /// layer will `FROM`. Unlike `output`, labels work on both the classic and buildx
     /// builders. An empty slice bakes nothing (the `up` path, which never labels).
     ///
     /// A non-empty slice on a bare `image:` config with no features has no build

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -1942,6 +1942,9 @@ impl EnsureUpContext<'_> {
                 // `up` has no `--output` (it must load the image to run the
                 // container); the buildx export spec is a `build`-only flag.
                 output: None,
+                // `up` has no `--label` either — image labels are a `build`-only
+                // flag (the container picks up config via the metadata label).
+                labels: &[],
                 omit_remote_env_from_metadata: self.config.metadata_options.omit_remote_env,
                 lockfile_policy: self.config.lockfile_policy,
                 progress: &self.progress,


### PR DESCRIPTION
## What

Adds `cella build --label key=value` (repeatable) — bakes image labels into the built image via `docker build --label`, matching official `devcontainer build --label` (`additionalLabels`).

## How

- `--label k=v` (validated at parse time: non-empty key; empty value `k=` is allowed, as docker permits) threads into the **final** build — base build when there are no features, the features layer otherwise — via the same `base_*` placement gate used for `--output`/`--push` (`base_labels`). Emitted as `--label <k=v>` on **both** the classic and buildx builders (unlike `--output`, `docker build --label` works on both).

## Boundaries (honest explicit errors — not silent no-ops)

- **Bare `image:` config with no features** has no build to attach labels to (cella uses such images as-is and doesn't stamp `devcontainer.metadata` on them either), so `--label` errors: `--label requires a build (a Dockerfile, build:, or features); a bare image: config is used as-is and cannot be labeled.` Fast-fails before pulling.
- **Docker Compose builds**: `--label is not yet supported on Docker Compose builds.` Official applies it as `build.labels` image labels via a generated override; cella doesn't write those yet, so it errors rather than silently dropping the flag or mislabeling the container. Tracked as a follow-up.

## Tests

Unit: parsing (repeatable, rejects no-`=`/empty-key, accepts empty value), the final-build placement gate, emission on both builders, both error boundaries. A `#[runtime_test(docker)]` builds a trivial Dockerfile with `--label cella.test=1`, inspects the built image, and asserts the label is actually baked in (runs in CI; skips locally without Docker).

## Scope

Single-container build/dockerfile/features. Compose `--label` (image-level via override `build.labels`) and `image:`-config labeling (would need a FROM-wrapper) are tracked follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
