### PR TITLE
fix(set-up,build): complete the structured-output contract

### DIFF
--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -185,6 +185,22 @@ impl BuildArgs {
         self,
         progress: crate::progress::Progress,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        match self.run(progress).await {
+            Ok(()) => Ok(()),
+            // Mirror the official: a build failure prints the error envelope to
+            // stdout (`{outcome:'error', …}`) and exits 1 — consistent with
+            // up/set-up/run-user-commands rather than a bare stderr report.
+            Err(e) => {
+                println!("{}", render_error_envelope(&e.to_string()));
+                std::process::exit(1);
+            }
+        }
+    }
+
+    async fn run(
+        self,
+        progress: crate::progress::Progress,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let cwd = super::resolve_workspace_folder(self.workspace_folder.as_deref())?;
 
         info!("Resolving devcontainer config...");
@@ -444,6 +460,17 @@ fn build_json_result(image_names: &[String]) -> String {
         image_name: image_names.to_vec(),
     })
     .unwrap_or_default()
+}
+
+/// Render the `build` error envelope (stdout JSON), mirroring the official's
+/// `{outcome:'error', message, description}` written on build failure.
+fn render_error_envelope(message: &str) -> String {
+    serde_json::to_string(&serde_json::json!({
+        "outcome": "error",
+        "message": message,
+        "description": "An error occurred building the container.",
+    }))
+    .expect("BUG: error envelope is not serialisable")
 }
 
 /// Print the build result.
@@ -836,6 +863,20 @@ mod tests {
         let result =
             TestCli::try_parse_from(["build", "--no-lockfile", "--experimental-frozen-lockfile"]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn error_envelope_shape() {
+        // Build failures emit `{outcome:'error', message, description}` to
+        // stdout, mirroring the official and matching the sibling commands.
+        let parsed: serde_json::Value =
+            serde_json::from_str(&render_error_envelope("boom")).expect("valid JSON");
+        assert_eq!(parsed["outcome"], "error");
+        assert_eq!(parsed["message"], "boom");
+        assert_eq!(
+            parsed["description"],
+            "An error occurred building the container."
+        );
     }
 
     #[test]

--- a/crates/cella-cli/src/commands/read_configuration.rs
+++ b/crates/cella-cli/src/commands/read_configuration.rs
@@ -315,7 +315,7 @@ pub async fn resolve_config_features(
 /// only the updateable properties (`remoteUser`/`userEnvProbe`/`remoteEnv`),
 /// while other targets (e.g. `--container-id`) append the full config (incl
 /// lifecycle/customizations). A single-object label is normalised to one entry.
-fn build_merged_from_label(
+pub fn build_merged_from_label(
     config: &serde_json::Value,
     label_json: &str,
     has_id_labels: bool,

--- a/crates/cella-cli/src/commands/read_configuration.rs
+++ b/crates/cella-cli/src/commands/read_configuration.rs
@@ -315,7 +315,7 @@ pub async fn resolve_config_features(
 /// only the updateable properties (`remoteUser`/`userEnvProbe`/`remoteEnv`),
 /// while other targets (e.g. `--container-id`) append the full config (incl
 /// lifecycle/customizations). A single-object label is normalised to one entry.
-pub fn build_merged_from_label(
+pub(super) fn build_merged_from_label(
     config: &serde_json::Value,
     label_json: &str,
     has_id_labels: bool,

--- a/crates/cella-cli/src/commands/set_up.rs
+++ b/crates/cella-cli/src/commands/set_up.rs
@@ -235,10 +235,14 @@ impl SetUpArgs {
         if self.result.include_merged_configuration {
             // Route through the canonical label-merge (shared with
             // `read-configuration`) so the shape matches `up`/`read-configuration`:
-            // plural lifecycle arrays + Record-of-arrays customizations. set-up
-            // always targets by container-id, so the full current config is
-            // appended (`has_id_labels = false`).
-            let merged = effective_metadata.as_deref().map_or_else(
+            // plural lifecycle arrays + Record-of-arrays customizations.
+            //
+            // Use the RAW label, not `effective_metadata`: `build_merged_from_label`
+            // appends the current config itself (in full, since set-up targets by
+            // container-id → `has_id_labels = false`), and `effective_metadata`
+            // has already appended the config's picked lifecycle hooks — passing
+            // it would duplicate them in the plural arrays.
+            let merged = metadata.as_deref().map_or_else(
                 || config.clone(),
                 |meta| super::read_configuration::build_merged_from_label(&config, meta, false),
             );

--- a/crates/cella-cli/src/commands/set_up.rs
+++ b/crates/cella-cli/src/commands/set_up.rs
@@ -233,9 +233,15 @@ impl SetUpArgs {
             envelope["configuration"] = config.clone();
         }
         if self.result.include_merged_configuration {
-            let merged = effective_metadata
-                .as_deref()
-                .map_or_else(|| config.clone(), |meta| build_merged_config(meta, &config));
+            // Route through the canonical label-merge (shared with
+            // `read-configuration`) so the shape matches `up`/`read-configuration`:
+            // plural lifecycle arrays + Record-of-arrays customizations. set-up
+            // always targets by container-id, so the full current config is
+            // appended (`has_id_labels = false`).
+            let merged = effective_metadata.as_deref().map_or_else(
+                || config.clone(),
+                |meta| super::read_configuration::build_merged_from_label(&config, meta, false),
+            );
             envelope["mergedConfiguration"] = merged;
         }
 
@@ -330,39 +336,12 @@ fn workspace_folder_in_container(
     "/workspaces".to_string()
 }
 
-/// Build a minimal merged config by folding metadata entries into the on-disk
-/// config, later-wins. Approximates `mergeConfiguration` for the
-/// `--include-merged-configuration` envelope key without pulling in the full
-/// feature-resolution pipeline.
-fn build_merged_config(metadata_json: &str, config: &Value) -> Value {
-    let entries: Vec<Value> = serde_json::from_str(metadata_json).unwrap_or_else(|e| {
-        tracing::warn!("devcontainer.metadata label is not valid JSON, treating as empty: {e}");
-        Vec::new()
-    });
-    let mut merged = serde_json::Map::new();
-    for entry in &entries {
-        if let Some(obj) = entry.as_object() {
-            for (k, v) in obj {
-                merged.insert(k.clone(), v.clone());
-            }
-        }
-    }
-    // On-disk config wins last (matches official: it is the final entry in the
-    // metadata array after mergeConfiguration appends it).
-    if let Some(obj) = config.as_object() {
-        for (k, v) in obj {
-            merged.insert(k.clone(), v.clone());
-        }
-    }
-    Value::Object(merged)
-}
-
 /// Render the JSON error envelope.
 fn render_error_envelope(message: &str) -> String {
     serde_json::to_string(&json!({
         "outcome": "error",
         "message": message,
-        "description": "An error occurred running user commands in the container.",
+        "description": "An error occurred setting up the container.",
     }))
     .expect("BUG: error envelope is not serialisable")
 }
@@ -462,25 +441,8 @@ mod tests {
         assert_eq!(parsed["message"], "boom");
         assert_eq!(
             parsed["description"],
-            "An error occurred running user commands in the container."
+            "An error occurred setting up the container."
         );
-    }
-
-    #[test]
-    fn build_merged_config_later_wins() {
-        let meta = json!([
-            {"remoteUser": "from-feature", "customizations": {"vscode": {}}},
-            {"remoteUser": "root"}
-        ])
-        .to_string();
-        let config = json!({"remoteUser": "vscode", "workspaceFolder": "/app"});
-        let merged = build_merged_config(&meta, &config);
-        // On-disk config wins for remoteUser
-        assert_eq!(merged["remoteUser"], "vscode");
-        // Config-only key survives
-        assert_eq!(merged["workspaceFolder"], "/app");
-        // Metadata-only key survives
-        assert!(merged.get("customizations").is_some());
     }
 
     #[test]


### PR DESCRIPTION
Two structured-output divergences surfaced by a fresh parity sweep — the last unblocked output-contract gaps.

**`set-up` emitted a malformed `mergedConfiguration`.** Its `--include-merged-configuration` used a flat last-wins merge that produced singular lifecycle keys (`onCreateCommand`) and scalar `customizations`, while `up` and `read-configuration` emit the official plural-array / Record-of-arrays shape for the same container. A consumer parsing `mergedConfiguration.onCreateCommands` on set-up's output silently misparsed. Fixed by routing set-up through the already-correct, shared `build_merged_from_label` (set-up always targets by container-id → `has_id_labels = false`) and deleting the duplicate merge — so all three commands now produce identical shape. Also corrected set-up's error `description` (it used the run-user-commands wording).

**`build` emitted no error envelope.** On failure, `build` printed a bare debug report to stderr while its three siblings (up/set-up/run-user-commands) emit `{outcome:'error', message, description}` to stdout and exit 1 — so `devcontainer build | jq .outcome` worked on success but broke on every failure. Split `execute` into `run`/`execute` and emit the official build error envelope. Verified live: a build in an empty dir now prints `{"outcome":"error","message":"…","description":"An error occurred building the container."}`.

Both validated against the official `mergeConfiguration` (imageMetadata.ts) and `doBuild` error branch (devContainersSpecCLI.ts:771). Full suite green (4735), clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)