### PR TITLE
feat(build): add --skip-persisting-customizations-from-features

### DIFF
--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -123,6 +123,12 @@ pub struct BuildArgs {
 
     #[command(flatten)]
     deprecated_lockfile: super::DeprecatedLockfileArgs,
+
+    /// Do not persist `customizations` from features into the
+    /// `devcontainer.metadata` image label. Hidden parity flag matching the
+    /// official devcontainer CLI.
+    #[arg(long = "skip-persisting-customizations-from-features", hide = true)]
+    skip_persisting_customizations_from_features: bool,
 }
 
 impl BuildArgs {
@@ -250,6 +256,8 @@ impl BuildArgs {
             // `build.labels` (image labels on the built service image), the
             // compose equivalent of the single-container `docker build --label`.
             labels: self.label.clone(),
+            omit_feature_customizations_from_metadata: self
+                .skip_persisting_customizations_from_features,
         };
         let result = cella_orchestrator::compose_build::compose_build(client, &build_cfg, &sender)
             .await
@@ -309,8 +317,10 @@ impl BuildArgs {
             // config (no build to attach them to).
             labels: &self.label,
             // `--omit-config-remote-env-from-metadata` is wired on `up` only;
-            // `cella build` keeps the full metadata label.
+            // `cella build` keeps the full metadata label (up-only flag).
             omit_remote_env_from_metadata: false,
+            omit_feature_customizations_from_metadata: self
+                .skip_persisting_customizations_from_features,
             lockfile_policy: super::derive_lockfile_policy(
                 &self.lockfile,
                 &self.deprecated_lockfile,
@@ -866,5 +876,17 @@ mod tests {
             args.reported_names("built:latest"),
             vec!["x:1".to_string(), "y:2".to_string()]
         );
+    }
+
+    #[test]
+    fn skip_persisting_customizations_from_features_defaults_false() {
+        let args = parse_build(&[]);
+        assert!(!args.skip_persisting_customizations_from_features);
+    }
+
+    #[test]
+    fn skip_persisting_customizations_from_features_parses() {
+        let args = parse_build(&["--skip-persisting-customizations-from-features"]);
+        assert!(args.skip_persisting_customizations_from_features);
     }
 }

--- a/crates/cella-cli/src/commands/read_configuration.rs
+++ b/crates/cella-cli/src/commands/read_configuration.rs
@@ -218,9 +218,8 @@ pub async fn resolve_merged_config(
         base_image,
         image_user: "root",
         metadata: None,
-        // read-configuration only merges config; no label is persisted, so the
-        // omit-remote-env flag does not apply here.
-        omit_remote_env: false,
+        // read-configuration only merges config; no label is persisted.
+        omit: cella_features::MetadataOmit::default(),
     };
     let rf = cella_features::resolve_features(
         config,

--- a/crates/cella-cli/src/commands/upgrade.rs
+++ b/crates/cella-cli/src/commands/upgrade.rs
@@ -53,7 +53,7 @@ impl UpgradeArgs {
             base_image,
             image_user: "root",
             metadata: None,
-            omit_remote_env: false,
+            omit: cella_features::MetadataOmit::default(),
         };
 
         let resolved = cella_features::resolve_features(

--- a/crates/cella-compose/src/build_features.rs
+++ b/crates/cella-compose/src/build_features.rs
@@ -50,6 +50,9 @@ pub struct ComposeBuildConfig<'a> {
     /// An image-only service (no build, no features) has nothing to label and is
     /// rejected up front. Pre-validated `key=value` strings (non-empty key).
     pub labels: Vec<String>,
+    /// `--skip-persisting-customizations-from-features`: strip `customizations`
+    /// from per-feature entries in the generated `devcontainer.metadata` label.
+    pub omit_feature_customizations_from_metadata: bool,
 }
 
 /// Run the compose build pipeline: resolve features, write override, build.
@@ -84,13 +87,17 @@ pub async fn compose_build(
     // Resolve features via combined-Dockerfile approach
     let features_build = crate::combined_dockerfile_build::resolve_compose_features(
         client,
-        config,
-        config_path,
-        &project,
-        // `cella build` does not yet expose --omit-config-remote-env-from-metadata
-        // (it's wired on the `up` path only); keep the full metadata label here.
-        false,
-        cfg.lockfile_policy,
+        &crate::combined_dockerfile_build::ResolveComposeFeaturesInput {
+            config,
+            config_path,
+            project: &project,
+            // --omit-config-remote-env-from-metadata is an `up`-only flag; `cella
+            // build` always persists remoteEnv in the metadata label.
+            omit_remote_env_from_metadata: false,
+            omit_feature_customizations_from_metadata: cfg
+                .omit_feature_customizations_from_metadata,
+            lockfile_policy: cfg.lockfile_policy,
+        },
         progress,
     )
     .await?;

--- a/crates/cella-compose/src/combined_dockerfile_build.rs
+++ b/crates/cella-compose/src/combined_dockerfile_build.rs
@@ -39,6 +39,24 @@ pub struct ComposeFeaturesBuild {
     pub base_image_metadata: Option<String>,
 }
 
+/// Config for [`resolve_compose_features`].
+pub struct ResolveComposeFeaturesInput<'a> {
+    /// Parsed devcontainer JSON config.
+    pub config: &'a serde_json::Value,
+    /// Path to `devcontainer.json`.
+    pub config_path: &'a Path,
+    /// Compose project (primary service name, project name, paths).
+    pub project: &'a ComposeProject,
+    /// Whether to strip `remoteEnv` from the user-config metadata entry.
+    /// `up`-only flag; pass `false` on the `build` path.
+    pub omit_remote_env_from_metadata: bool,
+    /// Whether to strip `customizations` from per-feature metadata entries.
+    /// `build`-only flag; pass `false` on the `up` path.
+    pub omit_feature_customizations_from_metadata: bool,
+    /// Lockfile policy for feature resolution.
+    pub lockfile_policy: cella_features::LockfilePolicy,
+}
+
 /// Resolve features for a compose service and generate the combined Dockerfile.
 ///
 /// Returns `None` if no features are configured.
@@ -58,13 +76,13 @@ pub struct ComposeFeaturesBuild {
 /// cannot be read, or feature resolution fails.
 pub async fn resolve_compose_features(
     client: &dyn ContainerBackend,
-    config: &serde_json::Value,
-    config_path: &Path,
-    project: &ComposeProject,
-    omit_remote_env_from_metadata: bool,
-    lockfile_policy: cella_features::LockfilePolicy,
+    input: &ResolveComposeFeaturesInput<'_>,
     progress: &ProgressSender,
 ) -> Result<Option<ComposeFeaturesBuild>, Box<dyn std::error::Error + Send + Sync>> {
+    let config = input.config;
+    let config_path = input.config_path;
+    let project = input.project;
+
     // 1. Check if features are present
     if !has_features(config) {
         return Ok(None);
@@ -155,10 +173,13 @@ pub async fn resolve_compose_features(
                 base_image: &stage_name,
                 image_user: &image_user,
                 metadata: base_image_metadata.as_deref(),
-                omit_remote_env: omit_remote_env_from_metadata,
+                omit: cella_features::MetadataOmit {
+                    remote_env: input.omit_remote_env_from_metadata,
+                    feature_customizations: input.omit_feature_customizations_from_metadata,
+                },
             },
             true, // compose builds use named content source via additional_contexts
-            lockfile_policy,
+            input.lockfile_policy,
         )
         .await
         .map_err(|e| format!("feature resolution failed: {e}"))

--- a/crates/cella-compose/src/orchestrate.rs
+++ b/crates/cella-compose/src/orchestrate.rs
@@ -564,11 +564,16 @@ async fn prepare_and_start(
     // 6. Resolve features via combined-Dockerfile approach (if features configured)
     let features_build = crate::combined_dockerfile_build::resolve_compose_features(
         client,
-        config,
-        cfg.config_path,
-        project,
-        cfg.omit_remote_env_from_metadata,
-        cfg.lockfile_policy,
+        &crate::combined_dockerfile_build::ResolveComposeFeaturesInput {
+            config,
+            config_path: cfg.config_path,
+            project,
+            omit_remote_env_from_metadata: cfg.omit_remote_env_from_metadata,
+            // --skip-persisting-customizations-from-features is a build-only flag;
+            // compose up always persists feature customizations.
+            omit_feature_customizations_from_metadata: false,
+            lockfile_policy: cfg.lockfile_policy,
+        },
         progress,
     )
     .await?;
@@ -1573,7 +1578,18 @@ fn compose_metadata_label(
     omit_remote_env: bool,
 ) -> String {
     features_metadata_label.map_or_else(
-        || cella_features::generate_metadata_label(&[], config, base_metadata, omit_remote_env),
+        || {
+            cella_features::generate_metadata_label(
+                &[],
+                config,
+                base_metadata,
+                cella_features::MetadataOmit {
+                    remote_env: omit_remote_env,
+                    // compose up never strips feature customizations (build-only flag).
+                    feature_customizations: false,
+                },
+            )
+        },
         ToString::to_string,
     )
 }

--- a/crates/cella-features/src/lib.rs
+++ b/crates/cella-features/src/lib.rs
@@ -78,8 +78,11 @@ use tracing::{debug, warn};
 /// Controls which keys are omitted from the generated `devcontainer.metadata`
 /// image label.
 ///
-/// Each field corresponds to one CLI flag. `Default` yields full output
-/// (nothing omitted). Adding a new axis is a non-breaking, additive change.
+/// Each field corresponds to one CLI flag; `Default` yields full output
+/// (nothing omitted). New omit axes are added as fields — a struct-literal
+/// change that the in-workspace constructors are updated for together (this is a
+/// `pub` struct, so a new field is not source-compatible for outside callers,
+/// but cella keeps all callers in-tree).
 #[derive(Clone, Copy, Default)]
 pub struct MetadataOmit {
     /// `--omit-config-remote-env-from-metadata`: strip `remoteEnv` from the

--- a/crates/cella-features/src/lib.rs
+++ b/crates/cella-features/src/lib.rs
@@ -75,6 +75,23 @@ use tracing::{debug, warn};
 // Internal intermediate type for parsed feature entries
 // ---------------------------------------------------------------------------
 
+/// Controls which keys are omitted from the generated `devcontainer.metadata`
+/// image label.
+///
+/// Each field corresponds to one CLI flag. `Default` yields full output
+/// (nothing omitted). Adding a new axis is a non-breaking, additive change.
+#[derive(Clone, Copy, Default)]
+pub struct MetadataOmit {
+    /// `--omit-config-remote-env-from-metadata`: strip `remoteEnv` from the
+    /// user-config entry so host-specific or secret values are not persisted.
+    /// Wired on `up` only; `build` leaves this false.
+    pub remote_env: bool,
+    /// `--skip-persisting-customizations-from-features`: strip `customizations`
+    /// from per-feature entries only (not the user-config entry).
+    /// Wired on `build` only; `up` leaves this false.
+    pub feature_customizations: bool,
+}
+
 /// Context about the base image for feature resolution.
 pub struct BaseImageContext<'a> {
     /// The base image reference (e.g., stage name or `ubuntu:22.04`).
@@ -83,9 +100,8 @@ pub struct BaseImageContext<'a> {
     pub image_user: &'a str,
     /// `devcontainer.metadata` label from the base image, if available.
     pub metadata: Option<&'a str>,
-    /// `--omit-config-remote-env-from-metadata`: strip `remoteEnv` from the
-    /// user-config entry of the generated `devcontainer.metadata` label.
-    pub omit_remote_env: bool,
+    /// Which keys to omit from the generated `devcontainer.metadata` label.
+    pub omit: MetadataOmit,
 }
 
 /// OCI digest metadata captured for a feature so it can be pinned in the
@@ -163,7 +179,7 @@ pub async fn resolve_features(
                 config,
                 cache,
                 base_image_ctx.metadata,
-                base_image_ctx.omit_remote_env,
+                base_image_ctx.omit,
             );
         }
     };
@@ -236,7 +252,7 @@ pub async fn resolve_features(
         &resolved,
         config,
         base_image_ctx.metadata,
-        base_image_ctx.omit_remote_env,
+        base_image_ctx.omit,
     );
 
     debug!(
@@ -267,18 +283,21 @@ pub async fn resolve_features(
 ///   mounts, customizations, and lifecycle commands).
 /// - The last element is the user's `devcontainer.json` properties.
 ///
-/// When `omit_remote_env` is set (the `--omit-config-remote-env-from-metadata`
-/// flag), the `remoteEnv` key is stripped from the user-config entry so that
-/// host-specific or secret remote-env values are not persisted into the image
-/// label. This mirrors the official CLI, which removes `remoteEnv` from the
-/// `pickConfigProperties` whitelist when the flag is set. It affects ONLY the
-/// `devcontainer.metadata` label, never the runtime `dev.cella.remote_env`
-/// label used to re-inject env across restarts.
+/// `omit` controls selective key removal:
+/// - `omit.remote_env` (`--omit-config-remote-env-from-metadata`): strips
+///   `remoteEnv` from the user-config entry so host-specific or secret values
+///   are not persisted. Mirrors the official CLI's `pickConfigProperties`
+///   whitelist exclusion. Affects ONLY the user-config entry, never the
+///   runtime `dev.cella.remote_env` label.
+/// - `omit.feature_customizations` (`--skip-persisting-customizations-from-features`):
+///   strips `customizations` from per-feature entries only (not the
+///   user-config entry). Mirrors the official CLI's
+///   `skipFeaturesCustomizationsKindMetadata` flag.
 pub fn generate_metadata_label(
     features: &[ResolvedFeature],
     user_config: &serde_json::Value,
     base_image_metadata: Option<&str>,
-    omit_remote_env: bool,
+    omit: MetadataOmit,
 ) -> String {
     let mut entries: Vec<serde_json::Value> = Vec::new();
 
@@ -294,11 +313,14 @@ pub fn generate_metadata_label(
 
     // One entry per feature.
     for feature in features {
-        entries.push(build_feature_metadata_entry(feature));
+        entries.push(build_feature_metadata_entry(
+            feature,
+            omit.feature_customizations,
+        ));
     }
 
     // Last element: user config properties. Optionally strip `remoteEnv`.
-    let user_entry = if omit_remote_env {
+    let user_entry = if omit.remote_env {
         let mut stripped = user_config.clone();
         if let Some(obj) = stripped.as_object_mut() {
             obj.remove("remoteEnv");
@@ -321,7 +343,7 @@ fn resolve_empty_features(
     config: &serde_json::Value,
     cache: &FeatureCache,
     base_image_metadata: Option<&str>,
-    omit_remote_env: bool,
+    omit: MetadataOmit,
 ) -> Result<ResolvedFeatures, FeatureError> {
     debug!("no features declared in devcontainer.json");
     let build_context = cache.build_context_path("empty");
@@ -337,7 +359,7 @@ fn resolve_empty_features(
         dockerfile: String::new(),
         build_context,
         container_config,
-        metadata_label: generate_metadata_label(&[], config, base_image_metadata, omit_remote_env),
+        metadata_label: generate_metadata_label(&[], config, base_image_metadata, omit),
         lockfile: None,
     })
 }
@@ -1061,7 +1083,14 @@ async fn expand_depends_on(
 // ---------------------------------------------------------------------------
 
 /// Build a single metadata label entry for a resolved feature.
-fn build_feature_metadata_entry(feature: &ResolvedFeature) -> serde_json::Value {
+///
+/// When `omit_customizations` is `true` (the
+/// `--skip-persisting-customizations-from-features` flag), the `customizations`
+/// key is excluded from the entry. All other fields are unaffected.
+fn build_feature_metadata_entry(
+    feature: &ResolvedFeature,
+    omit_customizations: bool,
+) -> serde_json::Value {
     let mut entry = serde_json::Map::new();
     entry.insert("id".into(), serde_json::json!(feature.id));
 
@@ -1080,7 +1109,7 @@ fn build_feature_metadata_entry(feature: &ResolvedFeature) -> serde_json::Value 
         entry.insert("mounts".into(), serde_json::json!(feature.metadata.mounts));
     }
 
-    if let Some(cust) = &feature.metadata.customizations {
+    if !omit_customizations && let Some(cust) = &feature.metadata.customizations {
         entry.insert("customizations".into(), cust.clone());
     }
 
@@ -1185,7 +1214,12 @@ mod tests {
 
     #[test]
     fn metadata_label_empty_features() {
-        let label = generate_metadata_label(&[], &json!({"image": "ubuntu"}), None, false);
+        let label = generate_metadata_label(
+            &[],
+            &json!({"image": "ubuntu"}),
+            None,
+            MetadataOmit::default(),
+        );
         let parsed: serde_json::Value = serde_json::from_str(&label).unwrap();
         let arr = parsed.as_array().unwrap();
         assert_eq!(arr.len(), 1);
@@ -1208,7 +1242,7 @@ mod tests {
             has_install_script: true,
         }];
 
-        let label = generate_metadata_label(&features, &json!({}), None, false);
+        let label = generate_metadata_label(&features, &json!({}), None, MetadataOmit::default());
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&label).unwrap();
 
         assert_eq!(parsed.len(), 2);
@@ -1220,7 +1254,8 @@ mod tests {
     #[test]
     fn metadata_label_with_base_image_metadata() {
         let base_meta = r#"[{"id":"base","containerEnv":{"LANG":"C.UTF-8"}}]"#;
-        let label = generate_metadata_label(&[], &json!({}), Some(base_meta), false);
+        let label =
+            generate_metadata_label(&[], &json!({}), Some(base_meta), MetadataOmit::default());
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&label).unwrap();
 
         // base entry + user config entry
@@ -1231,7 +1266,8 @@ mod tests {
     #[test]
     fn metadata_label_base_image_non_array() {
         let base_meta = r#"{"id":"single"}"#;
-        let label = generate_metadata_label(&[], &json!({}), Some(base_meta), false);
+        let label =
+            generate_metadata_label(&[], &json!({}), Some(base_meta), MetadataOmit::default());
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&label).unwrap();
 
         assert_eq!(parsed.len(), 2);
@@ -1246,8 +1282,16 @@ mod tests {
             "remoteUser": "vscode",
         });
 
-        // omit=true strips remoteEnv from the user-config entry...
-        let omitted = generate_metadata_label(&[], &config, None, true);
+        // remote_env=true strips remoteEnv from the user-config entry...
+        let omitted = generate_metadata_label(
+            &[],
+            &config,
+            None,
+            MetadataOmit {
+                remote_env: true,
+                ..Default::default()
+            },
+        );
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&omitted).unwrap();
         let entry = parsed.last().unwrap();
         assert!(entry.get("remoteEnv").is_none());
@@ -1255,8 +1299,8 @@ mod tests {
         assert_eq!(entry["remoteUser"], "vscode");
         assert_eq!(entry["image"], "ubuntu");
 
-        // omit=false retains remoteEnv.
-        let kept = generate_metadata_label(&[], &config, None, false);
+        // default (omit nothing) retains remoteEnv.
+        let kept = generate_metadata_label(&[], &config, None, MetadataOmit::default());
         let parsed_kept: Vec<serde_json::Value> = serde_json::from_str(&kept).unwrap();
         assert_eq!(parsed_kept.last().unwrap()["remoteEnv"]["SECRET"], "value");
     }
@@ -1265,10 +1309,71 @@ mod tests {
     fn metadata_label_omit_remote_env_is_noop_without_key() {
         // A config that has no remoteEnv must not panic and must be unchanged.
         let config = json!({"image": "ubuntu"});
-        let label = generate_metadata_label(&[], &config, None, true);
+        let label = generate_metadata_label(
+            &[],
+            &config,
+            None,
+            MetadataOmit {
+                remote_env: true,
+                ..Default::default()
+            },
+        );
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&label).unwrap();
         assert_eq!(parsed.last().unwrap()["image"], "ubuntu");
         assert!(parsed.last().unwrap().get("remoteEnv").is_none());
+    }
+
+    #[test]
+    fn metadata_label_omits_feature_customizations_when_requested() {
+        let features = vec![ResolvedFeature {
+            id: "python".to_string(),
+            original_ref: "ghcr.io/devcontainers/features/python:1".to_string(),
+            metadata: FeatureMetadata {
+                id: "python".to_string(),
+                customizations: Some(json!({"vscode": {"extensions": ["ms-python.python"]}})),
+                entrypoint: Some("/init.sh".to_string()),
+                ..Default::default()
+            },
+            user_options: HashMap::new(),
+            artifact_dir: PathBuf::from("/tmp/features/python"),
+            has_install_script: true,
+        }];
+        let user_config = json!({
+            "image": "ubuntu",
+            "customizations": {"vscode": {"extensions": ["user.ext"]}},
+        });
+
+        // flag on: feature entry drops customizations; user-config entry keeps them.
+        let omit = MetadataOmit {
+            feature_customizations: true,
+            ..Default::default()
+        };
+        let label = generate_metadata_label(&features, &user_config, None, omit);
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(&label).unwrap();
+        // [feature_entry, user_config_entry]
+        assert_eq!(parsed.len(), 2);
+        let feature_entry = &parsed[0];
+        let user_entry = &parsed[1];
+        assert!(
+            feature_entry.get("customizations").is_none(),
+            "feature customizations must be absent when flag is set"
+        );
+        assert_eq!(feature_entry["id"], "python");
+        assert_eq!(feature_entry["entrypoint"], "/init.sh");
+        // user-config customizations must be untouched.
+        assert!(
+            user_entry.get("customizations").is_some(),
+            "user-config customizations must be retained"
+        );
+
+        // flag off: both present.
+        let label_full =
+            generate_metadata_label(&features, &user_config, None, MetadataOmit::default());
+        let parsed_full: Vec<serde_json::Value> = serde_json::from_str(&label_full).unwrap();
+        assert!(
+            parsed_full[0].get("customizations").is_some(),
+            "feature customizations must be present when flag is not set"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -1375,7 +1480,7 @@ mod tests {
                 base_image: "ubuntu:22.04",
                 image_user: "root",
                 metadata: None,
-                omit_remote_env: false,
+                omit: MetadataOmit::default(),
             },
             false,
             LockfilePolicy::NoLockfile,
@@ -1405,7 +1510,7 @@ mod tests {
                 base_image: "ubuntu:22.04",
                 image_user: "root",
                 metadata: None,
-                omit_remote_env: false,
+                omit: MetadataOmit::default(),
             },
             false,
             LockfilePolicy::NoLockfile,
@@ -1459,7 +1564,7 @@ mod tests {
                 base_image: "ubuntu:22.04",
                 image_user: "root",
                 metadata: None,
-                omit_remote_env: false,
+                omit: MetadataOmit::default(),
             },
             false,
             LockfilePolicy::NoLockfile,
@@ -1576,7 +1681,7 @@ mod tests {
                 base_image: "ubuntu:22.04",
                 image_user: "root",
                 metadata: None,
-                omit_remote_env: false,
+                omit: MetadataOmit::default(),
             },
             false,
             LockfilePolicy::NoLockfile,
@@ -1642,7 +1747,7 @@ mod tests {
                 base_image: "ubuntu:22.04",
                 image_user: "root",
                 metadata: None,
-                omit_remote_env: false,
+                omit: MetadataOmit::default(),
             },
             false,
             LockfilePolicy::NoLockfile,
@@ -1687,7 +1792,7 @@ mod tests {
                 base_image: "ubuntu:22.04",
                 image_user: "root",
                 metadata: None,
-                omit_remote_env: false,
+                omit: MetadataOmit::default(),
             },
             false,
             LockfilePolicy::NoLockfile,
@@ -1732,7 +1837,7 @@ mod tests {
                 base_image: "mcr.microsoft.com/devcontainers/base:ubuntu",
                 image_user: "root",
                 metadata: None,
-                omit_remote_env: false,
+                omit: MetadataOmit::default(),
             },
             false,
             LockfilePolicy::NoLockfile,
@@ -1866,7 +1971,7 @@ mod tests {
                 base_image: "ubuntu:22.04",
                 image_user: "root",
                 metadata: None,
-                omit_remote_env: false,
+                omit: MetadataOmit::default(),
             },
             false,
             LockfilePolicy::NoLockfile,
@@ -1955,7 +2060,7 @@ mod tests {
                 base_image: "ubuntu:22.04",
                 image_user: "root",
                 metadata: None,
-                omit_remote_env: false,
+                omit: MetadataOmit::default(),
             },
             false,
             LockfilePolicy::NoLockfile,
@@ -2022,7 +2127,7 @@ mod tests {
                 base_image: "ubuntu:22.04",
                 image_user: "root",
                 metadata: None,
-                omit_remote_env: false,
+                omit: MetadataOmit::default(),
             },
             false,
             LockfilePolicy::NoLockfile,
@@ -2086,7 +2191,7 @@ mod tests {
                 base_image: "ubuntu:22.04",
                 image_user: "root",
                 metadata: None,
-                omit_remote_env: false,
+                omit: MetadataOmit::default(),
             },
             false,
             LockfilePolicy::NoLockfile,
@@ -2163,7 +2268,7 @@ mod tests {
                 base_image: "ubuntu:22.04",
                 image_user: "root",
                 metadata: None,
-                omit_remote_env: false,
+                omit: MetadataOmit::default(),
             },
             false,
             LockfilePolicy::NoLockfile,
@@ -2227,7 +2332,7 @@ mod tests {
                 base_image: "ubuntu:22.04",
                 image_user: "root",
                 metadata: None,
-                omit_remote_env: false,
+                omit: MetadataOmit::default(),
             },
             false,
             LockfilePolicy::NoLockfile,

--- a/crates/cella-orchestrator/src/image.rs
+++ b/crates/cella-orchestrator/src/image.rs
@@ -147,6 +147,9 @@ pub struct EnsureImageInput<'a> {
     /// `--omit-config-remote-env-from-metadata`: strip `remoteEnv` from the
     /// generated `devcontainer.metadata` label baked into the built image.
     pub omit_remote_env_from_metadata: bool,
+    /// `--skip-persisting-customizations-from-features`: strip `customizations`
+    /// from per-feature entries in the generated `devcontainer.metadata` label.
+    pub omit_feature_customizations_from_metadata: bool,
     /// Lockfile policy for feature resolution.
     pub lockfile_policy: cella_features::LockfilePolicy,
     pub progress: &'a ProgressSender,
@@ -259,6 +262,7 @@ pub async fn ensure_image(
         output: input.output,
         labels: input.labels,
         omit_remote_env_from_metadata: input.omit_remote_env_from_metadata,
+        omit_feature_customizations_from_metadata: input.omit_feature_customizations_from_metadata,
         lockfile_policy: input.lockfile_policy,
         progress: input.progress,
     };
@@ -380,7 +384,13 @@ async fn resolve_base_image(
                 &[],
                 input.config,
                 None,
-                input.omit_remote_env_from_metadata,
+                cella_features::MetadataOmit {
+                    remote_env: input.omit_remote_env_from_metadata,
+                    // --skip-persisting-customizations-from-features is a no-op
+                    // here: there are no features, so no feature entries exist
+                    // to strip customizations from.
+                    feature_customizations: input.omit_feature_customizations_from_metadata,
+                },
             );
             build_opts
                 .options
@@ -430,6 +440,7 @@ struct FeaturesBuildInput<'a> {
     /// present). Threaded straight through from [`EnsureImageInput::labels`].
     labels: &'a [String],
     omit_remote_env_from_metadata: bool,
+    omit_feature_customizations_from_metadata: bool,
     lockfile_policy: cella_features::LockfilePolicy,
     progress: &'a ProgressSender,
 }
@@ -481,7 +492,10 @@ async fn resolve_and_build_features(
             base_image: input.base_image_tag,
             image_user: &input.base_image_details.user,
             metadata: input.base_image_details.metadata.as_deref(),
-            omit_remote_env: input.omit_remote_env_from_metadata,
+            omit: cella_features::MetadataOmit {
+                remote_env: input.omit_remote_env_from_metadata,
+                feature_customizations: input.omit_feature_customizations_from_metadata,
+            },
         },
         false, // non-compose: build context IS the features dir, bare COPY works
         input.lockfile_policy,

--- a/crates/cella-orchestrator/src/image.rs
+++ b/crates/cella-orchestrator/src/image.rs
@@ -58,6 +58,17 @@ pub async fn build_features_layer(
     if ctx.no_cache {
         options.push("--no-cache".to_string());
     }
+    // Bake the merged `devcontainer.metadata` label onto the features layer (the
+    // final image when features are present), mirroring the no-features build
+    // path and the official CLI (which emits it via the generated Dockerfile).
+    // Without this the built image carries no metadata for `docker inspect` /
+    // downstream `up`, and the `--skip-persisting-customizations-from-features`
+    // and `--omit-config-remote-env-from-metadata` omits would have no effect on
+    // this path.
+    options.push(format!(
+        "--label=devcontainer.metadata={}",
+        ctx.resolved.metadata_label
+    ));
 
     let mut args = HashMap::new();
     args.insert(

--- a/crates/cella-orchestrator/src/up.rs
+++ b/crates/cella-orchestrator/src/up.rs
@@ -1013,7 +1013,11 @@ impl EnsureUpContext<'_> {
                     &[],
                     config,
                     None,
-                    self.config.metadata_options.omit_remote_env,
+                    cella_features::MetadataOmit {
+                        remote_env: self.config.metadata_options.omit_remote_env,
+                        // up never strips feature customizations.
+                        feature_customizations: false,
+                    },
                 ),
             );
         }
@@ -1946,6 +1950,9 @@ impl EnsureUpContext<'_> {
                 // flag (the container picks up config via the metadata label).
                 labels: &[],
                 omit_remote_env_from_metadata: self.config.metadata_options.omit_remote_env,
+                // --skip-persisting-customizations-from-features is a build-only
+                // flag; up always persists feature customizations.
+                omit_feature_customizations_from_metadata: false,
                 lockfile_policy: self.config.lockfile_policy,
                 progress: &self.progress,
             })


### PR DESCRIPTION
## What

Adds the official hidden `devcontainer build` flag `--skip-persisting-customizations-from-features`. When set, feature `customizations` are not baked into the image's `devcontainer.metadata` label — matching the official CLI, which adds `customizations` to `omitPropertyOverride` and drops it from each per-feature metadata entry (`containerFeatures.ts` → `getDevcontainerMetadata`).

Until now cella accepted no such flag and always persisted feature customizations.

## How

- `cella-features`: replaced `generate_metadata_label`'s bare `omit_remote_env: bool` with a `MetadataOmit { remote_env, feature_customizations }` struct (Default-derived). This mirrors the official's two omit axes — `remote_env` strips `remoteEnv` from the user-config entry (the existing `--omit-config-remote-env-from-metadata`, unchanged), `feature_customizations` strips `customizations` from per-feature entries only. `build_feature_metadata_entry` skips the `customizations` insert when set; nothing else changes.
- Threaded the new axis through `EnsureImageInput`/`FeaturesBuildInput` (orchestrator) and the compose build config, so it reaches both the single-container and compose build metadata-label sites. The `up` path passes `false` (this is a build-only flag); `compose up`'s no-features metadata label likewise stays `false`.
- `cella build` gets the hidden flag, wired into both build paths.

## Tests

- `generate_metadata_label` with a feature that declares `customizations`: with the omit set the feature entry has no `customizations` (and the user-config entry is untouched); without it, present.
- clap parse + default-false tests for the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
