### PR TITLE
feat(outdated): accept --config + make log flags functional

### DIFF
--- a/crates/cella-cli/src/commands/features/resolve.rs
+++ b/crates/cella-cli/src/commands/features/resolve.rs
@@ -12,7 +12,11 @@ use cella_templates::fetcher;
 #[derive(Args, Clone)]
 pub struct CommonFeatureFlags {
     /// Path to devcontainer.json (overrides auto-discovery).
-    #[arg(short = 'f', long = "file")]
+    ///
+    /// `--config` is accepted as an alias: it's the official flag name for
+    /// `outdated` (and the canonical devcontainer.json-path flag); cella's
+    /// feature subcommands historically used `--file`/`-f`.
+    #[arg(short = 'f', long = "file", visible_alias = "config")]
     pub file: Option<PathBuf>,
 
     /// Workspace folder path (defaults to current directory).

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -511,8 +511,8 @@ impl Command {
     ///
     /// `up` (and `code`, which embeds the `up` arg surface), `build`, `exec`,
     /// `read-configuration`, `run-user-commands`, `set-up`, `templates`,
-    /// `features`, and `upgrade` expose `--log-level`; every other variant
-    /// returns `None`. main.rs reads this once, before subcommand dispatch, to
+    /// `features`, `upgrade`, and `outdated` expose `--log-level`; every other
+    /// variant returns `None`. main.rs reads this once, before subcommand dispatch, to
     /// seed the global tracing filter — the level can't be applied inside
     /// `execute()` because the subscriber is already installed by then.
     pub const fn log_level(&self) -> Option<LogLevel> {
@@ -535,8 +535,8 @@ impl Command {
     /// The `--log-format` value (defaults to `Text`).
     ///
     /// `up`/`code`, `build`, `exec`, `read-configuration`, `run-user-commands`,
-    /// and `set-up` expose `--log-format`; every other variant returns
-    /// `Text`. Read once in main.rs to select the tracing formatter and to
+    /// `set-up`, and `outdated` expose `--log-format`; every other variant
+    /// returns `Text`. Read once in main.rs to select the tracing formatter and to
     /// force spinners off under `Json` (indicatif ANSI escapes would corrupt
     /// machine-readable JSON log lines on stderr).
     pub const fn log_format(&self) -> LogFormat {

--- a/crates/cella-cli/src/commands/mod.rs
+++ b/crates/cella-cli/src/commands/mod.rs
@@ -527,6 +527,7 @@ impl Command {
             Self::Templates(args) => args.apply_log_level(),
             Self::Features(args) => args.log_level(),
             Self::Upgrade(args) => Some(args.log_level),
+            Self::Outdated(args) => args.log_level,
             _ => None,
         }
     }
@@ -547,6 +548,7 @@ impl Command {
             Self::ReadConfiguration(args) => args.compat.log_format,
             Self::RunUserCommands(args) => args.compat.log_format,
             Self::SetUp(args) => args.compat.log_format,
+            Self::Outdated(args) => args.log_format,
             _ => LogFormat::Text,
         }
     }

--- a/crates/cella-cli/src/commands/outdated.rs
+++ b/crates/cella-cli/src/commands/outdated.rs
@@ -49,20 +49,26 @@ pub struct OutdatedArgs {
     #[arg(long, hide = true)]
     pub check: bool,
 
-    #[arg(long, hide = true)]
+    /// Number of columns to render output for (compatibility no-op).
+    #[arg(long)]
     pub terminal_columns: Option<u16>,
 
-    #[arg(long, hide = true)]
+    /// Number of rows to render output for (compatibility no-op).
+    #[arg(long)]
     pub terminal_rows: Option<u16>,
 
+    /// Accepted for parity; the official `outdated` doesn't actually expose this
+    /// (kept hidden as a no-op so scripts passing it don't break).
     #[arg(long, hide = true)]
     pub user_data_folder: Option<PathBuf>,
 
-    #[arg(long, hide = true)]
-    pub log_level: Option<String>,
+    /// Log verbosity (seeded into the global tracing filter by `main.rs`).
+    #[arg(long = "log-level", value_enum)]
+    pub log_level: Option<super::LogLevel>,
 
-    #[arg(long, hide = true)]
-    pub log_format: Option<String>,
+    /// Log output format (seeded into the tracing subscriber by `main.rs`).
+    #[arg(long = "log-format", value_enum, default_value = "text")]
+    pub log_format: super::LogFormat,
 }
 
 impl OutdatedArgs {
@@ -534,6 +540,39 @@ mod tests {
     /// Build a DESCENDING version list, as the production code passes around.
     fn versions(list: &[&str]) -> Vec<Version> {
         strict_semver_descending(&list.iter().map(ToString::to_string).collect::<Vec<_>>())
+    }
+
+    #[test]
+    fn accepts_official_config_and_log_flags() {
+        use clap::Parser as _;
+        let cli = crate::Cli::try_parse_from([
+            "cella",
+            "outdated",
+            "--config",
+            "/x/devcontainer.json",
+            "--log-level",
+            "debug",
+            "--log-format",
+            "json",
+            "--terminal-columns",
+            "80",
+            "--terminal-rows",
+            "40",
+        ])
+        .expect("official outdated flags must parse");
+        let crate::commands::Command::Outdated(args) = &cli.command else {
+            panic!("expected outdated subcommand");
+        };
+        assert_eq!(
+            args.common.file.as_deref(),
+            Some(std::path::Path::new("/x/devcontainer.json")),
+            "--config must populate the config path (alias of --file)"
+        );
+        assert!(matches!(
+            args.log_level,
+            Some(super::super::LogLevel::Debug)
+        ));
+        assert!(matches!(args.log_format, super::super::LogFormat::Json));
     }
 
     // -----------------------------------------------------------------------

--- a/crates/cella-cli/src/commands/outdated.rs
+++ b/crates/cella-cli/src/commands/outdated.rs
@@ -49,12 +49,14 @@ pub struct OutdatedArgs {
     #[arg(long, hide = true)]
     pub check: bool,
 
-    /// Number of columns to render output for (compatibility no-op).
-    #[arg(long)]
+    /// Number of columns to render output for (compatibility no-op). Paired with
+    /// `--terminal-rows`, matching the official's `implies: ['terminal-rows']`.
+    #[arg(long, requires = "terminal_rows")]
     pub terminal_columns: Option<u16>,
 
-    /// Number of rows to render output for (compatibility no-op).
-    #[arg(long)]
+    /// Number of rows to render output for (compatibility no-op). Paired with
+    /// `--terminal-columns`, matching the official's `implies`.
+    #[arg(long, requires = "terminal_columns")]
     pub terminal_rows: Option<u16>,
 
     /// Accepted for parity; the official `outdated` doesn't actually expose this


### PR DESCRIPTION
Two `outdated` flag-parity gaps from the exhaustive audit.

- **`--config` was rejected.** outdated routes its config path through the shared `CommonFeatureFlags`, which only defined `--file`/`-f`, but the official `outdated` uses `--config` (devContainersSpecCLI.ts:1161). Added `--config` as a visible alias of `--file` (it's the same devcontainer.json path); the feature subcommands accept it harmlessly too. `cella outdated --config <path>` now parses and reads the config.
- **`--log-level`/`--log-format` were hidden no-ops.** The official exposes them as visible flags with choices/defaults that actually drive logging. Converted to the shared `LogLevel`/`LogFormat` value-enums, un-hid them (and `--terminal-columns`/`--terminal-rows`), and wired outdated into the `Command` log dispatch so they seed the tracing filter/format like every other command.

Parity test added; full suite green (4736), clippy + fmt clean, smoke-tested against the real binary (`outdated --config … --log-level debug --log-format json` parses and runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)