### PR TITLE
feat(read-configuration): implement --include-features-configuration

### DIFF
--- a/crates/cella-cli/src/commands/features_configuration.rs
+++ b/crates/cella-cli/src/commands/features_configuration.rs
@@ -177,7 +177,7 @@ pub fn build(rf: &ResolvedFeatures) -> Result<Option<FeaturesConfiguration>, ser
         .features
         .iter()
         .enumerate()
-        .map(|(idx, f)| feature_set(f, idx, &dst_folder))
+        .map(|(idx, f)| feature_set(f, idx))
         .collect::<Result<Vec<_>, _>>()?;
     Ok(Some(FeaturesConfiguration {
         feature_sets,
@@ -185,14 +185,10 @@ pub fn build(rf: &ResolvedFeatures) -> Result<Option<FeaturesConfiguration>, ser
     }))
 }
 
-fn feature_set(
-    f: &ResolvedFeature,
-    idx: usize,
-    dst_folder: &str,
-) -> Result<FeatureSetOut, serde_json::Error> {
+fn feature_set(f: &ResolvedFeature, idx: usize) -> Result<FeatureSetOut, serde_json::Error> {
     Ok(FeatureSetOut {
         source_information: source_information(f)?,
-        features: vec![feature_out(f, idx, dst_folder)],
+        features: vec![feature_out(f, idx)],
     })
 }
 
@@ -207,7 +203,14 @@ fn source_information(f: &ResolvedFeature) -> Result<SourceInformationOut, serde
             // contract violation, so callers should see the failure.
             manifest: serde_json::to_value(&oci.manifest)?,
             manifest_digest: oci.digest.clone(),
-            feature_ref: parse_feature_ref(&f.original_ref),
+            // featureRef comes from the normalized/fetched coordinates, not the
+            // raw user ref: aliases (e.g. `maven` → java) resolve to a different
+            // registry/repo, and the official builds featureRef from the fetched
+            // identifier while `userFeatureId` keeps the original.
+            feature_ref: parse_feature_ref(&format!(
+                "{}/{}:{}",
+                oci.registry, oci.repository, oci.version
+            )),
             user_feature_id,
             user_feature_id_without_version,
         })),
@@ -224,7 +227,7 @@ fn source_information(f: &ResolvedFeature) -> Result<SourceInformationOut, serde
     })
 }
 
-fn feature_out(f: &ResolvedFeature, idx: usize, dst_folder: &str) -> FeatureOut {
+fn feature_out(f: &ResolvedFeature, idx: usize) -> FeatureOut {
     let m = &f.metadata;
     let consecutive_id = format!("{}_{}", f.id, idx);
     // Deterministic key order for `value` (the official preserves the
@@ -236,14 +239,11 @@ fn feature_out(f: &ResolvedFeature, idx: usize, dst_folder: &str) -> FeatureOut 
         id: f.id.clone(),
         included: true,
         value,
-        // Join with the platform separator (matches the official's
-        // path.join(dstFolder, consecutiveId)) rather than a hard-coded `/`.
-        cache_path: Some(
-            std::path::Path::new(dst_folder)
-                .join(&consecutive_id)
-                .to_string_lossy()
-                .into_owned(),
-        ),
+        // Point at cella's real cached feature directory — the only path
+        // guaranteed to exist for `read-configuration` (the official's
+        // dstFolder/consecutiveId is a build-time staging copy cella creates
+        // elsewhere).
+        cache_path: Some(f.artifact_dir.to_string_lossy().into_owned()),
         consecutive_id,
         version: non_empty(&m.version),
         name: m.name.clone(),
@@ -257,11 +257,7 @@ fn feature_out(f: &ResolvedFeature, idx: usize, dst_folder: &str) -> FeatureOut 
         installs_after: m.installs_after.clone(),
         legacy_ids: m.legacy_ids.clone(),
         customizations: m.customizations.clone(),
-        mounts: m
-            .mounts
-            .iter()
-            .map(|s| serde_json::Value::String(s.clone()))
-            .collect(),
+        mounts: m.mounts.iter().map(|s| parse_mount_spec(s)).collect(),
         init: m.init,
         privileged: m.privileged,
         cap_add: m.cap_add.clone(),
@@ -376,6 +372,33 @@ fn non_empty(s: &str) -> Option<String> {
     (!s.is_empty()).then(|| s.to_string())
 }
 
+/// Parse a docker mount-spec string (`type=…,source=…,target=…`) — the form
+/// cella's metadata parser flattens feature mounts into — back into the
+/// official object shape (`{type, source?, target}`). Feature mounts are
+/// object-only per the spec, so a string here would be the wrong type. Empty
+/// values are dropped; `src`/`dst` normalise to `source`/`target`.
+fn parse_mount_spec(spec: &str) -> serde_json::Value {
+    let mut obj = serde_json::Map::new();
+    for part in spec.split(',') {
+        let Some((key, value)) = part.split_once('=') else {
+            continue;
+        };
+        if value.is_empty() {
+            continue;
+        }
+        let key = match key.trim() {
+            "src" => "source",
+            "dst" => "target",
+            other => other,
+        };
+        obj.insert(
+            key.to_string(),
+            serde_json::Value::String(value.to_string()),
+        );
+    }
+    serde_json::Value::Object(obj)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -388,6 +411,9 @@ mod tests {
         // Build the typed manifest via deserialization so the test needs no
         // direct oci_distribution dependency (the field type is inferred).
         ResolvedOciManifest {
+            registry: "ghcr.io".to_string(),
+            repository: "devcontainers/features/node".to_string(),
+            version: "1".to_string(),
             digest: "sha256:manifestdigest".to_string(),
             manifest: serde_json::from_value(serde_json::json!({
                 "schemaVersion": 2,
@@ -498,7 +524,7 @@ mod tests {
         assert_eq!(feat["included"], true);
         assert_eq!(feat["value"], serde_json::json!({"version": "20"}));
         assert_eq!(feat["consecutiveId"], "node_0");
-        assert_eq!(feat["cachePath"], "/tmp/cella-features/node_0");
+        assert_eq!(feat["cachePath"], "/cache/node");
         assert_eq!(feat["version"], "1.3.0");
         assert_eq!(feat["name"], "Node.js");
         assert_eq!(feat["containerEnv"]["NVM_DIR"], "/usr/local/nvm");
@@ -526,6 +552,56 @@ mod tests {
         assert_eq!(si["type"], "file-path");
         assert_eq!(si["userFeatureId"], "./my-feature");
         assert!(si.get("manifest").is_none(), "non-OCI has no manifest");
+    }
+
+    #[test]
+    fn featureref_uses_normalized_coords_not_raw_alias() {
+        // A deprecated alias (`maven`) resolves to a different registry/repo;
+        // featureRef must reflect the fetched target, userFeatureId the alias.
+        let mut f = oci_feature();
+        f.id = "java".to_string();
+        f.original_ref = "maven".to_string();
+        f.oci = Some(ResolvedOciManifest {
+            registry: "ghcr.io".to_string(),
+            repository: "devcontainers/features/java".to_string(),
+            version: "1".to_string(),
+            digest: "sha256:javadigest".to_string(),
+            manifest: manifest().manifest,
+        });
+        let fc = build(&resolved(vec![f]))
+            .unwrap()
+            .expect("features present");
+        let v = serde_json::to_value(&fc).unwrap();
+        let si = &v["featureSets"][0]["sourceInformation"];
+        assert_eq!(si["userFeatureId"], "maven");
+        assert_eq!(si["userFeatureIdWithoutVersion"], "maven");
+        let fr = &si["featureRef"];
+        assert_eq!(fr["id"], "java");
+        assert_eq!(fr["resource"], "ghcr.io/devcontainers/features/java");
+        assert_eq!(fr["registry"], "ghcr.io");
+    }
+
+    #[test]
+    fn feature_mounts_emit_as_objects() {
+        let mut f = oci_feature();
+        f.metadata.mounts =
+            vec!["type=volume,source=node-modules,target=/usr/local/lib".to_string()];
+        let fc = build(&resolved(vec![f]))
+            .unwrap()
+            .expect("features present");
+        let v = serde_json::to_value(&fc).unwrap();
+        let mount = &v["featureSets"][0]["features"][0]["mounts"][0];
+        assert_eq!(mount["type"], "volume");
+        assert_eq!(mount["source"], "node-modules");
+        assert_eq!(mount["target"], "/usr/local/lib");
+    }
+
+    #[test]
+    fn parse_mount_spec_omits_empty_source() {
+        let m = parse_mount_spec("type=volume,source=,target=/data");
+        assert_eq!(m["type"], "volume");
+        assert_eq!(m["target"], "/data");
+        assert!(m.get("source").is_none(), "empty source must be omitted");
     }
 
     #[test]

--- a/crates/cella-cli/src/commands/features_configuration.rs
+++ b/crates/cella-cli/src/commands/features_configuration.rs
@@ -1,0 +1,541 @@
+//! Builds the `featuresConfiguration` value for `read-configuration`.
+//!
+//! Mirrors the raw `FeaturesConfig` object the official devcontainers/cli
+//! stringifies under the `featuresConfiguration` key: `{ featureSets[], dstFolder }`,
+//! with `featureSets` in install order. The shape, `featureRef` decomposition
+//! (`getRef`) and the empty-features behaviour (omit the key) are taken from
+//! devcontainers/cli `src/spec-configuration/{containerFeaturesConfiguration,
+//! containerCollectionsOCI,containerFeaturesOCI}.ts`.
+//!
+//! Known divergences (host-/registry-specific, not byte-matchable):
+//! - `dstFolder` and `features[].cachePath` are cella's real cache/build paths,
+//!   not the official's per-invocation temp folder.
+//! - `features[].value` is derived from the parsed options map, so the rare
+//!   string/boolean shorthand (`"feature": "latest"`) emits `{}` (the object
+//!   form is exact).
+//! - the embedded `manifest` is re-serialised from the typed manifest, so its
+//!   JSON key order may differ from the registry's original bytes.
+
+use std::collections::{BTreeMap, HashMap};
+
+use cella_features::types::{FeatureOption, OptionType, ResolvedFeature, ResolvedFeatures};
+use serde::Serialize;
+
+/// The `featuresConfiguration` value: `{ featureSets[], dstFolder }`.
+#[derive(Debug, Serialize)]
+pub struct FeaturesConfiguration {
+    #[serde(rename = "featureSets")]
+    feature_sets: Vec<FeatureSetOut>,
+    #[serde(rename = "dstFolder")]
+    dst_folder: String,
+}
+
+#[derive(Debug, Serialize)]
+struct FeatureSetOut {
+    #[serde(rename = "sourceInformation")]
+    source_information: SourceInformationOut,
+    features: Vec<FeatureOut>,
+}
+
+/// Per-source provenance. OCI features carry the full `featureRef` + manifest;
+/// non-OCI features carry the shared base info with a classified `type`.
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "kebab-case")]
+enum SourceInformationOut {
+    // Boxed: the OCI variant (manifest + featureRef) dwarfs the others.
+    Oci(Box<OciSourceInformationOut>),
+    DirectTarball(BaseSourceInfo),
+    FilePath(BaseSourceInfo),
+}
+
+#[derive(Debug, Serialize)]
+struct OciSourceInformationOut {
+    manifest: serde_json::Value,
+    #[serde(rename = "manifestDigest")]
+    manifest_digest: String,
+    #[serde(rename = "featureRef")]
+    feature_ref: FeatureRefOut,
+    #[serde(rename = "userFeatureId")]
+    user_feature_id: String,
+    #[serde(rename = "userFeatureIdWithoutVersion")]
+    user_feature_id_without_version: String,
+}
+
+/// Shared `BaseSourceInformation` for non-OCI sources (local path / tarball).
+#[derive(Debug, Serialize)]
+struct BaseSourceInfo {
+    #[serde(rename = "userFeatureId")]
+    user_feature_id: String,
+    #[serde(rename = "userFeatureIdWithoutVersion")]
+    user_feature_id_without_version: String,
+}
+
+/// The parsed OCI reference (`getRef`).
+#[derive(Debug, Serialize)]
+struct FeatureRefOut {
+    registry: String,
+    owner: String,
+    namespace: String,
+    path: String,
+    resource: String,
+    id: String,
+    version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tag: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    digest: Option<String>,
+}
+
+/// A single feature entry (`featureSets[].features[0]`): the internal fields
+/// (`id`/`included`/`value`/`consecutiveId`/`cachePath`) plus the published
+/// `devcontainer-feature.json` metadata. `undefined`/empty fields are omitted.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FeatureOut {
+    id: String,
+    included: bool,
+    value: serde_json::Value,
+    consecutive_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cache_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    options: BTreeMap<String, FeatureOptionOut>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    container_env: BTreeMap<String, String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    installs_after: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    legacy_ids: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    customizations: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    mounts: Vec<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    init: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    privileged: Option<bool>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    cap_add: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    security_opt: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    entrypoint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    deprecated: Option<bool>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    depends_on: BTreeMap<String, serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    on_create_command: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    update_content_command: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    post_create_command: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    post_start_command: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    post_attach_command: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize)]
+struct FeatureOptionOut {
+    #[serde(rename = "type")]
+    option_type: &'static str,
+    default: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(rename = "enum", skip_serializing_if = "Option::is_none")]
+    enum_values: Option<Vec<String>>,
+}
+
+/// Build the `featuresConfiguration` value, or `None` when no features are
+/// declared (the official omits the key entirely in that case).
+pub fn build(rf: &ResolvedFeatures) -> Option<FeaturesConfiguration> {
+    if rf.features.is_empty() {
+        return None;
+    }
+    let dst_folder = rf.build_context.to_string_lossy().into_owned();
+    let feature_sets = rf
+        .features
+        .iter()
+        .enumerate()
+        .map(|(idx, f)| feature_set(f, idx, &dst_folder))
+        .collect();
+    Some(FeaturesConfiguration {
+        feature_sets,
+        dst_folder,
+    })
+}
+
+fn feature_set(f: &ResolvedFeature, idx: usize, dst_folder: &str) -> FeatureSetOut {
+    FeatureSetOut {
+        source_information: source_information(f),
+        features: vec![feature_out(f, idx, dst_folder)],
+    }
+}
+
+fn source_information(f: &ResolvedFeature) -> SourceInformationOut {
+    let user_feature_id = f.original_ref.clone();
+    let user_feature_id_without_version = feature_id_without_version(&f.original_ref);
+
+    match &f.oci {
+        Some(oci) => SourceInformationOut::Oci(Box::new(OciSourceInformationOut {
+            manifest: serde_json::to_value(&oci.manifest).unwrap_or(serde_json::Value::Null),
+            manifest_digest: oci.digest.clone(),
+            feature_ref: parse_feature_ref(&f.original_ref),
+            user_feature_id,
+            user_feature_id_without_version,
+        })),
+        None if is_tarball(&f.original_ref) => {
+            SourceInformationOut::DirectTarball(BaseSourceInfo {
+                user_feature_id,
+                user_feature_id_without_version,
+            })
+        }
+        None => SourceInformationOut::FilePath(BaseSourceInfo {
+            user_feature_id,
+            user_feature_id_without_version,
+        }),
+    }
+}
+
+fn feature_out(f: &ResolvedFeature, idx: usize, dst_folder: &str) -> FeatureOut {
+    let m = &f.metadata;
+    let consecutive_id = format!("{}_{}", f.id, idx);
+    // Deterministic key order for `value` (the official preserves the
+    // devcontainer.json insertion order, which cella's option map drops).
+    let value = serde_json::to_value(f.user_options.iter().collect::<BTreeMap<_, _>>())
+        .unwrap_or_else(|_| serde_json::json!({}));
+
+    FeatureOut {
+        id: f.id.clone(),
+        included: true,
+        value,
+        cache_path: Some(format!("{dst_folder}/{consecutive_id}")),
+        consecutive_id,
+        version: non_empty(&m.version),
+        name: m.name.clone(),
+        description: m.description.clone(),
+        options: map_options(&m.options),
+        container_env: m
+            .container_env
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect(),
+        installs_after: m.installs_after.clone(),
+        legacy_ids: m.legacy_ids.clone(),
+        customizations: m.customizations.clone(),
+        mounts: m
+            .mounts
+            .iter()
+            .map(|s| serde_json::Value::String(s.clone()))
+            .collect(),
+        init: m.init,
+        privileged: m.privileged,
+        cap_add: m.cap_add.clone(),
+        security_opt: m.security_opt.clone(),
+        entrypoint: m.entrypoint.clone(),
+        deprecated: m.deprecated,
+        depends_on: m.depends_on.clone().into_iter().collect(),
+        on_create_command: m.on_create_command.clone(),
+        update_content_command: m.update_content_command.clone(),
+        post_create_command: m.post_create_command.clone(),
+        post_start_command: m.post_start_command.clone(),
+        post_attach_command: m.post_attach_command.clone(),
+    }
+}
+
+fn map_options(options: &HashMap<String, FeatureOption>) -> BTreeMap<String, FeatureOptionOut> {
+    options
+        .iter()
+        .map(|(k, o)| {
+            let option_type = match o.option_type {
+                OptionType::String => "string",
+                OptionType::Boolean => "boolean",
+            };
+            (
+                k.clone(),
+                FeatureOptionOut {
+                    option_type,
+                    default: o.default.clone(),
+                    description: o.description.clone(),
+                    enum_values: o.enum_values.clone(),
+                },
+            )
+        })
+        .collect()
+}
+
+/// Parse an OCI feature reference into its components, mirroring the official
+/// `getRef` (devcontainers/cli `containerCollectionsOCI.ts`). The version is
+/// taken from the digest (`@sha256:…`), else the tag (`:tag`), else `latest`.
+fn parse_feature_ref(input: &str) -> FeatureRefOut {
+    let lower = input.to_lowercase();
+    let last_at = lower.rfind('@');
+    let last_colon = lower.rfind(':');
+    let last_slash = lower.rfind('/');
+
+    // Split off the version: a digest (`@sha256:…`) wins, else a tag (`:tag`
+    // after the last slash, so not a registry port), else implicit `latest`.
+    let (resource, tag, digest) = match (
+        last_at,
+        last_colon.filter(|&c| last_slash.is_none_or(|s| c > s)),
+    ) {
+        (Some(at), _) => (
+            lower[..at].to_string(),
+            None,
+            Some(lower[at + 1..].to_string()),
+        ),
+        (None, Some(colon)) => (
+            lower[..colon].to_string(),
+            Some(lower[colon + 1..].to_string()),
+            None,
+        ),
+        (None, None) => (lower, Some("latest".to_string()), None),
+    };
+
+    let segments: Vec<&str> = resource.split('/').collect();
+    let registry = segments.first().copied().unwrap_or_default().to_string();
+    let id = segments.last().copied().unwrap_or_default().to_string();
+    let owner = segments.get(1).copied().unwrap_or_default().to_string();
+    let namespace = if segments.len() >= 2 {
+        segments[1..segments.len() - 1].join("/")
+    } else {
+        String::new()
+    };
+    let path = format!("{namespace}/{id}");
+    let version = digest
+        .as_deref()
+        .or(tag.as_deref())
+        .unwrap_or("latest")
+        .to_string();
+
+    FeatureRefOut {
+        registry,
+        owner,
+        namespace,
+        path,
+        resource,
+        id,
+        version,
+        tag,
+        digest,
+    }
+}
+
+/// Strip a trailing `:tag` or `@digest` from a feature id, mirroring the
+/// official `getFeatureIdWithoutVersion` regex `/[:@][^/]*$/` (the delimiter is
+/// the first `:`/`@` after the last `/`).
+fn feature_id_without_version(feature_id: &str) -> String {
+    let last_slash = feature_id.rfind('/').map_or(0, |i| i + 1);
+    feature_id[last_slash..].find(['@', ':']).map_or_else(
+        || feature_id.to_string(),
+        |rel| feature_id[..last_slash + rel].to_string(),
+    )
+}
+
+/// Classify a non-OCI reference: an `http(s)://` URL is a direct tarball,
+/// anything else (a relative/absolute path) is a local file path.
+fn is_tarball(reference: &str) -> bool {
+    reference.starts_with("http://") || reference.starts_with("https://")
+}
+
+fn non_empty(s: &str) -> Option<String> {
+    (!s.is_empty()).then(|| s.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cella_features::types::{
+        FeatureMetadata, ResolvedFeature, ResolvedFeatures, ResolvedOciManifest,
+    };
+    use std::path::PathBuf;
+
+    fn manifest() -> ResolvedOciManifest {
+        // Build the typed manifest via deserialization so the test needs no
+        // direct oci_distribution dependency (the field type is inferred).
+        ResolvedOciManifest {
+            digest: "sha256:manifestdigest".to_string(),
+            manifest: serde_json::from_value(serde_json::json!({
+                "schemaVersion": 2,
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "config": {
+                    "mediaType": "application/vnd.devcontainers",
+                    "digest": "sha256:configdigest",
+                    "size": 0
+                },
+                "layers": [{
+                    "mediaType": "application/vnd.devcontainers.layer.v1+tar",
+                    "digest": "sha256:layerdigest",
+                    "size": 1234,
+                    "annotations": { "org.opencontainers.image.title": "node.tgz" }
+                }]
+            }))
+            .expect("valid OCI manifest"),
+        }
+    }
+
+    fn oci_feature() -> ResolvedFeature {
+        ResolvedFeature {
+            id: "node".to_string(),
+            original_ref: "ghcr.io/devcontainers/features/node:1".to_string(),
+            metadata: FeatureMetadata {
+                id: "node".to_string(),
+                version: "1.3.0".to_string(),
+                name: Some("Node.js".to_string()),
+                container_env: HashMap::from([(
+                    "NVM_DIR".to_string(),
+                    "/usr/local/nvm".to_string(),
+                )]),
+                installs_after: vec!["ghcr.io/devcontainers/features/common-utils".to_string()],
+                customizations: Some(
+                    serde_json::json!({"vscode": {"extensions": ["dbaeumer.vscode-eslint"]}}),
+                ),
+                ..Default::default()
+            },
+            user_options: HashMap::from([(
+                "version".to_string(),
+                serde_json::Value::String("20".to_string()),
+            )]),
+            artifact_dir: PathBuf::from("/cache/node"),
+            has_install_script: true,
+            oci: Some(manifest()),
+        }
+    }
+
+    fn resolved(features: Vec<ResolvedFeature>) -> ResolvedFeatures {
+        ResolvedFeatures {
+            features,
+            dockerfile: String::new(),
+            build_context: PathBuf::from("/tmp/cella-features"),
+            container_config: cella_features::types::FeatureContainerConfig::default(),
+            metadata_label: String::new(),
+            lockfile: None,
+        }
+    }
+
+    #[test]
+    fn omits_when_no_features() {
+        assert!(build(&resolved(vec![])).is_none());
+    }
+
+    #[test]
+    fn oci_feature_full_shape() {
+        let fc = build(&resolved(vec![oci_feature()])).expect("features present");
+        let v = serde_json::to_value(&fc).unwrap();
+
+        assert_eq!(v["dstFolder"], "/tmp/cella-features");
+        let set = &v["featureSets"][0];
+
+        // sourceInformation (OCI).
+        let si = &set["sourceInformation"];
+        assert_eq!(si["type"], "oci");
+        assert_eq!(si["manifestDigest"], "sha256:manifestdigest");
+        assert_eq!(si["userFeatureId"], "ghcr.io/devcontainers/features/node:1");
+        assert_eq!(
+            si["userFeatureIdWithoutVersion"],
+            "ghcr.io/devcontainers/features/node"
+        );
+        // Embedded manifest round-trips with OCI key casing.
+        assert_eq!(si["manifest"]["schemaVersion"], 2);
+        assert_eq!(si["manifest"]["config"]["digest"], "sha256:configdigest");
+        assert_eq!(si["manifest"]["layers"][0]["digest"], "sha256:layerdigest");
+        assert_eq!(
+            si["manifest"]["layers"][0]["annotations"]["org.opencontainers.image.title"],
+            "node.tgz"
+        );
+
+        // featureRef decomposition.
+        let fr = &si["featureRef"];
+        assert_eq!(fr["registry"], "ghcr.io");
+        assert_eq!(fr["owner"], "devcontainers");
+        assert_eq!(fr["namespace"], "devcontainers/features");
+        assert_eq!(fr["path"], "devcontainers/features/node");
+        assert_eq!(fr["resource"], "ghcr.io/devcontainers/features/node");
+        assert_eq!(fr["id"], "node");
+        assert_eq!(fr["version"], "1");
+        assert_eq!(fr["tag"], "1");
+        assert!(fr.get("digest").is_none(), "tag ref has no digest");
+
+        // features[0].
+        let feat = &set["features"][0];
+        assert_eq!(feat["id"], "node");
+        assert_eq!(feat["included"], true);
+        assert_eq!(feat["value"], serde_json::json!({"version": "20"}));
+        assert_eq!(feat["consecutiveId"], "node_0");
+        assert_eq!(feat["cachePath"], "/tmp/cella-features/node_0");
+        assert_eq!(feat["version"], "1.3.0");
+        assert_eq!(feat["name"], "Node.js");
+        assert_eq!(feat["containerEnv"]["NVM_DIR"], "/usr/local/nvm");
+        assert_eq!(
+            feat["installsAfter"][0],
+            "ghcr.io/devcontainers/features/common-utils"
+        );
+        assert_eq!(
+            feat["customizations"]["vscode"]["extensions"][0],
+            "dbaeumer.vscode-eslint"
+        );
+    }
+
+    #[test]
+    fn non_oci_feature_is_file_path() {
+        let mut f = oci_feature();
+        f.id = "local".to_string();
+        f.original_ref = "./my-feature".to_string();
+        f.oci = None;
+        let fc = build(&resolved(vec![f])).expect("features present");
+        let v = serde_json::to_value(&fc).unwrap();
+        let si = &v["featureSets"][0]["sourceInformation"];
+        assert_eq!(si["type"], "file-path");
+        assert_eq!(si["userFeatureId"], "./my-feature");
+        assert!(si.get("manifest").is_none(), "non-OCI has no manifest");
+    }
+
+    #[test]
+    fn parse_feature_ref_tag() {
+        let r = parse_feature_ref("ghcr.io/devcontainers/features/go:1.2.3");
+        assert_eq!(r.version, "1.2.3");
+        assert_eq!(r.tag.as_deref(), Some("1.2.3"));
+        assert_eq!(r.digest, None);
+        assert_eq!(r.resource, "ghcr.io/devcontainers/features/go");
+        assert_eq!(r.namespace, "devcontainers/features");
+    }
+
+    #[test]
+    fn parse_feature_ref_digest() {
+        let r = parse_feature_ref("ghcr.io/owner/repo/tool@sha256:abc123");
+        assert_eq!(r.version, "sha256:abc123");
+        assert_eq!(r.digest.as_deref(), Some("sha256:abc123"));
+        assert_eq!(r.tag, None);
+        assert_eq!(r.id, "tool");
+    }
+
+    #[test]
+    fn parse_feature_ref_implicit_latest() {
+        let r = parse_feature_ref("ghcr.io/devcontainers/features/git");
+        assert_eq!(r.version, "latest");
+        assert_eq!(r.tag.as_deref(), Some("latest"));
+    }
+
+    #[test]
+    fn feature_id_without_version_cases() {
+        assert_eq!(
+            feature_id_without_version("ghcr.io/devcontainers/features/node:1"),
+            "ghcr.io/devcontainers/features/node"
+        );
+        assert_eq!(
+            feature_id_without_version("ghcr.io/owner/repo/tool@sha256:abc"),
+            "ghcr.io/owner/repo/tool"
+        );
+        assert_eq!(
+            feature_id_without_version("ghcr.io/devcontainers/features/git"),
+            "ghcr.io/devcontainers/features/git"
+        );
+    }
+}

--- a/crates/cella-cli/src/commands/features_configuration.rs
+++ b/crates/cella-cli/src/commands/features_configuration.rs
@@ -12,9 +12,19 @@
 //!   not the official's per-invocation temp folder.
 //! - `features[].value` is derived from the parsed options map, so the rare
 //!   string/boolean shorthand (`"feature": "latest"`) emits `{}` (the object
-//!   form is exact).
+//!   form is exact), and object keys are sorted (`serde_json` has no
+//!   `preserve_order`) rather than in devcontainer.json order.
 //! - the embedded `manifest` is re-serialised from the typed manifest, so its
 //!   JSON key order may differ from the registry's original bytes.
+//!
+//! Follow-ups, gated on `cella-features` modelling the field (it currently does
+//! not parse them, so they are dropped before reaching here, not invented):
+//! - `features[].documentationURL` / `licenseURL`, and string-option
+//!   `proposals` — unmodelled in `FeatureMetadata` / `FeatureOption`.
+//! - non-OCI `sourceInformation.tarballUri` (direct-tarball) /
+//!   `resolvedFilePath` (file-path) — not carried on `ResolvedFeature`.
+//! - explicitly-empty collections (`"capAdd": []`) are emitted as absent,
+//!   because the parser cannot distinguish them from an omitted key.
 
 use std::collections::{BTreeMap, HashMap};
 
@@ -146,6 +156,9 @@ struct FeatureOut {
 struct FeatureOptionOut {
     #[serde(rename = "type")]
     option_type: &'static str,
+    // Omit when absent (parsed `default` is `Null`): matches the official's
+    // optional `default?` being dropped from JSON when undefined.
+    #[serde(skip_serializing_if = "serde_json::Value::is_null")]
     default: serde_json::Value,
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
@@ -155,9 +168,9 @@ struct FeatureOptionOut {
 
 /// Build the `featuresConfiguration` value, or `None` when no features are
 /// declared (the official omits the key entirely in that case).
-pub fn build(rf: &ResolvedFeatures) -> Option<FeaturesConfiguration> {
+pub fn build(rf: &ResolvedFeatures) -> Result<Option<FeaturesConfiguration>, serde_json::Error> {
     if rf.features.is_empty() {
-        return None;
+        return Ok(None);
     }
     let dst_folder = rf.build_context.to_string_lossy().into_owned();
     let feature_sets = rf
@@ -165,27 +178,34 @@ pub fn build(rf: &ResolvedFeatures) -> Option<FeaturesConfiguration> {
         .iter()
         .enumerate()
         .map(|(idx, f)| feature_set(f, idx, &dst_folder))
-        .collect();
-    Some(FeaturesConfiguration {
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Some(FeaturesConfiguration {
         feature_sets,
         dst_folder,
+    }))
+}
+
+fn feature_set(
+    f: &ResolvedFeature,
+    idx: usize,
+    dst_folder: &str,
+) -> Result<FeatureSetOut, serde_json::Error> {
+    Ok(FeatureSetOut {
+        source_information: source_information(f)?,
+        features: vec![feature_out(f, idx, dst_folder)],
     })
 }
 
-fn feature_set(f: &ResolvedFeature, idx: usize, dst_folder: &str) -> FeatureSetOut {
-    FeatureSetOut {
-        source_information: source_information(f),
-        features: vec![feature_out(f, idx, dst_folder)],
-    }
-}
-
-fn source_information(f: &ResolvedFeature) -> SourceInformationOut {
+fn source_information(f: &ResolvedFeature) -> Result<SourceInformationOut, serde_json::Error> {
     let user_feature_id = f.original_ref.clone();
     let user_feature_id_without_version = feature_id_without_version(&f.original_ref);
 
-    match &f.oci {
+    Ok(match &f.oci {
         Some(oci) => SourceInformationOut::Oci(Box::new(OciSourceInformationOut {
-            manifest: serde_json::to_value(&oci.manifest).unwrap_or(serde_json::Value::Null),
+            // Propagate rather than emit `manifest: null` on the (practically
+            // impossible) serialization error — a null manifest is a silent
+            // contract violation, so callers should see the failure.
+            manifest: serde_json::to_value(&oci.manifest)?,
             manifest_digest: oci.digest.clone(),
             feature_ref: parse_feature_ref(&f.original_ref),
             user_feature_id,
@@ -201,7 +221,7 @@ fn source_information(f: &ResolvedFeature) -> SourceInformationOut {
             user_feature_id,
             user_feature_id_without_version,
         }),
-    }
+    })
 }
 
 fn feature_out(f: &ResolvedFeature, idx: usize, dst_folder: &str) -> FeatureOut {
@@ -422,12 +442,14 @@ mod tests {
 
     #[test]
     fn omits_when_no_features() {
-        assert!(build(&resolved(vec![])).is_none());
+        assert!(build(&resolved(vec![])).unwrap().is_none());
     }
 
     #[test]
     fn oci_feature_full_shape() {
-        let fc = build(&resolved(vec![oci_feature()])).expect("features present");
+        let fc = build(&resolved(vec![oci_feature()]))
+            .unwrap()
+            .expect("features present");
         let v = serde_json::to_value(&fc).unwrap();
 
         assert_eq!(v["dstFolder"], "/tmp/cella-features");
@@ -489,7 +511,9 @@ mod tests {
         f.id = "local".to_string();
         f.original_ref = "./my-feature".to_string();
         f.oci = None;
-        let fc = build(&resolved(vec![f])).expect("features present");
+        let fc = build(&resolved(vec![f]))
+            .unwrap()
+            .expect("features present");
         let v = serde_json::to_value(&fc).unwrap();
         let si = &v["featureSets"][0]["sourceInformation"];
         assert_eq!(si["type"], "file-path");

--- a/crates/cella-cli/src/commands/features_configuration.rs
+++ b/crates/cella-cli/src/commands/features_configuration.rs
@@ -236,7 +236,14 @@ fn feature_out(f: &ResolvedFeature, idx: usize, dst_folder: &str) -> FeatureOut 
         id: f.id.clone(),
         included: true,
         value,
-        cache_path: Some(format!("{dst_folder}/{consecutive_id}")),
+        // Join with the platform separator (matches the official's
+        // path.join(dstFolder, consecutiveId)) rather than a hard-coded `/`.
+        cache_path: Some(
+            std::path::Path::new(dst_folder)
+                .join(&consecutive_id)
+                .to_string_lossy()
+                .into_owned(),
+        ),
         consecutive_id,
         version: non_empty(&m.version),
         name: m.name.clone(),

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -10,6 +10,7 @@ mod doctor;
 mod down;
 mod exec;
 pub mod features;
+mod features_configuration;
 mod init;
 mod install;
 mod list;

--- a/crates/cella-cli/src/commands/read_configuration.rs
+++ b/crates/cella-cli/src/commands/read_configuration.rs
@@ -140,9 +140,8 @@ impl ReadConfigurationArgs {
         }
 
         if needs_features_config
-            && let Some(fc) = resolved_features
-                .as_ref()
-                .and_then(super::features_configuration::build)
+            && let Some(rf) = resolved_features.as_ref()
+            && let Some(fc) = super::features_configuration::build(rf)?
         {
             output["featuresConfiguration"] = serde_json::to_value(fc)?;
         }

--- a/crates/cella-cli/src/commands/read_configuration.rs
+++ b/crates/cella-cli/src/commands/read_configuration.rs
@@ -323,6 +323,7 @@ fn build_merged_from_label(
                 user_options: HashMap::new(),
                 artifact_dir: PathBuf::new(),
                 has_install_script: false,
+                oci_manifest: None,
             })
         })
         .collect();
@@ -807,6 +808,7 @@ mod tests {
                     user_options: HashMap::new(),
                     artifact_dir: PathBuf::from("/tmp"),
                     has_install_script: false,
+                    oci_manifest: None,
                 },
                 ResolvedFeature {
                     id: "feat-b".to_string(),
@@ -819,6 +821,7 @@ mod tests {
                     user_options: HashMap::new(),
                     artifact_dir: PathBuf::from("/tmp"),
                     has_install_script: false,
+                    oci_manifest: None,
                 },
             ],
             dockerfile: String::new(),
@@ -1124,6 +1127,7 @@ mod tests {
                 user_options: HashMap::new(),
                 artifact_dir: PathBuf::from("/tmp"),
                 has_install_script: false,
+                oci_manifest: None,
             }],
             dockerfile: String::new(),
             build_context: PathBuf::from("/tmp"),

--- a/crates/cella-cli/src/commands/read_configuration.rs
+++ b/crates/cella-cli/src/commands/read_configuration.rs
@@ -114,6 +114,19 @@ impl ReadConfigurationArgs {
             &host_mount_folder,
         );
 
+        // `featuresConfiguration` is emitted when explicitly requested, or when
+        // `mergedConfiguration` is requested without a container target — the
+        // official `needsFeaturesConfig = includeFeaturesConfig || (includeMergedConfig
+        // && !container)`. It always derives from the config's features (never a
+        // container label), so resolve once and share with the merged path.
+        let needs_features_config = self.include_features_configuration
+            || (self.include_merged_configuration && !has_container_target);
+        let resolved_features = if needs_features_config {
+            resolve_config_features(&resolved.config, &resolved.config_path).await?
+        } else {
+            None
+        };
+
         if self.include_merged_configuration {
             output["mergedConfiguration"] =
                 if let Some((label, has_id_labels)) = container_metadata_label {
@@ -122,8 +135,16 @@ impl ReadConfigurationArgs {
                     // `getImageMetadataFromContainer` path.
                     build_merged_from_label(&resolved.config, &label, has_id_labels)
                 } else {
-                    resolve_merged_config(&resolved.config, &resolved.config_path).await?
+                    build_merged_output(&resolved.config, resolved_features.as_ref())
                 };
+        }
+
+        if needs_features_config
+            && let Some(fc) = resolved_features
+                .as_ref()
+                .and_then(super::features_configuration::build)
+        {
+            output["featuresConfiguration"] = serde_json::to_value(fc)?;
         }
 
         // Official `read-configuration` prints compact (single-line) JSON.
@@ -232,9 +253,22 @@ pub async fn resolve_merged_config(
     config: &serde_json::Value,
     config_path: &Path,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
+    let rf = resolve_config_features(config, config_path).await?;
+    Ok(build_merged_output(config, rf.as_ref()))
+}
+
+/// Resolve the config's features for `mergedConfiguration`/`featuresConfiguration`,
+/// or `None` when the config declares no features.
+///
+/// Always derives from the config (never a container label), so it can be shared
+/// between both outputs in a single `read-configuration` invocation.
+pub async fn resolve_config_features(
+    config: &serde_json::Value,
+    config_path: &Path,
+) -> Result<Option<ResolvedFeatures>, Box<dyn std::error::Error + Send + Sync>> {
     let features = super::features::resolve::extract_features(config);
     if features.is_empty() {
-        return Ok(build_merged_output(config, None));
+        return Ok(None);
     }
 
     let platform =
@@ -259,7 +293,7 @@ pub async fn resolve_merged_config(
     )
     .await?;
 
-    Ok(build_merged_output(config, Some(&rf)))
+    Ok(Some(rf))
 }
 
 /// Build `mergedConfiguration` from a container's baked `devcontainer.metadata`
@@ -323,7 +357,7 @@ fn build_merged_from_label(
                 user_options: HashMap::new(),
                 artifact_dir: PathBuf::new(),
                 has_install_script: false,
-                oci_manifest: None,
+                oci: None,
             })
         })
         .collect();
@@ -808,7 +842,7 @@ mod tests {
                     user_options: HashMap::new(),
                     artifact_dir: PathBuf::from("/tmp"),
                     has_install_script: false,
-                    oci_manifest: None,
+                    oci: None,
                 },
                 ResolvedFeature {
                     id: "feat-b".to_string(),
@@ -821,7 +855,7 @@ mod tests {
                     user_options: HashMap::new(),
                     artifact_dir: PathBuf::from("/tmp"),
                     has_install_script: false,
-                    oci_manifest: None,
+                    oci: None,
                 },
             ],
             dockerfile: String::new(),
@@ -1127,7 +1161,7 @@ mod tests {
                 user_options: HashMap::new(),
                 artifact_dir: PathBuf::from("/tmp"),
                 has_install_script: false,
-                oci_manifest: None,
+                oci: None,
             }],
             dockerfile: String::new(),
             build_context: PathBuf::from("/tmp"),

--- a/crates/cella-compose/src/combined_dockerfile_build.rs
+++ b/crates/cella-compose/src/combined_dockerfile_build.rs
@@ -443,6 +443,7 @@ RUN echo install-as-node
             user_options: std::collections::HashMap::new(),
             artifact_dir: std::path::PathBuf::from("/tmp/marker"),
             has_install_script: true,
+            oci_manifest: None,
         };
         let feature_dockerfile =
             generate_dockerfile("base", &resolved_user, "node", "node", &[feature], true);

--- a/crates/cella-compose/src/combined_dockerfile_build.rs
+++ b/crates/cella-compose/src/combined_dockerfile_build.rs
@@ -443,7 +443,7 @@ RUN echo install-as-node
             user_options: std::collections::HashMap::new(),
             artifact_dir: std::path::PathBuf::from("/tmp/marker"),
             has_install_script: true,
-            oci_manifest: None,
+            oci: None,
         };
         let feature_dockerfile =
             generate_dockerfile("base", &resolved_user, "node", "node", &[feature], true);

--- a/crates/cella-features/src/cache.rs
+++ b/crates/cella-features/src/cache.rs
@@ -63,11 +63,13 @@ impl FeatureCache {
             .join(hash_ref_component(digest))
     }
 
-    /// Write the OCI manifest for a feature to the cache as `manifest.json`.
+    /// Write the OCI manifest for a feature to the cache.
     ///
-    /// The file is written alongside the artifact directory, keyed by the same
-    /// registry/repository/digest triple.  Serialisation errors are logged and
-    /// silently ignored — a missing manifest.json is treated as a cache miss by
+    /// Stored as a `manifest-<hash>.json` sidecar alongside the artifact
+    /// directory, keyed by the same registry/repository/digest triple, and
+    /// written atomically (staged temp file + `rename`) so a concurrent reader
+    /// never observes a partial file. Failures are logged and swallowed — a
+    /// missing or unreadable sidecar is treated as a cache miss by
     /// [`get_oci_manifest`] and triggers a one-time re-pull.
     pub fn put_oci_manifest(
         &self,
@@ -86,17 +88,25 @@ impl FeatureCache {
             );
             return;
         }
-        match serde_json::to_string(manifest) {
-            Ok(json) => {
-                if let Err(e) = std::fs::write(&path, json) {
-                    tracing::warn!("failed to write manifest cache {}: {e}", path.display());
-                }
-            }
+        let json = match serde_json::to_string(manifest) {
+            Ok(json) => json,
             Err(e) => {
                 tracing::warn!(
                     "failed to serialise OCI manifest for {registry}/{repository}@{digest}: {e}"
                 );
+                return;
             }
+        };
+        // Stage to a per-process temp file then atomically rename, so a
+        // concurrent reader never observes a partially-written manifest.
+        let staging = path.with_extension(format!("partial-{}", process::id()));
+        if let Err(e) = std::fs::write(&staging, &json) {
+            tracing::warn!("failed to write manifest cache {}: {e}", staging.display());
+            return;
+        }
+        if let Err(e) = std::fs::rename(&staging, &path) {
+            tracing::warn!("failed to commit manifest cache {}: {e}", path.display());
+            let _ = std::fs::remove_file(&staging);
         }
     }
 

--- a/crates/cella-features/src/cache.rs
+++ b/crates/cella-features/src/cache.rs
@@ -13,6 +13,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::process;
 
+use oci_distribution::manifest::OciImageManifest;
 use sha2::{Digest, Sha256};
 
 /// On-disk feature cache rooted at a platform-appropriate location.
@@ -60,6 +61,82 @@ impl FeatureCache {
             .join(hash_ref_component(registry))
             .join(hash_ref_component(repository))
             .join(hash_ref_component(digest))
+    }
+
+    /// Write the OCI manifest for a feature to the cache as `manifest.json`.
+    ///
+    /// The file is written alongside the artifact directory, keyed by the same
+    /// registry/repository/digest triple.  Serialisation errors are logged and
+    /// silently ignored — a missing manifest.json is treated as a cache miss by
+    /// [`get_oci_manifest`] and triggers a one-time re-pull.
+    pub fn put_oci_manifest(
+        &self,
+        registry: &str,
+        repository: &str,
+        digest: &str,
+        manifest: &OciImageManifest,
+    ) {
+        let path = self.oci_manifest_path(registry, repository, digest);
+        if let Some(parent) = path.parent()
+            && let Err(e) = std::fs::create_dir_all(parent)
+        {
+            tracing::warn!(
+                "failed to create manifest cache dir {}: {e}",
+                parent.display()
+            );
+            return;
+        }
+        match serde_json::to_string(manifest) {
+            Ok(json) => {
+                if let Err(e) = std::fs::write(&path, json) {
+                    tracing::warn!("failed to write manifest cache {}: {e}", path.display());
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "failed to serialise OCI manifest for {registry}/{repository}@{digest}: {e}"
+                );
+            }
+        }
+    }
+
+    /// Read a cached OCI manifest by registry/repository/digest.
+    ///
+    /// Returns `None` when the file is absent or cannot be parsed — the caller
+    /// should treat this as a cache miss and re-pull the manifest.
+    #[must_use]
+    pub fn get_oci_manifest(
+        &self,
+        registry: &str,
+        repository: &str,
+        digest: &str,
+    ) -> Option<OciImageManifest> {
+        let path = self.oci_manifest_path(registry, repository, digest);
+        let json = std::fs::read_to_string(&path).ok()?;
+        match serde_json::from_str(&json) {
+            Ok(manifest) => Some(manifest),
+            Err(e) => {
+                tracing::warn!("failed to parse manifest cache {}: {e}", path.display());
+                None
+            }
+        }
+    }
+
+    /// Compute the cache path for a stored OCI manifest.
+    ///
+    /// Lives alongside the artifact directory as a sibling file:
+    /// `<oci_parent>/manifest-<digest_hash>.json`.
+    fn oci_manifest_path(&self, registry: &str, repository: &str, digest: &str) -> PathBuf {
+        // Reuse the same three-hash key scheme as oci_path.  The manifest file
+        // lives inside the same parent directory as the artifact, so the
+        // registry and repository hashes form the directory while the digest
+        // hash is used as a filename component — avoiding a 5-segment path.
+        let parent = self
+            .root
+            .join("oci")
+            .join(hash_ref_component(registry))
+            .join(hash_ref_component(repository));
+        parent.join(format!("manifest-{}.json", hash_ref_component(digest)))
     }
 
     /// Check whether a URL-fetched feature tarball is already cached.
@@ -458,5 +535,111 @@ mod tests {
         assert!(path.ends_with("builds/abc123"));
         // Should be a sibling of the features root, not nested inside it.
         assert!(!path.starts_with(dir.path().join("features")));
+    }
+
+    // -----------------------------------------------------------------------
+    // OCI manifest cache: put_oci_manifest / get_oci_manifest
+    // -----------------------------------------------------------------------
+
+    /// Build a minimal `OciImageManifest` for testing.
+    fn make_test_manifest() -> OciImageManifest {
+        use oci_distribution::manifest::{OciDescriptor, OciImageManifest};
+        OciImageManifest {
+            schema_version: 2,
+            media_type: Some("application/vnd.oci.image.manifest.v1+json".to_string()),
+            config: OciDescriptor {
+                media_type: "application/vnd.devcontainers".to_string(),
+                digest: "sha256:cfgdigest000000000000000000000000000000000000000000000000000000"
+                    .to_string(),
+                size: 42,
+                ..OciDescriptor::default()
+            },
+            layers: vec![OciDescriptor {
+                media_type: "application/vnd.devcontainers.layer.v1+tar+gz".to_string(),
+                digest: "sha256:layerdigest0000000000000000000000000000000000000000000000000000"
+                    .to_string(),
+                size: 1024,
+                ..OciDescriptor::default()
+            }],
+            ..OciImageManifest::default()
+        }
+    }
+
+    #[test]
+    fn manifest_cache_miss_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = FeatureCache::with_root(dir.path());
+        let result = cache.get_oci_manifest("ghcr.io", "devcontainers/features/node", "sha256:abc");
+        assert!(result.is_none(), "expected None on cache miss");
+    }
+
+    #[test]
+    fn manifest_cache_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = FeatureCache::with_root(dir.path());
+
+        let manifest = make_test_manifest();
+        cache.put_oci_manifest(
+            "ghcr.io",
+            "devcontainers/features/node",
+            "sha256:abc",
+            &manifest,
+        );
+
+        let retrieved = cache
+            .get_oci_manifest("ghcr.io", "devcontainers/features/node", "sha256:abc")
+            .expect("manifest should be cached");
+
+        // Verify the key fields round-tripped correctly.
+        assert_eq!(retrieved.config.digest, manifest.config.digest);
+        assert_eq!(retrieved.config.size, manifest.config.size);
+        assert_eq!(retrieved.layers.len(), manifest.layers.len());
+        assert_eq!(retrieved.layers[0].digest, manifest.layers[0].digest);
+        assert_eq!(retrieved.layers[0].size, manifest.layers[0].size);
+    }
+
+    #[test]
+    fn manifest_cache_key_is_digest_scoped() {
+        // Two different digests must produce different cache entries.
+        let dir = tempfile::tempdir().unwrap();
+        let cache = FeatureCache::with_root(dir.path());
+
+        let manifest = make_test_manifest();
+        cache.put_oci_manifest(
+            "ghcr.io",
+            "devcontainers/features/node",
+            "sha256:aaa",
+            &manifest,
+        );
+
+        // Different digest — should miss.
+        assert!(
+            cache
+                .get_oci_manifest("ghcr.io", "devcontainers/features/node", "sha256:bbb")
+                .is_none(),
+            "different digest must be a cache miss"
+        );
+        // Same digest — should hit.
+        assert!(
+            cache
+                .get_oci_manifest("ghcr.io", "devcontainers/features/node", "sha256:aaa")
+                .is_some(),
+            "same digest must be a cache hit"
+        );
+    }
+
+    #[test]
+    fn manifest_path_is_sibling_of_artifact_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = FeatureCache::with_root(dir.path());
+
+        let artifact = cache.oci_path("ghcr.io", "devcontainers/features/node", "sha256:abc");
+        let manifest =
+            cache.oci_manifest_path("ghcr.io", "devcontainers/features/node", "sha256:abc");
+
+        // Both must share the same parent directory.
+        assert_eq!(artifact.parent(), manifest.parent());
+        // Manifest path must end in a .json file.
+        assert_eq!(manifest.extension().and_then(|e| e.to_str()), Some("json"));
     }
 }

--- a/crates/cella-features/src/dockerfile.rs
+++ b/crates/cella-features/src/dockerfile.rs
@@ -393,7 +393,7 @@ mod tests {
             user_options,
             artifact_dir: PathBuf::from(format!("/tmp/features/{id}")),
             has_install_script,
-            oci_manifest: None,
+            oci: None,
         }
     }
 

--- a/crates/cella-features/src/dockerfile.rs
+++ b/crates/cella-features/src/dockerfile.rs
@@ -393,6 +393,7 @@ mod tests {
             user_options,
             artifact_dir: PathBuf::from(format!("/tmp/features/{id}")),
             has_install_script,
+            oci_manifest: None,
         }
     }
 

--- a/crates/cella-features/src/lib.rs
+++ b/crates/cella-features/src/lib.rs
@@ -897,7 +897,15 @@ fn assemble_resolved(
             user_options: entry.user_options.clone(),
             artifact_dir: entry.artifact_dir.clone(),
             has_install_script: has_install,
-            oci_manifest: entry.oci_manifest.clone(),
+            // An OCI feature carries both its resolved digest (from the lock
+            // info) and the manifest blob; bundle them, or `None` for non-OCI.
+            oci: match (&entry.oci, &entry.oci_manifest) {
+                (Some(lock), Some(manifest)) => Some(ResolvedOciManifest {
+                    digest: lock.digest.clone(),
+                    manifest: manifest.clone(),
+                }),
+                _ => None,
+            },
         });
 
         debug!(
@@ -1259,7 +1267,7 @@ mod tests {
             user_options: HashMap::new(),
             artifact_dir: PathBuf::from("/tmp/features/node"),
             has_install_script: true,
-            oci_manifest: None,
+            oci: None,
         }];
 
         let label = generate_metadata_label(&features, &json!({}), None, MetadataOmit::default());
@@ -1357,7 +1365,7 @@ mod tests {
             user_options: HashMap::new(),
             artifact_dir: PathBuf::from("/tmp/features/python"),
             has_install_script: true,
-            oci_manifest: None,
+            oci: None,
         }];
         let user_config = json!({
             "image": "ubuntu",

--- a/crates/cella-features/src/lib.rs
+++ b/crates/cella-features/src/lib.rs
@@ -901,6 +901,9 @@ fn assemble_resolved(
             // info) and the manifest blob; bundle them, or `None` for non-OCI.
             oci: match (&entry.oci, &entry.oci_manifest) {
                 (Some(lock), Some(manifest)) => Some(ResolvedOciManifest {
+                    registry: lock.registry.clone(),
+                    repository: lock.repository.clone(),
+                    version: lock.version.clone(),
                     digest: lock.digest.clone(),
                     manifest: manifest.clone(),
                 }),

--- a/crates/cella-features/src/lib.rs
+++ b/crates/cella-features/src/lib.rs
@@ -140,6 +140,9 @@ struct FeatureEntry {
     /// registry. Drives lockfile generation, including transitive `dependsOn`
     /// features (which are appended to the install set during expansion).
     oci: Option<OciLockInfo>,
+    /// The full OCI image manifest, present only for OCI-fetched features.
+    /// Retained for `read-configuration --include-features-configuration`.
+    oci_manifest: Option<oci_distribution::manifest::OciImageManifest>,
 }
 
 /// Build the unique install identity for a feature instance.
@@ -452,7 +455,7 @@ fn parse_and_normalize(
 /// Result of fetching a single feature — OCI fetches carry digest metadata,
 /// other fetchers return only the artifact path.
 enum FetchResult {
-    Oci(oci::OciFetchResult),
+    Oci(Box<oci::OciFetchResult>),
     Other(PathBuf),
 }
 
@@ -473,6 +476,16 @@ impl FetchResult {
                 repository: r.repository.clone(),
                 digest: r.digest.clone(),
             }),
+            Self::Other(_) => None,
+        }
+    }
+
+    /// The full OCI image manifest, if this fetch came from an OCI registry —
+    /// retained for `read-configuration --include-features-configuration`
+    /// (`featureSets[].sourceInformation.manifest`).
+    fn oci_manifest(&self) -> Option<oci_distribution::manifest::OciImageManifest> {
+        match self {
+            Self::Oci(r) => Some(r.manifest.clone()),
             Self::Other(_) => None,
         }
     }
@@ -539,7 +552,7 @@ async fn fetch_one_with_digest(
             let result = oci_fetcher
                 .fetch_oci_with_digest(norm_ref, cache, locked_digest)
                 .await?;
-            Ok(FetchResult::Oci(result))
+            Ok(FetchResult::Oci(Box::new(result)))
         }
         NormalizedRef::HttpTarget { .. } => {
             let path = http_fetcher.fetch(norm_ref, platform, cache).await?;
@@ -679,6 +692,7 @@ fn parse_metadata_and_validate(
             user_options,
             original_ref: key.clone(),
             oci: fetch_result.oci_lock_info(),
+            oci_manifest: fetch_result.oci_manifest(),
         });
     }
 
@@ -883,6 +897,7 @@ fn assemble_resolved(
             user_options: entry.user_options.clone(),
             artifact_dir: entry.artifact_dir.clone(),
             has_install_script: has_install,
+            oci_manifest: entry.oci_manifest.clone(),
         });
 
         debug!(
@@ -1075,6 +1090,7 @@ async fn expand_depends_on(
             user_options,
             original_ref: dep_ref,
             oci: fetch_result.oci_lock_info(),
+            oci_manifest: fetch_result.oci_manifest(),
         });
     }
 
@@ -1243,6 +1259,7 @@ mod tests {
             user_options: HashMap::new(),
             artifact_dir: PathBuf::from("/tmp/features/node"),
             has_install_script: true,
+            oci_manifest: None,
         }];
 
         let label = generate_metadata_label(&features, &json!({}), None, MetadataOmit::default());
@@ -1340,6 +1357,7 @@ mod tests {
             user_options: HashMap::new(),
             artifact_dir: PathBuf::from("/tmp/features/python"),
             has_install_script: true,
+            oci_manifest: None,
         }];
         let user_config = json!({
             "image": "ubuntu",
@@ -2376,6 +2394,7 @@ mod tests {
                 repository: repo.to_string(),
                 digest: digest.to_string(),
             }),
+            oci_manifest: None,
         }
     }
 
@@ -2464,6 +2483,7 @@ mod tests {
             user_options: HashMap::new(),
             original_ref: "./local".to_string(),
             oci: None,
+            oci_manifest: None,
         };
         let lf = build_lockfile_from_entries(&[entry]);
         assert!(lf.features.is_empty());

--- a/crates/cella-features/src/merge/feature.rs
+++ b/crates/cella-features/src/merge/feature.rs
@@ -112,6 +112,7 @@ mod tests {
             user_options: HashMap::new(),
             artifact_dir: PathBuf::from("/tmp/features"),
             has_install_script: true,
+            oci_manifest: None,
         }
     }
 

--- a/crates/cella-features/src/merge/feature.rs
+++ b/crates/cella-features/src/merge/feature.rs
@@ -112,7 +112,7 @@ mod tests {
             user_options: HashMap::new(),
             artifact_dir: PathBuf::from("/tmp/features"),
             has_install_script: true,
-            oci_manifest: None,
+            oci: None,
         }
     }
 

--- a/crates/cella-features/src/oci.rs
+++ b/crates/cella-features/src/oci.rs
@@ -80,6 +80,13 @@ pub struct OciFetchResult {
     pub registry: String,
     /// The OCI repository path.
     pub repository: String,
+    /// The full OCI image manifest returned by the registry.
+    ///
+    /// Always populated — on a cache hit the manifest is read from the
+    /// sidecar `manifest.json` written during the original fetch; on a miss
+    /// it is stored there immediately after pulling.  If the sidecar is
+    /// absent (pre-existing cache entry), the manifest is re-pulled once.
+    pub manifest: oci_distribution::manifest::OciImageManifest,
 }
 
 /// Find the first extractable layer in a manifest, or return an error listing available types.
@@ -278,12 +285,35 @@ impl OciFetcher {
         cache: &FeatureCache,
     ) -> Result<OciFetchResult, FeatureError> {
         if let Some(cached) = cache.get_oci(registry, repository, digest) {
+            // Read the sidecar manifest; if absent (cache entry predates manifest
+            // caching), re-pull it once by the pinned digest and store it so the
+            // result always carries a manifest without re-downloading the layer.
+            let manifest =
+                if let Some(manifest) = cache.get_oci_manifest(registry, repository, digest) {
+                    manifest
+                } else {
+                    // Sidecar absent (cache entry predates manifest caching): re-pull
+                    // once by the pinned digest and store it so the result always
+                    // carries a manifest without re-downloading the layer.
+                    let oci_ref = Reference::with_digest(
+                        registry.to_owned(),
+                        repository.to_owned(),
+                        digest.to_owned(),
+                    );
+                    let auth = build_registry_auth(registry);
+                    let (manifest, _) = self
+                        .pull_manifest(&oci_ref, &auth, registry, repository, tag)
+                        .await?;
+                    cache.put_oci_manifest(registry, repository, digest, &manifest);
+                    manifest
+                };
             return Ok(OciFetchResult {
                 artifact_dir: cached,
                 digest: digest.to_owned(),
                 version: tag.to_owned(),
                 registry: registry.to_owned(),
                 repository: repository.to_owned(),
+                manifest,
             });
         }
 
@@ -320,12 +350,14 @@ impl OciFetcher {
             tag,
             &resolved_digest,
         )?;
+        cache.put_oci_manifest(registry, repository, &resolved_digest, &manifest);
         Ok(OciFetchResult {
             artifact_dir,
             digest: resolved_digest,
             version: tag.to_owned(),
             registry: registry.to_owned(),
             repository: repository.to_owned(),
+            manifest,
         })
     }
 
@@ -350,6 +382,7 @@ impl OciFetcher {
         let (manifest, digest) = self
             .pull_manifest(&oci_ref, &auth, registry, repository, tag)
             .await?;
+        cache.put_oci_manifest(registry, repository, &digest, &manifest);
 
         if let Some(cached) = cache.get_oci(registry, repository, &digest) {
             debug!("cache hit by digest {digest} for {registry}/{repository}:{tag}");
@@ -359,6 +392,7 @@ impl OciFetcher {
                 version: tag.to_owned(),
                 registry: registry.to_owned(),
                 repository: repository.to_owned(),
+                manifest,
             });
         }
 
@@ -379,6 +413,7 @@ impl OciFetcher {
             version: tag.to_owned(),
             registry: registry.to_owned(),
             repository: repository.to_owned(),
+            manifest,
         })
     }
 }
@@ -557,5 +592,50 @@ mod tests {
         // Second fetch should hit cache.
         let path2 = fetcher.fetch(&reference, &platform, &cache).await.unwrap();
         assert_eq!(path, path2, "second fetch should return cached path");
+    }
+
+    #[cella_testing::runtime_test(network)]
+    async fn oci_fetch_retains_manifest_across_cache_miss_and_hit() {
+        let fetcher = OciFetcher::new();
+        let cache_dir = tempfile::tempdir().unwrap();
+        let cache = FeatureCache::with_root(cache_dir.path());
+
+        let reference = NormalizedRef::OciTarget {
+            registry: "ghcr.io".to_owned(),
+            repository: "devcontainers/features/node".to_owned(),
+            tag: "1".to_owned(),
+        };
+
+        // Cache-miss path (fetch_by_tag): pulls the manifest, writes the sidecar,
+        // and populates the result field.
+        let fresh = fetcher
+            .fetch_oci_with_digest(&reference, &cache, None)
+            .await
+            .unwrap();
+        assert!(
+            !fresh.manifest.config.digest.is_empty(),
+            "retained manifest must carry the config descriptor digest"
+        );
+        assert!(
+            !fresh.manifest.layers.is_empty(),
+            "retained manifest must carry at least one layer descriptor"
+        );
+
+        // Cache-hit path (fetch_by_locked_digest): reads the manifest from the
+        // sidecar without re-downloading the layer; the field stays populated and
+        // identical to the original pull.
+        let cached = fetcher
+            .fetch_oci_with_digest(&reference, &cache, Some(&fresh.digest))
+            .await
+            .unwrap();
+        assert_eq!(
+            cached.manifest.config.digest, fresh.manifest.config.digest,
+            "cache-hit manifest must match the originally fetched manifest"
+        );
+        assert_eq!(
+            cached.manifest.layers.len(),
+            fresh.manifest.layers.len(),
+            "cache-hit manifest must carry the same layer set"
+        );
     }
 }

--- a/crates/cella-features/src/oci.rs
+++ b/crates/cella-features/src/oci.rs
@@ -83,8 +83,8 @@ pub struct OciFetchResult {
     /// The full OCI image manifest returned by the registry.
     ///
     /// Always populated — on a cache hit the manifest is read from the
-    /// sidecar `manifest.json` written during the original fetch; on a miss
-    /// it is stored there immediately after pulling.  If the sidecar is
+    /// `manifest-<hash>.json` sidecar written during the original fetch; on a
+    /// miss it is stored there immediately after pulling.  If the sidecar is
     /// absent (pre-existing cache entry), the manifest is re-pulled once.
     pub manifest: oci_distribution::manifest::OciImageManifest,
 }

--- a/crates/cella-features/src/types.rs
+++ b/crates/cella-features/src/types.rs
@@ -19,10 +19,28 @@ pub struct ResolvedFeature {
     pub user_options: HashMap<String, serde_json::Value>,
     pub artifact_dir: PathBuf,
     pub has_install_script: bool,
-    /// The full OCI image manifest, present only for OCI-fetched features.
-    /// Retained for `read-configuration --include-features-configuration`
-    /// (`featureSets[].sourceInformation.manifest`); `None` for local/tarball.
-    pub oci_manifest: Option<oci_distribution::manifest::OciImageManifest>,
+    /// OCI source artifact (resolved manifest digest + the manifest blob),
+    /// present only for OCI-fetched features. `None` for local/tarball.
+    ///
+    /// Retained for `read-configuration --include-features-configuration`:
+    /// `sourceInformation.manifestDigest` and `sourceInformation.manifest`. The
+    /// `featureRef` parts are parsed from `original_ref` (matching the official
+    /// `getRef`), so only the resolved digest + manifest blob need carrying.
+    pub oci: Option<ResolvedOciManifest>,
+}
+
+/// The resolved OCI artifact for a feature: its manifest digest and blob.
+///
+/// Both travel together — an OCI feature always has both — so they are bundled
+/// rather than two parallel `Option`s that could disagree. Retained for
+/// `read-configuration`'s `sourceInformation.{manifestDigest,manifest}`.
+#[derive(Debug, Clone)]
+pub struct ResolvedOciManifest {
+    /// The resolved manifest content digest (`sourceInformation.manifestDigest`,
+    /// e.g. `"sha256:abc…"`).
+    pub digest: String,
+    /// The manifest blob (`sourceInformation.manifest`).
+    pub manifest: oci_distribution::manifest::OciImageManifest,
 }
 
 /// Parsed devcontainer-feature.json.

--- a/crates/cella-features/src/types.rs
+++ b/crates/cella-features/src/types.rs
@@ -19,6 +19,10 @@ pub struct ResolvedFeature {
     pub user_options: HashMap<String, serde_json::Value>,
     pub artifact_dir: PathBuf,
     pub has_install_script: bool,
+    /// The full OCI image manifest, present only for OCI-fetched features.
+    /// Retained for `read-configuration --include-features-configuration`
+    /// (`featureSets[].sourceInformation.manifest`); `None` for local/tarball.
+    pub oci_manifest: Option<oci_distribution::manifest::OciImageManifest>,
 }
 
 /// Parsed devcontainer-feature.json.

--- a/crates/cella-features/src/types.rs
+++ b/crates/cella-features/src/types.rs
@@ -36,6 +36,13 @@ pub struct ResolvedFeature {
 /// `read-configuration`'s `sourceInformation.{manifestDigest,manifest}`.
 #[derive(Debug, Clone)]
 pub struct ResolvedOciManifest {
+    /// The normalized OCI coordinates actually fetched, after alias/redirect
+    /// resolution (e.g. `maven` → `ghcr.io/devcontainers/features/java`). Used
+    /// to build `sourceInformation.featureRef` — which the official derives from
+    /// the fetched identifier, not the raw user ref.
+    pub registry: String,
+    pub repository: String,
+    pub version: String,
     /// The resolved manifest content digest (`sourceInformation.manifestDigest`,
     /// e.g. `"sha256:abc…"`).
     pub digest: String,


### PR DESCRIPTION
`read-configuration --include-features-configuration` was a silent no-op. This wires it up to emit the official `featuresConfiguration` shape.

### Why it needed a refactor

We were throwing away the OCI manifest right after pulling a feature, but `featuresConfiguration.featureSets[].sourceInformation.manifest` needs exactly those bytes. So the first commit retains it: the manifest is cached as a sidecar next to the artifact (keyed by registry/repo/digest), so `up`'s network-free cache hits stay network-free — a cache hit reads the sidecar instead of re-pulling, and only pre-existing cache entries (no sidecar) trigger a one-time re-pull. It then rides along on `ResolvedFeature` as `oci` (digest + manifest bundled).

### What gets emitted

The new `features_configuration` module maps cella's resolved features to the official `{ featureSets[], dstFolder }`, in install order. `featureRef` is parsed straight from the user's ref with a direct port of the official `getRef`/`getFeatureIdWithoutVersion`, so registry/owner/namespace/path/resource/id/version/tag/digest all line up. Gating follows the official `needsFeaturesConfig = includeFeaturesConfig || (includeMergedConfig && !container)`; features resolve once and feed both `mergedConfiguration` and `featuresConfiguration`. No features declared → key omitted.

Validated end to end against `ghcr.io/devcontainers/features/node:1` — the emitted manifest is the real registry manifest (schemaVersion, config + layer digests/sizes, the layer's `org.opencontainers.image.title` annotation), `featureRef` decomposes correctly, and the flag-off path omits the key.

### Known divergences (documented in the module)

- `dstFolder` / `cachePath` are cella's real cache paths, not the official's per-invocation temp folder (host-specific, not matchable).
- the embedded manifest's JSON key order follows the typed re-serialization (registry byte-order isn't preserved).
- `value` uses the parsed options map, so the rare `"feature": "latest"` shorthand emits `{}` (object form is exact) and keys are sorted.
- a few fields are dropped because `cella-features` doesn't model them yet (`documentationURL`/`licenseURL`/`proposals`, non-OCI `tarballUri`/`resolvedFilePath`, explicitly-empty collections) — noted as follow-ups, not invented.

### Review

Ran code-quality + contract-parity reviews against the official source; addressed the findings (propagate the manifest serialization error instead of emitting null, omit null option defaults). Two flagged items turned out to be false positives that already match the official (`needsFeaturesConfig` gating and `featureRef.path`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)