### PR TITLE
feat(compose): run devcontainer feature entrypoints on the compose path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,6 +436,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "shell-words",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,10 @@ flate2 = "=1.1.9"
 # OCI registry
 oci-distribution = { version = "=0.11.0", default-features = false, features = ["rustls-tls"] }
 
+# Shell word splitting (POSIX-style; mirrors the official CLI's shellQuote.parse
+# when reading a compose service entrypoint/command given as a string)
+shell-words = "=1.1.1"
+
 # Pattern matching
 regex = "=1.12.4"
 

--- a/crates/cella-backend/src/types.rs
+++ b/crates/cella-backend/src/types.rs
@@ -169,6 +169,17 @@ pub struct ImageDetails {
     pub architecture: Option<String>,
     /// Architecture variant reported by the image (e.g. `"v8"`).
     pub variant: Option<String>,
+    /// Image `ENTRYPOINT` (the `Config.Entrypoint` array), empty when unset.
+    ///
+    /// Used by the compose override to preserve a service's original entrypoint
+    /// when the compose file doesn't restate it (the official CLI's
+    /// `imageDetails().Config.Entrypoint` fallback).
+    pub entrypoint: Vec<String>,
+    /// Image `CMD` (the `Config.Cmd` array), empty when unset.
+    ///
+    /// Used by the compose override to preserve a service's original command
+    /// when the compose file doesn't restate it.
+    pub cmd: Vec<String>,
 }
 
 /// A `BuildKit` build secret (`--secret id=X,src=Y` or `--secret id=X,env=Y`).

--- a/crates/cella-compose/Cargo.toml
+++ b/crates/cella-compose/Cargo.toml
@@ -17,6 +17,7 @@ hex.workspace = true
 miette.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+shell-words.workspace = true
 yaml_serde.workspace = true
 sha2.workspace = true
 thiserror.workspace = true

--- a/crates/cella-compose/src/build_features.rs
+++ b/crates/cella-compose/src/build_features.rs
@@ -132,6 +132,12 @@ pub async fn compose_build(
             request_gpu: false,
             // `cella build` only builds the image; runtime security props apply at `up`.
             security: cella_config::config_map::MergedSecurityConfig::default(),
+            // Feature entrypoints + entrypoint/command resolution belong to the
+            // runtime override (`write_final_override`); the build override never
+            // runs the container, and `docker compose build` ignores these keys.
+            feature_entrypoints: Vec::new(),
+            user_entrypoint: Vec::new(),
+            user_command: None,
             // This override persists and is reused at `up`, where the container
             // runs and needs the agent volume — keep the runtime sections.
             build_only: false,
@@ -275,6 +281,9 @@ fn write_labels_only_override(
         extra_volumes: Vec::new(),
         request_gpu: false,
         security: cella_config::config_map::MergedSecurityConfig::default(),
+        feature_entrypoints: Vec::new(),
+        user_entrypoint: Vec::new(),
+        user_command: None,
         build_only: true,
     };
     let yaml = crate::override_file::generate_override_yaml(&override_config);

--- a/crates/cella-compose/src/build_features.rs
+++ b/crates/cella-compose/src/build_features.rs
@@ -114,7 +114,13 @@ pub async fn compose_build(
         let override_config = crate::OverrideConfig {
             primary_service: project.primary_service.clone(),
             image_override: fb.image_name_override.clone(),
-            override_command: project.override_command,
+            // The build override is for `cella build` only: it builds the image and
+            // never runs the container (`cella up` writes its own runtime override
+            // via `write_final_override`). Force `override_command` false so this
+            // override emits NO runtime entrypoint — emitting the wrapper here
+            // without a resolved `command` would, if the persisted file were used
+            // to start the service, drop `overrideCommand`'s keepalive semantics.
+            override_command: false,
             agent_volume_name: agent_vol_name,
             agent_volume_target: agent_vol_target,
             extra_env: Vec::new(),
@@ -132,15 +138,16 @@ pub async fn compose_build(
             request_gpu: false,
             // `cella build` only builds the image; runtime security props apply at `up`.
             security: cella_config::config_map::MergedSecurityConfig::default(),
-            // Feature entrypoints + entrypoint/command resolution belong to the
-            // runtime override (`write_final_override`); the build override never
-            // runs the container, and `docker compose build` ignores these keys.
+            // Runtime entrypoint/command resolution belongs to the runtime
+            // override (`write_final_override`); `docker compose build` ignores
+            // these keys, so leave them empty.
             feature_entrypoints: Vec::new(),
             user_entrypoint: Vec::new(),
             user_command: None,
-            // This override persists and is reused at `up`, where the container
-            // runs and needs the agent volume — keep the runtime sections.
-            build_only: false,
+            // Build-only: `docker compose build` needs no agent volume and this
+            // override never runs the container, so omit the runtime volume
+            // sections (same as the labels-only build override).
+            build_only: true,
         };
         let yaml = crate::override_file::generate_override_yaml(&override_config);
         crate::override_file::write_override_file(&project.override_file, &yaml)?;

--- a/crates/cella-compose/src/config.rs
+++ b/crates/cella-compose/src/config.rs
@@ -63,6 +63,17 @@ pub struct ResolvedService {
     /// Secret file mounts. Same shape as `configs`.
     #[serde(default)]
     pub secrets: Vec<serde_json::Value>,
+    /// Service `entrypoint`. May be absent (→ `Value::Null`), a string (shell
+    /// form, e.g. `"/docker-entrypoint.sh foo"`), or an array of strings (exec
+    /// form). Kept as raw `serde_json::Value` and normalized by
+    /// [`extract_service_entrypoint_command`]; the compose override needs it to
+    /// preserve the service's original entrypoint when wrapping for feature
+    /// entrypoints.
+    #[serde(default)]
+    pub entrypoint: serde_json::Value,
+    /// Service `command`. Same string/array/absent shape as `entrypoint`.
+    #[serde(default)]
+    pub command: serde_json::Value,
 }
 
 /// Resolved build config for a compose service.
@@ -175,6 +186,70 @@ pub fn extract_service_build_info(
     Err(CellaComposeError::ServiceHasNoBuildOrImage {
         service: service.to_string(),
     })
+}
+
+/// A service's resolved `(entrypoint, command)` argv token lists.
+///
+/// Each is `None` when the service does not declare that key, and `Some(tokens)`
+/// otherwise (string forms shell-split, array forms verbatim). `Some(empty)`
+/// means an explicit empty list (`command: []`), which is distinct from absent.
+pub type ServiceEntrypointCommand = (Option<Vec<String>>, Option<Vec<String>>);
+
+/// Normalize a compose `entrypoint`/`command` value into argv tokens.
+///
+/// Mirrors the official CLI's `typeof x === 'string' ? shellQuote.parse(x) : x`:
+/// - **String** → POSIX shell word-split (so `"sh -c 'echo hi'"` becomes three
+///   tokens). A string that fails to parse (e.g. an unbalanced quote, which a
+///   resolved compose config should never produce) is kept as a single token
+///   rather than dropped.
+/// - **Array** → its string elements verbatim (non-string elements are skipped).
+/// - **Null / anything else** → `None` (the key was absent).
+fn compose_value_to_words(value: &serde_json::Value) -> Option<Vec<String>> {
+    match value {
+        serde_json::Value::String(s) => {
+            Some(shell_words::split(s).unwrap_or_else(|_| vec![s.clone()]))
+        }
+        serde_json::Value::Array(items) => Some(
+            items
+                .iter()
+                .filter_map(|v| v.as_str().map(ToString::to_string))
+                .collect(),
+        ),
+        _ => None,
+    }
+}
+
+/// Extract a service's resolved `entrypoint` and `command` as argv token lists.
+///
+/// Returns `(entrypoint, command)` where each is `None` when the service does
+/// not declare that key and `Some(tokens)` otherwise (string forms are
+/// shell-split, array forms taken as-is). Used by the compose override to
+/// resolve the wrapped entrypoint's `userEntrypoint`/`userCommand` the same way
+/// the official CLI does.
+///
+/// # Errors
+///
+/// Returns an error if the service is not present in the resolved config.
+pub fn extract_service_entrypoint_command(
+    config: &ResolvedComposeConfig,
+    service: &str,
+) -> Result<ServiceEntrypointCommand, CellaComposeError> {
+    let svc = config
+        .services
+        .get(service)
+        .ok_or_else(|| CellaComposeError::ServiceNotFound {
+            service: service.to_string(),
+            available: config
+                .services
+                .keys()
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(", "),
+        })?;
+    Ok((
+        compose_value_to_words(&svc.entrypoint),
+        compose_value_to_words(&svc.command),
+    ))
 }
 
 #[cfg(test)]
@@ -482,5 +557,89 @@ mod tests {
         assert!(svc.tmpfs.is_array());
         assert_eq!(svc.configs.len(), 1);
         assert_eq!(svc.secrets.len(), 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // extract_service_entrypoint_command (string / array / absent)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn entrypoint_command_string_form_is_shell_split() {
+        // Compose string form is shell-split (matching shellQuote.parse): the
+        // quoted segment stays a single token.
+        let json = r#"{
+            "services": {
+                "app": {
+                    "entrypoint": "/docker-entrypoint.sh",
+                    "command": "sh -c 'echo hi there'"
+                }
+            }
+        }"#;
+        let config: ResolvedComposeConfig = serde_json::from_str(json).unwrap();
+        let (ep, cmd) = extract_service_entrypoint_command(&config, "app").unwrap();
+        assert_eq!(ep, Some(vec!["/docker-entrypoint.sh".to_string()]));
+        assert_eq!(
+            cmd,
+            Some(vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                "echo hi there".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn entrypoint_command_array_form_is_verbatim() {
+        // Exec (array) form is taken element-for-element, no splitting.
+        let json = r#"{
+            "services": {
+                "app": {
+                    "entrypoint": ["/bin/tini", "--"],
+                    "command": ["node", "server.js", "--port=3000"]
+                }
+            }
+        }"#;
+        let config: ResolvedComposeConfig = serde_json::from_str(json).unwrap();
+        let (ep, cmd) = extract_service_entrypoint_command(&config, "app").unwrap();
+        assert_eq!(ep, Some(vec!["/bin/tini".to_string(), "--".to_string()]));
+        assert_eq!(
+            cmd,
+            Some(vec![
+                "node".to_string(),
+                "server.js".to_string(),
+                "--port=3000".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn entrypoint_command_absent_yields_none() {
+        // No keys declared -> both None (so the override falls back to image
+        // entrypoint/cmd, mirroring the official `composeEntrypoint || image`).
+        let json = r#"{ "services": { "app": { "image": "nginx" } } }"#;
+        let config: ResolvedComposeConfig = serde_json::from_str(json).unwrap();
+        let (ep, cmd) = extract_service_entrypoint_command(&config, "app").unwrap();
+        assert_eq!(ep, None);
+        assert_eq!(cmd, None);
+    }
+
+    #[test]
+    fn entrypoint_command_empty_array_is_some_empty() {
+        // An explicit empty array (`command: []`) is distinct from absent: it
+        // resolves to Some(empty), which the override must honor (it clears the
+        // image CMD) rather than treat as "fall back to image".
+        let json = r#"{ "services": { "app": { "command": [] } } }"#;
+        let config: ResolvedComposeConfig = serde_json::from_str(json).unwrap();
+        let (ep, cmd) = extract_service_entrypoint_command(&config, "app").unwrap();
+        assert_eq!(ep, None);
+        assert_eq!(cmd, Some(Vec::new()));
+    }
+
+    #[test]
+    fn entrypoint_command_service_not_found_errors() {
+        let json = r#"{ "services": { "app": { "image": "nginx" } } }"#;
+        let config: ResolvedComposeConfig = serde_json::from_str(json).unwrap();
+        let err = extract_service_entrypoint_command(&config, "web").unwrap_err();
+        assert!(matches!(err, CellaComposeError::ServiceNotFound { .. }));
     }
 }

--- a/crates/cella-compose/src/integration_tests/phase_tests.rs
+++ b/crates/cella-compose/src/integration_tests/phase_tests.rs
@@ -41,6 +41,9 @@ fn override_file_exists_before_compose_uses_it() {
         extra_volumes: Vec::new(),
         request_gpu: false,
         security: cella_config::config_map::MergedSecurityConfig::default(),
+        feature_entrypoints: Vec::new(),
+        user_entrypoint: Vec::new(),
+        user_command: None,
         build_only: false,
     };
 
@@ -195,6 +198,9 @@ fn additional_contexts_in_override_for_features() {
         extra_volumes: Vec::new(),
         request_gpu: false,
         security: cella_config::config_map::MergedSecurityConfig::default(),
+        feature_entrypoints: Vec::new(),
+        user_entrypoint: Vec::new(),
+        user_command: None,
         build_only: false,
     };
 

--- a/crates/cella-compose/src/integration_tests/smoke_tests.rs
+++ b/crates/cella-compose/src/integration_tests/smoke_tests.rs
@@ -132,6 +132,97 @@ async fn image_only_features_lifecycle() {
     crate::override_file::cleanup_override_file(&project.override_file);
 }
 
+/// Run a command inside the primary service via `docker compose -p <project> exec`
+/// and return its trimmed stdout (empty on failure).
+async fn compose_exec_stdout(project: &str, service: &str, script: &str) -> String {
+    let output = tokio::process::Command::new("docker")
+        .args([
+            "compose", "-p", project, "exec", "-T", service, "sh", "-c", script,
+        ])
+        .output()
+        .await;
+    match output {
+        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).trim().to_string(),
+        _ => String::new(),
+    }
+}
+
+/// A devcontainer feature `entrypoint` must run on container start for the
+/// compose path, then the service's original command must still run (the wrapped
+/// entrypoint `exec`s it). Proves the Phase 3 wrapped-entrypoint emission works
+/// end-to-end.
+#[cella_testing::runtime_test(docker, compose)]
+async fn compose_feature_entrypoint_runs() {
+    let ctx = ComposeTestContext::new("plain-compose");
+    let config = load_fixture_config(&ctx.fixture_dir);
+    let config_path = ctx.fixture_dir.join("devcontainer.json");
+    let project = ComposeProject::from_resolved(&config, &config_path, &ctx.fixture_dir)
+        .unwrap()
+        .with_project_name(ctx.project_name.clone());
+
+    // Ensure the cella-agent volume exists (the override mounts it read-only).
+    let _ = tokio::process::Command::new("docker")
+        .args(["volume", "create", "cella-agent"])
+        .output()
+        .await;
+
+    // Host dir bind-mounted into the container; the feature entrypoint drops a
+    // sentinel here so the host side can confirm it ran. Pre-created because the
+    // bind mount uses create_host_path: false.
+    let sentinel_dir = ctx.fixture_dir.join("sentinel");
+    std::fs::create_dir_all(&sentinel_dir).expect("failed to create sentinel dir");
+    let sentinel_host = sentinel_dir.join("ran");
+
+    // Build the override with a feature entrypoint that writes the sentinel, plus
+    // the bind mount. The fixture's `command: ["sleep","infinity"]` stays in the
+    // base compose, so the wrapped `exec "$@"` runs it (user_command = None).
+    let mut override_cfg = plain_override(&project.primary_service);
+    override_cfg.feature_entrypoints = vec!["touch /sentinel/ran".to_string()];
+    override_cfg.extra_volumes = vec![cella_backend::MountSpec::bind(
+        sentinel_dir.to_string_lossy().to_string(),
+        "/sentinel",
+    )];
+    let yaml = generate_override_yaml(&override_cfg);
+    write_override_file(&project.override_file, &yaml).unwrap();
+
+    let cmd = ComposeCommand::new(&project);
+    cmd.up(None, false).await.expect("compose up failed");
+
+    // The service must be running (the wrapped entrypoint's keepalive / the
+    // exec'd `sleep infinity` both hold it open).
+    let statuses = cmd.ps_json().await.expect("compose ps failed");
+    assert!(
+        statuses
+            .iter()
+            .any(|s| s.service == "app" && s.state == "running"),
+        "app service should be running; statuses: {statuses:?}"
+    );
+
+    // 1. The feature entrypoint ran (sentinel written, visible on the host).
+    assert!(
+        sentinel_host.exists(),
+        "feature entrypoint sentinel must exist at {} (entrypoint did not run)",
+        sentinel_host.display()
+    );
+
+    // 2. The service's original command still runs: `sleep infinity` is in the
+    //    process table (the wrapped entrypoint exec'd `$@`). `[s]leep` avoids the
+    //    grep matching its own argv.
+    let count = compose_exec_stdout(
+        &project.project_name,
+        "app",
+        "ps -o args 2>/dev/null | grep -c '[s]leep infinity'",
+    )
+    .await;
+    assert_eq!(
+        count, "1",
+        "original `sleep infinity` command must still run after the wrapped entrypoint execs it; got count={count:?}"
+    );
+
+    ctx.cleanup().await;
+    crate::override_file::cleanup_override_file(&project.override_file);
+}
+
 /// Whether a Docker image exists locally (`docker image inspect`).
 async fn docker_image_exists(image: &str) -> bool {
     tokio::process::Command::new("docker")

--- a/crates/cella-compose/src/integration_tests/smoke_tests.rs
+++ b/crates/cella-compose/src/integration_tests/smoke_tests.rs
@@ -26,6 +26,9 @@ fn plain_override(service: &str) -> OverrideConfig {
         extra_volumes: Vec::new(),
         request_gpu: false,
         security: cella_config::config_map::MergedSecurityConfig::default(),
+        feature_entrypoints: Vec::new(),
+        user_entrypoint: Vec::new(),
+        user_command: None,
         build_only: false,
     }
 }

--- a/crates/cella-compose/src/lib.rs
+++ b/crates/cella-compose/src/lib.rs
@@ -22,7 +22,10 @@ pub mod parse;
 pub mod project;
 
 pub use cli::{ComposeCommand, ComposeServiceStatus, check_compose_features_support};
-pub use config::{ResolvedComposeConfig, ServiceBuildInfo, extract_service_build_info};
+pub use config::{
+    ResolvedComposeConfig, ServiceBuildInfo, ServiceEntrypointCommand, extract_service_build_info,
+    extract_service_entrypoint_command,
+};
 pub use dockerfile::{
     AUTO_STAGE_NAME, FEATURES_TARGET_STAGE, ensure_stage_named, find_stage_base_image,
     find_user_statement, generate_combined_dockerfile, synthetic_dockerfile,

--- a/crates/cella-compose/src/mount_parity.rs
+++ b/crates/cella-compose/src/mount_parity.rs
@@ -3471,6 +3471,7 @@ mod tests {
                 tmpfs: json!(["/cella"]),
                 configs: vec![json!({"source": "x", "target": "/cella/cfg"})],
                 secrets: vec![json!("cella")],
+                ..ResolvedService::default()
             },
         );
         let resolved = ResolvedComposeConfig {
@@ -3506,6 +3507,7 @@ mod tests {
                 tmpfs: json!(["/run", "/var/tmp"]),
                 configs: vec![json!({"source": "cfg", "target": "/etc/cfg"})],
                 secrets: vec![json!("mysecret")], // default target: /mysecret
+                ..ResolvedService::default()
             },
         );
         let resolved = ResolvedComposeConfig {

--- a/crates/cella-compose/src/orchestrate.rs
+++ b/crates/cella-compose/src/orchestrate.rs
@@ -1125,6 +1125,13 @@ async fn resolve_compose_user_entrypoint_command(
     project: &ComposeProject,
     features_build: Option<&crate::combined_dockerfile_build::ComposeFeaturesBuild>,
 ) -> crate::override_file::UserEntrypointCommand {
+    // overrideCommand discards the service's original entrypoint+command, so the
+    // result is fixed regardless of the compose config or image — skip resolving
+    // the config and inspecting the image (the official CLI is lazy here too).
+    if project.override_command {
+        return crate::override_file::resolve_user_entrypoint_command(true, None, None, &[], &[]);
+    }
+
     let (dp, dcp) = ctx.cfg.docker_binaries();
     let compose_cmd = ComposeCommand::without_override(project).with_docker_binaries(dp, dcp);
     let resolved = match compose_cmd.config().await {

--- a/crates/cella-compose/src/orchestrate.rs
+++ b/crates/cella-compose/src/orchestrate.rs
@@ -453,6 +453,10 @@ struct ComposeRuntimeResolution {
     /// The `devcontainer.metadata` label value (base image + features + config
     /// entries), stamped on the primary service for tooling interop.
     metadata_label: String,
+    /// Feature `entrypoint` scripts in install order, `${devcontainerId}`-
+    /// substituted, sourced from the same merged feature/image-metadata config as
+    /// the security props (mirrors the single-container `feature_config.entrypoints`).
+    feature_entrypoints: Vec<String>,
 }
 
 /// Resolve the compose project's remote user, env-forwarding plan, ssh-agent
@@ -486,6 +490,17 @@ async fn resolve_user_and_env(
         cfg.config,
         effective_feature_config.as_ref(),
     );
+    // Feature entrypoints (install order), `${devcontainerId}`-substituted, from
+    // the same merged config the security props use. Empty when no feature (or
+    // base-image-metadata feature) declares an entrypoint, in which case the
+    // wrapped entrypoint is skipped unless `overrideCommand` is set.
+    let feature_entrypoints = effective_feature_config
+        .as_ref()
+        .map(|fc| {
+            let subst_ctx = cella_config::config_map::subst_ctx(cfg.resolved);
+            cella_config::config_map::substitute_feature_config(fc.clone(), &subst_ctx).entrypoints
+        })
+        .unwrap_or_default();
     // Merged `devcontainer.metadata` label: the features path reuses the label
     // computed during feature resolution; otherwise merge the base image's
     // metadata with the devcontainer.json config entry (mirrors single-container
@@ -515,6 +530,7 @@ async fn resolve_user_and_env(
         ssh_agent_proxy,
         security,
         metadata_label,
+        feature_entrypoints,
     }
 }
 
@@ -592,6 +608,10 @@ async fn prepare_and_start(
         request_gpu: false,
         // Runtime security props are applied in the final override, not at build.
         security: cella_config::config_map::MergedSecurityConfig::default(),
+        // Feature entrypoints + entrypoint/command resolution are emitted only in
+        // the final override; the build override never runs the container.
+        feature_entrypoints: Vec::new(),
+        user_entrypoint_command: crate::override_file::UserEntrypointCommand::default(),
     };
     write_build_override(project, features_build.as_ref(), &build_ov)?;
 
@@ -613,25 +633,27 @@ async fn prepare_and_start(
         ssh_agent_proxy,
         security,
         metadata_label,
+        feature_entrypoints,
     } = resolve_user_and_env(client, ctx, project, features_build.as_ref()).await;
     info!("Resolved remote user: {remote_user} (image user: {image_user})");
 
     // 11-15. Build override context, UID remap, write override, and start.
-    build_override_and_start(
+    build_override_and_start(BuildAndStartParams {
         ctx,
-        &compose_cmd,
+        compose_cmd: &compose_cmd,
         project,
-        features_build.as_ref(),
+        features_build: features_build.as_ref(),
         config,
         daemon_env,
-        &mut env_fwd,
-        &remote_user,
-        &image_user,
+        env_fwd: &mut env_fwd,
+        remote_user: &remote_user,
+        image_user: &image_user,
         agent_vol_name,
         agent_vol_target,
         security,
         metadata_label,
-    )
+        feature_entrypoints,
+    })
     .await?;
 
     let resolved_features = features_build.map(|b| b.resolved_features);
@@ -932,6 +954,14 @@ struct OverrideContext {
     /// Merged container security/runtime properties (containerUser, init,
     /// privileged, capAdd, securityOpt) applied to the primary service.
     security: cella_config::config_map::MergedSecurityConfig,
+    /// Feature `entrypoint` scripts (install order, `${devcontainerId}`-
+    /// substituted) to run before the service's entrypoint+command in the wrapped
+    /// entrypoint. Read only by `write_final_override` (the runtime override); the
+    /// build override leaves entrypoints empty.
+    feature_entrypoints: Vec<String>,
+    /// Resolved `userEntrypoint`/`userCommand` for the wrapped entrypoint (per the
+    /// official compose logic). Read only by `write_final_override`.
+    user_entrypoint_command: crate::override_file::UserEntrypointCommand,
 }
 
 // ---------------------------------------------------------------------------
@@ -968,6 +998,12 @@ fn write_build_override(
         request_gpu: false,
         // build_ov carries default (empty) security props at build time.
         security: ov.security.clone(),
+        // Feature entrypoints + entrypoint/command resolution are emitted only in
+        // the final override; this build override is overwritten by
+        // `write_final_override` before `compose up`.
+        feature_entrypoints: Vec::new(),
+        user_entrypoint: Vec::new(),
+        user_command: None,
         // The `up` flow provisions the agent volume during setup and reuses this
         // override at runtime, so keep the runtime sections (agent volume).
         build_only: false,
@@ -1073,6 +1109,71 @@ async fn resolve_compose_image_info(
             ("root".to_string(), None, None, None)
         }
     }
+}
+
+/// Resolve the wrapped entrypoint's `userEntrypoint`/`userCommand` for the
+/// primary service, mirroring the official compose logic.
+///
+/// Reads the service's resolved `entrypoint`/`command` from `docker compose
+/// config` and the base image's `ENTRYPOINT`/`CMD` from an inspect, then applies
+/// [`crate::override_file::resolve_user_entrypoint_command`]. Falls back to the
+/// default (empty entrypoint, no command) when the compose config can't be
+/// resolved — the wrapped entrypoint then just runs feature entrypoints and
+/// `exec "$@"` over whatever the service already had.
+async fn resolve_compose_user_entrypoint_command(
+    ctx: &Ctx<'_>,
+    project: &ComposeProject,
+    features_build: Option<&crate::combined_dockerfile_build::ComposeFeaturesBuild>,
+) -> crate::override_file::UserEntrypointCommand {
+    let (dp, dcp) = ctx.cfg.docker_binaries();
+    let compose_cmd = ComposeCommand::without_override(project).with_docker_binaries(dp, dcp);
+    let resolved = match compose_cmd.config().await {
+        Ok(r) => r,
+        Err(e) => {
+            warn!("Failed to resolve compose config for entrypoint/command: {e}");
+            return crate::override_file::UserEntrypointCommand::default();
+        }
+    };
+
+    let (compose_entrypoint, compose_command) =
+        match crate::extract_service_entrypoint_command(&resolved, &project.primary_service) {
+            Ok(pair) => pair,
+            Err(e) => {
+                warn!("Failed to extract service entrypoint/command: {e}");
+                (None, None)
+            }
+        };
+
+    // The base image to inspect for the ENTRYPOINT/CMD fallback: the
+    // features-build override if present, otherwise the service's resolved image.
+    let image_name = features_build
+        .and_then(|b| b.image_name_override.clone())
+        .or_else(|| {
+            crate::extract_service_build_info(&resolved, &project.primary_service)
+                .ok()
+                .map(|info| {
+                    info.resolved_image_name(&project.project_name, &project.primary_service)
+                })
+        });
+
+    let (image_entrypoint, image_cmd) = match image_name {
+        Some(name) => match ctx.client.inspect_image_details(&name).await {
+            Ok(details) => (details.entrypoint, details.cmd),
+            Err(e) => {
+                warn!("Failed to inspect image '{name}' for entrypoint/cmd: {e}");
+                (Vec::new(), Vec::new())
+            }
+        },
+        None => (Vec::new(), Vec::new()),
+    };
+
+    crate::override_file::resolve_user_entrypoint_command(
+        project.override_command,
+        compose_entrypoint.as_deref(),
+        compose_command.as_deref(),
+        &image_entrypoint,
+        &image_cmd,
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -1194,6 +1295,11 @@ fn write_final_override(
         extra_volumes: ov.extra_volumes.clone(),
         request_gpu: ov.request_gpu,
         security: ov.security.clone(),
+        // Wrapped entrypoint: feature entrypoints run before the service's
+        // original entrypoint+command is exec'd (resolved in build_override_and_start).
+        feature_entrypoints: ov.feature_entrypoints.clone(),
+        user_entrypoint: ov.user_entrypoint_command.entrypoint.clone(),
+        user_command: ov.user_entrypoint_command.command.clone(),
         // The final `up` override runs the container; keep the runtime sections.
         build_only: false,
     };
@@ -1206,24 +1312,47 @@ fn write_final_override(
     Ok(())
 }
 
-/// Build the override context (env, labels, mounts), UID remap image,
-/// and start compose services with SSH fallback retry.
-#[expect(clippy::too_many_arguments)]
-async fn build_override_and_start(
-    ctx: &Ctx<'_>,
-    compose_cmd: &ComposeCommand,
-    project: &ComposeProject,
-    features_build: Option<&crate::combined_dockerfile_build::ComposeFeaturesBuild>,
-    config: &serde_json::Value,
+/// Inputs to [`build_override_and_start`], bundled to keep the call under the
+/// `clippy::too_many_arguments` ceiling.
+struct BuildAndStartParams<'a> {
+    ctx: &'a Ctx<'a>,
+    compose_cmd: &'a ComposeCommand,
+    project: &'a ComposeProject,
+    features_build: Option<&'a crate::combined_dockerfile_build::ComposeFeaturesBuild>,
+    config: &'a serde_json::Value,
     daemon_env: Vec<String>,
-    env_fwd: &mut cella_env::EnvForwarding,
-    remote_user: &str,
-    image_user: &str,
+    env_fwd: &'a mut cella_env::EnvForwarding,
+    remote_user: &'a str,
+    image_user: &'a str,
     agent_vol_name: String,
     agent_vol_target: String,
     security: cella_config::config_map::MergedSecurityConfig,
     metadata_label: String,
+    /// Feature entrypoints (install order, substituted) for the wrapped entrypoint.
+    feature_entrypoints: Vec<String>,
+}
+
+/// Build the override context (env, labels, mounts), UID remap image,
+/// and start compose services with SSH fallback retry.
+async fn build_override_and_start(
+    params: BuildAndStartParams<'_>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let BuildAndStartParams {
+        ctx,
+        compose_cmd,
+        project,
+        features_build,
+        config,
+        daemon_env,
+        env_fwd,
+        remote_user,
+        image_user,
+        agent_vol_name,
+        agent_vol_target,
+        security,
+        metadata_label,
+        feature_entrypoints,
+    } = params;
     let cfg = ctx.cfg;
     let progress = ctx.progress;
 
@@ -1276,6 +1405,17 @@ async fn build_override_and_start(
 
     let request_gpu = resolve_compose_gpu(ctx, config).await;
 
+    // Resolve the wrapped entrypoint's userEntrypoint/userCommand: the service's
+    // own entrypoint/command (from the resolved compose config) falling back to
+    // the image's ENTRYPOINT/CMD, gated by `overrideCommand`. Skipped (default —
+    // empty/None) when there are no feature entrypoints and the command is not
+    // overridden, so the no-feature override stays byte-for-byte unchanged.
+    let user_entrypoint_command = if feature_entrypoints.is_empty() && !project.override_command {
+        crate::override_file::UserEntrypointCommand::default()
+    } else {
+        resolve_compose_user_entrypoint_command(ctx, project, features_build).await
+    };
+
     let mut ov_ctx = OverrideContext {
         agent_vol_name,
         agent_vol_target,
@@ -1284,6 +1424,8 @@ async fn build_override_and_start(
         extra_volumes: mount_specs,
         request_gpu,
         security,
+        feature_entrypoints,
+        user_entrypoint_command,
     };
 
     let uid_image =

--- a/crates/cella-compose/src/orchestrate.rs
+++ b/crates/cella-compose/src/orchestrate.rs
@@ -1115,72 +1115,74 @@ async fn resolve_compose_image_info(
 /// primary service, mirroring the official compose logic.
 ///
 /// Reads the service's resolved `entrypoint`/`command` from `docker compose
-/// config` and the base image's `ENTRYPOINT`/`CMD` from an inspect, then applies
-/// [`crate::override_file::resolve_user_entrypoint_command`]. Falls back to the
-/// default (empty entrypoint, no command) when the compose config can't be
-/// resolved — the wrapped entrypoint then just runs feature entrypoints and
-/// `exec "$@"` over whatever the service already had.
+/// config`, falling back to the base image's `ENTRYPOINT`/`CMD` (inspected
+/// lazily — only when the service declares no `entrypoint`), then applies
+/// [`crate::override_file::resolve_user_entrypoint_command`].
+///
+/// The wrapped `entrypoint:` REPLACES the service's own entrypoint, so these
+/// values are exactly what `exec "$@"` re-runs. A failure to resolve the compose
+/// config or inspect the needed image is therefore PROPAGATED, not defaulted:
+/// silently emitting an empty `userEntrypoint` would drop the service/image
+/// `ENTRYPOINT` and start the container with the wrong command. `overrideCommand`
+/// discards the original entirely, so the result is fixed and needs no lookup
+/// (the official short-circuits here too).
 async fn resolve_compose_user_entrypoint_command(
     ctx: &Ctx<'_>,
     project: &ComposeProject,
     features_build: Option<&crate::combined_dockerfile_build::ComposeFeaturesBuild>,
-) -> crate::override_file::UserEntrypointCommand {
+) -> Result<crate::override_file::UserEntrypointCommand, Box<dyn std::error::Error + Send + Sync>> {
     // overrideCommand discards the service's original entrypoint+command, so the
     // result is fixed regardless of the compose config or image — skip resolving
     // the config and inspecting the image (the official CLI is lazy here too).
     if project.override_command {
-        return crate::override_file::resolve_user_entrypoint_command(true, None, None, &[], &[]);
+        return Ok(crate::override_file::resolve_user_entrypoint_command(
+            true,
+            None,
+            None,
+            &[],
+            &[],
+        ));
     }
 
     let (dp, dcp) = ctx.cfg.docker_binaries();
     let compose_cmd = ComposeCommand::without_override(project).with_docker_binaries(dp, dcp);
-    let resolved = match compose_cmd.config().await {
-        Ok(r) => r,
-        Err(e) => {
-            warn!("Failed to resolve compose config for entrypoint/command: {e}");
-            return crate::override_file::UserEntrypointCommand::default();
-        }
-    };
-
+    let resolved = compose_cmd.config().await?;
     let (compose_entrypoint, compose_command) =
-        match crate::extract_service_entrypoint_command(&resolved, &project.primary_service) {
-            Ok(pair) => pair,
-            Err(e) => {
-                warn!("Failed to extract service entrypoint/command: {e}");
-                (None, None)
-            }
-        };
+        crate::extract_service_entrypoint_command(&resolved, &project.primary_service)?;
 
-    // The base image to inspect for the ENTRYPOINT/CMD fallback: the
-    // features-build override if present, otherwise the service's resolved image.
-    let image_name = features_build
-        .and_then(|b| b.image_name_override.clone())
-        .or_else(|| {
-            crate::extract_service_build_info(&resolved, &project.primary_service)
-                .ok()
-                .map(|info| {
-                    info.resolved_image_name(&project.project_name, &project.primary_service)
-                })
-        });
-
-    let (image_entrypoint, image_cmd) = match image_name {
-        Some(name) => match ctx.client.inspect_image_details(&name).await {
-            Ok(details) => (details.entrypoint, details.cmd),
-            Err(e) => {
-                warn!("Failed to inspect image '{name}' for entrypoint/cmd: {e}");
-                (Vec::new(), Vec::new())
+    // Image `ENTRYPOINT`/`CMD` are only a fallback for a service that declares no
+    // `entrypoint`: when one is declared neither image value is used (the command
+    // branch returns `[]` or the service's own command). Inspect lazily so a
+    // service with its own entrypoint needs no image lookup, mirroring the
+    // official `composeEntrypoint || imageEntrypoint` short-circuit.
+    let (image_entrypoint, image_cmd) = if compose_entrypoint.is_none() {
+        let image_name = features_build
+            .and_then(|b| b.image_name_override.clone())
+            .or_else(|| {
+                crate::extract_service_build_info(&resolved, &project.primary_service)
+                    .ok()
+                    .map(|info| {
+                        info.resolved_image_name(&project.project_name, &project.primary_service)
+                    })
+            });
+        match image_name {
+            Some(name) => {
+                let details = ctx.client.inspect_image_details(&name).await?;
+                (details.entrypoint, details.cmd)
             }
-        },
-        None => (Vec::new(), Vec::new()),
+            None => (Vec::new(), Vec::new()),
+        }
+    } else {
+        (Vec::new(), Vec::new())
     };
 
-    crate::override_file::resolve_user_entrypoint_command(
-        project.override_command,
+    Ok(crate::override_file::resolve_user_entrypoint_command(
+        false,
         compose_entrypoint.as_deref(),
         compose_command.as_deref(),
         &image_entrypoint,
         &image_cmd,
-    )
+    ))
 }
 
 // ---------------------------------------------------------------------------
@@ -1420,7 +1422,7 @@ async fn build_override_and_start(
     let user_entrypoint_command = if feature_entrypoints.is_empty() && !project.override_command {
         crate::override_file::UserEntrypointCommand::default()
     } else {
-        resolve_compose_user_entrypoint_command(ctx, project, features_build).await
+        resolve_compose_user_entrypoint_command(ctx, project, features_build).await?
     };
 
     let mut ov_ctx = OverrideContext {

--- a/crates/cella-compose/src/override_file.rs
+++ b/crates/cella-compose/src/override_file.rs
@@ -80,6 +80,24 @@ pub struct OverrideConfig {
     /// compose override. Shares the type with the single-container create path so
     /// both apply identical values.
     pub security: MergedSecurityConfig,
+    /// Devcontainer feature `entrypoint` scripts, in install order, already
+    /// `${devcontainerId}`-substituted. Each runs (verbatim, not `$`-escaped) in
+    /// the wrapped entrypoint before the service's original entrypoint+command is
+    /// `exec`d. Empty (with `override_command == false`) emits no entrypoint block
+    /// at all, preserving the current override byte-for-byte.
+    pub feature_entrypoints: Vec<String>,
+    /// The resolved `userEntrypoint` for the wrapped entrypoint, per the official
+    /// compose logic: `overrideCommand ? [] : (service.entrypoint || image
+    /// entrypoint($-escaped))`. Emitted as JSON-quoted array elements after the
+    /// `"-"` sentinel. Service-derived values arrive already compose-escaped (the
+    /// resolved compose config re-escapes `$`→`$$`); image-derived values are
+    /// `$`→`$$` escaped at resolution time.
+    pub user_entrypoint: Vec<String>,
+    /// The resolved `userCommand` for the wrapped entrypoint. `Some(cmd)` emits a
+    /// `command:` key (when it differs from the compose-declared command);
+    /// `None` omits it (the compose command already applies). Mirrors the
+    /// official `userCommand !== composeCommand` gate.
+    pub user_command: Option<Vec<String>>,
     /// Restrict the override to build-time only: skip the runtime sections that a
     /// `docker compose build` never needs — the agent volume mount and the
     /// top-level `volumes:` declarations. Set for the `--label`-only compose
@@ -88,6 +106,85 @@ pub struct OverrideConfig {
     /// path and the features build override leave this `false` to keep emitting
     /// the agent volume unchanged.
     pub build_only: bool,
+}
+
+/// The resolved `userEntrypoint`/`userCommand` for the wrapped compose entrypoint.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct UserEntrypointCommand {
+    /// Args appended after the `"-"` sentinel in the wrapped `entrypoint:` array.
+    pub entrypoint: Vec<String>,
+    /// The `command:` to emit (`None` = omit, value already equals the compose
+    /// command; `Some` = emit, possibly empty).
+    pub command: Option<Vec<String>>,
+}
+
+/// Escape `docker compose` interpolation in an image-derived value (`$` → `$$`).
+///
+/// Image `ENTRYPOINT`/`CMD` values are emitted into cella's `-f` override, which
+/// `docker compose` interpolates. Doubling each `$` makes compose yield a literal
+/// `$` for the shell (mirrors the official `c.replace(/\$/g, '$$$$')`). Service
+/// values are NOT escaped here — the resolved compose config already returns them
+/// in `$$`-escaped form.
+fn escape_dollars(value: &str) -> String {
+    value.replace('$', "$$")
+}
+
+/// Resolve the wrapped entrypoint's `userEntrypoint`/`userCommand`, mirroring the
+/// official `dockerCompose.ts` logic exactly:
+///
+/// ```text
+/// userEntrypoint = overrideCommand ? [] : (composeEntrypoint ?? imageEntrypoint($-esc))
+/// userCommand    = overrideCommand ? [] : (composeCommand ?? (composeEntrypoint ? [] : imageCmd($-esc)))
+/// emit command   = userCommand is NOT taken directly from composeCommand
+/// ```
+///
+/// `compose_entrypoint`/`compose_command` are `Some` when the service declares the
+/// key (even as an empty array — distinct from absent `None`), already in
+/// compose-escaped form. Image values are `$`→`$$` escaped here. The returned
+/// `command` is `None` exactly in the official "`userCommand === composeCommand`"
+/// case (the service command applies unchanged, so no `command:` key is emitted).
+#[must_use]
+pub fn resolve_user_entrypoint_command(
+    override_command: bool,
+    compose_entrypoint: Option<&[String]>,
+    compose_command: Option<&[String]>,
+    image_entrypoint: &[String],
+    image_cmd: &[String],
+) -> UserEntrypointCommand {
+    if override_command {
+        // overrideCommand discards the original: userEntrypoint = userCommand = [].
+        // userCommand ([]) is a fresh value, never === composeCommand, so it is
+        // always emitted (as `command: []`).
+        return UserEntrypointCommand {
+            entrypoint: Vec::new(),
+            command: Some(Vec::new()),
+        };
+    }
+
+    // composeEntrypoint present (even empty) is used verbatim; absent falls back
+    // to the image entrypoint ($-escaped) — official `composeEntrypoint || image`.
+    let entrypoint = compose_entrypoint.map_or_else(
+        || image_entrypoint.iter().map(|a| escape_dollars(a)).collect(),
+        <[String]>::to_vec,
+    );
+
+    // userCommand and whether to emit it. The `command:` key is omitted only when
+    // userCommand is taken directly from composeCommand (official `===`): i.e.
+    // when composeCommand is present. When absent, userCommand is a fresh array
+    // (always emitted) — `[]` if the service overrides the entrypoint (image CMD
+    // ignored per the compose spec), otherwise the image CMD ($-escaped).
+    let command = if compose_command.is_some() {
+        None
+    } else if compose_entrypoint.is_some() {
+        Some(Vec::new())
+    } else {
+        Some(image_cmd.iter().map(|a| escape_dollars(a)).collect())
+    };
+
+    UserEntrypointCommand {
+        entrypoint,
+        command,
+    }
 }
 
 /// Escape a string for embedding in a YAML double-quoted scalar (`key: "{v}"`).
@@ -116,6 +213,72 @@ fn yaml_dq_escape(value: &str) -> String {
     out
 }
 
+/// Emit one element of a YAML flow sequence as a double-quoted scalar.
+///
+/// Reuses [`yaml_dq_escape`] (escapes `"`/`\`/newlines/controls, leaves `$`
+/// untouched) so an embedded literal `$$` — which `docker compose` interpolates
+/// back to `$` when it reads this `-f` override — survives intact.
+fn yaml_flow_scalar(value: &str) -> String {
+    format!("\"{}\"", yaml_dq_escape(value))
+}
+
+/// Build the wrapped entrypoint shell script.
+///
+/// Mirrors the official compose override's `/bin/sh -c` script verbatim:
+/// announce start, install a SIGTERM trap, run each feature entrypoint, `exec`
+/// the service's original entrypoint+command (`"$@"`), then idle so the
+/// container stays up. The `$$@`/`$$!` are emitted as literal double-dollars so
+/// that, after `docker compose` interpolates this `-f` file (`$$`→`$`), the
+/// shell receives `$@`/`$!`. Feature entrypoints are inserted verbatim (NOT
+/// `$`-escaped), matching the official `customEntrypoints.join(...)`.
+///
+/// Deliberately contains NO agent restart loop: on the compose path the agent is
+/// launched separately via `nohup` after `up` (see `compose_up::launch_agent_exec`).
+fn build_wrapped_entrypoint_script(feature_entrypoints: &[String]) -> String {
+    let mut script = String::from("echo Container started\ntrap \"exit 0\" 15\n");
+    for ep in feature_entrypoints {
+        script.push_str(ep);
+        script.push('\n');
+    }
+    script.push_str("exec \"$$@\"\nwhile sleep 1 & wait $$!; do :; done");
+    script
+}
+
+/// Emit the `entrypoint:` (and conditional `command:`) keys for the primary
+/// service, wrapping feature entrypoints around the service's original
+/// entrypoint+command.
+///
+/// Emits nothing when there are no feature entrypoints AND the command is not
+/// being overridden — preserving the no-feature override byte-for-byte.
+/// Otherwise writes:
+/// - `entrypoint: ["/bin/sh", "-c", "<script>", "-"<, userEntrypoint args>]`
+/// - `command: <userCommand>` — only when `user_command` is `Some` (the resolver
+///   sets `None` when it equals the compose-declared command, matching the
+///   official `userCommand !== composeCommand` gate).
+fn write_entrypoint_section(yaml: &mut String, config: &OverrideConfig) {
+    if config.feature_entrypoints.is_empty() && !config.override_command {
+        return;
+    }
+
+    let script = build_wrapped_entrypoint_script(&config.feature_entrypoints);
+
+    let mut elements = vec![
+        yaml_flow_scalar("/bin/sh"),
+        yaml_flow_scalar("-c"),
+        yaml_flow_scalar(&script),
+        yaml_flow_scalar("-"),
+    ];
+    for arg in &config.user_entrypoint {
+        elements.push(yaml_flow_scalar(arg));
+    }
+    let _ = writeln!(yaml, "    entrypoint: [{}]", elements.join(", "));
+
+    if let Some(ref command) = config.user_command {
+        let items: Vec<String> = command.iter().map(|c| yaml_flow_scalar(c)).collect();
+        let _ = writeln!(yaml, "    command: [{}]", items.join(", "));
+    }
+}
+
 /// Generate the override compose YAML as a string.
 ///
 /// The output is a valid Docker Compose file that overrides the primary service
@@ -139,11 +302,11 @@ pub fn generate_override_yaml(config: &OverrideConfig) -> String {
     // and/or image labels).
     write_build_section(&mut yaml, config);
 
-    // Command override (only if explicitly enabled; compose default is false)
-    if config.override_command {
-        yaml.push_str("    entrypoint: [\"/bin/sh\", \"-c\"]\n");
-        yaml.push_str("    command: [\"while sleep 1000; do :; done\"]\n");
-    }
+    // Wrapped entrypoint that runs feature entrypoints, then execs the service's
+    // original entrypoint+command. Emitted only when there is something to wrap
+    // (feature entrypoints) or when the command is being overridden; otherwise no
+    // entrypoint/command keys are written and the service runs unchanged.
+    write_entrypoint_section(&mut yaml, config);
 
     // Container security/runtime properties (init, user, privileged, caps).
     write_security_section(&mut yaml, &config.security);
@@ -374,6 +537,9 @@ mod tests {
             extra_volumes: Vec::new(),
             request_gpu: false,
             security: MergedSecurityConfig::default(),
+            feature_entrypoints: Vec::new(),
+            user_entrypoint: Vec::new(),
+            user_command: None,
             build_only: false,
         }
     }
@@ -540,11 +706,25 @@ mod tests {
 
     #[test]
     fn with_command_override() {
+        // overrideCommand=true discards the service's original entrypoint/command:
+        // userEntrypoint = [] (no args after "-"), userCommand = Some([]) so the
+        // wrapped entrypoint's `exec "$@"` runs nothing and the keepalive loop
+        // holds the container open. (The resolver produces these values; here we
+        // set them directly to exercise the emitter.)
         let mut config = base_config();
         config.override_command = true;
+        config.user_entrypoint = Vec::new();
+        config.user_command = Some(Vec::new());
         let yaml = generate_override_yaml(&config);
-        assert!(yaml.contains("entrypoint:"));
-        assert!(yaml.contains("command:"));
+        assert!(
+            yaml.contains(
+                "    entrypoint: [\"/bin/sh\", \"-c\", \
+                 \"echo Container started\\ntrap \\\"exit 0\\\" 15\\n\
+                 exec \\\"$$@\\\"\\nwhile sleep 1 & wait $$!; do :; done\", \"-\"]\n"
+            ),
+            "yaml:\n{yaml}"
+        );
+        assert!(yaml.contains("    command: []\n"), "yaml:\n{yaml}");
     }
 
     #[test]
@@ -589,6 +769,10 @@ mod tests {
         let mut config = base_config();
         config.image_override = Some("cella-img-app-12345678".to_string());
         config.override_command = true;
+        // overrideCommand=true resolves to an empty userCommand (the resolver
+        // emits Some([])), which clears the original command; the wrapped
+        // entrypoint's keepalive loop keeps the container up.
+        config.user_command = Some(Vec::new());
         config.extra_env = vec!["CELLA_DAEMON_PORT=9876".to_string()];
         config
             .extra_labels
@@ -599,8 +783,8 @@ mod tests {
         services:
           app:
             image: "cella-img-app-12345678"
-            entrypoint: ["/bin/sh", "-c"]
-            command: ["while sleep 1000; do :; done"]
+            entrypoint: ["/bin/sh", "-c", "echo Container started\ntrap \"exit 0\" 15\nexec \"$$@\"\nwhile sleep 1 & wait $$!; do :; done", "-"]
+            command: []
             environment:
               - "CELLA_DAEMON_PORT=9876"
             labels:
@@ -618,6 +802,7 @@ mod tests {
         let mut config = base_config();
         config.image_override = Some("cella-img-app-12345678".to_string());
         config.override_command = true;
+        config.user_command = Some(Vec::new());
         config.extra_env = vec!["CELLA_DAEMON_PORT=9876".to_string()];
         config
             .extra_labels
@@ -632,8 +817,8 @@ mod tests {
         services:
           app:
             image: "cella-img-app-12345678"
-            entrypoint: ["/bin/sh", "-c"]
-            command: ["while sleep 1000; do :; done"]
+            entrypoint: ["/bin/sh", "-c", "echo Container started\ntrap \"exit 0\" 15\nexec \"$$@\"\nwhile sleep 1 & wait $$!; do :; done", "-"]
+            command: []
             environment:
               - "CELLA_DAEMON_PORT=9876"
             labels:
@@ -1144,5 +1329,206 @@ mod tests {
             external_count, 1,
             "only the agent volume should be external; yaml:\n{yaml}"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Wrapped entrypoint: resolution + emission
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn no_feature_no_override_emits_no_entrypoint_or_command() {
+        // The byte-for-byte preservation guarantee: with no feature entrypoints
+        // and overrideCommand=false, neither key is emitted.
+        let config = base_config();
+        let yaml = generate_override_yaml(&config);
+        assert!(!yaml.contains("entrypoint:"), "yaml:\n{yaml}");
+        assert!(!yaml.contains("command:"), "yaml:\n{yaml}");
+    }
+
+    #[test]
+    fn feature_entrypoints_build_wrapped_script_with_dollar_escaping() {
+        // Feature entrypoints run (verbatim) between the trap and `exec "$@"`.
+        // The script emits literal `$$@`/`$$!` so docker compose interpolates
+        // them back to `$@`/`$!`; feature entrypoint text is NOT $-escaped.
+        let mut config = base_config();
+        config.feature_entrypoints = vec![
+            "/usr/local/share/feat-a/entry.sh".to_string(),
+            "echo from-feature-b".to_string(),
+        ];
+        let yaml = generate_override_yaml(&config);
+        let expected = "    entrypoint: [\"/bin/sh\", \"-c\", \
+             \"echo Container started\\ntrap \\\"exit 0\\\" 15\\n\
+             /usr/local/share/feat-a/entry.sh\\necho from-feature-b\\n\
+             exec \\\"$$@\\\"\\nwhile sleep 1 & wait $$!; do :; done\", \"-\"]\n";
+        assert!(yaml.contains(expected), "yaml:\n{yaml}");
+        // No agent restart loop in the compose entrypoint.
+        assert!(!yaml.contains("cella-agent daemon"), "yaml:\n{yaml}");
+        assert!(!yaml.contains("while true"), "yaml:\n{yaml}");
+        // No `command:` when user_command is None (compose command applies).
+        assert!(!yaml.contains("command:"), "yaml:\n{yaml}");
+    }
+
+    #[test]
+    fn user_entrypoint_passthrough_after_dash_sentinel() {
+        // userEntrypoint args are appended as JSON-quoted elements after "-",
+        // preserving the service's/image's original entrypoint inside the wrap.
+        // An image-derived `$$` stays doubled (already escaped at resolution).
+        let mut config = base_config();
+        config.feature_entrypoints = vec!["echo hi".to_string()];
+        config.user_entrypoint = vec![
+            "/docker-entrypoint.sh".to_string(),
+            "--config=$$HOME/cfg".to_string(),
+        ];
+        let yaml = generate_override_yaml(&config);
+        assert!(
+            yaml.contains("\"-\", \"/docker-entrypoint.sh\", \"--config=$$HOME/cfg\"]\n"),
+            "yaml:\n{yaml}"
+        );
+    }
+
+    #[test]
+    fn user_command_emitted_only_when_some() {
+        // Some(cmd) -> `command:` is emitted as a JSON array; None -> omitted.
+        let mut config = base_config();
+        config.feature_entrypoints = vec!["echo hi".to_string()];
+        config.user_command = Some(vec!["node".to_string(), "server.js".to_string()]);
+        let yaml = generate_override_yaml(&config);
+        assert!(
+            yaml.contains("    command: [\"node\", \"server.js\"]\n"),
+            "yaml:\n{yaml}"
+        );
+
+        let mut none_config = base_config();
+        none_config.feature_entrypoints = vec!["echo hi".to_string()];
+        none_config.user_command = None;
+        let none_yaml = generate_override_yaml(&none_config);
+        assert!(!none_yaml.contains("command:"), "yaml:\n{none_yaml}");
+    }
+
+    #[test]
+    fn generated_wrapped_entrypoint_is_valid_yaml() {
+        // The flow-sequence entrypoint (with escaped quotes/newlines and `$$`)
+        // must parse as valid YAML and round-trip the script intact.
+        let mut config = base_config();
+        config.feature_entrypoints = vec!["echo hi".to_string()];
+        config.user_entrypoint = vec!["/entry".to_string()];
+        config.user_command = Some(vec!["run".to_string()]);
+        let yaml = generate_override_yaml(&config);
+        let parsed: yaml_serde::Value =
+            yaml_serde::from_str(&yaml).expect("wrapped-entrypoint override must be valid YAML");
+        let ep = &parsed["services"]["app"]["entrypoint"];
+        let elems = ep.as_sequence().expect("entrypoint is a sequence");
+        assert_eq!(elems[0].as_str(), Some("/bin/sh"));
+        assert_eq!(elems[1].as_str(), Some("-c"));
+        let script = elems[2].as_str().expect("script element is a string");
+        // YAML parse resolves the `\n`/`\"` escapes; `$$` is left for compose.
+        assert!(script.contains("echo Container started\ntrap \"exit 0\" 15\n"));
+        assert!(script.contains("echo hi\n"));
+        assert!(script.contains("exec \"$$@\"\nwhile sleep 1 & wait $$!; do :; done"));
+        assert_eq!(elems[3].as_str(), Some("-"));
+        assert_eq!(elems[4].as_str(), Some("/entry"));
+        assert_eq!(
+            parsed["services"]["app"]["command"][0].as_str(),
+            Some("run")
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // resolve_user_entrypoint_command (parity with dockerCompose.ts)
+    // -----------------------------------------------------------------------
+
+    fn sv(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn resolve_override_command_discards_to_empty() {
+        // overrideCommand=true => userEntrypoint=[] and userCommand=Some([])
+        // regardless of service/image values.
+        let r = resolve_user_entrypoint_command(
+            true,
+            Some(&sv(&["/svc-entry"])),
+            Some(&sv(&["svc-cmd"])),
+            &sv(&["img-entry"]),
+            &sv(&["img-cmd"]),
+        );
+        assert_eq!(r.entrypoint, Vec::<String>::new());
+        assert_eq!(r.command, Some(Vec::new()));
+    }
+
+    #[test]
+    fn resolve_uses_service_entrypoint_and_omits_command_when_service_has_command() {
+        // composeEntrypoint present -> userEntrypoint = it (verbatim).
+        // composeCommand present -> userCommand === composeCommand -> omit command.
+        let r = resolve_user_entrypoint_command(
+            false,
+            Some(&sv(&["/svc-entry", "--x"])),
+            Some(&sv(&["svc-cmd"])),
+            &sv(&["img-entry"]),
+            &sv(&["img-cmd"]),
+        );
+        assert_eq!(r.entrypoint, sv(&["/svc-entry", "--x"]));
+        assert_eq!(r.command, None);
+    }
+
+    #[test]
+    fn resolve_falls_back_to_image_entrypoint_and_cmd_when_service_absent() {
+        // Neither service entrypoint nor command -> image entrypoint + image cmd,
+        // both $-escaped, and command IS emitted (fresh array, != composeCommand).
+        let r = resolve_user_entrypoint_command(
+            false,
+            None,
+            None,
+            &sv(&["/img-entry", "$VAR"]),
+            &sv(&["img-cmd", "$X"]),
+        );
+        assert_eq!(r.entrypoint, sv(&["/img-entry", "$$VAR"]));
+        assert_eq!(r.command, Some(sv(&["img-cmd", "$$X"])));
+    }
+
+    #[test]
+    fn resolve_service_entrypoint_present_ignores_image_cmd() {
+        // composeEntrypoint present but composeCommand absent -> image CMD is
+        // ignored (compose spec) -> userCommand = Some([]) (emitted as empty).
+        let r = resolve_user_entrypoint_command(
+            false,
+            Some(&sv(&["/svc-entry"])),
+            None,
+            &sv(&["img-entry"]),
+            &sv(&["img-cmd"]),
+        );
+        assert_eq!(r.entrypoint, sv(&["/svc-entry"]));
+        assert_eq!(r.command, Some(Vec::new()));
+    }
+
+    #[test]
+    fn resolve_empty_service_entrypoint_is_used_not_image() {
+        // An explicit empty service entrypoint (Some([])) is truthy in the
+        // official `composeEntrypoint || image` -> it is used (empty), NOT the
+        // image entrypoint. Image CMD is then ignored too.
+        let r = resolve_user_entrypoint_command(
+            false,
+            Some(&[]),
+            None,
+            &sv(&["/img-entry"]),
+            &sv(&["img-cmd"]),
+        );
+        assert_eq!(r.entrypoint, Vec::<String>::new());
+        assert_eq!(r.command, Some(Vec::new()));
+    }
+
+    #[test]
+    fn resolve_service_command_present_without_entrypoint_omits_command() {
+        // composeCommand present (even without entrypoint) -> omit command;
+        // userEntrypoint falls back to the image entrypoint ($-escaped).
+        let r = resolve_user_entrypoint_command(
+            false,
+            None,
+            Some(&sv(&["svc-cmd"])),
+            &sv(&["/img-entry", "$Z"]),
+            &sv(&["img-cmd"]),
+        );
+        assert_eq!(r.entrypoint, sv(&["/img-entry", "$$Z"]));
+        assert_eq!(r.command, None);
     }
 }

--- a/crates/cella-compose/src/override_file.rs
+++ b/crates/cella-compose/src/override_file.rs
@@ -667,6 +667,36 @@ mod tests {
     }
 
     #[test]
+    fn build_override_shape_has_build_section_but_no_runtime_entrypoint_or_volumes() {
+        // The compose BUILD override (`cella build`) is build-only: it carries the
+        // `build:` section but must emit NO runtime entrypoint/command (it never
+        // runs the container — `cella up` regenerates the runtime override) and no
+        // agent volume. Regression: a build override built with `override_command`
+        // left on would emit the `exec "$@"` wrapper without a `command:`, so a
+        // container started from the persisted file would ignore overrideCommand.
+        let mut config = base_config();
+        config.build_dockerfile = Some(PathBuf::from("Dockerfile.combined"));
+        config.build_only = true;
+        config.override_command = false;
+        config.feature_entrypoints = Vec::new();
+        let yaml = generate_override_yaml(&config);
+
+        assert!(yaml.contains("    build:\n"), "yaml:\n{yaml}");
+        assert!(
+            !yaml.contains("entrypoint:"),
+            "build override must emit no runtime entrypoint; yaml:\n{yaml}"
+        );
+        assert!(
+            !yaml.contains("command:"),
+            "build override must emit no command; yaml:\n{yaml}"
+        );
+        assert!(
+            !yaml.contains("volumes:"),
+            "build override must omit volumes; yaml:\n{yaml}"
+        );
+    }
+
+    #[test]
     fn build_section_dockerfile_and_context_are_escaped() {
         // Regression (Windows paths): a `build.dockerfile`/`build.context` with
         // backslashes (or a `"` in `target`) must stay inside the double-quoted

--- a/crates/cella-container/src/backend.rs
+++ b/crates/cella-container/src/backend.rs
@@ -604,6 +604,13 @@ impl ContainerBackend for AppleContainerBackend {
                 os: None,
                 architecture: None,
                 variant: None,
+                // Image entrypoint/cmd only feed the docker-compose override's
+                // entrypoint fallback. The Apple `container` backend reports
+                // `compose: false` (see `capabilities()`), so compose is
+                // docker-only and this fallback is never exercised here — leave
+                // both empty rather than extend the CLI inspect parse.
+                entrypoint: Vec::new(),
+                cmd: Vec::new(),
             })
         })
     }

--- a/crates/cella-docker/src/container.rs
+++ b/crates/cella-docker/src/container.rs
@@ -1479,12 +1479,16 @@ mod tests {
                 os: Some("linux".to_string()),
                 architecture: Some("amd64".to_string()),
                 variant: None,
+                entrypoint: vec!["/entrypoint.sh".to_string()],
+                cmd: vec!["bash".to_string()],
             }));
 
         let details = mock.inspect_image_details("ubuntu:latest").await.unwrap();
         assert_eq!(details.user, "vscode");
         assert_eq!(details.env.len(), 1);
         assert!(details.metadata.is_some());
+        assert_eq!(details.entrypoint, vec!["/entrypoint.sh".to_string()]);
+        assert_eq!(details.cmd, vec!["bash".to_string()]);
     }
 
     // -----------------------------------------------------------------------

--- a/crates/cella-docker/src/image.rs
+++ b/crates/cella-docker/src/image.rs
@@ -25,6 +25,34 @@ pub(crate) fn normalize_user(raw: &str) -> String {
     }
 }
 
+/// Map a bollard image-inspect response into cella's [`ImageDetails`].
+///
+/// Pulls user (normalized), env, the `devcontainer.metadata` label, OS/arch, and
+/// the image `ENTRYPOINT`/`CMD` arrays out of `Config`. Pure (no I/O) so the
+/// mapping is unit-testable against a deserialized inspect response.
+fn image_details_from_inspect(details: &bollard::models::ImageInspect) -> ImageDetails {
+    let config = details.config.as_ref();
+    let user = normalize_user(config.and_then(|c| c.user.as_deref()).unwrap_or(""));
+    let env = config.and_then(|c| c.env.clone()).unwrap_or_default();
+    let metadata = config
+        .and_then(|c| c.labels.as_ref())
+        .and_then(|labels| labels.get("devcontainer.metadata").cloned());
+    let entrypoint = config
+        .and_then(|c| c.entrypoint.clone())
+        .unwrap_or_default();
+    let cmd = config.and_then(|c| c.cmd.clone()).unwrap_or_default();
+    ImageDetails {
+        user,
+        env,
+        metadata,
+        os: details.os.clone(),
+        architecture: details.architecture.clone(),
+        variant: details.variant.clone(),
+        entrypoint,
+        cmd,
+    }
+}
+
 /// Split an image reference into its repository and optional tag.
 ///
 /// The tag is the part after the LAST `:` that comes *after* the last `/`. A
@@ -427,26 +455,7 @@ impl DockerClient {
         image: &str,
     ) -> Result<ImageDetails, CellaDockerError> {
         match self.inner().inspect_image(image).await {
-            Ok(details) => {
-                let config = details.config.as_ref();
-                let user = normalize_user(config.and_then(|c| c.user.as_deref()).unwrap_or(""));
-                let env = details
-                    .config
-                    .as_ref()
-                    .and_then(|c| c.env.clone())
-                    .unwrap_or_default();
-                let metadata = config
-                    .and_then(|c| c.labels.as_ref())
-                    .and_then(|labels| labels.get("devcontainer.metadata").cloned());
-                Ok(ImageDetails {
-                    user,
-                    env,
-                    metadata,
-                    os: details.os.clone(),
-                    architecture: details.architecture.clone(),
-                    variant: details.variant.clone(),
-                })
-            }
+            Ok(details) => Ok(image_details_from_inspect(&details)),
             Err(bollard::errors::Error::DockerResponseServerError {
                 status_code: 404, ..
             }) => Err(CellaDockerError::ImageNotFound {
@@ -1075,5 +1084,91 @@ mod tests {
     #[test]
     fn has_buildx_false_for_missing_binary() {
         assert!(!has_buildx(Some("/nonexistent/docker-binary-xyz")));
+    }
+
+    // -----------------------------------------------------------------------
+    // image_details_from_inspect (Config -> ImageDetails mapping)
+    // -----------------------------------------------------------------------
+
+    fn image_config(
+        user: Option<&str>,
+        entrypoint: Option<Vec<&str>>,
+        cmd: Option<Vec<&str>>,
+    ) -> bollard::models::ImageConfig {
+        bollard::models::ImageConfig {
+            user: user.map(ToString::to_string),
+            entrypoint: entrypoint.map(|v| v.into_iter().map(ToString::to_string).collect()),
+            cmd: cmd.map(|v| v.into_iter().map(ToString::to_string).collect()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn image_details_maps_entrypoint_and_cmd() {
+        // A real `docker inspect` Config carries Entrypoint/Cmd arrays; the
+        // mapping must surface both for the compose override's entrypoint
+        // fallback, alongside user/env/metadata/os/arch. Os/Architecture/Variant
+        // are a pure passthrough (no arch-dependent logic), so the mapping test
+        // asserts whatever the inspect response carries rather than the host
+        // platform.
+        let mut labels = HashMap::new();
+        labels.insert(
+            "devcontainer.metadata".to_string(),
+            r#"[{"id":"x"}]"#.to_string(),
+        );
+        let config = bollard::models::ImageConfig {
+            env: Some(vec!["PATH=/usr/local/bin".to_string()]),
+            labels: Some(labels),
+            ..image_config(
+                Some("vscode:vscode"),
+                Some(vec!["/usr/local/bin/entry", "--flag"]),
+                Some(vec!["bash", "-l"]),
+            )
+        };
+        let inspect = bollard::models::ImageInspect {
+            os: Some("linux".to_string()),
+            architecture: Some("arm64".to_string()),
+            variant: Some("v8".to_string()),
+            config: Some(config),
+            ..Default::default()
+        };
+        let details = image_details_from_inspect(&inspect);
+        assert_eq!(details.user, "vscode");
+        assert_eq!(details.env, vec!["PATH=/usr/local/bin".to_string()]);
+        assert_eq!(details.os.as_deref(), Some("linux"));
+        assert_eq!(details.architecture.as_deref(), Some("arm64"));
+        assert_eq!(details.variant.as_deref(), Some("v8"));
+        assert_eq!(
+            details.entrypoint,
+            vec!["/usr/local/bin/entry".to_string(), "--flag".to_string()]
+        );
+        assert_eq!(details.cmd, vec!["bash".to_string(), "-l".to_string()]);
+        assert_eq!(details.metadata.as_deref(), Some(r#"[{"id":"x"}]"#));
+    }
+
+    #[test]
+    fn image_details_entrypoint_and_cmd_default_empty_when_absent() {
+        // No Entrypoint/Cmd in Config -> empty vecs (not a panic / missing key).
+        let inspect = bollard::models::ImageInspect {
+            config: Some(image_config(Some("root"), None, None)),
+            ..Default::default()
+        };
+        let details = image_details_from_inspect(&inspect);
+        assert!(details.entrypoint.is_empty());
+        assert!(details.cmd.is_empty());
+        assert_eq!(details.user, "root");
+    }
+
+    #[test]
+    fn image_details_no_config_yields_root_and_empty() {
+        // A Config-less inspect response (rare, but possible) must not panic and
+        // must default user to "root" with empty entrypoint/cmd/env.
+        let inspect = bollard::models::ImageInspect::default();
+        let details = image_details_from_inspect(&inspect);
+        assert_eq!(details.user, "root");
+        assert!(details.env.is_empty());
+        assert!(details.entrypoint.is_empty());
+        assert!(details.cmd.is_empty());
+        assert!(details.metadata.is_none());
     }
 }


### PR DESCRIPTION
## What

Devcontainer **feature entrypoints** now run on container start for docker-compose projects, matching the official devcontainer CLI. Until now only the single-container path chained them; on compose they were silently dropped, so a feature that relied on its `entrypoint` (e.g. starting a daemon, fixing perms) just didn't run.

The compose override now emits a wrapped entrypoint that runs each feature entrypoint in install order, then `exec`s the service's original entrypoint+command:

```yaml
    entrypoint: ["/bin/sh", "-c", "echo Container started\ntrap \"exit 0\" 15\n<feat-a ep>\n<feat-b ep>\nexec \"$$@\"\nwhile sleep 1 & wait $$!; do :; done", "-", "/docker-entrypoint.sh"]
```

This mirrors `devcontainers/cli` `dockerCompose.ts` — including the bits that are easy to get wrong:

- **`$$@` / `$$!` are literal double-dollars.** The override is a `-f` compose file, so `docker compose` interpolates `$`; doubling makes the shell receive `$@` / `$!`. Image-derived entrypoint/cmd values are `$`→`$$` escaped too; service-file values come from the already-resolved `docker compose config` (which re-escapes `$`→`$$`) so they're emitted verbatim.
- **No agent restart loop here.** The single-container entrypoint bakes in a `cella-agent daemon` restart loop; on compose the agent is launched separately via `nohup` after `up`, so the compose entrypoint must NOT include it. It only runs feature entrypoints + `exec` + keepalive.
- **`userEntrypoint`/`userCommand` resolution** matches the official `||` fallback exactly: `overrideCommand` discards both; otherwise the service's `entrypoint`/`command` win, falling back to the image's `Config.Entrypoint`/`Cmd`; when the service overrides the entrypoint the image CMD is ignored (compose spec); and `command:` is emitted only when it differs from the compose-declared command.

## How it's built

- `feat(backend)`: `ImageDetails` surfaces the image's `entrypoint`/`cmd` (needed for the fallback above). Pure `image_details_from_inspect` helper, unit-tested against real bollard types. Apple `container` backend reports `compose: false`, so its values default to empty (compose is docker-only).
- `feat(compose)`: extract the service `entrypoint`/`command` from the resolved compose config (string → shell-split, array → verbatim, absent → none). Pulls `shell-words` up to a pinned workspace dep.
- `feat(compose)`: `OverrideConfig` gains `feature_entrypoints` / `user_entrypoint` / `user_command`; `generate_override_yaml` emits the wrapped block **only** when there are feature entrypoints OR `overrideCommand` — so a no-feature, non-override service's override is byte-for-byte unchanged. Resolution lives in a pure `resolve_user_entrypoint_command` (faithful port, incl. the empty-array-is-truthy edge cases) plus a `resolve_compose_user_entrypoint_command` that reads the *un-overridden* config so it sees the user's original entrypoint, not cella's wrapper.
- `test(compose)`: a `runtime_test(docker, compose)` builds a feature whose entrypoint drops a sentinel, brings the service up, and asserts both that the sentinel exists (the entrypoint ran) and the base command is still running (the `exec` passthrough works). Skips locally, runs in CI.
- `refactor(compose)`: short-circuit the config+inspect when `overrideCommand` makes the result fixed (matches the official's lazy image inspect).

## Notes

- 11 emitter/resolver unit tests + the integration test cover escaping, the image fallback, the userEntrypoint passthrough, the conditional `command:`, the no-feature no-op, and `overrideCommand` discard.
- Full spec lives in `.claude/plans/compose-feature-entrypoints.md` (local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
