### PR TITLE
fix(config): fail up on an unreadable --env-file (match docker)

### DIFF
--- a/crates/cella-config/src/config_map/run_args.rs
+++ b/crates/cella-config/src/config_map/run_args.rs
@@ -520,14 +520,15 @@ fn parse_ulimit(s: &str) -> Option<UlimitSpec> {
 /// Errors are appended to `result.errors`; the `up` path checks them before
 /// calling into Docker, matching Docker's failure point.
 ///
-/// On I/O error, emits a warning and pushes nothing from the failed file (no
-/// `result.errors` entry — Docker would fail before even opening the file, but
-/// that error is indistinguishable from a normal I/O failure).
+/// On I/O error (missing path, permissions, …), records an error and pushes no
+/// vars: Docker fails `docker run` when it cannot read the env-file, so `up`
+/// fails too. The error rides the same create-time check, so `read-configuration`
+/// and `build` (which never reach container creation) are unaffected.
 fn parse_env_file(path: &str, result: &mut RunArgsOverrides) {
     let content = match std::fs::read_to_string(path) {
         Ok(c) => c,
         Err(err) => {
-            warn!("runArgs: --env-file {path:?}: {err}");
+            result.errors.push(format!("--env-file {path:?}: {err}"));
             return;
         }
     };
@@ -981,9 +982,10 @@ mod tests {
     }
 
     #[test]
-    fn parse_env_file_missing_warns_and_continues() {
-        // A missing env-file should not crash; the env list stays empty and
-        // other flags still parse correctly.
+    fn parse_env_file_missing_records_error() {
+        // A missing env-file must record a fatal error — Docker fails `docker
+        // run` when it can't read the file, so `up` fails too. Parsing itself
+        // doesn't crash and other flags still parse.
         let r = parse_run_args(&args(&[
             "--env-file",
             "/nonexistent/does/not/exist.env",
@@ -992,6 +994,11 @@ mod tests {
         assert!(r.env.is_empty());
         assert_eq!(r.privileged, Some(true));
         assert!(r.unrecognized.is_empty());
+        assert!(
+            r.errors.iter().any(|e| e.contains("--env-file")),
+            "missing env-file must record an error, got {:?}",
+            r.errors
+        );
     }
 
     // -- Malformed env-file: Docker-matching rejection --

--- a/crates/cella-config/src/config_map/run_args.rs
+++ b/crates/cella-config/src/config_map/run_args.rs
@@ -528,7 +528,10 @@ fn parse_env_file(path: &str, result: &mut RunArgsOverrides) {
     let content = match std::fs::read_to_string(path) {
         Ok(c) => c,
         Err(err) => {
-            result.errors.push(format!("--env-file {path:?}: {err}"));
+            // The error is surfaced wrapped as `invalid runArgs --env-file: …`,
+            // so don't repeat `--env-file` here; Display (not Debug) keeps the
+            // path unquoted, closer to Docker's message.
+            result.errors.push(format!("{path}: {err}"));
             return;
         }
     };
@@ -995,8 +998,8 @@ mod tests {
         assert_eq!(r.privileged, Some(true));
         assert!(r.unrecognized.is_empty());
         assert!(
-            r.errors.iter().any(|e| e.contains("--env-file")),
-            "missing env-file must record an error, got {:?}",
+            r.errors.iter().any(|e| e.contains("exist.env")),
+            "missing env-file must record an error naming the path, got {:?}",
             r.errors
         );
     }


### PR DESCRIPTION
Follow-up to #220. That PR made malformed env-file *lines* fail the `up` like Docker, but left the I/O-error case (a missing or unreadable `--env-file` path) lenient — it warned and continued. That's the inconsistent half: a missing/typo'd path is a more common mistake than a malformed line, and Docker fails `docker run` whenever it can't read the file.

So the I/O-error branch now records an error too, riding the exact same create-time check #220 added:
- `up` with a missing/unreadable env-file → fails
- `build` / `read-configuration` (which never open the file) → unaffected

Completes the "env-file matches Docker" story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)