### PR TITLE
feat(cli): complete official flag parity (boolean forms + missing flags)

### DIFF
--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -27,6 +27,16 @@ pub struct BuildArgs {
     #[arg(long)]
     workspace_folder: Option<PathBuf>,
 
+    /// Optional positional workspace path. The official CLI registers
+    /// `build [path]` but its `doBuild` IGNORES the positional entirely (it
+    /// always resolves from `--workspace-folder`, defaulting to cwd). cella
+    /// instead uses it as the workspace folder when `--workspace-folder` is
+    /// absent — a deliberate usability divergence so `cella build ./foo` works
+    /// as users expect. `--workspace-folder` still takes precedence when both
+    /// are given.
+    #[arg(value_name = "PATH")]
+    path: Option<PathBuf>,
+
     /// Path to devcontainer.json (overrides auto-discovery).
     #[arg(long)]
     config: Option<PathBuf>,
@@ -110,9 +120,10 @@ pub struct BuildArgs {
     #[arg(long = "docker-compose-path")]
     docker_compose_path: Option<String>,
 
-    /// Log verbosity for build output.
-    #[arg(long = "log-level", value_enum)]
-    log_level: Option<LogLevel>,
+    /// Log verbosity for build output. Defaults to `info`, matching the
+    /// official `devcontainer build --log-level`.
+    #[arg(long = "log-level", value_enum, default_value = "info")]
+    log_level: LogLevel,
 
     /// Log output format.
     #[arg(long = "log-format", value_enum, default_value = "text")]
@@ -171,14 +182,23 @@ struct BuildCompatArgs {
 
 impl BuildArgs {
     /// The `--log-level` value, seeded into the global tracing filter by main.rs
-    /// before dispatch (mirrors `up`).
-    pub const fn log_level(&self) -> Option<LogLevel> {
+    /// before dispatch (mirrors `up`). Build's log level always has a value
+    /// (defaults to `info`, matching the official CLI), so this is non-optional.
+    pub const fn log_level(&self) -> LogLevel {
         self.log_level
     }
 
     /// The `--log-format` value (defaults to `Text`).
     pub const fn log_format(&self) -> LogFormat {
         self.log_format
+    }
+
+    /// The effective workspace folder: `--workspace-folder` wins, else the
+    /// optional positional `[path]`, else (handled downstream) the cwd. Mirrors
+    /// the official `build [path]` surface where `--workspace-folder` takes
+    /// precedence over the positional.
+    fn effective_workspace_folder(&self) -> Option<&std::path::Path> {
+        self.workspace_folder.as_deref().or(self.path.as_deref())
     }
 
     pub async fn execute(
@@ -201,7 +221,7 @@ impl BuildArgs {
         self,
         progress: crate::progress::Progress,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let cwd = super::resolve_workspace_folder(self.workspace_folder.as_deref())?;
+        let cwd = super::resolve_workspace_folder(self.effective_workspace_folder())?;
 
         info!("Resolving devcontainer config...");
         let mut resolved = resolve::config(&cwd, self.config.as_deref())?;
@@ -792,15 +812,45 @@ mod tests {
     #[test]
     fn log_level_and_format_accessors_return_parsed_values() {
         let args = parse_build(&["--log-level", "debug", "--log-format", "json"]);
-        assert!(matches!(args.log_level(), Some(LogLevel::Debug)));
+        assert!(matches!(args.log_level(), LogLevel::Debug));
         assert!(matches!(args.log_format(), LogFormat::Json));
     }
 
     #[test]
-    fn log_level_defaults_to_none_and_format_to_text() {
+    fn log_level_defaults_to_info_and_format_to_text() {
+        // Official `devcontainer build --log-level` defaults to `info`; cella
+        // matches it (was previously unset/None).
         let args = parse_build(&[]);
-        assert!(args.log_level().is_none());
+        assert!(matches!(args.log_level(), LogLevel::Info));
         assert!(matches!(args.log_format(), LogFormat::Text));
+    }
+
+    #[test]
+    fn positional_path_sets_workspace_folder() {
+        // Official registers `build [path]`; cella accepts the optional
+        // positional and uses it as the workspace folder when present.
+        let args = parse_build(&["./some/path"]);
+        assert_eq!(
+            args.effective_workspace_folder(),
+            Some(std::path::Path::new("./some/path"))
+        );
+    }
+
+    #[test]
+    fn workspace_folder_flag_wins_over_positional() {
+        // When both are given, `--workspace-folder` takes precedence.
+        let args = parse_build(&["--workspace-folder", "/flag", "/positional"]);
+        assert_eq!(
+            args.effective_workspace_folder(),
+            Some(std::path::Path::new("/flag"))
+        );
+    }
+
+    #[test]
+    fn no_path_or_flag_leaves_workspace_folder_unset() {
+        // Neither given → None (resolve_workspace_folder defaults to cwd).
+        let args = parse_build(&[]);
+        assert!(args.effective_workspace_folder().is_none());
     }
 
     // ── lockfile policy derivation ──────────────────────────────────

--- a/crates/cella-cli/src/commands/exec.rs
+++ b/crates/cella-cli/src/commands/exec.rs
@@ -750,6 +750,37 @@ mod tests {
     }
 
     #[test]
+    fn exec_mount_git_worktree_common_dir_boolean_forms() {
+        use clap::Parser;
+        let parse = |argv: &[&str]| -> bool {
+            let cli = crate::Cli::try_parse_from(argv).expect("must parse");
+            let crate::commands::Command::Exec(args) = cli.command else {
+                panic!("expected exec subcommand");
+            };
+            args.compat.mount_git_worktree_common_dir
+        };
+        // Absent → default false.
+        assert!(!parse(&["cella", "exec", "--", "true"]));
+        // Bare flag (official yargs boolean no-value form) → true.
+        assert!(parse(&[
+            "cella",
+            "exec",
+            "--mount-git-worktree-common-dir",
+            "--",
+            "true",
+        ]));
+        // Explicit `false` (official `--mount-git-worktree-common-dir false`).
+        assert!(!parse(&[
+            "cella",
+            "exec",
+            "--mount-git-worktree-common-dir",
+            "false",
+            "--",
+            "true",
+        ]));
+    }
+
+    #[test]
     fn exec_terminal_columns_requires_rows() {
         use clap::Parser;
         // Official pairs terminal-columns/terminal-rows via `implies`; clap's

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -519,7 +519,7 @@ impl Command {
         match self {
             Self::Up(args) => args.compat.log_level,
             Self::Code(args) => args.up.compat.log_level,
-            Self::Build(args) => args.log_level(),
+            Self::Build(args) => Some(args.log_level()),
             Self::Exec(args) => args.compat.log_level,
             Self::ReadConfiguration(args) => args.compat.log_level,
             Self::RunUserCommands(args) => args.compat.log_level,

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -179,8 +179,15 @@ pub struct WorkspaceCompatArgs {
     )]
     pub(crate) mount_workspace_git_root: bool,
 
-    /// Mount the Git worktree common dir (compatibility no-op).
-    #[arg(long = "mount-git-worktree-common-dir")]
+    /// Mount the Git worktree common dir (compatibility no-op). Accepts the
+    /// official yargs boolean forms: bare (`--mount-git-worktree-common-dir`),
+    /// explicit (`... false`), and absent (defaults to `false`).
+    #[arg(
+        long = "mount-git-worktree-common-dir",
+        num_args = 0..=1,
+        default_value_t = false,
+        default_missing_value = "true",
+    )]
     pub(crate) mount_git_worktree_common_dir: bool,
 
     /// Log verbosity (seeded into the global tracing filter by `main.rs`).

--- a/crates/cella-cli/src/commands/run_user_commands.rs
+++ b/crates/cella-cli/src/commands/run_user_commands.rs
@@ -95,8 +95,15 @@ pub struct GateArgs {
 /// bool-count lint; flattened it merges back into the same CLI surface.
 #[derive(Args)]
 pub struct AttachArgs {
-    /// Do not run `postAttachCommand`.
-    #[arg(long = "skip-post-attach")]
+    /// Do not run `postAttachCommand`. Accepts the official yargs boolean forms:
+    /// bare (`--skip-post-attach`), explicit (`--skip-post-attach false`), and
+    /// absent (defaults to `false`).
+    #[arg(
+        long = "skip-post-attach",
+        num_args = 0..=1,
+        default_value_t = false,
+        default_missing_value = "true",
+    )]
     skip_post_attach: bool,
 }
 
@@ -141,12 +148,26 @@ pub struct CompatArgs {
     #[arg(long = "user-data-folder")]
     user_data_folder: Option<PathBuf>,
 
-    /// Mount the workspace using its Git root (compatibility no-op).
-    #[arg(long = "mount-workspace-git-root", default_value_t = true)]
+    /// Mount the workspace using its Git root (compatibility no-op, default
+    /// `true`). Accepts the official yargs boolean forms: bare, explicit
+    /// (`--mount-workspace-git-root false`), and absent (defaults to `true`).
+    #[arg(
+        long = "mount-workspace-git-root",
+        num_args = 0..=1,
+        default_value_t = true,
+        default_missing_value = "true",
+    )]
     mount_workspace_git_root: bool,
 
-    /// Mount the Git worktree common dir (compatibility no-op).
-    #[arg(long = "mount-git-worktree-common-dir")]
+    /// Mount the Git worktree common dir (compatibility no-op). Accepts the
+    /// official yargs boolean forms: bare, explicit (`... false`), and absent
+    /// (defaults to `false`).
+    #[arg(
+        long = "mount-git-worktree-common-dir",
+        num_args = 0..=1,
+        default_value_t = false,
+        default_missing_value = "true",
+    )]
     mount_git_worktree_common_dir: bool,
 
     /// Temporary option for testing; cella resolves no features on this path
@@ -755,6 +776,43 @@ mod tests {
             ]);
             assert!(r.is_ok(), "{flag} should parse");
         }
+    }
+
+    #[test]
+    fn boolean_flags_accept_explicit_values() {
+        use clap::Parser;
+        // Official `type:'boolean'` flags accept both the bare form and an
+        // explicit `--flag false` (yargs parity). A prior plain-bool definition
+        // rejected `--skip-post-attach false` etc.
+        let cli = crate::Cli::try_parse_from([
+            "cella",
+            "run-user-commands",
+            "--container-id",
+            "abc",
+            "--skip-post-attach",
+            "false",
+            "--mount-workspace-git-root",
+            "false",
+            "--mount-git-worktree-common-dir",
+            "true",
+        ])
+        .expect("explicit boolean values must parse");
+        let crate::commands::Command::RunUserCommands(args) = &cli.command else {
+            panic!("expected run-user-commands subcommand");
+        };
+        assert!(!args.attach.skip_post_attach());
+        assert!(!args.compat.mount_workspace_git_root);
+        assert!(args.compat.mount_git_worktree_common_dir);
+
+        // Bare forms and absence keep the official defaults.
+        let cli =
+            crate::Cli::try_parse_from(["cella", "run-user-commands", "--container-id", "abc"])
+                .expect("bare invocation must parse");
+        let crate::commands::Command::RunUserCommands(args) = &cli.command else {
+            panic!("expected run-user-commands subcommand");
+        };
+        assert!(!args.attach.skip_post_attach());
+        assert!(args.compat.mount_workspace_git_root);
     }
 
     #[test]

--- a/crates/cella-cli/src/commands/set_up.rs
+++ b/crates/cella-cli/src/commands/set_up.rs
@@ -441,6 +441,30 @@ mod tests {
     }
 
     #[test]
+    fn boolean_flags_accept_explicit_values() {
+        use clap::Parser;
+        // set-up flattens run-user-commands' CompatArgs/AttachArgs, so the same
+        // yargs boolean flags must accept the explicit `--flag false` form here.
+        let r = crate::Cli::try_parse_from([
+            "cella",
+            "set-up",
+            "--container-id",
+            "abc",
+            "--skip-post-attach",
+            "false",
+            "--mount-workspace-git-root",
+            "false",
+            "--mount-git-worktree-common-dir",
+            "true",
+        ]);
+        assert!(
+            r.is_ok(),
+            "explicit boolean values must parse on set-up: {:?}",
+            r.err()
+        );
+    }
+
+    #[test]
     fn error_envelope_shape() {
         let parsed: Value =
             serde_json::from_str(&render_error_envelope("boom")).expect("valid JSON");

--- a/crates/cella-cli/src/commands/templates.rs
+++ b/crates/cella-cli/src/commands/templates.rs
@@ -143,7 +143,7 @@ pub struct TemplatesApplyArgs {
 
 impl TemplatesArgs {
     /// Return the `--log-level` from whichever subcommand carries one (`apply`,
-    /// `metadata`, or `publish`), if active.
+    /// `metadata`, `publish`, or `generate-docs`), if active.
     ///
     /// Called by [`super::Command::log_level`] so the global tracing filter is
     /// seeded before dispatch — the same pattern used by `up` and

--- a/crates/cella-cli/src/commands/templates.rs
+++ b/crates/cella-cli/src/commands/templates.rs
@@ -82,6 +82,11 @@ pub struct TemplatesGenerateDocsArgs {
     /// GitHub repository name used to build the README footer URL.
     #[arg(long = "github-repo", default_value = "")]
     pub github_repo: String,
+
+    /// Log verbosity level. Defaults to `info`, matching the official
+    /// `devcontainer templates generate-docs --log-level`.
+    #[arg(long = "log-level", value_enum, default_value = "info")]
+    pub log_level: LogLevel,
 }
 
 /// Arguments for `cella templates metadata`.
@@ -148,8 +153,8 @@ impl TemplatesArgs {
             TemplatesCommand::Apply(args) => Some(args.log_level),
             TemplatesCommand::Metadata(args) => Some(args.log_level),
             TemplatesCommand::Publish(args) => Some(args.log_level),
-            TemplatesCommand::GenerateDocs(_)
-            | TemplatesCommand::New { .. }
+            TemplatesCommand::GenerateDocs(args) => Some(args.log_level),
+            TemplatesCommand::New { .. }
             | TemplatesCommand::List
             | TemplatesCommand::Edit { .. } => None,
         }
@@ -698,6 +703,54 @@ mod tests {
         assert!(matches!(
             templates_args.apply_log_level(),
             Some(LogLevel::Debug)
+        ));
+    }
+
+    fn parse_generate_docs(argv: &[&str]) -> Result<TemplatesGenerateDocsArgs, clap::Error> {
+        let mut full = vec!["templates", "generate-docs"];
+        full.extend_from_slice(argv);
+        let parsed = <MetadataHarness as clap::Parser>::try_parse_from(full)?;
+        match parsed.command {
+            TemplatesCommand::GenerateDocs(args) => Ok(args),
+            _ => unreachable!("parsed the generate-docs subcommand"),
+        }
+    }
+
+    #[test]
+    fn generate_docs_accepts_log_level_flag() {
+        // Regression: generate-docs lacked `--log-level` entirely; the official
+        // templatesGenerateDocsOptions registers it (info|debug|trace).
+        for level in ["info", "debug", "trace"] {
+            let args = parse_generate_docs(&["--log-level", level])
+                .unwrap_or_else(|e| panic!("--log-level {level} should parse: {e}"));
+            assert!(matches!(
+                args.log_level,
+                LogLevel::Info | LogLevel::Debug | LogLevel::Trace
+            ));
+        }
+    }
+
+    #[test]
+    fn generate_docs_log_level_defaults_to_info() {
+        let args = parse_generate_docs(&[]).unwrap();
+        assert!(matches!(args.log_level, LogLevel::Info));
+    }
+
+    #[test]
+    fn generate_docs_log_level_wired_through_apply_log_level() {
+        let parsed = <MetadataHarness as clap::Parser>::try_parse_from([
+            "templates",
+            "generate-docs",
+            "--log-level",
+            "trace",
+        ])
+        .unwrap();
+        let templates_args = TemplatesArgs {
+            command: parsed.command,
+        };
+        assert!(matches!(
+            templates_args.apply_log_level(),
+            Some(LogLevel::Trace)
         ));
     }
 

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -24,12 +24,26 @@ pub struct UpBuildArgs {
     #[arg(long)]
     pub(crate) rebuild: bool,
 
-    /// Do not use cache when building the image.
-    #[arg(long)]
+    /// Do not use cache when building the image. Accepts the official yargs
+    /// boolean forms: bare, explicit (`--build-no-cache false`), and absent
+    /// (defaults to `false`).
+    #[arg(
+        long,
+        num_args = 0..=1,
+        default_value_t = false,
+        default_missing_value = "true",
+    )]
     pub(crate) build_no_cache: bool,
 
-    /// Remove existing container before starting.
-    #[arg(long)]
+    /// Remove existing container before starting. Accepts the official yargs
+    /// boolean forms: bare, explicit (`--remove-existing-container false`), and
+    /// absent (defaults to `false`).
+    #[arg(
+        long,
+        num_args = 0..=1,
+        default_value_t = false,
+        default_missing_value = "true",
+    )]
     pub(crate) remove_existing_container: bool,
 
     /// Image pull policy.
@@ -79,13 +93,28 @@ pub struct UpMountArgs {
     #[arg(long, value_enum, default_value = "cached")]
     pub(crate) workspace_mount_consistency: MountConsistency,
 
-    /// Mount the workspace using its Git root (default: true).
-    #[arg(long, action = clap::ArgAction::Set, default_value_t = true)]
+    /// Mount the workspace using its Git root (default: true). Accepts the
+    /// official yargs boolean forms: bare (`--mount-workspace-git-root`),
+    /// explicit (`--mount-workspace-git-root false`), and absent (defaults to
+    /// `true`).
+    #[arg(
+        long,
+        num_args = 0..=1,
+        default_value_t = true,
+        default_missing_value = "true",
+    )]
     pub(crate) mount_workspace_git_root: bool,
 
     /// Mount the Git worktree common dir for Git operations in the container.
-    /// Requires the worktree to be created with relative paths.
-    #[arg(long)]
+    /// Requires the worktree to be created with relative paths. Accepts the
+    /// official yargs boolean forms: bare, explicit (`... false`), and absent
+    /// (defaults to `false`).
+    #[arg(
+        long,
+        num_args = 0..=1,
+        default_value_t = false,
+        default_missing_value = "true",
+    )]
     pub(crate) mount_git_worktree_common_dir: bool,
 }
 
@@ -111,16 +140,37 @@ pub struct UpConfigInputArgs {
     #[arg(long = "remote-env", value_parser = crate::commands::parse_remote_env)]
     pub(crate) remote_env: Vec<String>,
 
-    /// Do not run postAttachCommand.
-    #[arg(long)]
+    /// Do not run postAttachCommand. Accepts the official yargs boolean forms:
+    /// bare, explicit (`--skip-post-attach false`), and absent (defaults to
+    /// `false`).
+    #[arg(
+        long,
+        num_args = 0..=1,
+        default_value_t = false,
+        default_missing_value = "true",
+    )]
     pub(crate) skip_post_attach: bool,
 
-    /// Fail if the container does not already exist.
-    #[arg(long)]
+    /// Fail if the container does not already exist. Accepts the official yargs
+    /// boolean forms: bare, explicit (`--expect-existing-container false`), and
+    /// absent (defaults to `false`).
+    #[arg(
+        long,
+        num_args = 0..=1,
+        default_value_t = false,
+        default_missing_value = "true",
+    )]
     pub(crate) expect_existing_container: bool,
 
-    /// Disable automatic feature id mapping (testing only).
-    #[arg(long, hide = true)]
+    /// Disable automatic feature id mapping (testing only). Accepts the official
+    /// yargs boolean forms: bare, explicit (`... false`), and absent.
+    #[arg(
+        long,
+        hide = true,
+        num_args = 0..=1,
+        default_value_t = false,
+        default_missing_value = "true",
+    )]
     pub(crate) skip_feature_auto_mapping: bool,
 }
 
@@ -128,33 +178,72 @@ pub struct UpConfigInputArgs {
 #[derive(Args)]
 pub struct UpLifecycleArgs {
     /// Do not run onCreate/updateContent/postCreate/postStart/postAttach
-    /// commands and do not install dotfiles.
-    #[arg(long)]
+    /// commands and do not install dotfiles. Accepts the official yargs boolean
+    /// forms: bare, explicit (`--skip-post-create false`), and absent.
+    #[arg(
+        long,
+        num_args = 0..=1,
+        default_value_t = false,
+        default_missing_value = "true",
+    )]
     pub(crate) skip_post_create: bool,
 
     /// Stop running user commands after the `waitFor` phase (default
-    /// updateContentCommand).
-    #[arg(long)]
+    /// updateContentCommand). Accepts the official yargs boolean forms: bare,
+    /// explicit (`--skip-non-blocking-commands false`), and absent.
+    #[arg(
+        long,
+        num_args = 0..=1,
+        default_value_t = false,
+        default_missing_value = "true",
+    )]
     pub(crate) skip_non_blocking_commands: bool,
 
-    /// Stop after onCreateCommand and updateContentCommand.
-    #[arg(long)]
+    /// Stop after onCreateCommand and updateContentCommand. Accepts the official
+    /// yargs boolean forms: bare, explicit (`--prebuild false`), and absent.
+    #[arg(
+        long,
+        num_args = 0..=1,
+        default_value_t = false,
+        default_missing_value = "true",
+    )]
     pub(crate) prebuild: bool,
 }
 
 /// Result-shaping flags for an `up` invocation's JSON output.
 #[derive(Args)]
 pub struct UpResultArgs {
-    /// Include the configuration in the JSON result.
-    #[arg(long)]
+    /// Include the configuration in the JSON result. Accepts the official yargs
+    /// boolean forms: bare, explicit (`--include-configuration false`), and
+    /// absent.
+    #[arg(
+        long,
+        num_args = 0..=1,
+        default_value_t = false,
+        default_missing_value = "true",
+    )]
     pub(crate) include_configuration: bool,
 
-    /// Include the merged configuration in the JSON result.
-    #[arg(long)]
+    /// Include the merged configuration in the JSON result. Accepts the official
+    /// yargs boolean forms: bare, explicit (`--include-merged-configuration
+    /// false`), and absent.
+    #[arg(
+        long,
+        num_args = 0..=1,
+        default_value_t = false,
+        default_missing_value = "true",
+    )]
     pub(crate) include_merged_configuration: bool,
 
-    /// Omit remoteEnv from the container metadata label.
-    #[arg(long, hide = true)]
+    /// Omit remoteEnv from the container metadata label. Accepts the official
+    /// yargs boolean forms: bare, explicit (`... false`), and absent.
+    #[arg(
+        long,
+        hide = true,
+        num_args = 0..=1,
+        default_value_t = false,
+        default_missing_value = "true",
+    )]
     pub(crate) omit_config_remote_env_from_metadata: bool,
 }
 
@@ -229,8 +318,15 @@ pub struct UpCompatArgs {
     // its generated feature Dockerfile emits no `# syntax=` line at all. So
     // cella already behaves as if this flag is permanently on — there is
     // nothing to suppress. Accepted-and-ignored for drop-in parity.
-    /// Omit Dockerfile syntax directives (compatibility no-op).
-    #[arg(long, hide = true)]
+    /// Omit Dockerfile syntax directives (compatibility no-op). Accepts the
+    /// official yargs boolean forms: bare, explicit (`... false`), and absent.
+    #[arg(
+        long,
+        hide = true,
+        num_args = 0..=1,
+        default_value_t = false,
+        default_missing_value = "true",
+    )]
     pub(crate) omit_syntax_directive: bool,
 }
 
@@ -3055,6 +3151,60 @@ mod tests {
             "--include-merged-configuration",
         ]);
         assert!(r.is_ok(), "compat flags should parse: {:?}", r.err());
+    }
+
+    #[test]
+    fn up_mount_workspace_git_root_accepts_yargs_boolean_forms() {
+        // Regression: `--mount-workspace-git-root` used ArgAction::Set, which
+        // REQUIRED a value and rejected the bare official form. It must accept
+        // the bare form (→ true), the explicit `false`, and absence (→ true).
+        assert!(
+            up_args(&["--mount-workspace-git-root"])
+                .mounts
+                .mount_workspace_git_root
+        );
+        assert!(
+            !up_args(&["--mount-workspace-git-root", "false"])
+                .mounts
+                .mount_workspace_git_root
+        );
+        assert!(up_args(&[]).mounts.mount_workspace_git_root);
+    }
+
+    #[test]
+    fn up_boolean_flags_accept_explicit_values() {
+        // Every official `type:'boolean'` up flag must accept both the bare form
+        // and an explicit `--flag false` (yargs boolean parity).
+        let args = up_args(&[
+            "--gpu-availability",
+            "none",
+            "--update-remote-user-uid-default",
+            "off",
+            "--remove-existing-container",
+            "--build-no-cache",
+            "--mount-git-worktree-common-dir",
+            "--skip-post-attach",
+        ]);
+        assert!(args.build.remove_existing_container);
+        assert!(args.build.build_no_cache);
+        assert!(args.mounts.mount_git_worktree_common_dir);
+        assert!(args.config_inputs.skip_post_attach);
+
+        // Explicit `false` must parse and disable the flags.
+        let args = up_args(&[
+            "--remove-existing-container",
+            "false",
+            "--build-no-cache",
+            "false",
+            "--skip-post-attach",
+            "false",
+            "--mount-git-worktree-common-dir",
+            "false",
+        ]);
+        assert!(!args.build.remove_existing_container);
+        assert!(!args.build.build_no_cache);
+        assert!(!args.config_inputs.skip_post_attach);
+        assert!(!args.mounts.mount_git_worktree_common_dir);
     }
 
     #[test]

--- a/crates/cella-cli/src/commands/upgrade.rs
+++ b/crates/cella-cli/src/commands/upgrade.rs
@@ -38,16 +38,16 @@ pub struct UpgradeArgs {
     #[arg(long = "docker-compose-path", default_value = "docker-compose")]
     pub docker_compose_path: String,
 
-    /// Upgrade the version requirements of a given Feature (and its
-    /// dependencies), then upgrade the lockfile. Must be paired with
-    /// `--target-version`. Hidden parity flag (added for dependabot in the
-    /// official CLI); accepted-and-ignored.
+    /// Target a single Feature for upgrade (the official CLI's dependabot path,
+    /// alongside `--target-version`). Hidden parity flag, accepted-and-ignored:
+    /// cella currently refreshes the whole lockfile, so targeted single-Feature
+    /// upgrade is a follow-up. Accepted independently of `--target-version`.
     #[arg(short = 'f', long = "feature", hide = true)]
     pub feature: Option<String>,
 
-    /// The major (x), minor (x.y), or patch (x.y.z) version of the Feature to
-    /// pin in devcontainer.json. Must be paired with `--feature`. Hidden parity
-    /// flag; accepted-and-ignored.
+    /// The target version (`x`, `x.y`, or `x.y.z`) for `--feature`. Hidden
+    /// parity flag, accepted-and-ignored (see `--feature`); accepted
+    /// independently.
     #[arg(short = 'v', long = "target-version", hide = true)]
     pub target_version: Option<String>,
 

--- a/crates/cella-cli/src/commands/upgrade.rs
+++ b/crates/cella-cli/src/commands/upgrade.rs
@@ -28,6 +28,29 @@ pub struct UpgradeArgs {
     #[arg(long)]
     pub dry_run: bool,
 
+    /// Path to the `docker` executable (compatibility no-op; cella talks to the
+    /// engine API directly). Matches the official `--docker-path` default.
+    #[arg(long = "docker-path", default_value = "docker")]
+    pub docker_path: String,
+
+    /// Path to the `docker-compose` executable (compatibility no-op). Matches
+    /// the official `--docker-compose-path` default.
+    #[arg(long = "docker-compose-path", default_value = "docker-compose")]
+    pub docker_compose_path: String,
+
+    /// Upgrade the version requirements of a given Feature (and its
+    /// dependencies), then upgrade the lockfile. Must be paired with
+    /// `--target-version`. Hidden parity flag (added for dependabot in the
+    /// official CLI); accepted-and-ignored.
+    #[arg(short = 'f', long = "feature", hide = true)]
+    pub feature: Option<String>,
+
+    /// The major (x), minor (x.y), or patch (x.y.z) version of the Feature to
+    /// pin in devcontainer.json. Must be paired with `--feature`. Hidden parity
+    /// flag; accepted-and-ignored.
+    #[arg(short = 'v', long = "target-version", hide = true)]
+    pub target_version: Option<String>,
+
     /// Log verbosity level.
     #[arg(long, value_enum, default_value_t = crate::commands::LogLevel::Info)]
     pub log_level: crate::commands::LogLevel,
@@ -124,4 +147,56 @@ fn read_config_json(
     let stripped = cella_jsonc::strip(&raw).map_err(|e| e.to_string())?;
     let value = serde_json::from_str(&stripped)?;
     Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    fn upgrade_args(extra: &[&str]) -> super::UpgradeArgs {
+        let mut argv = vec!["cella", "upgrade"];
+        argv.extend_from_slice(extra);
+        let cli = crate::Cli::try_parse_from(argv).expect("upgrade args parse");
+        match cli.command {
+            crate::commands::Command::Upgrade(args) => args,
+            _ => panic!("expected upgrade command"),
+        }
+    }
+
+    #[test]
+    fn upgrade_accepts_official_flags() {
+        // Regression: `--docker-path`, `--docker-compose-path`, `--feature`
+        // (alias -f) and `--target-version` (alias -v) are official
+        // featuresUpgradeOptions flags that were missing. They must all parse.
+        let args = upgrade_args(&[
+            "--docker-path",
+            "/x",
+            "--docker-compose-path",
+            "/y",
+            "--feature",
+            "ghcr.io/devcontainers/features/node",
+            "-v",
+            "1",
+        ]);
+        assert_eq!(args.docker_path, "/x");
+        assert_eq!(args.docker_compose_path, "/y");
+        assert_eq!(
+            args.feature.as_deref(),
+            Some("ghcr.io/devcontainers/features/node")
+        );
+        assert_eq!(args.target_version.as_deref(), Some("1"));
+    }
+
+    #[test]
+    fn upgrade_flag_aliases_and_defaults_match_official() {
+        // -f is the alias for --feature; defaults mirror the official CLI.
+        let args = upgrade_args(&["-f", "node"]);
+        assert_eq!(args.feature.as_deref(), Some("node"));
+
+        let args = upgrade_args(&[]);
+        assert_eq!(args.docker_path, "docker");
+        assert_eq!(args.docker_compose_path, "docker-compose");
+        assert!(args.feature.is_none());
+        assert!(args.target_version.is_none());
+    }
 }

--- a/crates/cella-cli/src/main.rs
+++ b/crates/cella-cli/src/main.rs
@@ -1049,9 +1049,12 @@ mod tests {
     }
 
     #[test]
-    fn build_without_log_level_is_none() {
+    fn build_without_log_level_defaults_to_info() {
+        use super::commands::LogLevel;
+        // Official `devcontainer build --log-level` defaults to info; cella now
+        // matches it (was previously unset/None).
         let cli = parse(&["cella", "build"]).unwrap();
-        assert!(cli.command.log_level().is_none());
+        assert!(matches!(cli.command.log_level(), Some(LogLevel::Info)));
     }
 
     #[test]


### PR DESCRIPTION
An exhaustive flag/behavior audit found several commands rejecting valid official invocations or mishandling flags. This brings the CLI surface to parity.

- **up** — its `type:'boolean'` flags used `ArgAction::Set` (requiring a value), so `cella up --mount-workspace-git-root` (the bare yargs form) was *rejected*. Converted all 14 directly-owned booleans to the tri-state pattern (bare → true, explicit `--flag false` → false, absent → default), matching the official. (`gpu-availability`/`update-remote-user-uid-default` were already wired; `remove-existing-container`/`build-no-cache` already existed — verified against source.)
- **run-user-commands / set-up / exec** — `--skip-post-attach`, `--mount-workspace-git-root`, `--mount-git-worktree-common-dir` rejected the explicit `false` form; now tri-state (shared `CompatArgs`/`AttachArgs`/`WorkspaceCompatArgs`).
- **upgrade** — added the missing `--docker-path` (default `docker`), `--docker-compose-path` (default `docker-compose`), hidden `--feature`/`-f`, hidden `--target-version`/`-v`.
- **build** — added the optional positional `[path]` (the official registers `build [path]`); `--log-level` now defaults to `info`. Note: the official *ignores* its `[path]` positional (an oversight — no workflow relies on a path being silently dropped), so cella uses it as the workspace folder when `--workspace-folder` is absent (documented in-source), per the "fix known issues" mandate.
- **templates generate-docs** — added `--log-level` (default `info`), wired into the log seed.

Parity `try_parse_from` tests added per command (these drifted because they lacked them). Full cella-cli suite green (862), clippy + fmt clean, every new flag smoke-tested against the real binary.

Deferred (documented): the `up`/`build` lockfile booleans (`--no-lockfile` etc.) still reject the explicit `false` form — they use `conflicts_with_all` which fires on presence, and value-aware mutual-exclusion (the official only conflicts when both are truthy) is a separate, careful change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)