### PR TITLE
fix(set-up): restore the official error description

### DIFF
--- a/crates/cella-cli/src/commands/set_up.rs
+++ b/crates/cella-cli/src/commands/set_up.rs
@@ -345,7 +345,10 @@ fn render_error_envelope(message: &str) -> String {
     serde_json::to_string(&json!({
         "outcome": "error",
         "message": message,
-        "description": "An error occurred setting up the container.",
+        // set-up's job is running the lifecycle (user) commands in an existing
+        // container, so the official's fallback description is the
+        // run-user-commands wording (`setUp` catch, devContainersSpecCLI.ts:510).
+        "description": "An error occurred running user commands in the container.",
     }))
     .expect("BUG: error envelope is not serialisable")
 }
@@ -445,7 +448,7 @@ mod tests {
         assert_eq!(parsed["message"], "boom");
         assert_eq!(
             parsed["description"],
-            "An error occurred setting up the container."
+            "An error occurred running user commands in the container."
         );
     }
 


### PR DESCRIPTION
#206 changed set-up's error envelope `description` to "An error occurred setting up the container." — but the official `setUp` catch (devContainersSpecCLI.ts:510) uses **"An error occurred running user commands in the container."** `set-up`'s job is running the lifecycle (user) commands in an existing container, so it shares the run-user-commands wording; `up`/doProvision is the one that says "setting up the container" (:336).

I caught this in a fresh exhaustive flag/behavior audit and verified it against the function boundaries in the official source (`doProvision`@321→:336, `setUp`@393→:510, `doBuild`@583→:774). Reverts to the official wording; set_up.rs's module doc already described it correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)