### PR TITLE
feat: close devcontainer spec-parity gaps from the coverage audit

### DIFF
--- a/crates/cella-backend/src/types.rs
+++ b/crates/cella-backend/src/types.rs
@@ -235,6 +235,12 @@ pub struct BuildOptions {
     /// unconditionally. Set only on the final image build (the one that produces
     /// the image the user ends up with), mirroring `output`.
     pub labels: Vec<String>,
+    /// Push the built image to a registry (`docker buildx build --push`).
+    /// buildx-only: emits `--push` and suppresses `--load` (the two are
+    /// mutually exclusive). Silently dropped (with a warning) when buildx is
+    /// unavailable. `push` and `output` should not be combined — if `push` is
+    /// set, `output` is ignored.
+    pub push: bool,
 }
 
 impl Default for BuildOptions {
@@ -254,6 +260,7 @@ impl Default for BuildOptions {
             platform: None,
             output: None,
             labels: Vec::new(),
+            push: false,
         }
     }
 }

--- a/crates/cella-backend/src/types.rs
+++ b/crates/cella-backend/src/types.rs
@@ -645,6 +645,10 @@ pub struct RunArgsOverrides {
     pub init: Option<bool>,
     pub privileged: Option<bool>,
 
+    /// Environment variables from `--env`/`-e` and `--env-file`, in `KEY=VAL` form.
+    /// Appended after `containerEnv`-derived env; Docker last-wins on duplicate keys.
+    pub env: Vec<String>,
+
     /// Flags not recognized by the parser (emitted as warnings).
     pub unrecognized: Vec<String>,
 }

--- a/crates/cella-backend/src/uid_image.rs
+++ b/crates/cella-backend/src/uid_image.rs
@@ -186,6 +186,8 @@ pub async fn build_uid_remap_image(
         // Never the user's label target either; user `--label`s are baked onto
         // the final image (base or features layer) before this transform runs.
         labels: Vec::new(),
+        // Never push the UID-remap image to a registry; it is internal only.
+        push: false,
     };
 
     info!("Building UID remap image: {uid_image} (UID {host_uid}:{host_gid})");

--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -226,6 +226,10 @@ impl BuildArgs {
         self,
         progress: crate::progress::Progress,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        // Validate mutually-exclusive buildx outputs before any filesystem or
+        // daemon work, matching the official CLI's fail-fast ordering.
+        self.reject_conflicting_output_flags()?;
+
         let cwd = super::resolve_workspace_folder(self.effective_workspace_folder())?;
 
         info!("Resolving devcontainer config...");
@@ -283,6 +287,23 @@ impl BuildArgs {
     /// only affect the single-container buildx path; the official CLI accepts
     /// them without error, so cella warns rather than failing (never silently
     /// ignores).
+    /// Reject `--push` combined with `--output`, on any path.
+    ///
+    /// Mirrors the official CLI (`--push true cannot be used with --output.`):
+    /// pushing to a registry and exporting via `--output` are mutually
+    /// exclusive buildx outputs. Validated before the compose/single-container
+    /// split so the error matches regardless of project type — for a compose
+    /// project with both flags, the official emits this message, not the
+    /// `--platform or --push not supported.` one.
+    fn reject_conflicting_output_flags(
+        &self,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        if self.push && self.output.is_some() {
+            return Err("--push true cannot be used with --output.".into());
+        }
+        Ok(())
+    }
+
     fn reject_unsupported_compose_flags(
         &self,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -726,6 +747,32 @@ mod tests {
             .reject_unsupported_compose_flags()
             .expect_err("compose must reject --push");
         assert_eq!(err.to_string(), "--platform or --push not supported.");
+    }
+
+    #[test]
+    fn push_with_output_is_rejected() {
+        // The official CLI errors on `--push true` + `--output` with this exact
+        // message, before the compose/single split.
+        let err = parse_build(&["--push", "--output", "type=local,dest=out"])
+            .reject_conflicting_output_flags()
+            .expect_err("--push with --output must be rejected");
+        assert_eq!(err.to_string(), "--push true cannot be used with --output.");
+    }
+
+    #[test]
+    fn push_or_output_alone_is_allowed() {
+        // Each flag is fine on its own — only the combination is rejected.
+        assert!(
+            parse_build(&["--push"])
+                .reject_conflicting_output_flags()
+                .is_ok()
+        );
+        assert!(
+            parse_build(&["--output", "type=local,dest=out"])
+                .reject_conflicting_output_flags()
+                .is_ok()
+        );
+        assert!(parse_build(&[]).reject_conflicting_output_flags().is_ok());
     }
 
     // ── --label parsing / threading ─────────────────────────────────

--- a/crates/cella-cli/src/commands/build.rs
+++ b/crates/cella-cli/src/commands/build.rs
@@ -78,6 +78,11 @@ pub struct BuildArgs {
     #[arg(long)]
     platform: Option<String>,
 
+    /// Push the built image to a registry (buildx). Passes `--push` to
+    /// `docker buildx build`. Not supported on the Docker Compose path.
+    #[arg(long)]
+    push: bool,
+
     /// Additional image(s) to use as a layer cache during the build (repeatable).
     /// Single-container path only (not supported on the Docker Compose path).
     #[arg(long = "cache-from")]
@@ -281,7 +286,7 @@ impl BuildArgs {
     fn reject_unsupported_compose_flags(
         &self,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        if self.platform.is_some() {
+        if self.platform.is_some() || self.push {
             return Err("--platform or --push not supported.".into());
         }
         if self.output.is_some() {
@@ -381,6 +386,11 @@ impl BuildArgs {
                 cli_cache_from: &self.cache_from,
                 cache_to: self.cache_to.as_deref(),
                 platform: self.platform.as_deref(),
+                // `--push`: push the final image to a registry (buildx-only).
+                // The orchestrator routes it to the single final build (base
+                // when there are no features, features layer otherwise) so the
+                // base stays loadable for any `FROM`.
+                push: self.push,
             },
             // buildx `--output` export spec. The orchestrator routes it to the
             // single final build (base when there are no features, features
@@ -673,6 +683,12 @@ mod tests {
                 .is_err()
         );
         assert!(
+            parse_build(&["--push"])
+                .reject_unsupported_compose_flags()
+                .is_err(),
+            "--push must be rejected on compose path"
+        );
+        assert!(
             parse_build(&["--cache-to", "type=inline"])
                 .reject_unsupported_compose_flags()
                 .is_err()
@@ -690,6 +706,26 @@ mod tests {
                 .is_ok()
         );
         assert!(parse_build(&[]).reject_unsupported_compose_flags().is_ok());
+    }
+
+    #[test]
+    fn push_defaults_to_false() {
+        assert!(!parse_build(&[]).push);
+    }
+
+    #[test]
+    fn push_parses_as_boolean_flag() {
+        assert!(parse_build(&["--push"]).push);
+    }
+
+    #[test]
+    fn compose_rejects_push_with_correct_message() {
+        // The official CLI rejects --push for compose with "--platform or --push
+        // not supported." cella mirrors that exact message.
+        let err = parse_build(&["--push"])
+            .reject_unsupported_compose_flags()
+            .expect_err("compose must reject --push");
+        assert_eq!(err.to_string(), "--platform or --push not supported.");
     }
 
     // ── --label parsing / threading ─────────────────────────────────
@@ -1094,9 +1130,7 @@ mod tests {
     // Source of truth: devcontainers/cli `src/spec-node/devContainersSpecCLI.ts`
     // `buildOptions` (lines 523-548). Every official long flag MUST be declared
     // so no official `devcontainer build` invocation errors with "unknown
-    // argument" — EXCEPT `--push`/`--output` of the registry-write surface that
-    // cella intentionally defers (`--push`) or already supports (`--output` is
-    // present). This test pins the surface so it can't silently drift again.
+    // argument". This test pins the surface so it can't silently drift again.
     const OFFICIAL_BUILD_FLAGS: &[&str] = &[
         "user-data-folder",
         "docker-path",
@@ -1111,6 +1145,7 @@ mod tests {
         "cache-to",
         "buildkit",
         "platform",
+        "push",
         "label",
         "output",
         "additional-features",

--- a/crates/cella-cli/src/commands/up/mod.rs
+++ b/crates/cella-cli/src/commands/up/mod.rs
@@ -1582,6 +1582,8 @@ impl UpContext {
                 cli_cache_from: &self.cache_from,
                 cache_to: self.cache_to.as_deref(),
                 platform: None,
+                // `up` never pushes — it must load the image locally.
+                push: false,
             },
             gpu_availability: self.gpu_availability,
             update_remote_user_uid_default: self.update_remote_user_uid_default,

--- a/crates/cella-config/src/config_map/env.rs
+++ b/crates/cella-config/src/config_map/env.rs
@@ -16,6 +16,7 @@ pub(super) fn map_remote_env(config: &serde_json::Value) -> Vec<String> {
 
     env_obj
         .iter()
+        .filter(|(_, v)| !v.is_null())
         .map(|(k, v)| format!("{k}={}", v.as_str().unwrap_or("")))
         .collect()
 }
@@ -50,16 +51,32 @@ mod tests {
 
     #[test]
     fn map_remote_env_non_string_values() {
+        // null is filtered out; non-string non-null values (schema violations) coerce to ""
         let config = json!({"remoteEnv": {"NUM": 42, "BOOL": true, "NULL": null}});
         let env = map_remote_env(&config);
-        assert_eq!(env.len(), 3);
+        assert_eq!(
+            env.len(),
+            2,
+            "null must be omitted, not coerced to empty string"
+        );
         for entry in &env {
             let parts: Vec<&str> = entry.splitn(2, '=').collect();
             assert_eq!(parts.len(), 2);
             match parts[0] {
-                "NUM" | "BOOL" | "NULL" => assert_eq!(parts[1], ""),
-                _ => panic!("unexpected key: {}", parts[0]),
+                "NUM" | "BOOL" => assert_eq!(parts[1], ""),
+                other => panic!("unexpected key: {other} (NULL must be absent)"),
             }
         }
+        assert!(
+            !env.iter().any(|e| e.starts_with("NULL=")),
+            "null value must not produce a NULL= entry"
+        );
+    }
+
+    #[test]
+    fn map_remote_env_null_value_omitted() {
+        let config = json!({"remoteEnv": {"VAR": null, "OK": "x"}});
+        let env = map_remote_env(&config);
+        assert_eq!(env, vec!["OK=x"], "null remoteEnv entries must be omitted");
     }
 }

--- a/crates/cella-config/src/config_map/run_args.rs
+++ b/crates/cella-config/src/config_map/run_args.rs
@@ -498,11 +498,16 @@ fn parse_ulimit(s: &str) -> Option<UlimitSpec> {
     })
 }
 
-/// Read an env-file and push `KEY=VAL` lines into `out`.
+/// Read an env-file and push `KEY=VAL` entries into `out`, matching Docker's
+/// `--env-file` parsing.
 ///
-/// Lines that are blank or start with `#` are skipped, matching Docker's
-/// `--env-file` behaviour. On I/O error, emits a warning and returns without
-/// pushing anything from the failed file.
+/// Each line is left-trimmed; blank lines and those beginning with `#` are
+/// skipped. For `KEY=VALUE`, the variable name is trimmed but the value is
+/// passed through verbatim (Docker never trims the value, so a trailing space
+/// is significant). A bare `KEY` with no `=` inherits the value from cella's
+/// own environment, exactly as `docker run --env-file` resolves it from the
+/// client environment. On I/O error, emits a warning and pushes nothing from
+/// the failed file.
 fn parse_env_file(path: &str, out: &mut Vec<String>) {
     let content = match std::fs::read_to_string(path) {
         Ok(c) => c,
@@ -511,12 +516,25 @@ fn parse_env_file(path: &str, out: &mut Vec<String>) {
             return;
         }
     };
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() || trimmed.starts_with('#') {
+    for raw in content.lines() {
+        // Docker left-trims the line before testing for blank / comment lines.
+        let line = raw.trim_start();
+        if line.is_empty() || line.starts_with('#') {
             continue;
         }
-        out.push(trimmed.to_string());
+        if let Some((key, value)) = line.split_once('=') {
+            // `KEY=VALUE`: trim only the name, keep the value untouched.
+            let key = key.trim();
+            if !key.is_empty() {
+                out.push(format!("{key}={value}"));
+            }
+        } else {
+            // Bare `KEY`: inherit from the current environment, like Docker.
+            let key = line.trim();
+            if let Ok(value) = std::env::var(key) {
+                out.push(format!("{key}={value}"));
+            }
+        }
     }
 }
 
@@ -885,6 +903,33 @@ mod tests {
         let r = parse_run_args(&args(&["--env-file", &path]));
         assert_eq!(r.env, vec!["KEY1=val1", "KEY2=val2"]);
         assert!(r.unrecognized.is_empty());
+    }
+
+    #[test]
+    fn parse_env_file_matches_docker_whitespace() {
+        // Docker left-trims each line, treats a leading-space `#` as a comment,
+        // trims only the variable NAME, and keeps the value verbatim (trailing
+        // space significant). A value may itself contain `=`.
+        use std::io::Write as _;
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        writeln!(f, "   # indented comment").unwrap();
+        writeln!(f, "  PADDED = keep me ").unwrap();
+        writeln!(f, "URL=k=v&x=y").unwrap();
+        let path = f.path().to_str().unwrap().to_string();
+        let r = parse_run_args(&args(&["--env-file", &path]));
+        assert_eq!(r.env, vec!["PADDED= keep me ", "URL=k=v&x=y"]);
+    }
+
+    #[test]
+    fn parse_env_file_bare_key_absent_from_env_is_skipped() {
+        // A bare `KEY` (no `=`) inherits from the environment; when the var is
+        // unset, Docker contributes nothing — cella must not push a bare key.
+        use std::io::Write as _;
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        writeln!(f, "CELLA_DEFINITELY_UNSET_VAR_XYZ_42").unwrap();
+        let path = f.path().to_str().unwrap().to_string();
+        let r = parse_run_args(&args(&["--env-file", &path]));
+        assert!(r.env.is_empty(), "bare key absent from env must be skipped");
     }
 
     #[test]

--- a/crates/cella-config/src/config_map/run_args.rs
+++ b/crates/cella-config/src/config_map/run_args.rs
@@ -74,6 +74,18 @@ pub fn parse_run_args(args: &[String]) -> RunArgsOverrides {
                 parse_capability_arg(flag, &mut i, inline_val, &next_val, &mut result);
             }
 
+            "--env" | "-e" => {
+                if let Some(v) = next_val(&mut i, inline_val) {
+                    result.env.push(v);
+                }
+            }
+
+            "--env-file" => {
+                if let Some(path) = next_val(&mut i, inline_val) {
+                    parse_env_file(&path, &mut result.env);
+                }
+            }
+
             // -- Boolean flags (no value) --
             "--init" => result.init = Some(true),
             "--privileged" => result.privileged = Some(true),
@@ -486,6 +498,28 @@ fn parse_ulimit(s: &str) -> Option<UlimitSpec> {
     })
 }
 
+/// Read an env-file and push `KEY=VAL` lines into `out`.
+///
+/// Lines that are blank or start with `#` are skipped, matching Docker's
+/// `--env-file` behaviour. On I/O error, emits a warning and returns without
+/// pushing anything from the failed file.
+fn parse_env_file(path: &str, out: &mut Vec<String>) {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(err) => {
+            warn!("runArgs: --env-file {path:?}: {err}");
+            return;
+        }
+    };
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        out.push(trimmed.to_string());
+    }
+}
+
 /// Emit warnings for any unrecognized flags.
 pub fn warn_unrecognized(overrides: &RunArgsOverrides) {
     for flag in &overrides.unrecognized {
@@ -806,6 +840,64 @@ mod tests {
     fn parse_empty_args() {
         let r = parse_run_args(&[]);
         assert!(r.network_mode.is_none());
+        assert!(r.unrecognized.is_empty());
+    }
+
+    // -- Env flags --
+
+    #[test]
+    fn parse_env_long_flag() {
+        let r = parse_run_args(&args(&["--env", "FOO=bar"]));
+        assert_eq!(r.env, vec!["FOO=bar"]);
+        assert!(r.unrecognized.is_empty());
+    }
+
+    #[test]
+    fn parse_env_short_flag() {
+        let r = parse_run_args(&args(&["-e", "BAZ=qux"]));
+        assert_eq!(r.env, vec!["BAZ=qux"]);
+        assert!(r.unrecognized.is_empty());
+    }
+
+    #[test]
+    fn parse_env_inline_equals() {
+        let r = parse_run_args(&args(&["--env=HELLO=world"]));
+        assert_eq!(r.env, vec!["HELLO=world"]);
+        assert!(r.unrecognized.is_empty());
+    }
+
+    #[test]
+    fn parse_env_multiple() {
+        let r = parse_run_args(&args(&["--env", "A=1", "-e", "B=2", "--env=C=3"]));
+        assert_eq!(r.env, vec!["A=1", "B=2", "C=3"]);
+        assert!(r.unrecognized.is_empty());
+    }
+
+    #[test]
+    fn parse_env_file_reads_lines() {
+        use std::io::Write as _;
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        writeln!(f, "# comment").unwrap();
+        writeln!(f).unwrap();
+        writeln!(f, "KEY1=val1").unwrap();
+        writeln!(f, "KEY2=val2").unwrap();
+        let path = f.path().to_str().unwrap().to_string();
+        let r = parse_run_args(&args(&["--env-file", &path]));
+        assert_eq!(r.env, vec!["KEY1=val1", "KEY2=val2"]);
+        assert!(r.unrecognized.is_empty());
+    }
+
+    #[test]
+    fn parse_env_file_missing_warns_and_continues() {
+        // A missing env-file should not crash; the env list stays empty and
+        // other flags still parse correctly.
+        let r = parse_run_args(&args(&[
+            "--env-file",
+            "/nonexistent/does/not/exist.env",
+            "--privileged",
+        ]));
+        assert!(r.env.is_empty());
+        assert_eq!(r.privileged, Some(true));
         assert!(r.unrecognized.is_empty());
     }
 }

--- a/crates/cella-docker/src/config_map/mod.rs
+++ b/crates/cella-docker/src/config_map/mod.rs
@@ -44,14 +44,27 @@ pub fn to_bollard_config(opts: &CreateContainerOptions) -> ContainerCreateBody {
     host_config.privileged = Some(merged.privileged);
     host_config.init = Some(merged.init);
 
+    // Merge containerEnv-derived env with any `--env`/`-e`/`--env-file` entries from
+    // runArgs.  Docker applies env in order, last-wins on duplicate keys, which matches
+    // the official CLI where runArgs flags come after containerEnv-derived entries.
+    let env = {
+        let run_args_env = opts
+            .run_args_overrides
+            .as_ref()
+            .map_or(&[] as &[String], |ra| ra.env.as_slice());
+        if opts.env.is_empty() && run_args_env.is_empty() {
+            None
+        } else {
+            let mut combined = opts.env.clone();
+            combined.extend_from_slice(run_args_env);
+            Some(combined)
+        }
+    };
+
     ContainerCreateBody {
         image: Some(opts.image.clone()),
         labels: Some(merged.labels),
-        env: if opts.env.is_empty() {
-            None
-        } else {
-            Some(opts.env.clone())
-        },
+        env,
         user: opts.user.clone(),
         hostname: merged.hostname,
         working_dir: Some(opts.workspace_folder.clone()),

--- a/crates/cella-docker/src/image.rs
+++ b/crates/cella-docker/src/image.rs
@@ -152,14 +152,18 @@ fn build_command_args(opts: &BuildOptions, use_buildx: bool) -> Vec<String> {
     }
     args.push("build".to_string());
 
-    // `--progress=plain`, `--load`, and `--output` are buildx-only. The classic
-    // builder rejects `--progress`, and official emits none of these on the
-    // legacy path. A `--output <spec>` *replaces* `--load` (which is itself
-    // shorthand for `--output=docker`); the two are mutually exclusive, so the
-    // export spec wins when set (mirrors the official singleContainer.ts).
+    // `--progress=plain`, `--load`, `--push`, and `--output` are buildx-only.
+    // The classic builder rejects `--progress`, and official emits none of these
+    // on the legacy path. `--push` takes highest precedence (pushes to registry
+    // and suppresses `--load`). A `--output <spec>` *replaces* `--load` (which
+    // is itself shorthand for `--output=docker`). The three are mutually
+    // exclusive: push wins first, then output, then the --load default.
+    // Mirrors the official singleContainer.ts ordering.
     if use_buildx {
         args.push("--progress=plain".to_string());
-        if let Some(output) = &opts.output {
+        if opts.push {
+            args.push("--push".to_string());
+        } else if let Some(output) = &opts.output {
             args.extend(["--output".to_string(), output.clone()]);
         } else {
             args.push("--load".to_string());
@@ -348,6 +352,17 @@ impl DockerClient {
             });
         }
 
+        // `--push` is buildx-only (classic `docker build` has no registry push).
+        // Unlike `--output`, it can be silently dropped on the classic path —
+        // the image is still built locally, so nothing is lost to the local
+        // store. Warn so the user knows the registry push did not happen.
+        if !use_buildx && opts.push {
+            tracing::warn!(
+                "--push is ignored without BuildKit/buildx (classic docker build); \
+                 the image was built locally but NOT pushed to the registry"
+            );
+        }
+
         let args = build_command_args(opts, use_buildx);
 
         debug!("{bin} {}", args.join(" "));
@@ -509,6 +524,7 @@ mod tests {
             platform: None,
             output: None,
             labels: Vec::new(),
+            push: false,
         }
     }
 
@@ -1011,6 +1027,65 @@ mod tests {
         assert!(
             !args.contains(&"--platform".to_string()),
             "--platform must be suppressed on classic builder; args: {args:?}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // --push flag
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn build_args_push_emits_push_and_suppresses_load_on_buildx() {
+        // `--push` (buildx registry push) is mutually exclusive with `--load`.
+        // When push is set on the buildx path, `--push` must be emitted and
+        // `--load` must be suppressed.
+        let mut opts = basic_opts();
+        opts.push = true;
+        let args = build_command_args(&opts, true);
+        assert!(
+            args.contains(&"--push".to_string()),
+            "--push must be emitted when push=true; args: {args:?}"
+        );
+        assert!(
+            !args.contains(&"--load".to_string()),
+            "--load must be suppressed when --push is set; args: {args:?}"
+        );
+        assert!(
+            !args.contains(&"--output".to_string()),
+            "--output must not appear alongside --push; args: {args:?}"
+        );
+    }
+
+    #[test]
+    fn build_args_push_false_no_push_arg() {
+        // push=false → --push must never appear in the args (even on buildx path).
+        let opts = basic_opts();
+        let args = build_command_args(&opts, true);
+        assert!(
+            !args.contains(&"--push".to_string()),
+            "--push must not appear when push=false; args: {args:?}"
+        );
+        // Default --load is preserved.
+        assert!(
+            args.contains(&"--load".to_string()),
+            "--load must be present when push=false and no output; args: {args:?}"
+        );
+    }
+
+    #[test]
+    fn build_args_push_suppressed_on_classic_builder() {
+        // `--push` is buildx-only; classic `docker build` does not support it.
+        // On the classic path it must not be emitted (build_image warns instead).
+        let mut opts = basic_opts();
+        opts.push = true;
+        let args = build_command_args(&opts, false);
+        assert!(
+            !args.contains(&"--push".to_string()),
+            "--push must not appear on classic builder; args: {args:?}"
+        );
+        assert!(
+            !args.contains(&"--load".to_string()),
+            "--load must not appear on classic builder; args: {args:?}"
         );
     }
 

--- a/crates/cella-docker/src/integration_tests/output_export_tests.rs
+++ b/crates/cella-docker/src/integration_tests/output_export_tests.rs
@@ -80,6 +80,7 @@ async fn output_type_local_exports_to_dest() {
         platform: None,
         output: Some(format!("type=local,dest={}", dest.display())),
         labels: Vec::new(),
+        push: false,
     };
 
     let result = client.build_image(&opts, |_| {}).await;

--- a/crates/cella-features/src/dockerfile.rs
+++ b/crates/cella-features/src/dockerfile.rs
@@ -5,6 +5,7 @@
 
 use std::fmt::Write;
 
+use crate::reference::feature_id_without_version;
 use crate::types::ResolvedFeature;
 
 /// Named build context for feature content in Docker Compose builds.
@@ -273,8 +274,21 @@ pub fn generate_builtin_env(container_user: &str, remote_user: &str) -> String {
 /// are converted to UPPERCASE, matching the original devcontainer CLI behavior.
 /// The resulting file is sourced with `set -a` in the wrapper script.
 pub fn generate_feature_env(feature: &ResolvedFeature) -> String {
-    let mut out = String::new();
+    feature_env_lines(feature)
+        .into_iter()
+        .fold(String::new(), |mut acc, l| {
+            acc.push_str(&l);
+            acc.push('\n');
+            acc
+        })
+}
 
+/// Build the per-feature option env-var lines as a `Vec<String>`.
+///
+/// Each entry is a `KEY="value"` string without a trailing newline. Used both
+/// by [`generate_feature_env`] (joined with newlines) and by
+/// [`generate_wrapper_script`] (indented into the header block).
+fn feature_env_lines(feature: &ResolvedFeature) -> Vec<String> {
     // Collect all option names: union of declared options and user-provided options.
     let mut all_keys: Vec<String> = feature
         .metadata
@@ -289,6 +303,7 @@ pub fn generate_feature_env(feature: &ResolvedFeature) -> String {
     // Sort for deterministic output.
     all_keys.sort();
 
+    let mut lines = Vec::new();
     for key in &all_keys {
         let value = if let Some(user_val) = feature.user_options.get(key) {
             json_value_to_string(user_val)
@@ -304,28 +319,112 @@ pub fn generate_feature_env(feature: &ResolvedFeature) -> String {
             // User-provided key with no declared option and no value -- skip
             continue;
         };
-
-        writeln!(out, "{}=\"{value}\"", option_key_to_env_var(key)).unwrap();
+        lines.push(format!("{}=\"{value}\"", option_key_to_env_var(key)));
     }
 
-    out
+    lines
+}
+
+/// Replace every `'` in a string with `'\''` so the value can be safely
+/// embedded inside single quotes in a POSIX shell script.
+fn escape_quotes_for_shell(s: &str) -> String {
+    s.replace('\'', "'\\''")
 }
 
 /// Generate `devcontainer-features-install.sh` wrapper script for a feature.
 ///
-/// The wrapper sources the builtin env file and the per-feature env file with
-/// `set -a` (auto-export), then runs `install.sh`. This matches the original
-/// devcontainer CLI's approach of wrapping each feature install.
-pub fn generate_wrapper_script(feature_id: &str) -> String {
+/// Produces a script matching the official `getFeatureInstallWrapperScript`
+/// output, grafted onto cella's `cd /tmp/dev-container-features/<id>` directory
+/// model (instead of Docker WORKDIR). The displayed `Id` field uses the
+/// version-stripped `original_ref`; the `cd` path uses `feature.id` (the
+/// on-disk directory name) — these are intentionally different values.
+pub fn generate_wrapper_script(feature: &ResolvedFeature) -> String {
+    let name = escape_quotes_for_shell(feature.metadata.name.as_deref().unwrap_or("Unknown"));
+    let description =
+        escape_quotes_for_shell(feature.metadata.description.as_deref().unwrap_or(""));
+    let version = escape_quotes_for_shell(&feature.metadata.version);
+    let documentation =
+        escape_quotes_for_shell(feature.metadata.documentation_url.as_deref().unwrap_or(""));
+    // Displayed id: version-stripped user ref, falling back to "Unknown".
+    let display_id = {
+        let raw = feature.original_ref.as_str();
+        let stripped = if raw.is_empty() {
+            "Unknown"
+        } else {
+            feature_id_without_version(raw)
+        };
+        escape_quotes_for_shell(stripped)
+    };
+
+    // troubleshootingMessage: leading space + doc link, only when doc non-empty.
+    let troubleshooting = if feature.metadata.documentation_url.is_some()
+        && !feature
+            .metadata
+            .documentation_url
+            .as_deref()
+            .unwrap_or("")
+            .is_empty()
+    {
+        format!(
+            " Look at the documentation at {documentation} for help troubleshooting this error."
+        )
+    } else {
+        String::new()
+    };
+
+    // echoWarning slot: blank line when not deprecated, echo when deprecated.
+    let echo_warning = if feature.metadata.deprecated == Some(true) {
+        format!(
+            "echo '(!) WARNING: Using the deprecated Feature \"{display_id}\". \
+             This Feature will no longer receive any further updates/support.'"
+        )
+    } else {
+        String::new()
+    };
+
+    // Options block: indented env-var lines, shell-escaped, joined with literal newlines.
+    let option_lines: Vec<String> = feature_env_lines(feature)
+        .into_iter()
+        .map(|l| format!("    {}", escape_quotes_for_shell(&l)))
+        .collect();
+    let options_indented = if option_lines.is_empty() {
+        String::new()
+    } else {
+        option_lines.join("\n")
+    };
+
+    // The `cd` path uses the canonical feature.id (on-disk dir), NOT original_ref.
+    let dir_id = &feature.id;
+
     format!(
         "#!/bin/sh\n\
          set -e\n\
-         cd /tmp/dev-container-features/{feature_id}\n\
-         chmod +x ./install.sh\n\
+         \n\
+         on_exit () {{\n\
+         \t[ $? -eq 0 ] && exit\n\
+         \techo 'ERROR: Feature \"{name}\" ({display_id}) failed to install!{troubleshooting}'\n\
+         }}\n\
+         \n\
+         trap on_exit EXIT\n\
+         \n\
+         echo ===========================================================================\n\
+         {echo_warning}\n\
+         echo 'Feature       : {name}'\n\
+         echo 'Description   : {description}'\n\
+         echo 'Id            : {display_id}'\n\
+         echo 'Version       : {version}'\n\
+         echo 'Documentation : {documentation}'\n\
+         echo 'Options       :'\n\
+         echo '{options_indented}'\n\
+         echo ===========================================================================\n\
+         \n\
+         cd /tmp/dev-container-features/{dir_id}\n\
          set -a\n\
          . ../devcontainer-features.builtin.env\n\
          . ./devcontainer-features.env\n\
          set +a\n\
+         \n\
+         chmod +x ./install.sh\n\
          ./install.sh\n"
     )
 }
@@ -880,8 +979,88 @@ mod tests {
 
     #[test]
     fn wrapper_script_content() {
-        let script = generate_wrapper_script("node");
+        let mut options = HashMap::new();
+        options.insert("version".to_string(), make_option(serde_json::json!("lts")));
+        options.insert(
+            "nodeGypDependencies".to_string(),
+            make_option(serde_json::json!(true)),
+        );
+        let mut user_options = HashMap::new();
+        user_options.insert("version".to_string(), serde_json::json!("18"));
+
+        let feature = make_feature(
+            "node",
+            "ghcr.io/devcontainers/features/node:1",
+            true,
+            user_options,
+            FeatureMetadata {
+                id: "node".to_string(),
+                version: "2.1.0".to_string(),
+                name: Some("Node.js".to_string()),
+                description: Some("Installs Node.js".to_string()),
+                documentation_url: Some("https://example.com/node".to_string()),
+                options,
+                ..Default::default()
+            },
+        );
+
+        let script = generate_wrapper_script(&feature);
         insta::assert_snapshot!(script);
+    }
+
+    #[test]
+    fn wrapper_script_deprecated_feature() {
+        let feature = make_feature(
+            "node",
+            "ghcr.io/devcontainers/features/node:1",
+            true,
+            HashMap::new(),
+            FeatureMetadata {
+                id: "node".to_string(),
+                version: "2.1.0".to_string(),
+                name: Some("Node.js".to_string()),
+                description: Some("Installs Node.js".to_string()),
+                documentation_url: Some("https://example.com/node".to_string()),
+                deprecated: Some(true),
+                ..Default::default()
+            },
+        );
+
+        let script = generate_wrapper_script(&feature);
+        assert!(
+            script.contains("(!) WARNING: Using the deprecated Feature"),
+            "deprecation warning missing:\n{script}"
+        );
+        insta::assert_snapshot!(script);
+    }
+
+    #[test]
+    fn wrapper_script_shell_escape() {
+        // A value with an apostrophe must be escaped so the shell script is valid.
+        let feature = make_feature(
+            "my-tool",
+            "ghcr.io/example/my-tool:1",
+            true,
+            HashMap::new(),
+            FeatureMetadata {
+                id: "my-tool".to_string(),
+                version: "1.0.0".to_string(),
+                name: Some("Eve's Tool".to_string()),
+                description: Some("A user's best friend".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let script = generate_wrapper_script(&feature);
+        // Apostrophe in name should be shell-escaped as '\''
+        assert!(
+            script.contains("Eve'\\''s Tool"),
+            "name apostrophe not escaped:\n{script}"
+        );
+        assert!(
+            script.contains("A user'\\''s best friend"),
+            "description apostrophe not escaped:\n{script}"
+        );
     }
 
     // ---------------------------------------------------------------

--- a/crates/cella-features/src/graph.rs
+++ b/crates/cella-features/src/graph.rs
@@ -272,7 +272,18 @@ fn parse_norm_ref(reference: &str) -> Result<NormalizedRef, FeatureError> {
     // misidentified as the tag separator.  Carry the full `sha256:<hex>`
     // string as the `tag` field so downstream fetchers can detect it via
     // `tag.starts_with("sha256:")` and route to the locked-digest fetch path.
+    //
+    // `@` in a feature reference is only ever a digest separator, so validate
+    // the digest format (same check as `reference.rs`) and reject a malformed
+    // pin here with a clear error rather than routing a bogus digest to the
+    // registry as a locked-digest fetch.
     if let Some((repo_part, digest)) = rest.split_once('@') {
+        if !crate::reference::is_digest(digest) {
+            return Err(FeatureError::InvalidReference {
+                reference: reference.to_owned(),
+                reason: format!("malformed digest in pinned reference: {digest:?}"),
+            });
+        }
         return Ok(NormalizedRef::OciTarget {
             registry: registry.to_owned(),
             repository: repo_part.to_owned(),
@@ -489,5 +500,14 @@ mod tests {
             }
             _ => panic!("expected OciTarget"),
         }
+    }
+
+    #[test]
+    fn parse_norm_ref_rejects_malformed_digest() {
+        // A too-short / non-hex digest must fail clearly here, not get routed
+        // to the registry as a bogus locked-digest fetch.
+        let err = parse_norm_ref("ghcr.io/devcontainers/features/node@sha256:tooshort")
+            .expect_err("malformed digest must be rejected");
+        assert!(matches!(err, FeatureError::InvalidReference { .. }));
     }
 }

--- a/crates/cella-features/src/graph.rs
+++ b/crates/cella-features/src/graph.rs
@@ -267,15 +267,16 @@ fn parse_norm_ref(reference: &str) -> Result<NormalizedRef, FeatureError> {
                 reason: "expected registry/repository format".to_owned(),
             })?;
 
-    // Digest-pinned references (`repo@sha256:<hex>`) carry a `:` inside the
-    // digest. Splitting on it would treat the hex as a tag and `@sha256` as
-    // part of the repository, fetching the wrong artifact. Reject them
-    // explicitly rather than silently resolving the wrong target — dependency
-    // graphs don't yet resolve digest pins.
-    if rest.contains('@') {
-        return Err(FeatureError::InvalidReference {
-            reference: reference.to_owned(),
-            reason: "digest-pinned dependency references are not supported".to_owned(),
+    // Digest-pinned references (`repo@sha256:<hex>`) must be split on `@`
+    // rather than `:` — the digest contains a `:` that would otherwise be
+    // misidentified as the tag separator.  Carry the full `sha256:<hex>`
+    // string as the `tag` field so downstream fetchers can detect it via
+    // `tag.starts_with("sha256:")` and route to the locked-digest fetch path.
+    if let Some((repo_part, digest)) = rest.split_once('@') {
+        return Ok(NormalizedRef::OciTarget {
+            registry: registry.to_owned(),
+            repository: repo_part.to_owned(),
+            tag: digest.to_owned(),
         });
     }
 
@@ -468,14 +469,25 @@ mod tests {
     }
 
     #[test]
-    fn parse_norm_ref_rejects_digest() {
-        // A digest pin must not be silently mis-parsed (repo `node@sha256`,
-        // tag `<hex>`); it should be rejected explicitly.
-        let err = parse_norm_ref(
-            "ghcr.io/devcontainers/features/node@sha256:\
-             aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        )
-        .unwrap_err();
-        assert!(matches!(err, FeatureError::InvalidReference { .. }));
+    fn parse_norm_ref_parses_digest() {
+        // Digest-pinned dependency refs must be parsed correctly: the full
+        // `sha256:<hex>` string is carried as the `tag` so the fetcher can
+        // route to the locked-digest fetch path.
+        const DIGEST: &str =
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let result =
+            parse_norm_ref(&format!("ghcr.io/devcontainers/features/node@{DIGEST}")).unwrap();
+        match result {
+            NormalizedRef::OciTarget {
+                registry,
+                repository,
+                tag,
+            } => {
+                assert_eq!(registry, "ghcr.io");
+                assert_eq!(repository, "devcontainers/features/node");
+                assert_eq!(tag, DIGEST);
+            }
+            _ => panic!("expected OciTarget"),
+        }
     }
 }

--- a/crates/cella-features/src/lib.rs
+++ b/crates/cella-features/src/lib.rs
@@ -950,7 +950,7 @@ fn prepare_build_context(
             )?;
             std::fs::write(
                 dest.join("devcontainer-features-install.sh"),
-                generate_wrapper_script(&feature.id),
+                generate_wrapper_script(feature),
             )?;
         }
     }

--- a/crates/cella-features/src/metadata.rs
+++ b/crates/cella-features/src/metadata.rs
@@ -49,6 +49,8 @@ struct FeatureMetadataDto {
     version: String,
     name: Option<String>,
     description: Option<String>,
+    #[serde(rename = "documentationURL")]
+    documentation_url: Option<String>,
     #[serde(default)]
     options: HashMap<String, FeatureOptionDto>,
     /// Hard dependencies: `Record<featureId, options>` where options is
@@ -140,6 +142,7 @@ impl FeatureMetadataDto {
             version: self.version,
             name: self.name,
             description: self.description,
+            documentation_url: self.documentation_url,
             options,
             depends_on: self.depends_on,
             installs_after: self.installs_after,
@@ -433,6 +436,27 @@ mod tests {
         let meta = parse_feature_metadata(json).unwrap();
         let opt = &meta.options["name"];
         assert!(opt.default.is_null());
+    }
+
+    #[test]
+    fn documentation_url_parsed() {
+        let json = r#"{
+            "id": "node",
+            "version": "2.0.0",
+            "documentationURL": "https://github.com/devcontainers/features/tree/main/src/node"
+        }"#;
+        let meta = parse_feature_metadata(json).expect("should parse documentationURL");
+        assert_eq!(
+            meta.documentation_url.as_deref(),
+            Some("https://github.com/devcontainers/features/tree/main/src/node")
+        );
+    }
+
+    #[test]
+    fn documentation_url_absent_yields_none() {
+        let json = r#"{"id": "node", "version": "1.0.0"}"#;
+        let meta = parse_feature_metadata(json).expect("should parse without documentationURL");
+        assert!(meta.documentation_url.is_none());
     }
 
     #[test]

--- a/crates/cella-features/src/oci.rs
+++ b/crates/cella-features/src/oci.rs
@@ -437,6 +437,18 @@ impl FeatureFetcher for OciFetcher {
             });
         };
 
+        // When the `tag` field carries a content digest (`sha256:<hex>`),
+        // route to the pinned-digest fetch path so the registry serves the
+        // exact artifact — a moved tag can never substitute different content.
+        if tag.starts_with("sha256:") {
+            // The "tag" used for display / version reporting is the digest
+            // itself; the caller set no mutable tag.
+            return self
+                .fetch_by_locked_digest(registry, repository, tag, tag, cache)
+                .await
+                .map(|r| r.artifact_dir);
+        }
+
         if let Some(cached) = cache.get_oci(registry, repository, tag) {
             debug!("cache hit for {registry}/{repository}:{tag}");
             return Ok(cached);

--- a/crates/cella-features/src/reference.rs
+++ b/crates/cella-features/src/reference.rs
@@ -103,9 +103,44 @@ fn split_tag(s: &str) -> (&str, &str) {
 /// etc.) are reserved but not in common registry use.  The 64-char hex
 /// constraint matches SHA-256 output exactly (256 bits → 32 bytes → 64 hex
 /// digits).
-fn is_digest(s: &str) -> bool {
+pub(crate) fn is_digest(s: &str) -> bool {
     s.strip_prefix("sha256:")
         .is_some_and(|hex| hex.len() == 64 && hex.bytes().all(|b| b.is_ascii_hexdigit()))
+}
+
+/// Try to parse `input` as a digest-pinned OCI reference
+/// (`registry/repo@sha256:<hex>`).
+///
+/// Returns `None` when `input` is not digest-pinned (no `@`, or the suffix is
+/// not a valid digest) so the caller continues with tag parsing. Returns
+/// `Some(Err(..))` for a valid digest that lacks a fully-qualified registry —
+/// digest pins resolve only against an OCI registry.
+///
+/// Must run before `split_tag`, which uses `rsplit_once(':')` and would
+/// otherwise split on the `:` inside `sha256:…`, mis-reading the hex as a tag.
+fn parse_digest_ref(raw: &str, input: &str) -> Option<Result<FeatureRef, FeatureError>> {
+    let (base_no_digest, digest) = input.rsplit_once('@')?;
+    if !is_digest(digest) {
+        return None;
+    }
+    let first_component = base_no_digest.split('/').next().unwrap_or(base_no_digest);
+    if first_component.contains('.') || first_component.contains(':') {
+        // Fully-qualified OCI reference with a hostname.
+        let (registry, repository) = base_no_digest
+            .split_once('/')
+            .expect("contains '/' — first component has '.' or ':'");
+        // Carry the digest in the `tag` field so downstream fetchers can detect
+        // it via `tag.starts_with("sha256:")`.
+        return Some(Ok(FeatureRef::Oci {
+            registry: registry.to_owned(),
+            repository: repository.to_owned(),
+            tag: digest.to_owned(),
+        }));
+    }
+    Some(Err(FeatureError::InvalidReference {
+        reference: raw.to_owned(),
+        reason: "digest-pinned references require a fully-qualified registry".to_owned(),
+    }))
 }
 
 /// Strip a trailing `:tag` or `@digest` from a feature id.
@@ -186,28 +221,10 @@ impl FeatureRef {
             });
         }
 
-        // Rule 3b: digest-pinned OCI reference (`registry/repo@sha256:<hex>`).
-        //
-        // Must be checked BEFORE `split_tag` — `split_tag` uses `rsplit_once(':')`
-        // which would split on the `:` inside the digest (`sha256:abc…`) and
-        // treat `abc…` as the tag and `…@sha256` as part of the repository path.
-        if let Some((base_no_digest, digest)) = input.rsplit_once('@')
-            && is_digest(digest)
-        {
-            let first_component = base_no_digest.split('/').next().unwrap_or(base_no_digest);
-            if first_component.contains('.') || first_component.contains(':') {
-                // Fully-qualified OCI reference with a hostname.
-                let (registry, repository) = base_no_digest
-                    .split_once('/')
-                    .expect("contains '/' — first component has '.' or ':'");
-                return Ok(Self::Oci {
-                    registry: registry.to_owned(),
-                    repository: repository.to_owned(),
-                    // Carry the digest in the `tag` field so downstream
-                    // fetchers can detect it via `tag.starts_with("sha256:")`.
-                    tag: digest.to_owned(),
-                });
-            }
+        // Rule 3b: digest-pinned OCI reference (`registry/repo@sha256:<hex>`),
+        // resolved before `split_tag` (which would mis-split the digest `:`).
+        if let Some(result) = parse_digest_ref(raw, input) {
+            return result;
         }
 
         // Split off the tag before counting components.
@@ -733,6 +750,15 @@ mod tests {
     #[test]
     fn is_digest_rejects_no_prefix() {
         assert!(!is_digest(&"a".repeat(64)));
+    }
+
+    #[test]
+    fn parse_rejects_digest_without_registry() {
+        // A valid digest but no fully-qualified registry must fail with a clear
+        // error, not fall through to `split_tag` and mis-split the digest `:`.
+        let err = FeatureRef::parse(&format!("owner/repo@{SHA256_DIGEST}"))
+            .expect_err("digest without a registry must be rejected");
+        assert!(matches!(err, FeatureError::InvalidReference { .. }));
     }
 
     // -----------------------------------------------------------------------

--- a/crates/cella-features/src/reference.rs
+++ b/crates/cella-features/src/reference.rs
@@ -97,6 +97,17 @@ fn split_tag(s: &str) -> (&str, &str) {
     }
 }
 
+/// Return whether `s` is a well-formed OCI content digest.
+///
+/// Only `sha256:<64-hex-chars>` is recognised — other algorithms (`sha512`,
+/// etc.) are reserved but not in common registry use.  The 64-char hex
+/// constraint matches SHA-256 output exactly (256 bits → 32 bytes → 64 hex
+/// digits).
+fn is_digest(s: &str) -> bool {
+    s.strip_prefix("sha256:")
+        .is_some_and(|hex| hex.len() == 64 && hex.bytes().all(|b| b.is_ascii_hexdigit()))
+}
+
 /// Strip a trailing `:tag` or `@digest` from a feature id.
 ///
 /// Matches the official `getFeatureIdWithoutVersion` (`/[:@][^/]*$/`): the
@@ -173,6 +184,30 @@ impl FeatureRef {
                      use a fully-qualified OCI reference instead"
                 ),
             });
+        }
+
+        // Rule 3b: digest-pinned OCI reference (`registry/repo@sha256:<hex>`).
+        //
+        // Must be checked BEFORE `split_tag` — `split_tag` uses `rsplit_once(':')`
+        // which would split on the `:` inside the digest (`sha256:abc…`) and
+        // treat `abc…` as the tag and `…@sha256` as part of the repository path.
+        if let Some((base_no_digest, digest)) = input.rsplit_once('@')
+            && is_digest(digest)
+        {
+            let first_component = base_no_digest.split('/').next().unwrap_or(base_no_digest);
+            if first_component.contains('.') || first_component.contains(':') {
+                // Fully-qualified OCI reference with a hostname.
+                let (registry, repository) = base_no_digest
+                    .split_once('/')
+                    .expect("contains '/' — first component has '.' or ':'");
+                return Ok(Self::Oci {
+                    registry: registry.to_owned(),
+                    repository: repository.to_owned(),
+                    // Carry the digest in the `tag` field so downstream
+                    // fetchers can detect it via `tag.starts_with("sha256:")`.
+                    tag: digest.to_owned(),
+                });
+            }
         }
 
         // Split off the tag before counting components.
@@ -362,6 +397,13 @@ impl std::fmt::Display for FeatureRef {
                 registry,
                 repository,
                 tag,
+            } if tag.starts_with("sha256:") => {
+                write!(f, "{registry}/{repository}@{tag}")
+            }
+            Self::Oci {
+                registry,
+                repository,
+                tag,
             } => write!(f, "{registry}/{repository}:{tag}"),
             Self::GitHubShorthand {
                 owner,
@@ -385,6 +427,13 @@ impl std::fmt::Display for FeatureRef {
 impl std::fmt::Display for NormalizedRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::OciTarget {
+                registry,
+                repository,
+                tag,
+            } if tag.starts_with("sha256:") => {
+                write!(f, "{registry}/{repository}@{tag}")
+            }
             Self::OciTarget {
                 registry,
                 repository,
@@ -600,6 +649,90 @@ mod tests {
                 tag: "latest".to_owned(),
             }
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Rule 3b: digest-pinned OCI references
+    // -----------------------------------------------------------------------
+
+    const SHA256_DIGEST: &str =
+        "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4";
+
+    #[test]
+    fn parse_oci_digest_ghcr() {
+        let input = format!("ghcr.io/devcontainers/features/go@{SHA256_DIGEST}");
+        let r = FeatureRef::parse(&input).unwrap();
+        assert_eq!(
+            r,
+            FeatureRef::Oci {
+                registry: "ghcr.io".to_owned(),
+                repository: "devcontainers/features/go".to_owned(),
+                tag: SHA256_DIGEST.to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_oci_digest_custom_registry() {
+        let input = format!("myregistry.azurecr.io/team/features/node@{SHA256_DIGEST}");
+        let r = FeatureRef::parse(&input).unwrap();
+        assert_eq!(
+            r,
+            FeatureRef::Oci {
+                registry: "myregistry.azurecr.io".to_owned(),
+                repository: "team/features/node".to_owned(),
+                tag: SHA256_DIGEST.to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_oci_digest_localhost_port() {
+        let input = format!("localhost:5000/myfeatures/go@{SHA256_DIGEST}");
+        let r = FeatureRef::parse(&input).unwrap();
+        assert_eq!(
+            r,
+            FeatureRef::Oci {
+                registry: "localhost:5000".to_owned(),
+                repository: "myfeatures/go".to_owned(),
+                tag: SHA256_DIGEST.to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_oci_digest_display_uses_at_separator() {
+        let r = FeatureRef::Oci {
+            registry: "ghcr.io".to_owned(),
+            repository: "devcontainers/features/go".to_owned(),
+            tag: SHA256_DIGEST.to_owned(),
+        };
+        assert_eq!(
+            r.to_string(),
+            format!("ghcr.io/devcontainers/features/go@{SHA256_DIGEST}")
+        );
+    }
+
+    #[test]
+    fn is_digest_valid() {
+        assert!(is_digest(SHA256_DIGEST));
+    }
+
+    #[test]
+    fn is_digest_rejects_short_hex() {
+        assert!(!is_digest("sha256:abc123"));
+    }
+
+    #[test]
+    fn is_digest_rejects_non_sha256() {
+        // sha512 is a valid digest algo but we only accept sha256 for now.
+        let sha512 = format!("sha512:{}", "a".repeat(128));
+        assert!(!is_digest(&sha512));
+    }
+
+    #[test]
+    fn is_digest_rejects_no_prefix() {
+        assert!(!is_digest(&"a".repeat(64)));
     }
 
     // -----------------------------------------------------------------------

--- a/crates/cella-features/src/snapshots/cella_features__dockerfile__tests__wrapper_script_deprecated_feature.snap
+++ b/crates/cella-features/src/snapshots/cella_features__dockerfile__tests__wrapper_script_deprecated_feature.snap
@@ -13,15 +13,14 @@ on_exit () {
 trap on_exit EXIT
 
 echo ===========================================================================
-
+echo '(!) WARNING: Using the deprecated Feature "ghcr.io/devcontainers/features/node". This Feature will no longer receive any further updates/support.'
 echo 'Feature       : Node.js'
 echo 'Description   : Installs Node.js'
 echo 'Id            : ghcr.io/devcontainers/features/node'
 echo 'Version       : 2.1.0'
 echo 'Documentation : https://example.com/node'
 echo 'Options       :'
-echo '    NODEGYPDEPENDENCIES="true"
-    VERSION="18"'
+echo ''
 echo ===========================================================================
 
 cd /tmp/dev-container-features/node

--- a/crates/cella-features/src/types.rs
+++ b/crates/cella-features/src/types.rs
@@ -57,6 +57,7 @@ pub struct FeatureMetadata {
     pub version: String,
     pub name: Option<String>,
     pub description: Option<String>,
+    pub documentation_url: Option<String>,
     pub options: HashMap<String, FeatureOption>,
     /// Hard dependencies declared via `dependsOn` in `devcontainer-feature.json`.
     ///

--- a/crates/cella-orchestrator/src/config.rs
+++ b/crates/cella-orchestrator/src/config.rs
@@ -30,6 +30,14 @@ pub struct BuildTuning<'a> {
     /// every build site (base + features layer) so the whole chain targets the
     /// same arch.
     pub platform: Option<&'a str>,
+    /// Push the FINAL image to a registry (`docker buildx build --push`).
+    /// buildx-only; `build`-command only. Applied to exactly one build — the
+    /// final image: the base build when there are no features, the features
+    /// layer otherwise. The `up` path leaves this `false` (it must load the
+    /// image locally to run the container). The `toolchain()` view preserves
+    /// this flag so the features layer (which IS the final image when features
+    /// are present) can push.
+    pub push: bool,
 }
 
 impl Default for BuildTuning<'_> {
@@ -42,6 +50,7 @@ impl Default for BuildTuning<'_> {
             cli_cache_from: &[],
             cache_to: None,
             platform: None,
+            push: false,
         }
     }
 }
@@ -49,6 +58,11 @@ impl Default for BuildTuning<'_> {
 impl BuildTuning<'_> {
     /// Toolchain-only view (docker binary + `BuildKit` decision) for build
     /// sites that must NOT inherit cache I/O (features layer, UID remap).
+    ///
+    /// `push` is preserved: the features layer is explicitly the final image
+    /// when features are present, so it must carry the push flag through. The
+    /// UID-remap build is the only non-final-image toolchain site, and its
+    /// caller always sets `push: false` on `BuildOptions` directly.
     #[must_use]
     pub const fn toolchain(self) -> Self {
         Self {
@@ -57,6 +71,7 @@ impl BuildTuning<'_> {
             cli_cache_from: &[],
             cache_to: None,
             platform: self.platform,
+            push: self.push,
         }
     }
 }

--- a/crates/cella-orchestrator/src/image.rs
+++ b/crates/cella-orchestrator/src/image.rs
@@ -39,6 +39,10 @@ pub struct FeaturesLayerContext<'a> {
     /// rule as `output`: when features are layered the features image is the
     /// final image, so the labels are baked here. Empty slice = no labels.
     pub labels: &'a [String],
+    /// Push the FINAL image to a registry (`--push`, buildx-only). When features
+    /// are layered, the features image is the final image, so the push belongs
+    /// here — never on the base build, which must stay loadable for the `FROM`.
+    pub push: bool,
     pub progress: &'a ProgressSender,
 }
 
@@ -99,6 +103,8 @@ pub async fn build_features_layer(
         // Likewise the final image, so user `--label`s are baked here (the base
         // build stays unlabeled — it is an internal FROM, not the user's image).
         labels: ctx.labels.to_vec(),
+        // Features layer is the final image, so `--push` belongs here too.
+        push: ctx.push,
     };
 
     info!(
@@ -194,6 +200,17 @@ fn base_labels(will_build_features: bool, labels: &[String]) -> Vec<String> {
     }
 }
 
+/// Whether to push on the *base* image build.
+///
+/// Same placement rule as [`base_output`]: `--push` belongs on exactly one build
+/// — the final image. When a features layer follows (`will_build_features`), the
+/// features image is the final image and carries `--push`; the base build must
+/// stay `--load`-able for the features `FROM`. Returns `false` in that case;
+/// otherwise the base build is the final image and gets the push flag as-is.
+const fn base_push(will_build_features: bool, push: bool) -> bool {
+    !will_build_features && push
+}
+
 /// Whether `--label`s were requested but have no build to attach to.
 ///
 /// `--label` bakes a label via a `docker build --label`, so it needs a build.
@@ -209,14 +226,15 @@ const fn image_labels_have_no_target(will_build_features: bool, has_labels: bool
 
 /// Whether to skip inspecting the base image after the build.
 ///
-/// A non-loading `--output` export with no features builds the image but does
-/// NOT load it into the local store, so a follow-up `inspect_image_details`
-/// would fail right after a successful export. In that one case the inspect is
-/// skipped (the no-features build path discards these details, and `up` never
-/// exports). With features, the base build still `--load`s (the export rides the
-/// features layer), so the base remains inspectable.
-const fn skip_base_inspect(has_features: bool, output: Option<&str>) -> bool {
-    !has_features && output.is_some()
+/// A non-loading `--output` export or a `--push` with no features builds the
+/// image but does NOT load it into the local store, so a follow-up
+/// `inspect_image_details` would fail right after a successful export/push. In
+/// those cases the inspect is skipped (the no-features build path discards these
+/// details, and `up` never exports or pushes). With features, the base build
+/// still `--load`s (the export/push rides the features layer), so the base
+/// remains inspectable.
+const fn skip_base_inspect(has_features: bool, output: Option<&str>, push: bool) -> bool {
+    !has_features && (output.is_some() || push)
 }
 
 /// Ensure the dev container image exists (pull or build), including features layer.
@@ -246,11 +264,12 @@ pub async fn ensure_image(
 
     let base_image_tag = resolve_base_image(input, has_features).await?;
 
-    // A non-loading `--output` export (no features) builds the image but does
-    // NOT load it into the local store, so inspecting it would fail right after a
-    // successful export. `cella build` discards these details on the no-features
-    // path and `up` never exports, so return empty details instead of failing.
-    if skip_base_inspect(has_features, input.output) {
+    // A non-loading `--output` export or `--push` (no features) builds the image
+    // but does NOT load it into the local store, so inspecting it would fail
+    // right after a successful export/push. `cella build` discards these details
+    // on the no-features path and `up` never exports or pushes, so return empty
+    // details instead of failing.
+    if skip_base_inspect(has_features, input.output, input.build_tuning.push) {
         return Ok((base_image_tag, None, ImageDetails::default()));
     }
 
@@ -389,6 +408,10 @@ async fn resolve_base_image(
         // User `--label`s land on the base build only when it is the final image;
         // with features they move to the features layer (the final image).
         build_opts.labels = base_labels(will_build_features, input.labels);
+        // `--push` lands on the base build only when it is the final image.
+        // With features the features layer is the final image and gets `--push`;
+        // the base must stay `--load`-able for the features `FROM`.
+        build_opts.push = base_push(will_build_features, input.build_tuning.push);
 
         if !will_build_features {
             let metadata_label = cella_features::generate_metadata_label(
@@ -526,6 +549,11 @@ async fn resolve_and_build_features(
         build_tuning: input.build_tuning.toolchain(),
         output: input.output,
         labels: input.labels,
+        // Features layer is the final image when features are present, so it
+        // should push when requested. The toolchain() view preserves `push`
+        // (the features layer is explicitly the final image, unlike the base
+        // build which must stay loadable when features will follow).
+        push: input.build_tuning.push,
         progress: input.progress,
     };
     let features_image = build_features_layer(&ctx).await?;
@@ -704,6 +732,9 @@ pub fn parse_build_options(
         // Same as `output`: the caller sets labels via `base_labels` only when
         // this base build is the final image (no features layer to follow).
         labels: Vec::new(),
+        // `push` likewise: the caller sets it via `base_push` only when this
+        // base build is the final image (no features layer to follow).
+        push: false,
     }
 }
 
@@ -915,6 +946,7 @@ mod tests {
             cache_to: Some("type=registry,ref=r"),
             cli_cache_from: &[],
             platform: None,
+            push: false,
         };
         let opts = parse_build_options(&build, "img", Path::new("/ws"), false, None, tuning);
         assert_eq!(opts.cache_to.as_deref(), Some("type=registry,ref=r"));
@@ -1287,12 +1319,58 @@ mod tests {
     #[test]
     fn skip_base_inspect_only_for_no_features_export() {
         // No features + a `--output` export → skip the inspect (image not loaded).
-        assert!(skip_base_inspect(false, Some("type=local,dest=/tmp/out")));
-        // No export → inspect normally (the build loaded the image).
-        assert!(!skip_base_inspect(false, None));
+        assert!(skip_base_inspect(
+            false,
+            Some("type=local,dest=/tmp/out"),
+            false
+        ));
+        // No export, no push → inspect normally (the build loaded the image).
+        assert!(!skip_base_inspect(false, None, false));
         // With features the base build still loads (export rides the features
         // layer), so the base stays inspectable regardless of `--output`.
-        assert!(!skip_base_inspect(true, Some("type=local,dest=/tmp/out")));
-        assert!(!skip_base_inspect(true, None));
+        assert!(!skip_base_inspect(
+            true,
+            Some("type=local,dest=/tmp/out"),
+            false
+        ));
+        assert!(!skip_base_inspect(true, None, false));
+        // No features + `--push` → skip the inspect (push does not load locally).
+        assert!(skip_base_inspect(false, None, true));
+        // With features + `--push` → base build still loads (push rides the
+        // features layer), so the base remains inspectable.
+        assert!(!skip_base_inspect(true, None, true));
+        // Both output and push (unusual combo, but test both paths covered).
+        assert!(skip_base_inspect(
+            false,
+            Some("type=local,dest=/tmp/out"),
+            true
+        ));
+        assert!(!skip_base_inspect(
+            true,
+            Some("type=local,dest=/tmp/out"),
+            true
+        ));
+    }
+
+    // ── base_push: --push placement (final-build only) ───────────────
+    //
+    // Same load-bearing rule as `base_output`: `--push` belongs on the final
+    // image. A base build that a features layer will `FROM` must stay
+    // `--load`-able (the push moves to the features layer). Pinned on the
+    // pure helper since `resolve_base_image` is Docker-coupled.
+
+    #[test]
+    fn base_push_suppressed_when_features_will_build() {
+        // Features to follow → the base build must NOT carry push
+        // (it has to stay loadable for the features `FROM`).
+        assert!(!base_push(true, true));
+        assert!(!base_push(true, false));
+    }
+
+    #[test]
+    fn base_push_applied_when_base_is_final() {
+        // No features: the base build IS the final image.
+        assert!(base_push(false, true));
+        assert!(!base_push(false, false));
     }
 }


### PR DESCRIPTION
A coverage audit (enumerate every spec feature, verify each is actually implemented — not just diff cella against the official) turned up a handful of real gaps that the usual diff-scans missed. This closes them. They're independent areas but all the same theme, so they're bundled into one PR rather than five separate bot/CI loops.

### What's fixed

**config**
- `remoteEnv` entries with a `null` value are now omitted instead of being coerced to `VAR=""`. That matches the spec (`remoteEnv` is `string | null`; null means "don't set it"). `containerEnv` is left alone — it's non-nullable per spec.
- `runArgs` now honours `--env`/`-e` and `--env-file`. The env-file reader matches Docker's own parser (verified against `docker/cli` `pkg/kvfile`): left-trim for blank/comment detection, split on the first `=`, value passed through verbatim, and a bare `KEY` inherits from the environment like `docker run --env-file` does.

**features**
- `@sha256:<digest>`-pinned feature references now resolve instead of being rejected/mis-parsed. The `:` inside the digest used to get split as a tag; it's now detected before tag-splitting, carried through, and routed to the locked-digest fetch so you get the exact pinned artifact. Both the top-level parser and the dependency-graph parser validate the digest format and reject a pin without a fully-qualified registry up front.
- The feature install wrapper now matches the official output: a header block (name/description/id/version/docs/options), an `on_exit` trap with a troubleshooting hint, and a deprecation warning when a feature sets `deprecated: true`. Adds `documentationURL` parsing. Grafted onto cella's existing `cd` + relative-source model.

**build**
- `--push` is accepted and wired to `docker buildx build --push` (it suppresses `--load`, and lands on the single final image only — never an intermediate base). Rejects `--push` together with `--output` with the same message the official uses, and keeps rejecting `--push` on the compose path.

### Reviewed
Ran a review pass over the branch — it caught a couple of parity nits in the new code (env-file value trimming, missing digest validation in the dep-graph parser) which are folded in as follow-up commits.

### Deferred (tracked, not in this PR)
The feature *rename* warning (`This feature has been renamed…`) is intentionally left out. Its condition depends on `currentId`, which cella currently drops when reading fetched metadata, and getting the `id != currentId` check right needs tracing how the official assigns those through the OCI fetch pipeline — a wrong guess just spams or never fires. The deprecation half of the wrapper warnings is in. Will do rename as its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)