### PR TITLE
feat(cli): accept official compat flags on exec/read-configuration/build

### DIFF
--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -129,6 +129,44 @@ pub struct BuildArgs {
     /// official devcontainer CLI.
     #[arg(long = "skip-persisting-customizations-from-features", hide = true)]
     skip_persisting_customizations_from_features: bool,
+
+    #[command(flatten)]
+    compat: BuildCompatArgs,
+}
+
+/// Compatibility/diagnostic flags accepted for `devcontainer build` parity.
+///
+/// All no-ops in cella, split into their own struct so `BuildArgs` stays under
+/// `clippy::struct_excessive_bools`. Source: devcontainers/cli `buildOptions`
+/// (`devContainersSpecCLI.ts`, lines 525, 542, 548).
+#[derive(Args)]
+struct BuildCompatArgs {
+    /// Host directory persisted across sessions (compatibility no-op). cella
+    /// manages its own data dirs; accepted for drop-in parity with the official
+    /// `devcontainer build --user-data-folder`.
+    #[arg(long = "user-data-folder")]
+    user_data_folder: Option<PathBuf>,
+
+    /// Temporary option for testing; cella performs no feature auto-mapping on
+    /// the build path (compatibility no-op, hidden — matches the official
+    /// `hidden: true`).
+    #[arg(long = "skip-feature-auto-mapping", hide = true)]
+    skip_feature_auto_mapping: bool,
+
+    // `--omit-syntax-directive` is a true no-op in cella's build path. The
+    // official CLI has two effects: (A) it parses the user's Dockerfile in JS
+    // and strips any `# syntax=` directive (a moby/buildkit#4556 workaround),
+    // and (B) it suppresses the `# syntax=` line it would otherwise prepend to
+    // its generated feature-extension Dockerfile. cella does NEITHER: it never
+    // parses Dockerfile content (`BuildOptions.dockerfile` is a filename passed
+    // verbatim as `-f`; the engine reads any `# syntax=` natively), and
+    // `cella_features::generate_dockerfile` emits no `# syntax=` line at all (it
+    // opens with `ARG`/`FROM`). So cella already behaves as if this flag is
+    // permanently on — there is nothing to suppress. Accepted-and-ignored for
+    // drop-in parity (mirrors `up`'s `--omit-syntax-directive`).
+    /// Omit Dockerfile syntax directives (compatibility no-op).
+    #[arg(long = "omit-syntax-directive", hide = true)]
+    omit_syntax_directive: bool,
 }
 
 impl BuildArgs {
@@ -888,5 +926,113 @@ mod tests {
     fn skip_persisting_customizations_from_features_parses() {
         let args = parse_build(&["--skip-persisting-customizations-from-features"]);
         assert!(args.skip_persisting_customizations_from_features);
+    }
+
+    // ── newly-added compat flags ────────────────────────────────────
+
+    #[test]
+    fn user_data_folder_parses() {
+        let args = parse_build(&["--user-data-folder", "/persist"]);
+        assert_eq!(
+            args.compat.user_data_folder,
+            Some(PathBuf::from("/persist"))
+        );
+    }
+
+    #[test]
+    fn skip_feature_auto_mapping_defaults_false_and_parses() {
+        assert!(!parse_build(&[]).compat.skip_feature_auto_mapping);
+        assert!(
+            parse_build(&["--skip-feature-auto-mapping"])
+                .compat
+                .skip_feature_auto_mapping
+        );
+    }
+
+    #[test]
+    fn omit_syntax_directive_defaults_false_and_parses() {
+        // No-op in cella (the generated feature Dockerfile emits no `# syntax=`
+        // line and cella never rewrites a user Dockerfile), but it must parse so
+        // `devcontainer build --omit-syntax-directive` is accepted as a drop-in.
+        assert!(!parse_build(&[]).compat.omit_syntax_directive);
+        assert!(
+            parse_build(&["--omit-syntax-directive"])
+                .compat
+                .omit_syntax_directive
+        );
+    }
+
+    // ── devcontainer-CLI flag parity ───────────────────────────────
+    //
+    // Source of truth: devcontainers/cli `src/spec-node/devContainersSpecCLI.ts`
+    // `buildOptions` (lines 523-548). Every official long flag MUST be declared
+    // so no official `devcontainer build` invocation errors with "unknown
+    // argument" — EXCEPT `--push`/`--output` of the registry-write surface that
+    // cella intentionally defers (`--push`) or already supports (`--output` is
+    // present). This test pins the surface so it can't silently drift again.
+    const OFFICIAL_BUILD_FLAGS: &[&str] = &[
+        "user-data-folder",
+        "docker-path",
+        "docker-compose-path",
+        "workspace-folder",
+        "config",
+        "log-level",
+        "log-format",
+        "no-cache",
+        "image-name",
+        "cache-from",
+        "cache-to",
+        "buildkit",
+        "platform",
+        "label",
+        "output",
+        "additional-features",
+        "skip-feature-auto-mapping",
+        "skip-persisting-customizations-from-features",
+        "experimental-lockfile",
+        "experimental-frozen-lockfile",
+        "no-lockfile",
+        "frozen-lockfile",
+        "omit-syntax-directive",
+    ];
+
+    #[test]
+    fn build_flag_parity() {
+        use clap::CommandFactory;
+        use std::collections::HashSet;
+        let cli = crate::Cli::command();
+        let cmd = cli
+            .find_subcommand("build")
+            .expect("`build` subcommand must exist");
+        let longs: HashSet<&str> = cmd
+            .get_arguments()
+            .filter_map(clap::Arg::get_long)
+            .collect();
+        let missing: Vec<&&str> = OFFICIAL_BUILD_FLAGS
+            .iter()
+            .filter(|f| !longs.contains(**f))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "`build` is missing official flags: {missing:?}"
+        );
+    }
+
+    #[test]
+    fn build_accepts_all_new_compat_flags_together() {
+        // A maximal official-style invocation including the three newly-added
+        // flags must parse Ok.
+        let args = parse_build(&[
+            "--user-data-folder",
+            "/persist",
+            "--skip-feature-auto-mapping",
+            "--omit-syntax-directive",
+        ]);
+        assert_eq!(
+            args.compat.user_data_folder,
+            Some(PathBuf::from("/persist"))
+        );
+        assert!(args.compat.skip_feature_auto_mapping);
+        assert!(args.compat.omit_syntax_directive);
     }
 }

--- a/crates/cella-cli/src/commands/exec.rs
+++ b/crates/cella-cli/src/commands/exec.rs
@@ -69,8 +69,23 @@ pub struct ExecArgs {
     #[arg(long, value_enum, default_value = "text")]
     output: super::OutputFormat,
 
+    /// Container data folder for in-container user data (compatibility no-op).
+    #[arg(long = "container-data-folder")]
+    container_data_folder: Option<PathBuf>,
+
+    /// Container system data folder (compatibility no-op).
+    #[arg(long = "container-system-data-folder")]
+    container_system_data_folder: Option<PathBuf>,
+
     #[command(flatten)]
     backend: crate::backend::BackendArgs,
+
+    /// Shared devcontainer-CLI compat flags (`--docker-path`, `--user-data-folder`,
+    /// `--mount-*`, `--log-level`/`--log-format`, `--terminal-*`,
+    /// `--skip-feature-auto-mapping`). All no-ops except log-level/log-format
+    /// (seeded into tracing by `main.rs`).
+    #[command(flatten)]
+    pub(crate) compat: super::WorkspaceCompatArgs,
 
     /// The command to execute.
     #[arg(trailing_var_arg = true, required = true)]
@@ -595,6 +610,153 @@ mod tests {
             panic!("expected exec subcommand");
         };
         assert_eq!(args.id_label, ["a=1", "b=2"]);
+    }
+
+    // ── devcontainer-CLI flag parity ───────────────────────────────
+    //
+    // Source of truth: devcontainers/cli `src/spec-node/devContainersSpecCLI.ts`
+    // `execOptions` (lines 1250-1271). Every official long flag MUST be declared
+    // so no official `devcontainer exec` invocation errors with "unknown
+    // argument". This test exists because exec drifted from the spec for lack of
+    // one — adding a flag to the official means adding it here.
+    const OFFICIAL_EXEC_FLAGS: &[&str] = &[
+        "user-data-folder",
+        "docker-path",
+        "docker-compose-path",
+        "container-data-folder",
+        "container-system-data-folder",
+        "workspace-folder",
+        "mount-workspace-git-root",
+        "mount-git-worktree-common-dir",
+        "container-id",
+        "id-label",
+        "config",
+        "override-config",
+        "log-level",
+        "log-format",
+        "terminal-columns",
+        "terminal-rows",
+        "default-user-env-probe",
+        "remote-env",
+        "skip-feature-auto-mapping",
+    ];
+
+    #[test]
+    fn exec_flag_parity() {
+        use clap::CommandFactory;
+        use std::collections::HashSet;
+        let cli = crate::Cli::command();
+        let cmd = cli
+            .find_subcommand("exec")
+            .expect("`exec` subcommand must exist");
+        let longs: HashSet<&str> = cmd
+            .get_arguments()
+            .filter_map(clap::Arg::get_long)
+            .collect();
+        let missing: Vec<&&str> = OFFICIAL_EXEC_FLAGS
+            .iter()
+            .filter(|f| !longs.contains(**f))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "`exec` is missing official flags: {missing:?}"
+        );
+    }
+
+    #[test]
+    fn exec_accepts_all_new_compat_flags() {
+        use clap::Parser;
+        // A maximal official-style invocation must parse Ok. Mirrors the kind of
+        // command that previously errored with "unexpected argument".
+        let cli = crate::Cli::try_parse_from([
+            "cella",
+            "exec",
+            "--log-format",
+            "json",
+            "--log-level",
+            "debug",
+            "--user-data-folder",
+            "/x",
+            "--docker-path",
+            "/usr/bin/docker",
+            "--docker-compose-path",
+            "/usr/bin/docker-compose",
+            "--container-data-folder",
+            "/cdata",
+            "--container-system-data-folder",
+            "/csys",
+            "--mount-git-worktree-common-dir",
+            "--terminal-columns",
+            "80",
+            "--terminal-rows",
+            "40",
+            "--skip-feature-auto-mapping",
+            "--",
+            "true",
+        ])
+        .expect("all official exec compat flags must parse");
+        let crate::commands::Command::Exec(args) = &cli.command else {
+            panic!("expected exec subcommand");
+        };
+        // log-level/log-format are wired (read by main.rs); confirm they land.
+        assert!(matches!(
+            args.compat.log_level,
+            Some(super::super::LogLevel::Debug)
+        ));
+        assert!(matches!(
+            args.compat.log_format,
+            super::super::LogFormat::Json
+        ));
+    }
+
+    #[test]
+    fn exec_mount_workspace_git_root_boolean_forms() {
+        use clap::Parser;
+        let parse = |argv: &[&str]| -> bool {
+            let cli = crate::Cli::try_parse_from(argv).expect("must parse");
+            let crate::commands::Command::Exec(args) = cli.command else {
+                panic!("expected exec subcommand");
+            };
+            args.compat.mount_workspace_git_root
+        };
+        // Absent → default true.
+        assert!(parse(&["cella", "exec", "--", "true"]));
+        // Explicit value false (official `--mount-workspace-git-root false`).
+        assert!(!parse(&[
+            "cella",
+            "exec",
+            "--mount-workspace-git-root",
+            "false",
+            "--",
+            "true",
+        ]));
+        // Explicit value true.
+        assert!(parse(&[
+            "cella",
+            "exec",
+            "--mount-workspace-git-root",
+            "true",
+            "--",
+            "true",
+        ]));
+        // Bare flag (official yargs boolean accepts the no-value form) → true.
+        assert!(parse(&[
+            "cella",
+            "exec",
+            "--mount-workspace-git-root",
+            "--",
+            "true",
+        ]));
+    }
+
+    #[test]
+    fn exec_terminal_columns_requires_rows() {
+        use clap::Parser;
+        // Official pairs terminal-columns/terminal-rows via `implies`; clap's
+        // `requires` enforces the same — one without the other is rejected.
+        let r =
+            crate::Cli::try_parse_from(["cella", "exec", "--terminal-columns", "80", "--", "true"]);
+        assert!(r.is_err(), "--terminal-columns alone must be rejected");
     }
 
     #[test]

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -133,6 +133,99 @@ pub fn derive_lockfile_policy(
     }
 }
 
+/// Compatibility/diagnostic flags shared by the workspace-resolving commands
+/// `exec` and `read-configuration`, sized to the **common** subset of their
+/// official option surfaces (devcontainers/cli `execOptions`, lines 1250-1271,
+/// and `readConfigurationOptions`, lines 993-1012).
+///
+/// Every field here is a no-op in cella, accepted purely for drop-in parity:
+/// cella manages its own data dirs, talks to the engine API directly (not the
+/// `docker`/`docker compose` CLI), fixes the workspace mount layout at create
+/// time, and resolves no features on these paths. `--log-level`/`--log-format`
+/// are the exception — they ARE wired, seeded into the global tracing subscriber
+/// by `main.rs` via [`Command::log_level`]/[`Command::log_format`] before
+/// dispatch (the same path `up`/`run-user-commands` use).
+///
+/// This is deliberately NOT [`run_user_commands::CompatArgs`]: that struct
+/// carries `--secrets-file` (which it *wires*) and `--container-session-data-
+/// folder`, neither of which the official `exec`/`read-configuration` accept —
+/// flattening it would over-expose and silently ignore `--secrets-file`. The
+/// container data-folder flags that ARE exec-only (`--container-data-folder`,
+/// `--container-system-data-folder`) live on `ExecArgs` directly, since
+/// `read-configuration` does not accept them.
+#[derive(Args)]
+pub struct WorkspaceCompatArgs {
+    /// `docker` CLI binary path (compatibility no-op).
+    #[arg(long = "docker-path")]
+    pub(crate) docker_path: Option<String>,
+
+    /// `docker compose` CLI binary path (compatibility no-op).
+    #[arg(long = "docker-compose-path")]
+    pub(crate) docker_compose_path: Option<String>,
+
+    /// Host directory persisted across sessions (compatibility no-op).
+    #[arg(long = "user-data-folder")]
+    pub(crate) user_data_folder: Option<std::path::PathBuf>,
+
+    /// Mount the workspace using its Git root (compatibility no-op, default
+    /// `true`). Accepts the official yargs boolean forms: bare
+    /// (`--mount-workspace-git-root`), explicit (`--mount-workspace-git-root
+    /// false`), and absent (defaults to `true`).
+    #[arg(
+        long = "mount-workspace-git-root",
+        num_args = 0..=1,
+        default_value_t = true,
+        default_missing_value = "true",
+    )]
+    pub(crate) mount_workspace_git_root: bool,
+
+    /// Mount the Git worktree common dir (compatibility no-op).
+    #[arg(long = "mount-git-worktree-common-dir")]
+    pub(crate) mount_git_worktree_common_dir: bool,
+
+    /// Log verbosity (seeded into the global tracing filter by `main.rs`).
+    #[arg(long = "log-level", value_enum)]
+    pub(crate) log_level: Option<LogLevel>,
+
+    /// Log output format (seeded into the global tracing subscriber by `main.rs`).
+    #[arg(long = "log-format", value_enum, default_value = "text")]
+    pub(crate) log_format: LogFormat,
+
+    /// Number of columns to render subprocess output for (compatibility no-op).
+    #[arg(long = "terminal-columns", requires = "terminal_rows")]
+    pub(crate) terminal_columns: Option<u16>,
+
+    /// Number of rows to render subprocess output for (compatibility no-op).
+    #[arg(long = "terminal-rows", requires = "terminal_columns")]
+    pub(crate) terminal_rows: Option<u16>,
+
+    /// Temporary option for testing; cella resolves no features on these paths
+    /// (compatibility no-op, hidden — matches the official `hidden: true`).
+    #[arg(long = "skip-feature-auto-mapping", hide = true)]
+    pub(crate) skip_feature_auto_mapping: bool,
+}
+
+impl Default for WorkspaceCompatArgs {
+    /// Matches the clap-parsed defaults so struct-literal test construction (via
+    /// `..Default::default()`) mirrors a bare invocation. `mount_workspace_git_root`
+    /// defaults to `true` (the official default), which `#[derive(Default)]` would
+    /// get wrong (`false`).
+    fn default() -> Self {
+        Self {
+            docker_path: None,
+            docker_compose_path: None,
+            user_data_folder: None,
+            mount_workspace_git_root: true,
+            mount_git_worktree_common_dir: false,
+            log_level: None,
+            log_format: LogFormat::Text,
+            terminal_columns: None,
+            terminal_rows: None,
+            skip_feature_auto_mapping: false,
+        }
+    }
+}
+
 /// Common flags for commands that support verbose output.
 #[derive(Args, Clone)]
 pub struct VerboseArgs {
@@ -409,17 +502,19 @@ impl Command {
 
     /// The `--log-level` value, if the subcommand carries one.
     ///
-    /// `up` (and `code`, which embeds the `up` arg surface), `build`,
-    /// `run-user-commands`, `set-up`, `templates`, `features`, and `upgrade`
-    /// expose `--log-level`; every other variant returns
-    /// `None`. main.rs reads this once, before subcommand dispatch, to seed the
-    /// global tracing filter — the level can't be applied inside `execute()`
-    /// because the subscriber is already installed by then.
+    /// `up` (and `code`, which embeds the `up` arg surface), `build`, `exec`,
+    /// `read-configuration`, `run-user-commands`, `set-up`, `templates`,
+    /// `features`, and `upgrade` expose `--log-level`; every other variant
+    /// returns `None`. main.rs reads this once, before subcommand dispatch, to
+    /// seed the global tracing filter — the level can't be applied inside
+    /// `execute()` because the subscriber is already installed by then.
     pub const fn log_level(&self) -> Option<LogLevel> {
         match self {
             Self::Up(args) => args.compat.log_level,
             Self::Code(args) => args.up.compat.log_level,
             Self::Build(args) => args.log_level(),
+            Self::Exec(args) => args.compat.log_level,
+            Self::ReadConfiguration(args) => args.compat.log_level,
             Self::RunUserCommands(args) => args.compat.log_level,
             Self::SetUp(args) => args.compat.log_level,
             Self::Templates(args) => args.apply_log_level(),
@@ -431,8 +526,8 @@ impl Command {
 
     /// The `--log-format` value (defaults to `Text`).
     ///
-    /// `up`/`code`, `build`, `run-user-commands`, and `set-up` expose
-    /// `--log-format`; every other variant returns
+    /// `up`/`code`, `build`, `exec`, `read-configuration`, `run-user-commands`,
+    /// and `set-up` expose `--log-format`; every other variant returns
     /// `Text`. Read once in main.rs to select the tracing formatter and to
     /// force spinners off under `Json` (indicatif ANSI escapes would corrupt
     /// machine-readable JSON log lines on stderr).
@@ -441,6 +536,8 @@ impl Command {
             Self::Up(args) => args.compat.log_format,
             Self::Code(args) => args.up.compat.log_format,
             Self::Build(args) => args.log_format(),
+            Self::Exec(args) => args.compat.log_format,
+            Self::ReadConfiguration(args) => args.compat.log_format,
             Self::RunUserCommands(args) => args.compat.log_format,
             Self::SetUp(args) => args.compat.log_format,
             _ => LogFormat::Text,

--- a/crates/cella-cli/src/commands/read_configuration.rs
+++ b/crates/cella-cli/src/commands/read_configuration.rs
@@ -47,6 +47,16 @@ pub struct ReadConfigurationArgs {
     /// Additional features as JSON string.
     #[arg(long = "additional-features")]
     additional_features: Option<String>,
+
+    /// Shared devcontainer-CLI compat flags (`--docker-path`,
+    /// `--user-data-folder`, `--mount-*`, `--log-level`/`--log-format`,
+    /// `--terminal-*`, `--skip-feature-auto-mapping`). All no-ops except
+    /// log-level/log-format (seeded into tracing by `main.rs`). The
+    /// `--mount-workspace-git-root` value is not consumed here: cella always
+    /// reports the git-root mount (see `find_git_root_folder` below), matching
+    /// the official default of `true`.
+    #[command(flatten)]
+    pub(crate) compat: super::WorkspaceCompatArgs,
 }
 
 impl ReadConfigurationArgs {
@@ -743,6 +753,105 @@ mod tests {
         );
     }
 
+    // ── devcontainer-CLI flag parity ───────────────────────────────
+    //
+    // Source of truth: devcontainers/cli `src/spec-node/devContainersSpecCLI.ts`
+    // `readConfigurationOptions` (lines 993-1012). Every official long flag MUST
+    // be declared so no official `devcontainer read-configuration` invocation
+    // errors with "unknown argument". This test exists because the command
+    // drifted from the spec for lack of one.
+    const OFFICIAL_READ_CONFIGURATION_FLAGS: &[&str] = &[
+        "user-data-folder",
+        "docker-path",
+        "docker-compose-path",
+        "workspace-folder",
+        "mount-workspace-git-root",
+        "mount-git-worktree-common-dir",
+        "container-id",
+        "id-label",
+        "config",
+        "override-config",
+        "log-level",
+        "log-format",
+        "terminal-columns",
+        "terminal-rows",
+        "include-features-configuration",
+        "include-merged-configuration",
+        "additional-features",
+        "skip-feature-auto-mapping",
+    ];
+
+    #[test]
+    fn read_configuration_flag_parity() {
+        use clap::CommandFactory;
+        use std::collections::HashSet;
+        let cli = crate::Cli::command();
+        let cmd = cli
+            .find_subcommand("read-configuration")
+            .expect("`read-configuration` subcommand must exist");
+        let longs: HashSet<&str> = cmd
+            .get_arguments()
+            .filter_map(clap::Arg::get_long)
+            .collect();
+        let missing: Vec<&&str> = OFFICIAL_READ_CONFIGURATION_FLAGS
+            .iter()
+            .filter(|f| !longs.contains(**f))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "`read-configuration` is missing official flags: {missing:?}"
+        );
+    }
+
+    #[test]
+    fn read_configuration_accepts_all_new_compat_flags() {
+        use clap::Parser;
+        // A maximal official-style invocation must parse Ok.
+        let cli = crate::Cli::try_parse_from([
+            "cella",
+            "read-configuration",
+            "--log-format",
+            "json",
+            "--log-level",
+            "debug",
+            "--user-data-folder",
+            "/x",
+            "--docker-path",
+            "/usr/bin/docker",
+            "--docker-compose-path",
+            "/usr/bin/docker-compose",
+            "--mount-workspace-git-root",
+            "false",
+            "--mount-git-worktree-common-dir",
+            "--terminal-columns",
+            "80",
+            "--terminal-rows",
+            "40",
+            "--skip-feature-auto-mapping",
+        ])
+        .expect("all official read-configuration compat flags must parse");
+        let crate::commands::Command::ReadConfiguration(args) = &cli.command else {
+            panic!("expected read-configuration subcommand");
+        };
+        assert!(matches!(
+            args.compat.log_level,
+            Some(super::super::LogLevel::Debug)
+        ));
+        assert!(matches!(
+            args.compat.log_format,
+            super::super::LogFormat::Json
+        ));
+        assert!(!args.compat.mount_workspace_git_root);
+    }
+
+    #[test]
+    fn read_configuration_terminal_columns_requires_rows() {
+        use clap::Parser;
+        let r =
+            crate::Cli::try_parse_from(["cella", "read-configuration", "--terminal-columns", "80"]);
+        assert!(r.is_err(), "--terminal-columns alone must be rejected");
+    }
+
     // -------------------------------------------------------------------------
     // build_merged_output — lifecycle plural arrays
     // -------------------------------------------------------------------------
@@ -1268,6 +1377,7 @@ mod tests {
             override_config: None,
             id_label: Vec::new(),
             container_id: None,
+            compat: crate::commands::WorkspaceCompatArgs::default(),
             additional_features: None,
         };
         args.execute().await.unwrap();
@@ -1289,6 +1399,7 @@ mod tests {
             override_config: Some(override_path),
             id_label: Vec::new(),
             container_id: None,
+            compat: crate::commands::WorkspaceCompatArgs::default(),
             additional_features: None,
         };
         args.execute().await.unwrap();
@@ -1307,6 +1418,7 @@ mod tests {
             override_config: None,
             id_label: Vec::new(),
             container_id: None,
+            compat: crate::commands::WorkspaceCompatArgs::default(),
             additional_features: Some(
                 r#"{"ghcr.io/devcontainers/features/git:1": {}}"#.to_string(),
             ),
@@ -1327,6 +1439,7 @@ mod tests {
             override_config: None,
             id_label: Vec::new(),
             container_id: None,
+            compat: crate::commands::WorkspaceCompatArgs::default(),
             additional_features: Some("not valid json".to_string()),
         };
         let err = args.execute().await.unwrap_err();
@@ -1346,6 +1459,7 @@ mod tests {
             override_config: None,
             id_label: Vec::new(),
             container_id: None,
+            compat: crate::commands::WorkspaceCompatArgs::default(),
             additional_features: Some(r#"["not", "an", "object"]"#.to_string()),
         };
         let err = args.execute().await.unwrap_err();
@@ -1366,6 +1480,7 @@ mod tests {
             override_config: None,
             id_label: Vec::new(),
             container_id: None,
+            compat: crate::commands::WorkspaceCompatArgs::default(),
             additional_features: None,
         };
         // Capture stdout to verify the shape.

--- a/crates/cella-cli/src/commands/read_configuration.rs
+++ b/crates/cella-cli/src/commands/read_configuration.rs
@@ -50,11 +50,11 @@ pub struct ReadConfigurationArgs {
 
     /// Shared devcontainer-CLI compat flags (`--docker-path`,
     /// `--user-data-folder`, `--mount-*`, `--log-level`/`--log-format`,
-    /// `--terminal-*`, `--skip-feature-auto-mapping`). All no-ops except
-    /// log-level/log-format (seeded into tracing by `main.rs`). The
-    /// `--mount-workspace-git-root` value is not consumed here: cella always
-    /// reports the git-root mount (see `find_git_root_folder` below), matching
-    /// the official default of `true`.
+    /// `--terminal-*`, `--skip-feature-auto-mapping`). Mostly no-ops; the
+    /// exceptions are log-level/log-format (seeded into tracing by `main.rs`)
+    /// and `--mount-workspace-git-root`, which is honored here — when `false`
+    /// the reported `workspaceMount` binds the workspace folder itself rather
+    /// than its git root (defaults to `true`, matching the official).
     #[command(flatten)]
     pub(crate) compat: super::WorkspaceCompatArgs,
 }
@@ -116,7 +116,8 @@ impl ReadConfigurationArgs {
         // bind-mounts the git-root folder (mountWorkspaceGitRoot defaults to
         // true). read-configuration exposes no flag to override this, so the
         // default is reported. Compose configs ignore this (no bind mount).
-        let host_mount_folder = cella_git::find_git_root_folder(&cwd, true);
+        let host_mount_folder =
+            cella_git::find_git_root_folder(&cwd, self.compat.mount_workspace_git_root);
         let mut output = build_base_output(
             &resolved.config,
             &resolved.config_path,
@@ -842,6 +843,24 @@ mod tests {
             super::super::LogFormat::Json
         ));
         assert!(!args.compat.mount_workspace_git_root);
+    }
+
+    #[test]
+    fn workspace_mount_reflects_mount_workspace_git_root() {
+        // `execute` now feeds `find_git_root_folder(cwd, mount_workspace_git_root)`
+        // into the reported `workspaceMount`. A git-root mount and a
+        // workspace-folder mount must therefore yield different sources — so
+        // `--mount-workspace-git-root false` is honored, not ignored.
+        let config = serde_json::json!({ "image": "ubuntu" });
+        let cfg = PathBuf::from("/repo/sub/.devcontainer/devcontainer.json");
+        let workspace = PathBuf::from("/repo/sub");
+        let git_root_mount = build_base_output(&config, &cfg, &workspace, &PathBuf::from("/repo"));
+        let workspace_mount = build_base_output(&config, &cfg, &workspace, &workspace);
+        assert_ne!(
+            git_root_mount["workspace"]["workspaceMount"],
+            workspace_mount["workspace"]["workspaceMount"],
+            "mount source must differ between git-root and workspace-folder mounts"
+        );
     }
 
     #[test]


### PR DESCRIPTION
`cella exec --log-format json …` (and other valid official invocations) errored with "unexpected argument" — these three commands were missing flags the real `@devcontainers/cli` accepts, which breaks the drop-in contract for scripted use. This adds them.

A shared `WorkspaceCompatArgs` (`docker-path`, `docker-compose-path`, `user-data-folder`, `mount-workspace-git-root`, `mount-git-worktree-common-dir`, `log-level`, `log-format`, `terminal-columns`/`rows`, `skip-feature-auto-mapping`) is flattened into `exec` and `read-configuration`; `build` gets the three it lacked (`user-data-folder`, `skip-feature-auto-mapping`, `omit-syntax-directive`). Flag shapes match the official — `mount-workspace-git-root` parses the yargs boolean forms (bare/`=value`/absent→true), terminal dims require each other, and the testing-only flags are `hide`d like the official's `hidden: true`.

Most are accept-and-ignore no-ops; `log-level`/`log-format` hook into the existing tracing seed via the `Command` dispatch. `omit-syntax-directive` is a verified no-op here — cella never emits a `# syntax=` directive (the Dockerfile is passed verbatim and `generate_dockerfile` opens with ARG/FROM), so there's nothing to suppress. Kept deliberately separate from `run-user-commands`' `CompatArgs` so flattening doesn't over-expose its `--secrets-file`.

Parity tests added per command — these drifted precisely because they had none. Verified live: `exec --log-format json --user-data-folder … --terminal-rows 40 --terminal-columns 80` now parses (reaches the runtime backend check instead of rejecting). Full suite green (4734), clippy + fmt clean, no help-snapshot drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)