### PR TITLE
feat(features): surface documentationURL/licenseURL/proposals in read-configuration

### DIFF
--- a/crates/cella-cli/src/commands/features_configuration.rs
+++ b/crates/cella-cli/src/commands/features_configuration.rs
@@ -19,8 +19,6 @@
 //!
 //! Follow-ups, gated on `cella-features` modelling the field (it currently does
 //! not parse them, so they are dropped before reaching here, not invented):
-//! - `features[].documentationURL` / `licenseURL`, and string-option
-//!   `proposals` — unmodelled in `FeatureMetadata` / `FeatureOption`.
 //! - non-OCI `sourceInformation.tarballUri` (direct-tarball) /
 //!   `resolvedFilePath` (file-path) — not carried on `ResolvedFeature`.
 //! - explicitly-empty collections (`"capAdd": []`) are emitted as absent,
@@ -114,6 +112,10 @@ struct FeatureOut {
     name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
+    #[serde(rename = "documentationURL", skip_serializing_if = "Option::is_none")]
+    documentation_url: Option<String>,
+    #[serde(rename = "licenseURL", skip_serializing_if = "Option::is_none")]
+    license_url: Option<String>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     options: BTreeMap<String, FeatureOptionOut>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
@@ -164,6 +166,8 @@ struct FeatureOptionOut {
     description: Option<String>,
     #[serde(rename = "enum", skip_serializing_if = "Option::is_none")]
     enum_values: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    proposals: Option<Vec<String>>,
 }
 
 /// Build the `featuresConfiguration` value, or `None` when no features are
@@ -249,6 +253,8 @@ fn feature_out(f: &ResolvedFeature, idx: usize) -> FeatureOut {
         version: non_empty(&m.version),
         name: m.name.clone(),
         description: m.description.clone(),
+        documentation_url: m.documentation_url.clone(),
+        license_url: m.license_url.clone(),
         options: map_options(&m.options),
         container_env: m
             .container_env
@@ -289,6 +295,7 @@ fn map_options(options: &HashMap<String, FeatureOption>) -> BTreeMap<String, Fea
                     default: o.default.clone(),
                     description: o.description.clone(),
                     enum_values: o.enum_values.clone(),
+                    proposals: o.proposals.clone(),
                 },
             )
         })
@@ -393,7 +400,8 @@ fn parse_mount_spec(spec: &str) -> serde_json::Value {
 mod tests {
     use super::*;
     use cella_features::types::{
-        FeatureMetadata, ResolvedFeature, ResolvedFeatures, ResolvedOciManifest,
+        FeatureMetadata, FeatureOption, OptionType, ResolvedFeature, ResolvedFeatures,
+        ResolvedOciManifest,
     };
     use std::path::PathBuf;
 
@@ -526,6 +534,76 @@ mod tests {
             feat["customizations"]["vscode"]["extensions"][0],
             "dbaeumer.vscode-eslint"
         );
+    }
+
+    #[test]
+    fn documentation_url_license_url_and_proposals_emitted() {
+        let mut f = oci_feature();
+        f.metadata.documentation_url =
+            Some("https://github.com/devcontainers/features/tree/main/src/node".to_string());
+        f.metadata.license_url =
+            Some("https://github.com/devcontainers/features/blob/main/LICENSE".to_string());
+        f.metadata.options = HashMap::from([(
+            "version".to_string(),
+            FeatureOption {
+                option_type: OptionType::String,
+                default: serde_json::json!("lts"),
+                description: None,
+                enum_values: None,
+                proposals: Some(vec!["lts".to_string(), "20".to_string(), "18".to_string()]),
+            },
+        )]);
+        let fc = build(&resolved(vec![f]))
+            .unwrap()
+            .expect("features present");
+        let v = serde_json::to_value(&fc).unwrap();
+        let feat = &v["featureSets"][0]["features"][0];
+
+        // All three new fields present with the exact official key names.
+        assert_eq!(
+            feat["documentationURL"],
+            "https://github.com/devcontainers/features/tree/main/src/node"
+        );
+        assert_eq!(
+            feat["licenseURL"],
+            "https://github.com/devcontainers/features/blob/main/LICENSE"
+        );
+        assert_eq!(
+            feat["options"]["version"]["proposals"],
+            serde_json::json!(["lts", "20", "18"])
+        );
+
+        // Sanity: camelCase variants must NOT appear (wrong key casing).
+        assert!(
+            feat.get("documentationUrl").is_none(),
+            "must be documentationURL, not documentationUrl"
+        );
+        assert!(
+            feat.get("licenseUrl").is_none(),
+            "must be licenseURL, not licenseUrl"
+        );
+    }
+
+    #[test]
+    fn documentation_url_license_url_and_proposals_omitted_when_absent() {
+        // oci_feature() sets no documentationURL/licenseURL and default options
+        // have no proposals — verify the keys are completely absent (not null).
+        let fc = build(&resolved(vec![oci_feature()]))
+            .unwrap()
+            .expect("features present");
+        let v = serde_json::to_value(&fc).unwrap();
+        let feat = &v["featureSets"][0]["features"][0];
+
+        assert!(
+            feat.get("documentationURL").is_none(),
+            "documentationURL must be omitted when absent, not null"
+        );
+        assert!(
+            feat.get("licenseURL").is_none(),
+            "licenseURL must be omitted when absent, not null"
+        );
+        // oci_feature has no options, so no proposals to check — any option
+        // without proposals must not emit the key.
     }
 
     #[test]

--- a/crates/cella-features/src/dockerfile.rs
+++ b/crates/cella-features/src/dockerfile.rs
@@ -559,6 +559,7 @@ mod tests {
             default,
             description: None,
             enum_values: None,
+            proposals: None,
         }
     }
 

--- a/crates/cella-features/src/merge/validation.rs
+++ b/crates/cella-features/src/merge/validation.rs
@@ -118,6 +118,7 @@ mod tests {
                 default: json!(false),
                 description: None,
                 enum_values: None,
+                proposals: None,
             },
         )]);
         let user = HashMap::from([("flag".to_string(), json!(42))]);
@@ -143,6 +144,7 @@ mod tests {
                 default: json!(false),
                 description: None,
                 enum_values: None,
+                proposals: None,
             },
         )]);
 
@@ -171,6 +173,7 @@ mod tests {
                 default: json!(false),
                 description: None,
                 enum_values: None,
+                proposals: None,
             },
         )]);
         let user = HashMap::from([("flag".to_string(), json!("yes"))]);
@@ -200,6 +203,7 @@ mod tests {
                     "latest".to_string(),
                     "18".to_string(),
                 ]),
+                proposals: None,
             },
         )]);
         let user = HashMap::from([("version".to_string(), json!("99"))]);
@@ -225,6 +229,7 @@ mod tests {
                 default: json!("lts"),
                 description: None,
                 enum_values: Some(vec!["lts".to_string(), "latest".to_string()]),
+                proposals: None,
             },
         )]);
         let user = HashMap::from([("version".to_string(), json!("lts"))]);
@@ -243,6 +248,7 @@ mod tests {
                     default: json!("lts"),
                     description: None,
                     enum_values: None,
+                    proposals: None,
                 },
             ),
             (
@@ -252,6 +258,7 @@ mod tests {
                     default: json!(true),
                     description: None,
                     enum_values: None,
+                    proposals: None,
                 },
             ),
         ]);
@@ -273,6 +280,7 @@ mod tests {
                 default: json!(false),
                 description: None,
                 enum_values: None,
+                proposals: None,
             },
         )]);
         let user = HashMap::from([

--- a/crates/cella-features/src/metadata.rs
+++ b/crates/cella-features/src/metadata.rs
@@ -51,6 +51,8 @@ struct FeatureMetadataDto {
     description: Option<String>,
     #[serde(rename = "documentationURL")]
     documentation_url: Option<String>,
+    #[serde(rename = "licenseURL")]
+    license_url: Option<String>,
     #[serde(default)]
     options: HashMap<String, FeatureOptionDto>,
     /// Hard dependencies: `Record<featureId, options>` where options is
@@ -97,6 +99,7 @@ struct FeatureOptionDto {
     description: Option<String>,
     #[serde(rename = "enum")]
     enum_values: Option<Vec<String>>,
+    proposals: Option<Vec<String>>,
 }
 
 impl FeatureMetadataDto {
@@ -122,6 +125,7 @@ impl FeatureMetadataDto {
                     default: dto.default,
                     description: dto.description,
                     enum_values: dto.enum_values,
+                    proposals: dto.proposals,
                 },
             );
         }
@@ -145,6 +149,7 @@ impl FeatureMetadataDto {
             name: self.name,
             description: self.description,
             documentation_url: self.documentation_url,
+            license_url: self.license_url,
             options,
             depends_on: self.depends_on,
             installs_after: self.installs_after,
@@ -439,6 +444,65 @@ mod tests {
         let meta = parse_feature_metadata(json).unwrap();
         let opt = &meta.options["name"];
         assert!(opt.default.is_null());
+    }
+
+    #[test]
+    fn license_url_parsed() {
+        let json = r#"{
+            "id": "node",
+            "version": "2.0.0",
+            "licenseURL": "https://github.com/devcontainers/features/blob/main/LICENSE"
+        }"#;
+        let meta = parse_feature_metadata(json).expect("should parse licenseURL");
+        assert_eq!(
+            meta.license_url.as_deref(),
+            Some("https://github.com/devcontainers/features/blob/main/LICENSE")
+        );
+    }
+
+    #[test]
+    fn license_url_absent_yields_none() {
+        let json = r#"{"id": "node", "version": "1.0.0"}"#;
+        let meta = parse_feature_metadata(json).expect("should parse without licenseURL");
+        assert!(meta.license_url.is_none());
+    }
+
+    #[test]
+    fn proposals_parsed() {
+        let json = r#"{
+            "id": "test",
+            "version": "1.0.0",
+            "options": {
+                "flavor": {
+                    "type": "string",
+                    "default": "vanilla",
+                    "proposals": ["vanilla", "chocolate", "strawberry"]
+                }
+            }
+        }"#;
+        let meta = parse_feature_metadata(json).expect("should parse proposals");
+        let opt = &meta.options["flavor"];
+        assert_eq!(
+            opt.proposals.as_deref(),
+            Some(&["vanilla", "chocolate", "strawberry"].map(String::from)[..])
+        );
+    }
+
+    #[test]
+    fn proposals_absent_yields_none() {
+        let json = r#"{
+            "id": "test",
+            "version": "1.0.0",
+            "options": {
+                "flavor": {
+                    "type": "string",
+                    "default": "vanilla"
+                }
+            }
+        }"#;
+        let meta = parse_feature_metadata(json).expect("should parse without proposals");
+        let opt = &meta.options["flavor"];
+        assert!(opt.proposals.is_none());
     }
 
     #[test]

--- a/crates/cella-features/src/types.rs
+++ b/crates/cella-features/src/types.rs
@@ -58,6 +58,7 @@ pub struct FeatureMetadata {
     pub name: Option<String>,
     pub description: Option<String>,
     pub documentation_url: Option<String>,
+    pub license_url: Option<String>,
     pub options: HashMap<String, FeatureOption>,
     /// Hard dependencies declared via `dependsOn` in `devcontainer-feature.json`.
     ///
@@ -99,6 +100,10 @@ pub struct FeatureOption {
     pub default: serde_json::Value,
     pub description: Option<String>,
     pub enum_values: Option<Vec<String>>,
+    /// Suggested string values (for IDE autocompletion); only valid on
+    /// `string`-typed options. Distinct from `enum_values` — proposals are
+    /// non-exhaustive hints, not a closed set.
+    pub proposals: Option<Vec<String>>,
 }
 
 /// Option type variants.


### PR DESCRIPTION
A focused audit of what's left after the recent parity batches turned up three feature fields the official CLI emits in `read-configuration --include-features-configuration` output that cella was dropping. The official spreads the whole `devcontainer-feature.json` onto each feature object, so these all flow through; cella just didn't model them (it even had a code comment noting them as unmodelled).

- `documentationURL` — was already parsed (the install wrapper uses it), just not emitted in the read-config output.
- `licenseURL` — wasn't parsed at all.
- `proposals` — the string-option suggestion list, wasn't parsed.

Now modelled and emitted. Absent fields stay omitted (not `null`), matching the official. One subtlety worth calling out: the output struct uses `rename_all = "camelCase"`, which would have turned these into `documentationUrl`/`licenseUrl` — so they use explicit `#[serde(rename)]`, with a test asserting the lowercase-`url` spelling never regresses.

None of this touches the build/install/lifecycle paths — it only affects tooling that consumes the `featuresConfiguration` JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)