### PR TITLE
feat(config): fail up on a malformed runArgs --env-file line (match docker)

### DIFF
--- a/crates/cella-backend/src/error.rs
+++ b/crates/cella-backend/src/error.rs
@@ -105,4 +105,15 @@ pub enum BackendError {
     #[error(transparent)]
     #[diagnostic(code(cella::backend::runtime))]
     Runtime(Box<dyn std::error::Error + Send + Sync>),
+
+    /// A `runArgs` `--env-file` contained a malformed variable definition.
+    ///
+    /// Docker errors here and aborts `docker run`; cella surfaces the same
+    /// failure at container-creation time.
+    #[error("invalid runArgs --env-file: {message}")]
+    #[diagnostic(
+        code(cella::backend::invalid_run_args),
+        help("Fix the env-file referenced by runArgs --env-file in devcontainer.json.")
+    )]
+    InvalidRunArgs { message: String },
 }

--- a/crates/cella-backend/src/types.rs
+++ b/crates/cella-backend/src/types.rs
@@ -658,6 +658,15 @@ pub struct RunArgsOverrides {
 
     /// Flags not recognized by the parser (emitted as warnings).
     pub unrecognized: Vec<String>,
+
+    /// Fatal env-file parse errors collected during `--env-file` processing.
+    ///
+    /// Docker aborts `docker run` if an env-file contains a malformed line (e.g.
+    /// an empty variable name or a variable name containing whitespace).  cella
+    /// mirrors this by recording the error here during `parse_run_args` and then
+    /// failing at container-creation time — the same point the official CLI would
+    /// fail.  Empty means no errors were found.
+    pub errors: Vec<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/cella-config/src/config_map/run_args.rs
+++ b/crates/cella-config/src/config_map/run_args.rs
@@ -82,7 +82,7 @@ pub fn parse_run_args(args: &[String]) -> RunArgsOverrides {
 
             "--env-file" => {
                 if let Some(path) = next_val(&mut i, inline_val) {
-                    parse_env_file(&path, &mut result.env);
+                    parse_env_file(&path, &mut result);
                 }
             }
 
@@ -498,17 +498,32 @@ fn parse_ulimit(s: &str) -> Option<UlimitSpec> {
     })
 }
 
-/// Read an env-file and push `KEY=VAL` entries into `out`, matching Docker's
-/// `--env-file` parsing.
+/// Read an env-file and push `KEY=VAL` entries into `result.env`, matching
+/// Docker's `--env-file` parsing.
 ///
 /// Each line is left-trimmed; blank lines and those beginning with `#` are
 /// skipped. For `KEY=VALUE`, the variable name is trimmed but the value is
 /// passed through verbatim (Docker never trims the value, so a trailing space
 /// is significant). A bare `KEY` with no `=` inherits the value from cella's
 /// own environment, exactly as `docker run --env-file` resolves it from the
-/// client environment. On I/O error, emits a warning and pushes nothing from
-/// the failed file.
-fn parse_env_file(path: &str, out: &mut Vec<String>) {
+/// client environment.
+///
+/// Rejects malformed lines like Docker does (all-or-nothing per file):
+///
+/// - A line whose key part (before `=`), when trimmed, is empty records a
+///   `"no variable name on line '…'"` error and contributes NO vars from the
+///   whole file (matches `docker/cli pkg/kvfile/kvfile.go`).
+/// - A key that contains internal ASCII whitespace records a
+///   `"variable '…' contains whitespaces"` error with the same all-or-nothing
+///   semantics.
+///
+/// Errors are appended to `result.errors`; the `up` path checks them before
+/// calling into Docker, matching Docker's failure point.
+///
+/// On I/O error, emits a warning and pushes nothing from the failed file (no
+/// `result.errors` entry — Docker would fail before even opening the file, but
+/// that error is indistinguishable from a normal I/O failure).
+fn parse_env_file(path: &str, result: &mut RunArgsOverrides) {
     let content = match std::fs::read_to_string(path) {
         Ok(c) => c,
         Err(err) => {
@@ -516,26 +531,59 @@ fn parse_env_file(path: &str, out: &mut Vec<String>) {
             return;
         }
     };
+
+    // Buffer vars for this file; only extend result.env if the whole file is clean.
+    let mut buffered: Vec<String> = Vec::new();
+
     for raw in content.lines() {
         // Docker left-trims the line before testing for blank / comment lines.
         let line = raw.trim_start();
         if line.is_empty() || line.starts_with('#') {
             continue;
         }
-        if let Some((key, value)) = line.split_once('=') {
-            // `KEY=VALUE`: trim only the name, keep the value untouched.
-            let key = key.trim();
-            if !key.is_empty() {
-                out.push(format!("{key}={value}"));
+
+        if let Some((key_raw, value)) = line.split_once('=') {
+            // `KEY=VALUE`: trim the name, keep the value untouched.
+            let key = key_raw.trim();
+
+            if key.is_empty() {
+                // Empty key — e.g. `=value` or `  =value`.
+                result
+                    .errors
+                    .push(format!("no variable name on line '{line}'"));
+                return;
             }
+
+            if key.contains(|c: char| c.is_ascii_whitespace()) {
+                // Key contains internal whitespace — e.g. `MY KEY=value`.
+                result
+                    .errors
+                    .push(format!("variable '{key}' contains whitespaces"));
+                return;
+            }
+
+            buffered.push(format!("{key}={value}"));
         } else {
-            // Bare `KEY`: inherit from the current environment, like Docker.
+            // Bare `KEY` (no `=`): inherit from the current environment, like Docker.
             let key = line.trim();
-            if let Ok(value) = std::env::var(key) {
-                out.push(format!("{key}={value}"));
+
+            if key.contains(|c: char| c.is_ascii_whitespace()) {
+                // Bare key with internal whitespace — e.g. `MY KEY`.
+                result
+                    .errors
+                    .push(format!("variable '{key}' contains whitespaces"));
+                return;
             }
+
+            if let Ok(value) = std::env::var(key) {
+                buffered.push(format!("{key}={value}"));
+            }
+            // If unset, Docker contributes nothing for bare keys — skip silently.
         }
     }
+
+    // Whole file parsed cleanly — commit all entries.
+    result.env.extend(buffered);
 }
 
 /// Emit warnings for any unrecognized flags.
@@ -944,5 +992,96 @@ mod tests {
         assert!(r.env.is_empty());
         assert_eq!(r.privileged, Some(true));
         assert!(r.unrecognized.is_empty());
+    }
+
+    // -- Malformed env-file: Docker-matching rejection --
+
+    #[test]
+    fn parse_env_file_empty_key_records_error_and_no_vars() {
+        // A line like `=value` has an empty key — Docker errors with
+        // "no variable name on line '…'".  The whole file's vars must be
+        // discarded (all-or-nothing).
+        use std::io::Write as _;
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        writeln!(f, "GOOD=val").unwrap();
+        writeln!(f, "=bad_empty_key").unwrap();
+        let path = f.path().to_str().unwrap().to_string();
+        let r = parse_run_args(&args(&["--env-file", &path]));
+        assert!(
+            r.env.is_empty(),
+            "all-or-nothing: no vars when the file has an empty key"
+        );
+        assert_eq!(r.errors.len(), 1, "exactly one error recorded");
+        assert!(
+            r.errors[0].contains("no variable name"),
+            "error message must mention missing name: {:?}",
+            r.errors[0]
+        );
+        assert!(
+            r.errors[0].contains("=bad_empty_key"),
+            "error message must include the offending line: {:?}",
+            r.errors[0]
+        );
+    }
+
+    #[test]
+    fn parse_env_file_whitespace_key_records_error_and_no_vars() {
+        // A line like `MY KEY=value` has a key with internal whitespace —
+        // Docker errors with "variable '…' contains whitespaces".
+        use std::io::Write as _;
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        writeln!(f, "GOOD=val").unwrap();
+        writeln!(f, "MY KEY=value").unwrap();
+        let path = f.path().to_str().unwrap().to_string();
+        let r = parse_run_args(&args(&["--env-file", &path]));
+        assert!(
+            r.env.is_empty(),
+            "all-or-nothing: no vars when the file has a whitespace key"
+        );
+        assert_eq!(r.errors.len(), 1, "exactly one error recorded");
+        assert!(
+            r.errors[0].contains("contains whitespaces"),
+            "error message must mention whitespaces: {:?}",
+            r.errors[0]
+        );
+        assert!(
+            r.errors[0].contains("MY KEY"),
+            "error message must include the key: {:?}",
+            r.errors[0]
+        );
+    }
+
+    #[test]
+    fn parse_env_file_all_or_nothing_mixed_file() {
+        // If a file has one good line followed by a bad line, zero vars
+        // must be contributed — the good line is not partially written.
+        use std::io::Write as _;
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        writeln!(f, "VALID=yes").unwrap();
+        writeln!(f, "ALSO_VALID=yes").unwrap();
+        writeln!(f, "=bad_empty").unwrap();
+        let path = f.path().to_str().unwrap().to_string();
+        let r = parse_run_args(&args(&["--env-file", &path]));
+        assert!(
+            r.env.is_empty(),
+            "good lines before a bad one must not leak"
+        );
+        assert!(!r.errors.is_empty(), "error must be recorded");
+    }
+
+    #[test]
+    fn parse_env_file_clean_file_still_works() {
+        // Sanity: a fully valid file must still push its vars and record no
+        // errors.  Regression guard for the existing valid-input behaviour.
+        use std::io::Write as _;
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        writeln!(f, "# comment").unwrap();
+        writeln!(f).unwrap();
+        writeln!(f, "ALPHA=1").unwrap();
+        writeln!(f, "BETA=hello world").unwrap();
+        let path = f.path().to_str().unwrap().to_string();
+        let r = parse_run_args(&args(&["--env-file", &path]));
+        assert_eq!(r.env, vec!["ALPHA=1", "BETA=hello world"]);
+        assert!(r.errors.is_empty(), "no errors for a clean file");
     }
 }

--- a/crates/cella-docker/src/container.rs
+++ b/crates/cella-docker/src/container.rs
@@ -113,6 +113,28 @@ pub(crate) fn container_info_from_summary(
     }
 }
 
+/// Validate `run_args_overrides` before container creation.
+///
+/// Returns `Err(CellaDockerError::InvalidRunArgs)` if the overrides carry any
+/// env-file parse errors (populated by `parse_run_args` when it encounters a
+/// malformed `--env-file`).  This is the single, early, fallible check that
+/// mirrors the point at which Docker would reject the file via `docker run`.
+///
+/// `build` and `read-configuration` never call this function — they do not
+/// reach `create_container` — so they are unaffected by malformed env-files.
+fn validate_run_args_overrides(
+    opts: &cella_backend::CreateContainerOptions,
+) -> Result<(), CellaDockerError> {
+    if let Some(ra) = opts.run_args_overrides.as_ref()
+        && let Some(first_err) = ra.errors.first()
+    {
+        return Err(CellaDockerError::InvalidRunArgs {
+            message: first_err.clone(),
+        });
+    }
+    Ok(())
+}
+
 impl DockerClient {
     /// Find an existing container for the given workspace.
     ///
@@ -186,12 +208,19 @@ impl DockerClient {
     ///
     /// # Errors
     ///
+    /// Returns `CellaDockerError::InvalidRunArgs` if any `--env-file` referenced
+    /// in `runArgs` contained a malformed variable definition (e.g. an empty
+    /// variable name or a variable name containing whitespace).  This matches
+    /// Docker's behaviour: `docker run` would abort with the same error.
+    ///
     /// Returns `CellaDockerError::DockerApi` on API errors.
     pub async fn create_container(
         &self,
         opts: &cella_backend::CreateContainerOptions,
     ) -> Result<String, CellaDockerError> {
         info!("Creating container: {}", opts.name);
+
+        validate_run_args_overrides(opts)?;
 
         let bollard_opts = BollardCreateOptions {
             name: Some(opts.name.clone()),
@@ -1692,6 +1721,91 @@ mod tests {
         assert!(
             info.labels.contains_key("dev.cella.workspace_path"),
             "cella-managed container must have dev.cella.workspace_path"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // validate_run_args_overrides
+    // -----------------------------------------------------------------------
+
+    /// Minimal `CreateContainerOptions` with clean (no errors) `run_args_overrides`.
+    fn minimal_opts_no_errors() -> cella_backend::CreateContainerOptions {
+        cella_backend::CreateContainerOptions {
+            name: "test".to_string(),
+            image: "ubuntu:latest".to_string(),
+            labels: std::collections::HashMap::new(),
+            env: Vec::new(),
+            remote_env: Vec::new(),
+            user: None,
+            workspace_folder: "/workspace".to_string(),
+            workspace_mount: None,
+            mounts: Vec::new(),
+            port_bindings: std::collections::HashMap::new(),
+            entrypoint: None,
+            cmd: None,
+            cap_add: Vec::new(),
+            security_opt: Vec::new(),
+            privileged: false,
+            init: false,
+            run_args_overrides: None,
+            gpu_request: None,
+        }
+    }
+
+    #[test]
+    fn validate_run_args_overrides_no_overrides_ok() {
+        // No run_args_overrides at all — must pass.
+        let opts = minimal_opts_no_errors();
+        assert!(validate_run_args_overrides(&opts).is_ok());
+    }
+
+    #[test]
+    fn validate_run_args_overrides_clean_overrides_ok() {
+        // run_args_overrides present but errors is empty — must pass.
+        let mut opts = minimal_opts_no_errors();
+        opts.run_args_overrides = Some(cella_backend::RunArgsOverrides {
+            env: vec!["FOO=bar".to_string()],
+            ..Default::default()
+        });
+        assert!(validate_run_args_overrides(&opts).is_ok());
+    }
+
+    #[test]
+    fn validate_run_args_overrides_with_errors_returns_err() {
+        // run_args_overrides.errors non-empty — must Err with InvalidRunArgs.
+        let mut opts = minimal_opts_no_errors();
+        opts.run_args_overrides = Some(cella_backend::RunArgsOverrides {
+            errors: vec!["no variable name on line '=bad'".to_string()],
+            ..Default::default()
+        });
+        let result = validate_run_args_overrides(&opts);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, CellaDockerError::InvalidRunArgs { .. }),
+            "expected InvalidRunArgs, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("no variable name"),
+            "error message should surface the env-file error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_run_args_overrides_surfaces_first_error() {
+        // When multiple errors are present, the first is surfaced.
+        let mut opts = minimal_opts_no_errors();
+        opts.run_args_overrides = Some(cella_backend::RunArgsOverrides {
+            errors: vec![
+                "no variable name on line '=first'".to_string(),
+                "variable 'MY KEY' contains whitespaces".to_string(),
+            ],
+            ..Default::default()
+        });
+        let err = validate_run_args_overrides(&opts).unwrap_err();
+        assert!(
+            err.to_string().contains("=first"),
+            "first error must be surfaced: {err}"
         );
     }
 }

--- a/crates/cella-docker/src/error.rs
+++ b/crates/cella-docker/src/error.rs
@@ -157,6 +157,22 @@ mod tests {
     }
 
     #[test]
+    fn invalid_run_args_maps_correctly() {
+        let err = CellaDockerError::InvalidRunArgs {
+            message: "no variable name on line '=x'".to_string(),
+        };
+        // Display format carries the env-file context plus the inner message.
+        assert_eq!(
+            err.to_string(),
+            "invalid runArgs --env-file: no variable name on line '=x'"
+        );
+        let be: BackendError = err.into();
+        assert!(
+            matches!(be, BackendError::InvalidRunArgs { message } if message == "no variable name on line '=x'")
+        );
+    }
+
+    #[test]
     fn docker_cli_not_found_maps_to_cli_not_found() {
         let err = CellaDockerError::DockerCliNotFound {
             message: "not in PATH".to_string(),
@@ -483,6 +499,9 @@ mod tests {
             CellaDockerError::AgentChecksumMismatch {
                 expected: "a".to_string(),
                 actual: "b".to_string(),
+            },
+            CellaDockerError::InvalidRunArgs {
+                message: "x".to_string(),
             },
         ];
         for err in variants {

--- a/crates/cella-docker/src/error.rs
+++ b/crates/cella-docker/src/error.rs
@@ -80,6 +80,17 @@ pub enum CellaDockerError {
     #[error("I/O error: {0}")]
     #[diagnostic(code(cella::docker::io))]
     Io(#[from] std::io::Error),
+
+    /// A `runArgs` `--env-file` contained a malformed variable definition.
+    ///
+    /// Docker errors here and aborts `docker run`; cella surfaces the same
+    /// failure at container-creation time.
+    #[error("invalid runArgs --env-file: {message}")]
+    #[diagnostic(
+        code(cella::docker::invalid_run_args),
+        help("Fix the env-file referenced by runArgs --env-file in devcontainer.json.")
+    )]
+    InvalidRunArgs { message: String },
 }
 
 impl From<CellaDockerError> for cella_backend::BackendError {
@@ -115,6 +126,7 @@ impl From<CellaDockerError> for cella_backend::BackendError {
                 Self::AgentChecksumMismatch { expected, actual }
             }
             CellaDockerError::Io(e) => Self::Io(e),
+            CellaDockerError::InvalidRunArgs { message } => Self::InvalidRunArgs { message },
         }
     }
 }


### PR DESCRIPTION
The official CLI hands `runArgs` to `docker run`, so Docker parses `--env-file` and errors on a malformed line — an empty variable name (`=value`) or a name with internal whitespace (`MY KEY=value`) — aborting the run. cella parses the file itself (it uses bollard) and was lenient: it silently skipped empty-key lines and passed a spaced key through as a garbage var.

This brings it to strict parity. A malformed line now records a Docker-matching error (`no variable name on line '…'` / `variable '…' contains whitespaces`), the whole file's vars are discarded (Docker's all-or-nothing per file), and the error surfaces at container creation so `cella up` fails.

Crucially the timing matches the official — it only validates at the `docker run` equivalent (container creation), so:
- `up` with a malformed env-file → fails
- `build` (never processes runArgs) → unaffected
- `read-configuration` (never parses the file) → unaffected

Valid env-files were already byte-for-byte identical to Docker; this only changes malformed-input handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)