### PR TITLE
feat(features): warn when a feature is referenced by a renamed (legacy) id

### DIFF
--- a/crates/cella-features/src/dockerfile.rs
+++ b/crates/cella-features/src/dockerfile.rs
@@ -331,6 +331,58 @@ fn escape_quotes_for_shell(s: &str) -> String {
     s.replace('\'', "'\\''")
 }
 
+/// Build the `warningHeader` string that appears inside the `echo` slot of the
+/// wrapper script, mirroring the official `getFeatureInstallWrapperScript`.
+///
+/// The returned string is empty when no warnings apply; otherwise it contains
+/// one or both of:
+/// - Deprecation line (WITH trailing `\n` so the shell echoes a blank line
+///   after it, matching the official output).
+/// - Rename line (NO trailing newline), when the user's ref leaf differs from
+///   the canonical `currentId` — i.e. the feature was referenced by a legacy id.
+fn build_warning_header(feature: &ResolvedFeature, display_id: &str) -> String {
+    let mut warning_header = String::new();
+
+    if feature.metadata.deprecated == Some(true) {
+        // writeln! appends '\n', matching the official's trailing newline on the
+        // deprecation line (which causes the shell to echo a blank line after it).
+        writeln!(
+            warning_header,
+            "(!) WARNING: Using the deprecated Feature \"{display_id}\". \
+             This Feature will no longer receive any further updates/support."
+        )
+        .unwrap();
+    }
+
+    // The user's ref leaf: last `/`-segment of the version-stripped original_ref.
+    // This matches `feature.id` in the official source (set to featureRef.id =
+    // last path segment of the user's OCI ref), NOT our `feature.id` (on-disk dir).
+    let raw = feature.original_ref.as_str();
+    let user_ref_leaf = if raw.is_empty() {
+        ""
+    } else {
+        feature_id_without_version(raw)
+            .rsplit('/')
+            .next()
+            .unwrap_or("")
+    };
+
+    if !feature.metadata.legacy_ids.is_empty()
+        && let Some(current_id) = feature.metadata.current_id.as_deref()
+        && user_ref_leaf != current_id
+    {
+        write!(
+            warning_header,
+            "(!) WARNING: This feature has been renamed. \
+             Please update the reference in devcontainer.json to \"{escaped}\".",
+            escaped = escape_quotes_for_shell(current_id)
+        )
+        .unwrap();
+    }
+
+    warning_header
+}
+
 /// Generate `devcontainer-features-install.sh` wrapper script for a feature.
 ///
 /// Produces a script matching the official `getFeatureInstallWrapperScript`
@@ -357,13 +409,11 @@ pub fn generate_wrapper_script(feature: &ResolvedFeature) -> String {
     };
 
     // troubleshootingMessage: leading space + doc link, only when doc non-empty.
-    let troubleshooting = if feature.metadata.documentation_url.is_some()
-        && !feature
-            .metadata
-            .documentation_url
-            .as_deref()
-            .unwrap_or("")
-            .is_empty()
+    let troubleshooting = if feature
+        .metadata
+        .documentation_url
+        .as_deref()
+        .is_some_and(|u| !u.is_empty())
     {
         format!(
             " Look at the documentation at {documentation} for help troubleshooting this error."
@@ -372,14 +422,13 @@ pub fn generate_wrapper_script(feature: &ResolvedFeature) -> String {
         String::new()
     };
 
-    // echoWarning slot: blank line when not deprecated, echo when deprecated.
-    let echo_warning = if feature.metadata.deprecated == Some(true) {
-        format!(
-            "echo '(!) WARNING: Using the deprecated Feature \"{display_id}\". \
-             This Feature will no longer receive any further updates/support.'"
-        )
-    } else {
+    // Build the combined warning header (deprecation + rename), matching the
+    // official single-echo pattern.
+    let warning_header = build_warning_header(feature, &display_id);
+    let echo_warning = if warning_header.is_empty() {
         String::new()
+    } else {
+        format!("echo '{warning_header}'")
     };
 
     // Options block: indented env-var lines, shell-escaped, joined with literal newlines.
@@ -1060,6 +1109,129 @@ mod tests {
         assert!(
             script.contains("A user'\\''s best friend"),
             "description apostrophe not escaped:\n{script}"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Rename warning (referenced by legacy id)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn wrapper_script_renamed_feature_emits_warning() {
+        // User referenced `maven:1`; canonical id is `java` — rename warning fires.
+        let feature = make_feature(
+            "java",
+            "ghcr.io/devcontainers/features/maven:1",
+            true,
+            HashMap::new(),
+            FeatureMetadata {
+                id: "java".to_string(),
+                version: "1.0.0".to_string(),
+                name: Some("Java".to_string()),
+                legacy_ids: vec!["maven".to_string(), "gradle".to_string()],
+                current_id: Some("java".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let script = generate_wrapper_script(&feature);
+        assert!(
+            script.contains("(!) WARNING: This feature has been renamed."),
+            "rename warning missing:\n{script}"
+        );
+        assert!(
+            script.contains("devcontainer.json to \"java\""),
+            "rename warning should mention canonical id:\n{script}"
+        );
+        assert!(
+            !script.contains("(!) WARNING: Using the deprecated Feature"),
+            "should not have deprecation warning:\n{script}"
+        );
+    }
+
+    #[test]
+    fn wrapper_script_canonical_ref_no_rename_warning() {
+        // User referenced `java:1`; leaf matches current_id — no rename warning.
+        let feature = make_feature(
+            "java",
+            "ghcr.io/devcontainers/features/java:1",
+            true,
+            HashMap::new(),
+            FeatureMetadata {
+                id: "java".to_string(),
+                version: "1.0.0".to_string(),
+                name: Some("Java".to_string()),
+                legacy_ids: vec!["maven".to_string(), "gradle".to_string()],
+                current_id: Some("java".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let script = generate_wrapper_script(&feature);
+        assert!(
+            !script.contains("(!) WARNING: This feature has been renamed."),
+            "should not emit rename warning for canonical ref:\n{script}"
+        );
+    }
+
+    #[test]
+    fn wrapper_script_legacy_ids_without_current_id_no_rename_warning() {
+        // legacyIds present but currentId absent — no rename warning.
+        let feature = make_feature(
+            "java",
+            "ghcr.io/devcontainers/features/maven:1",
+            true,
+            HashMap::new(),
+            FeatureMetadata {
+                id: "java".to_string(),
+                version: "1.0.0".to_string(),
+                name: Some("Java".to_string()),
+                legacy_ids: vec!["maven".to_string()],
+                current_id: None,
+                ..Default::default()
+            },
+        );
+
+        let script = generate_wrapper_script(&feature);
+        assert!(
+            !script.contains("(!) WARNING: This feature has been renamed."),
+            "should not emit rename warning without currentId:\n{script}"
+        );
+    }
+
+    #[test]
+    fn wrapper_script_deprecated_and_renamed() {
+        // Both deprecated AND referenced by legacy id — both warnings in one echo.
+        let feature = make_feature(
+            "java",
+            "ghcr.io/devcontainers/features/maven:1",
+            true,
+            HashMap::new(),
+            FeatureMetadata {
+                id: "java".to_string(),
+                version: "1.0.0".to_string(),
+                name: Some("Java".to_string()),
+                legacy_ids: vec!["maven".to_string()],
+                current_id: Some("java".to_string()),
+                deprecated: Some(true),
+                ..Default::default()
+            },
+        );
+
+        let script = generate_wrapper_script(&feature);
+        assert!(
+            script.contains("(!) WARNING: Using the deprecated Feature"),
+            "deprecation warning missing:\n{script}"
+        );
+        assert!(
+            script.contains("(!) WARNING: This feature has been renamed."),
+            "rename warning missing:\n{script}"
+        );
+        // Both must be inside a single echo (the echo appears exactly once).
+        let echo_count = script.matches("echo '(!)").count();
+        assert_eq!(
+            echo_count, 1,
+            "both warnings must share one echo: {echo_count} found"
         );
     }
 

--- a/crates/cella-features/src/dockerfile.rs
+++ b/crates/cella-features/src/dockerfile.rs
@@ -340,6 +340,14 @@ fn escape_quotes_for_shell(s: &str) -> String {
 ///   after it, matching the official output).
 /// - Rename line (NO trailing newline), when the user's ref leaf differs from
 ///   the canonical `currentId` — i.e. the feature was referenced by a legacy id.
+///
+/// The rename check is leaf-to-leaf, and that matches the official exactly:
+/// `currentId` is the feature's bare `id` field (e.g. `docker-outside-of-docker`,
+/// never a namespaced path — it is injected from `id` at packaging time), and the
+/// official compares it to `feature.id`, which the OCI fetch sets to
+/// `featureRef.id` = the last path segment of the user's reference. So both sides
+/// are bare ids (e.g. `docker-from-docker` vs `docker-outside-of-docker`); a
+/// canonical reference's leaf equals `currentId` and correctly does NOT warn.
 fn build_warning_header(feature: &ResolvedFeature, display_id: &str) -> String {
     let mut warning_header = String::new();
 

--- a/crates/cella-features/src/metadata.rs
+++ b/crates/cella-features/src/metadata.rs
@@ -82,6 +82,8 @@ struct FeatureMetadataDto {
     post_attach_command: Option<serde_json::Value>,
     #[serde(default)]
     legacy_ids: Vec<String>,
+    #[serde(rename = "currentId")]
+    current_id: Option<String>,
     deprecated: Option<bool>,
 }
 
@@ -161,6 +163,7 @@ impl FeatureMetadataDto {
             post_start_command: self.post_start_command,
             post_attach_command: self.post_attach_command,
             legacy_ids: self.legacy_ids,
+            current_id: self.current_id,
             deprecated: self.deprecated,
         })
     }
@@ -551,6 +554,26 @@ mod tests {
             meta.installs_after,
             vec!["ghcr.io/devcontainers/features/base:1"]
         );
+    }
+
+    #[test]
+    fn current_id_parsed() {
+        let json = r#"{
+            "id": "java",
+            "version": "1.0.0",
+            "legacyIds": ["maven", "gradle"],
+            "currentId": "java"
+        }"#;
+        let meta = parse_feature_metadata(json).expect("should parse currentId");
+        assert_eq!(meta.current_id.as_deref(), Some("java"));
+        assert_eq!(meta.legacy_ids, vec!["maven", "gradle"]);
+    }
+
+    #[test]
+    fn current_id_absent_yields_none() {
+        let json = r#"{"id": "node", "version": "1.0.0"}"#;
+        let meta = parse_feature_metadata(json).expect("should parse without currentId");
+        assert!(meta.current_id.is_none());
     }
 
     #[test]

--- a/crates/cella-features/src/snapshots/cella_features__dockerfile__tests__wrapper_script_deprecated_feature.snap
+++ b/crates/cella-features/src/snapshots/cella_features__dockerfile__tests__wrapper_script_deprecated_feature.snap
@@ -13,7 +13,8 @@ on_exit () {
 trap on_exit EXIT
 
 echo ===========================================================================
-echo '(!) WARNING: Using the deprecated Feature "ghcr.io/devcontainers/features/node". This Feature will no longer receive any further updates/support.'
+echo '(!) WARNING: Using the deprecated Feature "ghcr.io/devcontainers/features/node". This Feature will no longer receive any further updates/support.
+'
 echo 'Feature       : Node.js'
 echo 'Description   : Installs Node.js'
 echo 'Id            : ghcr.io/devcontainers/features/node'

--- a/crates/cella-features/src/types.rs
+++ b/crates/cella-features/src/types.rs
@@ -84,6 +84,11 @@ pub struct FeatureMetadata {
     pub post_start_command: Option<serde_json::Value>,
     pub post_attach_command: Option<serde_json::Value>,
     pub legacy_ids: Vec<String>,
+    /// Canonical id injected at packaging time, present in fetched metadata only
+    /// when `legacyIds` is non-empty.  Used to detect rename warnings: when the
+    /// user's ref leaf differs from `current_id`, the feature was referenced by a
+    /// legacy id and we emit `(!) WARNING: This feature has been renamed…`.
+    pub current_id: Option<String>,
     pub deprecated: Option<bool>,
 }
 


### PR DESCRIPTION
The feature install wrapper was missing the official CLI's *rename* warning — when you pull a feature through one of its `legacyIds`, the official prints:

```
(!) WARNING: This feature has been renamed. Please update the reference in devcontainer.json to "<currentId>".
```

This was deferred from the recent wrapper-parity work (#216) because the fire condition was non-obvious. Traced it through the official source: `currentId` is injected into a feature's metadata at packaging time (= its canonical id) and ships in the artifact under every legacy namespace, while `feature.id` stays the **last segment of the reference the user actually wrote** (the OCI fetch sets it from the ref and a later merge keeps it). So the warning fires exactly when the user's ref-leaf differs from `currentId` — i.e. they used an old name.

So:
- Parse `currentId` from the fetched `devcontainer-feature.json` into `FeatureMetadata.current_id` (it was being dropped).
- In the wrapper, fire the rename warning when `legacyIds` is non-empty, `currentId` is present, and the user's version-stripped ref-leaf != `currentId`.
- Both warnings now share one `echo` like the official does, and the deprecation line picks up the trailing newline the official has (so the deprecated-feature snapshot shifts by one blank line).

Referencing the canonical id, or a feature with no `currentId`, doesn't warn — covered by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)