### PR TITLE
fix(docker): empty-id robustness + perf(lifecycle): lazy content-hash compute

### DIFF
--- a/crates/cella-backend/src/lifecycle.rs
+++ b/crates/cella-backend/src/lifecycle.rs
@@ -1106,7 +1106,9 @@ pub async fn content_changed(
     lc_ctx: &LifecycleContext<'_>,
     workspace_root: &std::path::Path,
 ) -> bool {
-    let current = cella_git::content_hash::compute(workspace_root);
+    // Read the stored hash FIRST: when none is stored (first run / older
+    // container) the answer is "changed" regardless, so we skip the workspace
+    // scan entirely.
     let stored = lc_ctx
         .client
         .exec_command(
@@ -1122,7 +1124,7 @@ pub async fn content_changed(
         .ok()
         .filter(|r| r.exit_code == 0)
         .map(|r| r.stdout.trim().to_string());
-    stored.as_deref() != Some(&current)
+    stored.is_none_or(|stored| cella_git::content_hash::compute(workspace_root) != stored)
 }
 
 /// Whether the container's last background lifecycle run recorded a failure.
@@ -1186,8 +1188,8 @@ pub async fn check_and_run_content_update(
 
     // --prebuild force-reruns updateContentCommand even when the hash matches
     // (official injectHeadless.ts: rerun = !!prebuild). Otherwise honor the
-    // content-hash short-circuit.
-    if !content_changed(lc_ctx, workspace_root).await && !gate.rerun_update_content() {
+    // content-hash short-circuit. Check rerun FIRST so prebuild skips the scan.
+    if !gate.rerun_update_content() && !content_changed(lc_ctx, workspace_root).await {
         return Ok(());
     }
 

--- a/crates/cella-docker/src/container.rs
+++ b/crates/cella-docker/src/container.rs
@@ -169,11 +169,11 @@ impl DockerClient {
             ..Default::default()
         };
         let containers = self.inner().list_containers(Some(options)).await?;
-        if let Some(summary) = containers.into_iter().next() {
-            let id = summary.id.as_deref().unwrap_or_default();
-            Ok(Some(self.inspect_container(id).await?))
-        } else {
-            Ok(None)
+        match containers.into_iter().next().and_then(|s| s.id) {
+            // A summary without an id can't be inspected — treat it as "no match"
+            // rather than inspecting "" and turning it into a hard API error.
+            Some(id) if !id.is_empty() => Ok(Some(self.inspect_container(&id).await?)),
+            _ => Ok(None),
         }
     }
 

--- a/crates/cella-docker/src/container.rs
+++ b/crates/cella-docker/src/container.rs
@@ -169,11 +169,16 @@ impl DockerClient {
             ..Default::default()
         };
         let containers = self.inner().list_containers(Some(options)).await?;
-        match containers.into_iter().next().and_then(|s| s.id) {
-            // A summary without an id can't be inspected — treat it as "no match"
-            // rather than inspecting "" and turning it into a hard API error.
-            Some(id) if !id.is_empty() => Ok(Some(self.inspect_container(&id).await?)),
-            _ => Ok(None),
+        // Use the first summary that actually has a usable id. A summary without
+        // one can't be inspected — skipping it (rather than inspecting "" and
+        // hard-failing) also lets a later valid match still be found.
+        match containers
+            .into_iter()
+            .filter_map(|s| s.id)
+            .find(|id| !id.is_empty())
+        {
+            Some(id) => Ok(Some(self.inspect_container(&id).await?)),
+            None => Ok(None),
         }
     }
 

--- a/crates/cella-orchestrator/src/run_user_commands.rs
+++ b/crates/cella-orchestrator/src/run_user_commands.rs
@@ -227,11 +227,17 @@ pub async fn run_user_commands(
     // read-modify-write that preserves any fields a later PR adds.
     let mut lc_state = read_lifecycle_state(lc_ctx.client, lc_ctx.container_id, remote_user).await;
     let oncreate_done = lc_state.oncreate_done;
-    // No workspace_root (e.g. bare --container-id) → default to changed (run)
-    // — safe fallback that matches today's unconditional behavior.
-    let is_content_changed = match input.workspace_root {
-        Some(ws) => content_changed(lc_ctx, ws).await,
-        None => true,
+    // Under prebuild, content_changed only feeds run_post_create, which is
+    // unreachable (the flow returns STATUS_PREBUILD before postCreate), and
+    // run_update_content is forced anyway — so skip the workspace scan. No
+    // workspace_root (bare --container-id) → default to changed (safe).
+    let is_content_changed = if g.stop.prebuild {
+        false
+    } else {
+        match input.workspace_root {
+            Some(ws) => content_changed(lc_ctx, ws).await,
+            None => true,
+        }
     };
     // If the previous background lifecycle FAILED, re-run every gated phase —
     // run-user-commands is cella's recovery path, and the content-hash skip is


### PR DESCRIPTION
Two small follow-ups I committed to during the #213/#214 reviews — both internal, neither a spec-parity change.

**`find_one_by_label` empty-id robustness** (Copilot, #214): the label lookup fell back to inspecting `""` when a Docker list summary had no id, turning a "no usable container" case into a hard API error for `up`. Now a missing id is treated as no-match.

**Lazy content-hash compute** (Copilot, #213): three call paths scanned the workspace for the content hash when the result couldn't change the outcome — `content_changed` computed it before checking whether any hash was even stored; `check_and_run_content_update` awaited it under `--prebuild` (which force-reruns updateContent regardless); and `run-user-commands` computed it up front under `--prebuild` (where it only feeds the unreachable postCreate gate). Reordered to read-stored-first and short-circuit on prebuild. Behavior is unchanged — these only skip a `git`/mtime scan on large repos when it's wasted.