### PR TITLE
fix(lockfile): record the resolved feature version, not the OCI tag

### DIFF
--- a/crates/cella-features/src/lib.rs
+++ b/crates/cella-features/src/lib.rs
@@ -619,7 +619,10 @@ fn build_lockfile_from_entries(feature_entries: &[FeatureEntry]) -> Lockfile {
             depends_on.dedup();
             Some((
                 entry.original_ref.clone(),
-                oci.version.clone(),
+                // The lockfile records the resolved feature version (e.g.
+                // `"1.7.1"`), not the OCI tag (`"1"`) — matching the official
+                // `version: set.features[0].version`.
+                entry.metadata.version.clone(),
                 resolved,
                 oci.digest.clone(),
                 depends_on,
@@ -2394,6 +2397,9 @@ mod tests {
             install_id: install_identity(original_ref, "{}"),
             metadata: FeatureMetadata {
                 id: repo.rsplit('/').next().unwrap_or(repo).to_string(),
+                // The resolved feature version (from devcontainer-feature.json),
+                // distinct from the OCI tag — this is what the lockfile records.
+                version: "1.7.1".to_string(),
                 ..Default::default()
             },
             artifact_dir: PathBuf::from("/tmp/feature"),
@@ -2426,7 +2432,9 @@ mod tests {
                 .contains_key("ghcr.io/devcontainers/features/node:1")
         );
         let entry = &lf.features["ghcr.io/devcontainers/features/node:1"];
-        assert_eq!(entry.version, "1");
+        // The key keeps the authored tag (`:1`), but `version` is the resolved
+        // feature version (matching the official `set.features[0].version`).
+        assert_eq!(entry.version, "1.7.1");
         assert_eq!(entry.integrity, "sha256:abc");
         assert_eq!(
             entry.resolved,

--- a/crates/cella-features/src/lockfile.rs
+++ b/crates/cella-features/src/lockfile.rs
@@ -18,7 +18,9 @@ use crate::FeatureError;
 /// A single feature entry inside the lockfile.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LockfileEntry {
-    /// Resolved version (OCI tag, e.g. `"1"` or `"latest"`).
+    /// Resolved feature version (e.g. `"1.7.1"`), from the feature's
+    /// `devcontainer-feature.json` — not the OCI tag. Matches the official
+    /// lockfile's `version: set.features[0].version`.
     pub version: String,
     /// Full resolved reference with manifest digest, e.g.
     /// `"ghcr.io/devcontainers/features/node@sha256:abc..."`.
@@ -154,7 +156,8 @@ pub fn write_lockfile(config_path: &Path, lockfile: &Lockfile) -> Result<(), Fea
 /// Generate a [`Lockfile`] from a list of resolved OCI features.
 ///
 /// Each tuple is `(key, version, resolved_full, integrity, depends_on)` where:
-/// - `key` — feature ID with any `:version` / `@digest` suffix stripped
+/// - `key` — the feature ref exactly as authored; the `:tag` / `@digest`
+///   suffix is part of the key, never stripped
 /// - `version` — the resolved feature version (e.g. `"1.7.1"`), not the tag
 /// - `resolved_full` — `"registry/repository@digest"`
 /// - `integrity` — the manifest digest (`"sha256:..."`)
@@ -187,6 +190,14 @@ pub fn generate_lockfile(
 /// Returns `Ok(())` when they match, or [`LockfileError::Mismatch`] when they
 /// differ. The missing-file case is handled by the caller before this point
 /// (a `read_lockfile` returning `None`), so this only compares structure.
+///
+/// The comparison is a strict whole-entry equality, matching the official CLI's
+/// frozen check (a normalized full-content string compare). A lockfile written
+/// before features[].version switched from the OCI tag to the resolved version
+/// will therefore mismatch under `--frozen` even though the pinned digest is
+/// unchanged — a one-time regeneration, exactly as the official requires for any
+/// lockfile content change. Loosening this to pin only on the digest would make
+/// cella *more* permissive than the official, so it is intentionally strict.
 ///
 /// # Errors
 ///

--- a/crates/cella-features/src/lockfile.rs
+++ b/crates/cella-features/src/lockfile.rs
@@ -155,7 +155,7 @@ pub fn write_lockfile(config_path: &Path, lockfile: &Lockfile) -> Result<(), Fea
 ///
 /// Each tuple is `(key, version, resolved_full, integrity, depends_on)` where:
 /// - `key` — feature ID with any `:version` / `@digest` suffix stripped
-/// - `version` — the OCI tag that was fetched
+/// - `version` — the resolved feature version (e.g. `"1.7.1"`), not the tag
 /// - `resolved_full` — `"registry/repository@digest"`
 /// - `integrity` — the manifest digest (`"sha256:..."`)
 /// - `depends_on` — keys of features this one depends on (may be empty)


### PR DESCRIPTION
cella's `devcontainer-lock.json` stored the OCI **tag** (`"1"`) in `features[].version`, but the official records the **resolved feature version** — `version: set.features[0].version` (e.g. `"1.7.1"`). This switches cella to the feature's metadata version.

Two payoffs:
- cella's lockfile now matches the official byte-for-key.
- `outdated` reports the actually-installed version in `current` — its full-semver guard (added in #203) now passes the lockfile version through instead of falling back to `wanted`, since the stored value is a real version.

Pinning/reproducibility is unaffected: features resolve by digest (`resolved`/`integrity`), and `version` is informational — `compare_lockfile` is whole-entry equality, so writing and comparing the full version stays consistent. Existing tag-based lockfiles will regenerate on the next write (cella has no backward-compat constraint). The lockfile test now asserts the key keeps the authored tag while `version` is the resolved version. Full suite green (4735).

Surfaced by Codex's review on #203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)